### PR TITLE
docs: fix broken links after migration

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -99,7 +99,7 @@ Use workflow_dispatch with `testpypi` target:
   - CLI: `python -m structural_lib.excel_integration`
 - Documentation:
   - `docs/specs/v0.7_DATA_MAPPING.md`
-  - `docs/RESEARCH_DETAILING.md`
+  - `docs/planning/research-detailing.md`
   - `docs/AGENT_WORKFLOW.md`
 - Tests: 67 passing (31 detailing + 15 integration + 21 original)
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -7,8 +7,8 @@ Deep dives into project structure and design decisions.
 | Document | Purpose |
 |----------|---------|
 | [Project Overview](project-overview.md) | High-level scope, layers, workflows |
-| [Deep Map](deep-map.md) | Consolidated architecture and data flow |
-| [Mission](mission.md) | Core principles and non-negotiables |
+| [Deep Project Map](deep-project-map.md) | Consolidated architecture and data flow |
+| [Mission & Principles](mission-and-principles.md) | Core principles and non-negotiables |
 
 ## Quick architecture summary
 

--- a/docs/architecture/deep-project-map.md
+++ b/docs/architecture/deep-project-map.md
@@ -196,9 +196,9 @@ The spec mapping is explicit in `docs/specs/v0.7_DATA_MAPPING.md`:
 There are three “surfaces”:
 - Core modules called from macros.
 - Worksheet UDFs (typically via `M09_UDFs.bas`).
-- Add-in packaging (.xlam) described in `docs/EXCEL_ADDIN_GUIDE.md`.
+- Add-in packaging (.xlam) described in `docs/contributing/excel-addin-guide.md`.
 
-See `docs/VBA_GUIDE.md` for the current entry points list.
+See `docs/contributing/vba-guide.md` for the current entry points list.
 
 ---
 
@@ -235,9 +235,9 @@ When changing any of the above, treat it as a parity change and add/extend Pytho
 
 ### 9.3 Docs updates that accompany v0.8
 
-- `docs/API_REFERENCE.md` — new serviceability functions and units.
-- `docs/KNOWN_PITFALLS.md` — unit traps and typical boundary cases.
-- `docs/TASKS.md` / `docs/NEXT_SESSION_BRIEF.md` — update status and acceptance criteria.
+- `docs/reference/api.md` — new serviceability functions and units.
+- `docs/reference/known-pitfalls.md` — unit traps and typical boundary cases.
+- `docs/TASKS.md` / `docs/planning/next-session-brief.md` — update status and acceptance criteria.
 
 ---
 
@@ -253,8 +253,8 @@ When changing any of the above, treat it as a parity change and add/extend Pytho
 ## 11) Pointers (start here)
 
 - Docs index: `docs/README.md`
-- Project scope/architecture: `docs/PROJECT_OVERVIEW.md`
-- API contract: `docs/API_REFERENCE.md`
-- Pitfalls/unit rules: `docs/KNOWN_PITFALLS.md`
+- Project scope/architecture: `docs/architecture/project-overview.md`
+- API contract: `docs/reference/api.md`
+- Pitfalls/unit rules: `docs/reference/known-pitfalls.md`
 - v0.7 data mapping: `docs/specs/v0.7_DATA_MAPPING.md`
-- Next session plan: `docs/NEXT_SESSION_BRIEF.md`
+- Next session plan: `docs/planning/next-session-brief.md`

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -73,11 +73,12 @@ The VBA and Python implementations must:
 structural_engineering_lib/
 ├── docs/
 │   ├── README.md                   ← Docs index (start here)
-│   ├── RESEARCH_AI_ENHANCEMENTS.md ← Active research log (v0.8+)
-│   ├── _archive/RESEARCH_AND_FINDINGS.md ← Historical research/reference (archived)
-│   ├── DEVELOPMENT_GUIDE.md        ← This document
-│   ├── API_REFERENCE.md            ← Function signatures and examples
-│   └── IS456_QUICK_REFERENCE.md    ← Formulas cheat sheet
+│   ├── getting-started/            ← Quickstart guides
+│   ├── reference/                  ← API, formulas, troubleshooting
+│   ├── contributing/               ← This document lives here
+│   ├── architecture/               ← Project structure, design decisions
+│   ├── planning/                   ← Roadmaps, research notes
+│   └── verification/               ← Test examples, benchmark data
 │
 ├── VBA/
 │   ├── Modules/                    ← Core library (.bas files)

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -6,16 +6,16 @@ Internal planning documents and research notes.
 
 | Document | Purpose |
 |----------|---------|
-| [Next Session](next-session.md) | What to work on next |
-| [Current State](current-state.md) | Where we are now |
-| [Roadmap](roadmap.md) | Production readiness checklist |
+| [Next Session Brief](next-session-brief.md) | What to work on next |
+| [Current State & Goals](current-state-and-goals.md) | Where we are now |
+| [Production Roadmap](production-roadmap.md) | Production readiness checklist |
 
 ## Research
 
 | Document | Topic |
 |----------|-------|
-| [AI Enhancements](ai-enhancements.md) | Future AI/ML integration ideas |
-| [Detailing Research](detailing.md) | Bar arrangement algorithms |
+| [AI Enhancements Research](research-ai-enhancements.md) | Future AI/ML integration ideas |
+| [Detailing Research](research-detailing.md) | Bar arrangement algorithms |
 
 ## Active priorities
 

--- a/docs/planning/current-state-and-goals.md
+++ b/docs/planning/current-state-and-goals.md
@@ -45,12 +45,12 @@ Use these as pass/fail signals for roadmap decisions:
 ## 3) Source of truth references
 
 Primary references for deeper detail:
-- Project overview: `docs/PROJECT_OVERVIEW.md`
-- Production roadmap: `docs/PRODUCTION_ROADMAP.md`
+- Project overview: `docs/architecture/project-overview.md`
+- Production roadmap: `docs/planning/production-roadmap.md`
 - Task board: `docs/TASKS.md`
 - Job schema (batch runner): `docs/specs/v0.9_JOB_SCHEMA.md`
-- Testing strategy: `docs/TESTING_STRATEGY.md`
-- Public API reference: `docs/API_REFERENCE.md`
+- Testing strategy: `docs/contributing/testing-strategy.md`
+- Public API reference: `docs/reference/api.md`
 - Docs index: `docs/README.md`
 
 ## 4) Current feature inventory (from README, normalized)
@@ -154,11 +154,11 @@ CSV integration (Python and VBA paths):
 - Input columns: `BeamID, Story, b, D, Span, Cover, fck, fy, Mu, Vu,
     Ast_req, Asc_req, Stirrup_Dia, Stirrup_Spacing` (case-insensitive).
 - Outputs: optional DXF folder + schedule CSV.
-Reference: `docs/GETTING_STARTED_PYTHON.md`
+Reference: `docs/getting-started/python-quickstart.md`
 
 ETABS import (Excel/VBA path):
 - CSV import with header normalization and sign preservation.
-Reference: `docs/PROJECT_OVERVIEW.md` and `docs/specs/v0.7_DATA_MAPPING.md`
+Reference: `docs/architecture/project-overview.md` and `docs/specs/v0.7_DATA_MAPPING.md`
 
 ## 9) Outputs and deliverables
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -19,7 +19,7 @@
 
 If you want to resume quickly without re-reading the repo:
 
-1. **Whole-project map (architecture + data flow + parity hotspots):** `docs/DEEP_PROJECT_MAP.md`
+1. **Whole-project map (architecture + data flow + parity hotspots):** `docs/architecture/deep-project-map.md`
 2. **Version management:** `docs/_internal/VERSION_STRATEGY.md`
 3. **Canonical backlog:** `docs/TASKS.md`
 4. **Primary reference index:** `docs/README.md`
@@ -98,7 +98,7 @@ If you want to resume quickly without re-reading the repo:
 - ETABS/compliance batch workflows can be deepened (see `docs/TASKS.md`).
 
 #### 5. **Research Log + Dev Workflow Docs Updated** ✅
-- `docs/RESEARCH_AI_ENHANCEMENTS.md`: Added Pass 3 (source-backed research + decision matrix) and Pass 4 (notes extracted from your local Downloads snapshot).
+- `docs/planning/research-ai-enhancements.md`: Added Pass 3 (source-backed research + decision matrix) and Pass 4 (notes extracted from your local Downloads snapshot).
 - `docs/_references/README.md`: Added a simple place to drop local reference files (PDFs/spreadsheets) for future benchmark extraction.
 - `.gitignore`: Prevents accidentally committing large local reference snapshots.
 - README: Added quick dev commands and contributor setup notes.


### PR DESCRIPTION
## Summary
Fixes broken links found during post-migration review.

## Issues Fixed

### High Priority
- **planning/README.md**: Fixed filenames (next-session.md → next-session-brief.md, etc.)
- **architecture/README.md**: Fixed filenames (deep-map.md → deep-project-map.md, etc.)

### Medium Priority
- **development-guide.md**: Updated directory layout to reflect new docs structure
- **current-state-and-goals.md**: Updated all doc references to new paths
- **next-session-brief.md**: Updated DEEP_PROJECT_MAP and RESEARCH_AI_ENHANCEMENTS paths
- **deep-project-map.md**: Updated VBA guide, API, and other references

### Low Priority
- **RELEASES.md**: Updated RESEARCH_DETAILING path

## Decision
Kept the long filenames as canonical (e.g., `next-session-brief.md` not `next-session.md`) since they're more descriptive. Updated all README index tables to match.