### PR TITLE
docs: fix remaining broken links to old root paths

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -38,7 +38,7 @@ When working on tasks, specify which agent role to use:
 - [x] **TASK-023: IS Code Detailing Research (v0.7)**
   - **Agent:** RESEARCHER
   - **Status:** ✅ Complete
-  - **Output:** `docs/RESEARCH_DETAILING.md`
+  - **Output:** `docs/planning/research-detailing.md`
   - Covers: IS 456, IS 13920, SP 34
 
 - [x] **TASK-024: PM Scope Lock (v0.7)**
@@ -105,7 +105,7 @@ When working on tasks, specify which agent role to use:
 
 ### Mindset (v0.8+)
 
-These tasks are based on the research log (`docs/RESEARCH_AI_ENHANCEMENTS.md`) and are intended to make the library *production-ready* for real engineering workflows.
+These tasks are based on the research log (`docs/planning/research-ai-enhancements.md`) and are intended to make the library *production-ready* for real engineering workflows.
 
 - **Deterministic first:** same inputs → same outputs (no “magic”).
 - **Auditable outputs:** every check should show inputs, assumptions, and “why pass/fail”.
@@ -309,7 +309,7 @@ These tasks are based on the research log (`docs/RESEARCH_AI_ENHANCEMENTS.md`) a
   - **Status:** ✅ Complete — unified runner + documentation created.
   - **Outputs:**
     - `VBA/Tests/Test_RunAll.bas` — single entrypoint macro
-    - `docs/VBA_TESTING_GUIDE.md` — run guide + expected output
+    - `docs/contributing/vba-testing-guide.md` — run guide + expected output
   - **Checklist:**
     - [x] Add a single entrypoint macro: `RunAllVBATests`
     - [x] Standardize test output/log format (counts + failures)
@@ -472,7 +472,7 @@ python -c "from structural_lib import api; print(api.get_library_version())"  # 
 ```
 
 **Files to read first:**
-- `docs/NEXT_SESSION_BRIEF.md` — session context
+- `docs/planning/next-session-brief.md` — session context
 - `Python/tests/data/parity_test_vectors.json` — shared test vectors
 - `VBA/Tests/Test_Parity.bas` — current VBA test harness
 

--- a/docs/_internal/AGENT_WORKFLOW.md
+++ b/docs/_internal/AGENT_WORKFLOW.md
@@ -445,7 +445,7 @@ Before tagging a release:
 ## 7. Session Protocol
 
 ### 7.1 Session Start
-1. PM reads `docs/NEXT_SESSION_BRIEF.md`
+1. PM reads `docs/planning/next-session-brief.md`
 2. PM reviews `docs/TASKS.md`
 3. PM identifies next priority
 4. PM assigns agents

--- a/docs/_references/README.md
+++ b/docs/_references/README.md
@@ -10,7 +10,7 @@ This folder is intended for **local** reference materials you want to cite/summa
 ## How it’s used
 - These files are **not** used by the library at runtime.
 - They exist to make it easy to:
-  - extract benchmark examples into `docs/RESEARCH_AI_ENHANCEMENTS.md`
+  - extract benchmark examples into `docs/planning/research-ai-enhancements.md`
   - derive test cases in `Python/tests/`
   - document assumptions and verification steps
 

--- a/docs/architecture/deep-project-map.md
+++ b/docs/architecture/deep-project-map.md
@@ -186,7 +186,7 @@ The spec mapping is explicit in `docs/specs/v0.7_DATA_MAPPING.md`:
 
 ### 7.1 Python
 
-- Public-ish functions are documented in `docs/API_REFERENCE.md`.
+- Public-ish functions are documented in `docs/reference/api.md`.
 - `Python/structural_lib/api.py` is intentionally thin; most usage is currently module-level.
 
 **Contract rule:** docs are the public contract; if code differs, either fix code or fix docs.
@@ -246,7 +246,7 @@ When changing any of the above, treat it as a parity change and add/extend Pytho
 - Python: run `pytest` in `Python/`.
 - If you change core behavior: add/adjust Python tests.
 - If you change parity-critical logic: mirror the formula in VBA (or explicitly document divergence).
-- If you change any public signature: update `docs/API_REFERENCE.md` in the same PR.
+- If you change any public signature: update `docs/reference/api.md` in the same PR.
 
 ---
 

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -801,7 +801,7 @@ Mu_lim_kNm = Mu_lim_Nmm * Nmm_TO_kNm  ' Convert to kN·m for output
 
 ### 9.3 API Reference Document
 
-Maintain `docs/API_REFERENCE.md` with:
+Maintain `docs/reference/api.md` with:
 - All public function signatures
 - Input/output descriptions with units
 - IS 456 clause references

--- a/docs/contributing/excel-addin-guide.md
+++ b/docs/contributing/excel-addin-guide.md
@@ -283,7 +283,7 @@ Sub Test_Addin_Ductile()
     Debug.Print "Geo OK:"; dres.IsGeometryValid; " MinPt:"; dres.MinPt; " MaxPt:"; dres.MaxPt; " Spacing:"; dres.ConfinementSpacing
 End Sub
 ```
-Compare outputs to `docs/API_REFERENCE.md` worked examples (flexure/shear) and ductile checks (spacing = min(d/4, 8*db_min, 100)).
+Compare outputs to `docs/reference/api.md` worked examples (flexure/shear) and ductile checks (spacing = min(d/4, 8*db_min, 100)).
 
 If you don’t add the reference, you can often still call `Ast_singly_IS456` directly (because the add-in is in global scope), but namespacing with `StructEngLib.` is cleaner and avoids name conflicts.
 
@@ -349,7 +349,7 @@ The add-in architecture only starts paying off once the library is relatively st
 
 ## 8. Testing and Validation
 - Run VBA tests (manual/Rubberduck) in a workbook that references the add-in to confirm functions behave identically to the module version.
-- Cross-check against Python tests/values for key cases (see `docs/API_REFERENCE.md` worked examples).
+- Cross-check against Python tests/values for key cases (see `docs/reference/api.md` worked examples).
 - Keep unit conventions consistent (kN·m, kN, mm, N/mm²) and table policies (pt clamped 0.15–3.0, no fck interpolation for Table 19) aligned with the library code.
 
 ---

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -25,7 +25,7 @@ If you want to resume quickly without re-reading the repo:
 4. **Primary reference index:** `docs/README.md`
 
 **Verified state (as of 2025-12-27):**
-- Release version is **v0.9.4** (merged to main).
+- Release version is **v0.9.5** (merged to main, published to PyPI).
 - Unified CLI: **implemented** (`python -m structural_lib design|bbs|dxf|job`).
 - Cutting-stock optimizer: **implemented** (first-fit-decreasing bin packing).
 - VBA BBS + Compliance: **implemented** (parity with Python modules).

--- a/docs/v0.8_EXECUTION_CHECKLIST.md
+++ b/docs/v0.8_EXECUTION_CHECKLIST.md
@@ -146,8 +146,8 @@ Add tests under `Python/tests/`:
 
 ### 4.3 Docs (Python)
 
-- [ ] Update `docs/API_REFERENCE.md` with serviceability API and units.
-- [ ] Update `docs/KNOWN_PITFALLS.md` with serviceability-specific unit traps/assumption traps.
+- [ ] Update `docs/reference/api.md` with serviceability API and units.
+- [ ] Update `docs/reference/known-pitfalls.md` with serviceability-specific unit traps/assumption traps.
 
 ---
 
@@ -156,7 +156,7 @@ Add tests under `Python/tests/`:
 - [ ] Port Level A formulas into `M17_Serviceability.bas`
 - [ ] Mirror input validation (fail with a reason rather than crashing)
 - [ ] If exposing as UDFs: add wrappers in `M09_UDFs.bas`
-- [ ] Update `docs/VBA_GUIDE.md` to list the new entry points
+- [ ] Update `docs/contributing/vba-guide.md` to list the new entry points
 
 **Parity checklist:**
 - same limits/config values


### PR DESCRIPTION
## Summary
Fixes remaining broken links that would break once redirect stubs are removed.

## High Priority Fixes
- **deep-project-map.md**: `API_REFERENCE` → `reference/api.md` (lines 189, 249)
- **development-guide.md**: `API_REFERENCE` → `reference/api.md` (line 804)
- **excel-addin-guide.md**: `API_REFERENCE` → `reference/api.md` (lines 286, 352)
- **TASKS.md**: Updated 4 references to new locations
- **v0.8_EXECUTION_CHECKLIST.md**: Updated `API_REFERENCE`, `KNOWN_PITFALLS`, `VBA_GUIDE`

## Medium Priority
- **next-session-brief.md**: Version marker `v0.9.4` → `v0.9.5` (now published to PyPI)

## Low Priority (consistency)
- **AGENT_WORKFLOW.md**: `NEXT_SESSION_BRIEF` → `planning/next-session-brief.md`
- **_references/README.md**: `RESEARCH_AI_ENHANCEMENTS` → `planning/research-ai-enhancements.md`

All links now point to actual files in the new folder structure.