### PR TITLE
chore: sync VBA version to 0.9.1 + remove doc drift

### DIFF
--- a/VBA/Modules/M08_API.bas
+++ b/VBA/Modules/M08_API.bas
@@ -4,12 +4,12 @@ Option Explicit
 ' ==============================================================================
 ' Module:       M08_API
 ' Description:  Public facing API functions (Simplified wrappers)
-' Version:      1.0.0
+' Version:      0.9.1
 ' License:      MIT
 ' ==============================================================================
 
 Public Function Get_Library_Version() As String
-    Get_Library_Version = "0.8.1"
+    Get_Library_Version = "0.9.1"
 End Function
 
 '

--- a/docs/NEXT_SESSION_BRIEF.md
+++ b/docs/NEXT_SESSION_BRIEF.md
@@ -1,16 +1,16 @@
 # Next Session Briefing
 
-**Last Updated:** 2025-12-25  
-**Status:** v0.9.1 released (patch tag for latest green main)  
+**Last Updated:** 2025-12-26  
+**Status:** v0.9.1 released (tagged release; verify CI status via GitHub Actions)  
 **Branch:** `main`
 
 ## TL;DR (What Changed Recently)
-- Released v0.9.1 (versions/docs aligned; tag exists for latest green main).
+- Released v0.9.1 (versions/docs aligned; tag exists for the latest release baseline).
 - Hardened GitHub Actions workflow permissions (least-privilege; low maintenance).
 - Enabled GitHub `main` protection via Ruleset (PR-only merges + required checks + up-to-date + no force-push).
 - Reduced maintenance noise: Dependabot updates are grouped + consistently labeled.
 - Merged action updates for CI/CodeQL (keeps workflows on supported majors).
-- CI was green at last verification time (see “Verified state” and GitHub Actions for live status).
+- CI status: use GitHub Actions for the live truth.
 
 ---
 
@@ -24,7 +24,7 @@ If you want to resume quickly without re-reading the repo:
 4. **Primary reference index:** `docs/README.md`
 
 **Verified state (as of 2025-12-25):**
-- Release baseline is **v0.9.1** (patch tag for the latest green main state).
+- Release baseline tag is **v0.9.1**.
 - Version pins updated across docs + package metadata.
 - Serviceability (Level A): **implemented** (deflection + crack width).
 - Compliance checker: **implemented** (multi-case orchestration + summary).
@@ -40,7 +40,7 @@ If you want to resume quickly without re-reading the repo:
 - Keep CI workflows least-privilege (avoid broad default `GITHUB_TOKEN` permissions).
 - Prefer **repo settings** for protection (branch protection rules) over complex workflow tricks.
 - Avoid high-maintenance hardening (e.g., pinning every action to a commit SHA) unless needed.
-- Status: secret-pattern scan of git-tracked files was clean.
+- If needed: run a secrets scan before publishing changes.
 - Status: `main` is protected via GitHub ruleset (PR required + required checks + up-to-date branches + no force pushes).
 - Status: Dependabot grouped updates are enabled (`.github/dependabot.yml`).
 

--- a/docs/PRODUCTION_ROADMAP.md
+++ b/docs/PRODUCTION_ROADMAP.md
@@ -215,7 +215,7 @@ To use this library for **actual project submissions**, you need:
 | v0.7.0 | Detailing + DXF | ✅ Done |
 | v0.8.0 | Deflection + Crack Width | ✅ Done |
 | v0.8.2 | Robustness + CI | ✅ Done |
-| **v0.9.1** | **Stable public API + deterministic job runner (patch tag for latest green main)** | ✅ Current |
+| **v0.9.1** | **Stable public API + deterministic job runner (tagged release baseline)** | ✅ Current |
 | v0.10.0 | BBS + PDF Reports | Planned |
 | v1.0.0 | Production Release | Goal |
 

--- a/docs/RESEARCH_AI_ENHANCEMENTS.md
+++ b/docs/RESEARCH_AI_ENHANCEMENTS.md
@@ -1,7 +1,7 @@
 # Research Log — AI/High-Value Enhancements
 
 **Research Version:** v0.9.1 baseline (+ CI hardening)  
-**Last Updated:** 2025-12-25  
+**Last Updated:** 2025-12-26  
 **Scope:** Identify additions that make the library materially more valuable for professional use (beyond current strength/detailing + serviceability Level A baseline).
 
 This log captures goals/mindset, a lightweight online-scan snapshot, and a prioritized shortlist of high-value additions (serviceability, rebar optimizer, BBS/BOM export, load-combo compliance checking), plus longer-horizon AI/NL helper ideas.


### PR DESCRIPTION
Small housekeeping:
- Sync VBA `Get_Library_Version` to `0.9.1` (was `0.8.1`).
- Remove drift-prone "CI was green" / "latest green main" wording from docs.
- Update Last Updated dates to Dec 26.