### PR TITLE
feat: add PyPI publish workflow with Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,115 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on version tags like v0.9.5, v1.0.0
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Publish target'
+        required: true
+        default: 'testpypi'
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Python  # Build from Python/ subdirectory
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build
+      
+      - name: Build package
+        run: python -m build
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: Python/dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'
+    
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/structural-lib-is456
+    
+    permissions:
+      id-token: write  # Required for Trusted Publishing
+    
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    
+    environment:
+      name: pypi
+      url: https://pypi.org/p/structural-lib-is456
+    
+    permissions:
+      id-token: write  # Required for Trusted Publishing
+    
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    
+    permissions:
+      contents: write  # Required to create releases
+    
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          draft: false

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -24,6 +24,13 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 
+[project.urls]
+Homepage = "https://github.com/Pravin-surawase/structural_engineering_lib"
+Repository = "https://github.com/Pravin-surawase/structural_engineering_lib"
+Documentation = "https://github.com/Pravin-surawase/structural_engineering_lib/tree/main/docs"
+Changelog = "https://github.com/Pravin-surawase/structural_engineering_lib/blob/main/CHANGELOG.md"
+Issues = "https://github.com/Pravin-surawase/structural_engineering_lib/issues"
+
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "black", "mypy", "pre-commit", "ruff"]
 dxf = ["ezdxf>=1.0"]  # For DXF drawing generation

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -6,6 +6,57 @@ Entries here represent "locked" versions that have been verified and approved.
 
 ---
 
+## Release Process
+
+### For maintainers: How to publish a new release
+
+1. **Update version** in 3 files:
+   - `Python/pyproject.toml` → `version = "X.Y.Z"`
+   - `Python/structural_lib/api.py` → `__version__ = "X.Y.Z"`
+   - `VBA/Modules/M08_API.bas` → `VERSION = "X.Y.Z"`
+
+2. **Update CHANGELOG.md** with release notes
+
+3. **Create and push tag:**
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z - Short description"
+   git push origin vX.Y.Z
+   ```
+
+4. **Automatic publishing:**
+   - GitHub Actions builds wheel + sdist
+   - Publishes to PyPI via Trusted Publishing
+   - Creates GitHub Release with assets
+
+5. **Verify installation:**
+   ```bash
+   pip install structural-lib-is456==X.Y.Z
+   python -c "from structural_lib import api; print(api.get_library_version())"
+   ```
+
+### TestPyPI (for testing before release)
+
+Use workflow_dispatch with `testpypi` target:
+1. Go to Actions → Publish to PyPI → Run workflow
+2. Select `testpypi` and run
+3. Test: `pip install -i https://test.pypi.org/simple/ structural-lib-is456`
+
+---
+
+## v0.9.4
+**Date:** 2025-12-27
+**Status:** ✅ Locked & Verified
+**Mindset:** Unified CLI + VBA parity + Cutting-stock optimizer
+**Key Changes:**
+- **Unified CLI:** `python -m structural_lib design|bbs|dxf|job`
+- **Cutting-Stock Optimizer:** First-fit-decreasing bin packing for rebar nesting
+- **VBA BBS Module:** `M18_BBS.bas` — bar weights, cut lengths, stirrup lengths
+- **VBA Compliance Module:** `M19_Compliance.bas` — multi-check orchestration
+- **Tests:** 1680+ passed, 9 VBA test suites
+- **Docs:** Professional README with pipeline diagram, trust section
+
+---
+
 ## v0.9.3
 **Date:** 2025-12-26
 **Status:** ✅ Locked & Verified


### PR DESCRIPTION
## Summary
Adds automated PyPI publishing workflow using Trusted Publishing (OIDC - no API tokens needed).

## Changes

### .github/workflows/publish.yml
- Triggers on `v*` tags → publishes to PyPI
- Manual `workflow_dispatch` → publishes to TestPyPI
- Builds from `Python/` subdirectory (monorepo-aware)
- Creates GitHub Release with wheel/sdist artifacts
- Uses `pypa/gh-action-pypi-publish` with Trusted Publishing

### Python/pyproject.toml
- Added `project.urls` section (Homepage, Repository, Documentation, Changelog, Issues)

### docs/RELEASES.md
- Added release process documentation
- Added v0.9.4 entry

## Setup Required (one-time)
1. Create GitHub environments: `pypi` and `testpypi`
2. Configure Trusted Publishing on PyPI:
   - Go to https://pypi.org/manage/account/publishing/
   - Add publisher: owner=Pravin-surawase, repo=structural_engineering_lib, workflow=publish.yml
3. Same for TestPyPI

## Testing
After merge, test with:
```bash
# Manual TestPyPI publish
gh workflow run publish.yml -f target=testpypi
```