### PR TITLE
chore(deps): group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Keep Python dependencies up to date (best-effort with setuptools/pyproject)
   - package-ecosystem: "pip"
@@ -13,3 +21,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      python:
+        patterns:
+          - "*"


### PR DESCRIPTION
Groups Dependabot updates to reduce PR noise and adds consistent labels/commit message prefix.

- GitHub Actions updates: grouped weekly
- Python (pip) updates: grouped weekly

No runtime/code behavior changes.