### PR TITLE
docs: add migration scaffold folders (Phase 1)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,28 @@
+# Architecture
+
+Deep dives into project structure and design decisions.
+
+## Contents
+
+| Document | Purpose |
+|----------|---------|
+| [Project Overview](project-overview.md) | High-level scope, layers, workflows |
+| [Deep Map](deep-map.md) | Consolidated architecture and data flow |
+| [Mission](mission.md) | Core principles and non-negotiables |
+
+## Quick architecture summary
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         IS 456 DESIGN PIPELINE                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│   CSV/JSON ──► Design ──► Compliance ──► Detailing ──► DXF/Schedule    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Key design decisions
+
+- **Deterministic outputs** — Same input → same output
+- **Explicit units** — No hidden conversions
+- **Python/VBA parity** — Matching behavior where implemented
+- **Layer separation** — Core has no I/O dependencies

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Guides for developers and maintainers.
+
+## Contents
+
+| Guide | Audience |
+|-------|----------|
+| [Development Guide](development-guide.md) | Coding standards, PR workflow |
+| [Testing Strategy](testing-strategy.md) | Test structure, coverage goals |
+| [VBA Guide](vba-guide.md) | VBA module conventions |
+| [VBA Testing Guide](vba-testing-guide.md) | Running VBA test suites |
+| [Excel Add-in Guide](excel-addin-guide.md) | Packaging the .xlam |
+
+## Before contributing
+
+1. Read [Development Guide](development-guide.md) for coding standards
+2. Run tests locally: `cd Python && pytest`
+3. Format code: `python -m black .`
+
+## Layer architecture (must follow)
+
+| Layer | Modules | Rules |
+|-------|---------|-------|
+| Core | flexure, shear, detailing, etc. | Pure functions, no I/O |
+| Application | api, job_runner, bbs | Orchestrates core |
+| UI/I-O | excel_integration, dxf_export, job_cli | External data |

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1,0 +1,28 @@
+# Cookbook
+
+Task-focused recipes for common workflows.
+
+## Contents
+
+| Recipe | Use case |
+|--------|----------|
+| [CLI Reference](cli-reference.md) | All command-line options with examples |
+| [Python Recipes](python-recipes.md) | Copy-paste snippets for common tasks |
+
+## Quick CLI examples
+
+```bash
+# Design beams from CSV
+python -m structural_lib design input.csv -o results.json
+
+# Generate bar bending schedule
+python -m structural_lib bbs results.json -o schedule.csv
+
+# Generate DXF drawings
+python -m structural_lib dxf results.json -o drawings.dxf
+
+# Run complete job
+python -m structural_lib job job.json -o ./output
+```
+
+See [cli-reference.md](cli-reference.md) for full documentation.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,18 @@
+# Getting Started
+
+Quick onboarding guides for new users.
+
+## Contents
+
+| Guide | Audience | Time |
+|-------|----------|------|
+| [Beginner's Guide](beginners-guide.md) | First-time users | 30 min |
+| [Python Quickstart](python-quickstart.md) | Python users | 5 min |
+| [Excel Quickstart](excel-quickstart.md) | Excel users | 5 min |
+| [Excel Tutorial](excel-tutorial.md) | Excel users | 15 min |
+
+## Which guide should I read?
+
+- **Never used this library?** → Start with [Beginner's Guide](beginners-guide.md)
+- **Python developer, want to get running fast?** → [Python Quickstart](python-quickstart.md)
+- **Excel user, want formulas?** → [Excel Quickstart](excel-quickstart.md)

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -1,0 +1,22 @@
+# Planning
+
+Internal planning documents and research notes.
+
+## Contents
+
+| Document | Purpose |
+|----------|---------|
+| [Next Session](next-session.md) | What to work on next |
+| [Current State](current-state.md) | Where we are now |
+| [Roadmap](roadmap.md) | Production readiness checklist |
+
+## Research
+
+| Document | Topic |
+|----------|-------|
+| [AI Enhancements](ai-enhancements.md) | Future AI/ML integration ideas |
+| [Detailing Research](detailing.md) | Bar arrangement algorithms |
+
+## Active priorities
+
+See [../TASKS.md](../TASKS.md) for the canonical task backlog.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,18 @@
+# Reference
+
+Lookup documentation for API, formulas, and troubleshooting.
+
+## Contents
+
+| Document | Purpose |
+|----------|---------|
+| [API Reference](api.md) | Full Python/VBA function signatures |
+| [IS 456 Formulas](is456-formulas.md) | Quick formula cheat sheet |
+| [Known Pitfalls](known-pitfalls.md) | Common traps and how to avoid them |
+| [Troubleshooting](troubleshooting.md) | Error messages and fixes |
+
+## Quick links
+
+- Function signatures → [api.md](api.md)
+- "Why is my output wrong?" → [known-pitfalls.md](known-pitfalls.md)
+- Error messages → [troubleshooting.md](troubleshooting.md)

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -1,0 +1,19 @@
+# Verification
+
+Benchmark examples and verification packs for validating library calculations.
+
+## Contents
+
+| Document | Purpose |
+|----------|---------|
+| [Examples](examples.md) | Worked examples with hand calculations |
+| [Verification Pack](pack.md) | Test vectors for regression testing |
+
+## Why verification matters
+
+Engineering software must be verifiable. These documents provide:
+
+- **Hand calculation comparisons** — Every formula traced to IS 456 clause
+- **SP:16 cross-references** — Design aids table lookups
+- **Tolerance specifications** — Acceptable error bounds
+- **Reproducible test cases** — Same input → same output


### PR DESCRIPTION
## Phase 1 of docs restructure

Creates folder scaffold with README.md indexes. No file moves yet.

### New folders
- `getting-started/` — User onboarding
- `reference/` — API, formulas, troubleshooting
- `verification/` — Benchmark examples
- `cookbook/` — CLI and Python recipes
- `contributing/` — Developer guides
- `architecture/` — Project structure deep dives
- `planning/` — Internal planning docs

### Next phases
- Phase 2: Move verification docs (lowest risk)
- Phase 3: Move reference docs
- Phase 4-6: Remaining moves

Each phase will be a separate PR with redirect stubs.