### PR TITLE
feat(devops): Release automation sprint (TASK-065 through TASK-068)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           python -m mypy
 
+      - name: Doc version drift check
+        run: |
+          python scripts/check_doc_versions.py --ci
+
   pytest:
     runs-on: ubuntu-latest
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,50 @@
+# Pre-commit hooks for structural_engineering_lib
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+
 repos:
+  # General file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: check-toml
+      - id: check-json
       - id: end-of-file-fixer
+        exclude: ^(VBA/|Excel/)
       - id: trailing-whitespace
+        exclude: ^(VBA/|Excel/)
       - id: mixed-line-ending
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=500']
 
+  # Python formatting
   - repo: https://github.com/psf/black
     rev: 25.9.0
     hooks:
       - id: black
         language_version: python3
+        files: ^Python/
+
+  # Python linting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+        files: ^Python/
+
+  # Doc version drift check (local script, non-blocking)
+  - repo: local
+    hooks:
+      - id: check-doc-versions
+        name: Check doc version drift
+        entry: python scripts/check_doc_versions.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
+
+# CI note: pre-commit hooks run locally only.
+# CI has separate lint/format checks in .github/workflows/python-tests.yml

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -27,7 +27,23 @@ See also: `docs/_internal/AGENT_WORKFLOW.md`
 
 ## Active
 
-_(none — pick from Up Next)_
+### Release Automation Sprint (TASK-065 through TASK-068) — ✅ COMPLETE
+
+**Goal:** Automate release workflow to prevent version drift and missed updates.
+
+| ID | Task | Agent | Est. | Status |
+|----|------|-------|------|--------|
+| **TASK-065** | Release helper script | DEVOPS | 30 min | ✅ Done |
+| **TASK-066** | Doc drift check script | DEVOPS | 30 min | ✅ Done |
+| **TASK-067** | Pre-commit hook config | DEVOPS | 15 min | ✅ Done |
+| **TASK-068** | CI release-check job | DEVOPS | 30 min | ✅ Done |
+
+**Deliverables (all merged in PR #59):**
+- `scripts/release.py` — One-command release helper
+- `scripts/check_doc_versions.py` — Validate no stale versions
+- `.pre-commit-config.yaml` — Enhanced with ruff, doc check hooks
+- `.github/workflows/python-tests.yml` — Added doc drift check step
+- `scripts/bump_version.py` — Fixed api.md version pattern
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,6 +1,6 @@
 # IS 456 RC Beam Design Library — API Reference
 
-**Document Version:** 0.11.0  
+**Document Version:** 0.9.6  
 **Last Updated:** 2025-12-27  
 **Scope:** Public APIs for Python/VBA implementations (flexure, shear, ductile detailing, integration, reporting, detailing, DXF export, BBS, cutting-stock optimizer, unified CLI).
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -74,6 +74,7 @@ DOC_DATE_FILES = {
         (r"^\*\*Last Updated:\*\* .+", "**Last Updated:** {date}  "),
     ],
     "docs/reference/api.md": [
+        (r"^\*\*Document Version:\*\* [0-9]+\.[0-9]+\.[0-9]+", "**Document Version:** {version}"),
         (r"^\*\*Last Updated:\*\* .+", "**Last Updated:** {date}  "),
     ],
     "docs/verification/examples.md": [

--- a/scripts/check_doc_versions.py
+++ b/scripts/check_doc_versions.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Doc Version Drift Check — Validate no stale version strings.
+
+USAGE:
+    python scripts/check_doc_versions.py          # Check against current version
+    python scripts/check_doc_versions.py --fix    # Auto-fix with bump_version.py --sync-docs
+    python scripts/check_doc_versions.py --ci     # Exit with error code if drift found
+
+This script scans docs for version patterns and reports mismatches.
+Used in CI to prevent stale docs from shipping.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+BUMP_SCRIPT = REPO_ROOT / "scripts" / "bump_version.py"
+
+# Patterns to check for version drift
+VERSION_PATTERNS = [
+    # Pattern, file glob, description
+    (r"\*\*Current version:\*\* v([0-9]+\.[0-9]+\.[0-9]+)", "docs/**/*.md", "Current version marker"),
+    (r"Document Version: ([0-9]+\.[0-9]+\.[0-9]+)", "docs/**/*.md", "Document Version header"),
+    (r"\*\*Document Version:\*\* ([0-9]+\.[0-9]+\.[0-9]+)", "docs/**/*.md", "Document Version (bold)"),
+    (r"\*\*Version:\*\* ([0-9]+\.[0-9]+\.[0-9]+)", "docs/**/*.md", "Version header"),
+    (r"@v([0-9]+\.[0-9]+\.[0-9]+)", "docs/**/*.md", "Git tag reference"),
+    (r"structural-lib-is456==([0-9]+\.[0-9]+\.[0-9]+)", "**/*.md", "PyPI pin"),
+]
+
+# Files to skip (always allowed to have old versions for historical context)
+SKIP_FILES = [
+    "CHANGELOG.md",
+    "RELEASES.md",
+    "SESSION_LOG.md",
+    "docs/_archive/",
+]
+
+
+def read_current_version() -> str:
+    """Read current version from pyproject.toml."""
+    pyproject = REPO_ROOT / "Python" / "pyproject.toml"
+    content = pyproject.read_text()
+    match = re.search(r'^version = "([^"]+)"', content, re.MULTILINE)
+    if match:
+        return match.group(1)
+    raise ValueError("Could not find version in pyproject.toml")
+
+
+def should_skip(filepath: Path) -> bool:
+    """Check if file should be skipped."""
+    rel_path = str(filepath.relative_to(REPO_ROOT))
+    for skip in SKIP_FILES:
+        if skip in rel_path:
+            return True
+    return False
+
+
+def find_version_drift(current_version: str) -> list:
+    """Find all files with version drift."""
+    issues = []
+    
+    for pattern, glob_pattern, description in VERSION_PATTERNS:
+        for filepath in REPO_ROOT.glob(glob_pattern):
+            if not filepath.is_file():
+                continue
+            if should_skip(filepath):
+                continue
+            
+            try:
+                content = filepath.read_text()
+            except Exception:
+                continue
+            
+            for match in re.finditer(pattern, content):
+                found_version = match.group(1)
+                if found_version != current_version:
+                    rel_path = filepath.relative_to(REPO_ROOT)
+                    issues.append({
+                        "file": str(rel_path),
+                        "pattern": description,
+                        "found": found_version,
+                        "expected": current_version,
+                        "line": content[:match.start()].count("\n") + 1,
+                    })
+    
+    return issues
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check for doc version drift")
+    parser.add_argument("--fix", action="store_true", help="Auto-fix with bump_version.py --sync-docs")
+    parser.add_argument("--ci", action="store_true", help="Exit with error code if drift found")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show all checked patterns")
+    
+    args = parser.parse_args()
+    
+    current = read_current_version()
+    print(f"Current version: {current}")
+    print()
+    
+    if args.verbose:
+        print("Checking patterns:")
+        for pattern, glob_pat, desc in VERSION_PATTERNS:
+            print(f"  - {desc}: {glob_pat}")
+        print()
+        print("Skipping:")
+        for skip in SKIP_FILES:
+            print(f"  - {skip}")
+        print()
+    
+    issues = find_version_drift(current)
+    
+    if not issues:
+        print("✓ No version drift found")
+        return 0
+    
+    print(f"✗ Found {len(issues)} version drift issue(s):")
+    print()
+    
+    for issue in issues:
+        print(f"  {issue['file']}:{issue['line']}")
+        print(f"    Pattern: {issue['pattern']}")
+        print(f"    Found: {issue['found']} (expected: {issue['expected']})")
+        print()
+    
+    if args.fix:
+        print("Attempting auto-fix with bump_version.py --sync-docs...")
+        result = subprocess.run(
+            [sys.executable, str(BUMP_SCRIPT), "--sync-docs"],
+            capture_output=True, text=True
+        )
+        print(result.stdout)
+        if result.returncode == 0:
+            print("✓ Auto-fix complete. Re-run to verify.")
+        else:
+            print(f"✗ Auto-fix failed: {result.stderr}")
+            return 1
+        return 0
+    
+    if args.ci:
+        print("CI mode: failing due to version drift.")
+        print("Run: python scripts/check_doc_versions.py --fix")
+        return 1
+    
+    print("To fix: python scripts/check_doc_versions.py --fix")
+    print("Or run: python scripts/bump_version.py --sync-docs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Release Helper Script — One-command release workflow.
+
+USAGE:
+    python scripts/release.py 0.9.7           # Full release flow
+    python scripts/release.py 0.9.7 --dry-run # Preview what would happen
+    python scripts/release.py --checklist     # Show release checklist only
+
+This script:
+1. Bumps version via bump_version.py
+2. Syncs doc versions/dates
+3. Prints release checklist
+4. Opens CHANGELOG.md for editing (macOS only)
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+BUMP_SCRIPT = REPO_ROOT / "scripts" / "bump_version.py"
+
+
+def run_command(cmd: list, dry_run: bool = False) -> bool:
+    """Run a command and return success status."""
+    if dry_run:
+        print(f"  [DRY-RUN] Would run: {' '.join(cmd)}")
+        return True
+    
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  ERROR: {result.stderr}")
+        return False
+    if result.stdout:
+        for line in result.stdout.strip().split("\n"):
+            print(f"  {line}")
+    return True
+
+
+def print_checklist(version: str):
+    """Print the release checklist."""
+    print()
+    print("=" * 60)
+    print("RELEASE CHECKLIST")
+    print("=" * 60)
+    print()
+    print(f"Version: v{version}")
+    print()
+    print("Automated (done by this script):")
+    print("  ✓ Version bumped in pyproject.toml, api.py, M08_API.bas")
+    print("  ✓ Doc version references synced")
+    print("  ✓ Doc dates updated to today")
+    print()
+    print("Manual steps (you must do these):")
+    print("  [ ] 1. Edit CHANGELOG.md — Add release notes")
+    print("  [ ] 2. Edit docs/RELEASES.md — Add release entry")
+    print("  [ ] 3. Review changes: git diff")
+    print("  [ ] 4. Commit: git add -A && git commit -m 'chore: release v{}'".format(version))
+    print("  [ ] 5. Create PR and merge to main")
+    print("  [ ] 6. Tag: git tag v{} && git push origin v{}".format(version, version))
+    print("  [ ] 7. GitHub Release will trigger PyPI publish")
+    print()
+    print("Verification:")
+    print("  [ ] Check PyPI: pip install structural-lib-is456=={}".format(version))
+    print("  [ ] Check GitHub Release page")
+    print()
+
+
+def open_file_in_editor(filepath: Path):
+    """Open a file in the default editor (macOS)."""
+    try:
+        subprocess.run(["open", str(filepath)], check=True)
+        print(f"  Opened: {filepath}")
+    except Exception as e:
+        print(f"  (Could not open {filepath}: {e})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Release helper script")
+    parser.add_argument("version", nargs="?", help="New version (e.g., 0.9.7)")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without making changes")
+    parser.add_argument("--checklist", action="store_true", help="Show checklist only")
+    parser.add_argument("--no-open", action="store_true", help="Don't open files in editor")
+    
+    args = parser.parse_args()
+    
+    if args.checklist:
+        if not args.version:
+            # Read current version
+            result = subprocess.run(
+                [sys.executable, str(BUMP_SCRIPT), "--current"],
+                capture_output=True, text=True
+            )
+            current = result.stdout.strip().replace("Current version: ", "")
+            print(f"Current version: {current}")
+            print("\nUsage: python scripts/release.py <new_version>")
+            print("Example: python scripts/release.py 0.9.7")
+        else:
+            print_checklist(args.version)
+        return 0
+    
+    if not args.version:
+        # Show current version and usage
+        result = subprocess.run(
+            [sys.executable, str(BUMP_SCRIPT), "--current"],
+            capture_output=True, text=True
+        )
+        print(result.stdout.strip())
+        print("\nUsage: python scripts/release.py <new_version>")
+        print("Example: python scripts/release.py 0.9.7")
+        print("\nOptions:")
+        print("  --dry-run    Preview what would happen")
+        print("  --checklist  Show release checklist only")
+        print("  --no-open    Don't open files in editor")
+        return 1
+    
+    version = args.version
+    dry_run = args.dry_run
+    
+    print()
+    print("=" * 60)
+    print(f"{'[DRY-RUN] ' if dry_run else ''}RELEASE v{version}")
+    print("=" * 60)
+    print()
+    
+    # Step 1: Bump version
+    print("Step 1: Bumping version...")
+    bump_cmd = [sys.executable, str(BUMP_SCRIPT), version]
+    if dry_run:
+        bump_cmd.append("--dry-run")
+    if not run_command(bump_cmd, dry_run=False):  # Actually run bump_version
+        print("ERROR: Version bump failed")
+        return 1
+    print()
+    
+    # Step 2: Print checklist
+    print_checklist(version)
+    
+    # Step 3: Open files for editing
+    if not args.no_open and not dry_run:
+        print("Opening files for editing...")
+        open_file_in_editor(REPO_ROOT / "CHANGELOG.md")
+        open_file_in_editor(REPO_ROOT / "docs" / "RELEASES.md")
+        print()
+    
+    if dry_run:
+        print("[DRY-RUN] No changes were made.")
+    else:
+        print("Done! Follow the checklist above to complete the release.")
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements full release automation workflow with four deliverables:

### TASK-065: Release Helper Script
- **New:** `scripts/release.py` — One-command release workflow
- Usage: `python scripts/release.py 0.9.7`
- Features: version bump, doc sync, checklist, opens CHANGELOG for editing

### TASK-066: Doc Drift Check Script
- **New:** `scripts/check_doc_versions.py` — Detect stale version strings
- Usage: `python scripts/check_doc_versions.py --ci`
- Features: scans docs for version patterns, auto-fix with `--fix`

### TASK-067: Pre-commit Hook Config
- **Enhanced:** `.pre-commit-config.yaml`
- Added: ruff linter, check-json, check-merge-conflict, check-added-large-files
- Added: local doc version drift check hook
- Added: proper excludes for VBA/Excel directories

### TASK-068: CI Release-Check Job
- **Modified:** `.github/workflows/python-tests.yml`
- Added: 'Doc version drift check' step in lint job

### Bugfixes
- `scripts/bump_version.py`: Added `**Document Version:**` pattern for api.md
- `docs/reference/api.md`: Fixed version drift (was 0.11.0, now 0.9.6)

## Testing
```bash
python scripts/check_doc_versions.py -v   # ✓ No version drift found
python scripts/release.py --checklist 0.9.7  # Shows release checklist
```

## Files Changed
- `scripts/release.py` (NEW)
- `scripts/check_doc_versions.py` (NEW)
- `scripts/bump_version.py` (MODIFIED)
- `.pre-commit-config.yaml` (MODIFIED)
- `.github/workflows/python-tests.yml` (MODIFIED)
- `docs/TASKS.md` (MODIFIED)
- `docs/reference/api.md` (MODIFIED)