### PR TITLE
chore: bump version to 0.9.5 for PyPI release

### DIFF
--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "structural-lib-is456"
-version = "0.9.4"
+version = "0.9.5"
 description = "IS 456 RC Beam Design Library (flexure, shear, ductile detailing, DXF export for RC beams)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump for first production PyPI release.

After merge, will tag v0.9.5 to trigger publish workflow.