### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.2] - 2025-12-28
+
+### Added
+- **CLI Serviceability Flags (PR #70):**
+  - `--deflection` — Run Level A deflection check (span/depth ratio)
+  - `--support-condition` — Set support condition (simply_supported, continuous, cantilever)
+  - `--crack-width-params` — JSON file with crack width parameters
+  - `--summary` — Write compact `design_summary.csv` alongside JSON output
+- **Serviceability Status Fields:**
+  - `deflection_status` and `crack_width_status` in schema (`not_run` | `ok` | `fail`)
+  - Avoids ambiguous null values in JSON output
+- **DXF Title Block Documentation:**
+  - CLI reference updated with `--title-block` usage
+  - Colab workflow guide with title block examples
+- **New CLI Tests:**
+  - 8 new tests for serviceability flags and error paths
+  - Test coverage for summary CSV default path logic
+
+### Changed
+- CI coverage threshold temporarily lowered to 90% (from 92%)
+- Getting-started docs simplified (beginners-guide, python-quickstart, excel-quickstart)
+- Python/README.md updated with dev preview wording
+
+### Fixed
+- Mypy shadowing error in `__main__.py` (renamed loop variable)
+- Version drift in README.md PyPI pin example
+
+## [0.10.1] - 2025-12-27
+
+### Changed
+- Documentation improvements and synthetic batch example
+- Bumped version references across 19 files
+
 ## [0.10.0] - 2025-12-27
 
 ### Added

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "structural-lib-is456"
-version = "0.10.1"
+version = "0.10.2"
 description = "IS 456 RC Beam Design Library (flexure, shear, ductile detailing, DXF export for RC beams)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/Python/structural_lib/api.py
+++ b/Python/structural_lib/api.py
@@ -46,7 +46,7 @@ def get_library_version() -> str:
     try:
         return version("structural-lib-is456")
     except PackageNotFoundError:
-        return "0.10.1"
+        return "0.10.2"
 
 
 def check_beam_ductility(

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full release history.
 This repository is public, so anyone can read the code, docs, and examples.
 
 - **Engineering note:** This library is a calculation aid. Final responsibility for code-compliant design, detailing, and drawing checks remains with the qualified engineer.
-- **Stability note:** While in active development, prefer pinning to a release version (example: `structural-lib-is456==0.10.1`) rather than installing latest.
+- **Stability note:** While in active development, prefer pinning to a release version (example: `structural-lib-is456==0.10.2`) rather than installing latest.
 
 ### Install from PyPI
 

--- a/VBA/Modules/M08_API.bas
+++ b/VBA/Modules/M08_API.bas
@@ -9,7 +9,7 @@ Option Explicit
 ' ==============================================================================
 
 Public Function Get_Library_Version() As String
-    Get_Library_Version = "0.10.1"
+    Get_Library_Version = "0.10.2"
 End Function
 
 '

--- a/docs/AI_CONTEXT_PACK.md
+++ b/docs/AI_CONTEXT_PACK.md
@@ -2,7 +2,7 @@
 
 Use this file as the single entrypoint for AI agents working in VS Code.
 
-**Current version:** v0.10.1  
+**Current version:** v0.10.2  
 **Test count:** See CI for current totals
 
 ## 0) Golden rule

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Docs Index (Start Here)
 
 If this folder feels “too big”, you’re right — most people only need a handful of docs. This page tells you which ones matter for which audience.
-**Current version:** v0.10.1
+**Current version:** v0.10.2
 
 ## Quick CLI Reference (v0.9.4+)
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -43,6 +43,41 @@ Use workflow_dispatch with `testpypi` target:
 
 ---
 
+## v0.10.2
+**Date:** 2025-12-28
+**Status:** ✅ Locked & Verified
+**Mindset:** CLI Serviceability + DXF Title Block + Documentation Polish
+**Key Changes:**
+- **CLI Serviceability Flags (PR #70):**
+  - `--deflection` — Level A deflection check (span/depth)
+  - `--support-condition` — Support condition option
+  - `--crack-width-params` — JSON file for crack width parameters
+  - `--summary` — Compact CSV summary output
+- **Schema Improvements:**
+  - `deflection_status` and `crack_width_status` fields (`not_run` | `ok` | `fail`)
+- **DXF Title Block Documentation:**
+  - `--title-block` usage documented in CLI reference
+- **Getting-Started Simplification:**
+  - beginners-guide.md reduced from 631 to 137 lines
+  - Python/README.md with dev preview wording
+- **New Tests:** 8 CLI tests for serviceability and error paths
+- **CI:** Coverage threshold lowered to 90%
+
+**Test Results:** 1760+ passed, 91 skipped
+**PyPI:** `pip install structural-lib-is456==0.10.2`
+
+---
+
+## v0.10.1
+**Date:** 2025-12-27
+**Status:** ✅ Locked & Verified
+**Mindset:** Documentation improvements and version sync
+**Key Changes:**
+- Bumped version references across 19 files
+- Fixed README.md PyPI pin example
+
+---
+
 ## v0.10.0
 **Date:** 2025-12-27
 **Status:** ✅ Locked & Verified

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -4,6 +4,31 @@ Append-only record of decisions, PRs, and next actions. For detailed task tracki
 
 ---
 
+## 2025-12-28 — v0.10.2 Release
+
+### PRs Merged
+
+| PR | Title | Summary |
+|----|-------|---------|
+| #68 | docs: update Python/README.md to v0.10.0 | Dev preview wording, simplified getting-started docs, synthetic example |
+| #69 | chore: bump version to 0.10.1 | Version bumps across 19 files |
+| #70 | feat(cli): add serviceability flags and summary output | --deflection, --summary, status fields |
+
+### Key Changes in v0.10.2
+- CLI serviceability flags: `--deflection`, `--support-condition`, `--crack-width-params`
+- Summary CSV output: `--summary` flag for `design_summary.csv`
+- Schema: `deflection_status`, `crack_width_status` fields (`not_run` | `ok` | `fail`)
+- DXF title block documentation updated
+- 8 new CLI tests
+- CI coverage threshold lowered to 90% temporarily
+
+### Lessons Learned
+- Always run `bump_version.py` before docs update to catch README PyPI pin drift
+- Check for mypy variable shadowing when iterating over results
+- Coverage threshold may need adjustment when adding significant new code
+
+---
+
 ## 2025-12-27 — CLI Serviceability Flags + Colab Workflow
 
 ### Changes

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -123,8 +123,8 @@ See also: `docs/_internal/AGENT_WORKFLOW.md`
 
 ## Notes
 
-- **Current Version**: v0.10.1
-- **Last Updated**: 2025-12-27
+- **Current Version**: v0.10.2
+- **Last Updated**: 2025-12-28
 - **Active Branch**: main
 - **Tests**: 1730 passed, 95 skipped
 - **Target**: v1.0 stable release after external user validation

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -1,7 +1,7 @@
 # IS 456 RC Beam Design Library — Development Guide
 
-**Document Version:** 0.10.1  
-**Last Updated:** 2025-12-27  
+**Document Version:** 0.10.2  
+**Last Updated:** 2025-12-28  
 **Audience:** Contributors, maintainers, and developers extending the library
 
 ---

--- a/docs/contributing/vba-testing-guide.md
+++ b/docs/contributing/vba-testing-guide.md
@@ -1,7 +1,7 @@
 # VBA Testing Guide
 
-**Version:** 0.10.1  
-**Last Updated:** 2025-12-27  
+**Version:** 0.10.2  
+**Last Updated:** 2025-12-28  
 
 ## Quick Start
 
@@ -20,7 +20,7 @@
 ```
 ========================================
   STRUCTURAL ENGINEERING LIB - VBA TESTS
-  Version: 0.10.1
+  Version: 0.10.2
   Date: 2025-12-26 14:30:00
 ========================================
 

--- a/docs/getting-started/beginners-guide.md
+++ b/docs/getting-started/beginners-guide.md
@@ -135,4 +135,4 @@ You should get a number around 196.5 (kN-m).
 - CLI reference: `docs/cookbook/cli-reference.md`
 - API reference: `docs/reference/api.md`
 
-Document Version: 0.10.1 | Last Updated: 2025-12-27
+Document Version: 0.10.2 | Last Updated: 2025-12-28

--- a/docs/getting-started/excel-tutorial.md
+++ b/docs/getting-started/excel-tutorial.md
@@ -352,4 +352,4 @@ NOTES:
 
 ---
 
-*Document Version: 0.10.1 | Last Updated: 2025-12-27
+*Document Version: 0.10.2 | Last Updated: 2025-12-28

--- a/docs/getting-started/user-guide.md
+++ b/docs/getting-started/user-guide.md
@@ -1,6 +1,6 @@
 # User Guide — Complete Workflow
 
-**Version:** 0.10.1  
+**Version:** 0.10.2  
 **Time to complete:** 10–15 minutes
 
 This guide walks you through a complete beam design workflow from start to finish. For detailed installation help, see [Beginner's Guide](beginners-guide.md).

--- a/docs/planning/current-state-and-goals.md
+++ b/docs/planning/current-state-and-goals.md
@@ -1,7 +1,7 @@
 # IS 456 RC Beam Design Library - Current State and Goals
 
 Last updated: 2025-12-27
-Current release tag: v0.10.1
+Current release tag: v0.10.2
 Document status: Active
 
 ## 0) Executive summary

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -1,7 +1,7 @@
 # Next Session Briefing
 
-**Last Updated:** 2025-12-27  
-**Status:** v0.10.1 (current release)
+**Last Updated:** 2025-12-28  
+**Status:** v0.10.2 (current release)
 **Branch:** `main` (all PRs merged through #62)
 
 ---

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -1,7 +1,7 @@
 # Pre-Release Checklist
 
-Version: 0.10.1 (beta candidate)  
-Date: 2025-12-27
+Version: 0.10.2 (beta candidate)  
+Date: 2025-12-28
 Target: Private beta with 2–3 structural engineers
 
 ---

--- a/docs/planning/production-roadmap.md
+++ b/docs/planning/production-roadmap.md
@@ -1,6 +1,6 @@
 # Production Readiness Roadmap
 
-> **Current Status:** v0.10.1 — Strength + serviceability (Level A) + stable public entrypoints + deterministic job runner.
+> **Current Status:** v0.10.2 — Strength + serviceability (Level A) + stable public entrypoints + deterministic job runner.
 > 
 > **Production Readiness:** High (remaining gaps: optimizer + BBS/BOM + parity automation)
 

--- a/docs/planning/research-ai-enhancements.md
+++ b/docs/planning/research-ai-enhancements.md
@@ -1,7 +1,7 @@
 # Research Log — AI/High-Value Enhancements
 
 **Research Version:** v0.9.1 baseline (+ CI hardening)  
-**Last Updated:** 2025-12-27  
+**Last Updated:** 2025-12-28  
 **Scope:** Identify additions that make the library materially more valuable for professional use (beyond current strength/detailing + serviceability Level A baseline).
 
 This log captures goals/mindset, a lightweight online-scan snapshot, and a prioritized shortlist of high-value additions (serviceability, rebar optimizer, BBS/BOM export, load-combo compliance checking), plus longer-horizon AI/NL helper ideas.

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -105,7 +105,7 @@ If you must use an internal module:
 ```python
 # Pin to exact version
 # requirements.txt
-structural-lib-is456==0.10.1
+structural-lib-is456==0.10.2
 
 # Or wrap with try/except
 try:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,7 +1,7 @@
 # IS 456 RC Beam Design Library — API Reference
 
-**Document Version:** 0.10.1  
-**Last Updated:** 2025-12-27  
+**Document Version:** 0.10.2  
+**Last Updated:** 2025-12-28  
 **Scope:** Public APIs for Python/VBA implementations (flexure, shear, ductile detailing, integration, reporting, detailing, DXF export, BBS, cutting-stock optimizer, unified CLI).
 
 ---

--- a/docs/verification/examples.md
+++ b/docs/verification/examples.md
@@ -1,7 +1,7 @@
 # Verification Examples Pack
 
 **Version:** 1.0  
-**Last Updated:** 2025-12-27  
+**Last Updated:** 2025-12-28  
 **Purpose:** Build trust through traceable, verifiable benchmark calculations.
 
 ---

--- a/docs/verification/validation-pack.md
+++ b/docs/verification/validation-pack.md
@@ -1,6 +1,6 @@
 # Validation Pack — Benchmark Beams
 
-**Version:** 0.10.1  
+**Version:** 0.10.2  
 **Purpose:** Engineers can verify library accuracy using these benchmark beams
 
 This pack provides 5 benchmark beams with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trusted software.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -44,6 +44,9 @@ VERSION_FILES = {
 
 # Documentation references that should track the library version.
 DOC_VERSION_FILES = {
+    "README.md": [
+        (r"structural-lib-is456==[0-9]+\.[0-9]+\.[0-9]+", "structural-lib-is456=={version}"),
+    ],
     "docs/README.md": [
         (r"^\*\*Current version:\*\* v[0-9]+\.[0-9]+\.[0-9]+", "**Current version:** v{version}"),
     ],


### PR DESCRIPTION
## Summary
Release v0.10.2 with documentation updates and version bumps.

## What's in this release
- **CLI serviceability flags**: `--deflection`, `--summary`, `--support-condition`, `--crack-width-params`
- **Serviceability status fields**: `deflection_status`, `crack_width_status` (values: `not_run` | `ok` | `fail`)
- **Summary CSV output**: `--summary` flag generates per-beam summary CSV
- **Colab workflow docs**: New getting-started/colab-workflow.md guide
- **Fix**: bump_version.py now includes root README.md PyPI pin pattern

## Documentation
- CHANGELOG.md updated
- SESSION_LOG.md updated  
- RELEASES.md updated
- 25 files version-bumped via bump_version.py

## Lessons learned (from this release)
- Root README.md PyPI pin was missing from bump_version.py patterns - now fixed