### PR TITLE
docs: fix expected output in beginners-guide (S-014)

### DIFF
--- a/docs/getting-started/beginners-guide.md
+++ b/docs/getting-started/beginners-guide.md
@@ -52,9 +52,9 @@ Run it:
 python3 check.py
 ```
 
-Expected output (numbers may vary slightly):
+Expected output:
 ```
-Ast required (mm^2): 942
+Ast required (mm^2): 882
 Status: OK
 ```
 

--- a/docs/planning/v0.20-stabilization-checklist.md
+++ b/docs/planning/v0.20-stabilization-checklist.md
@@ -39,7 +39,7 @@
 | S-011 | README accurate | DOCS | ✅ | Updated 2025-12-28 |
 | S-012 | CHANGELOG complete | DOCS | ✅ | Updated 2025-12-28 |
 | S-013 | API docs match code | DOCS | ✅ | Fixed Level B helper signatures |
-| S-014 | All examples runnable | DOCS | ⏳ | Copy-paste works |
+| S-014 | All examples runnable | DOCS | ✅ | Fixed expected output in beginners-guide |
 | S-015 | No broken links | DOCS | ✅ | Fixed 4 broken links, added scripts/check_links.py |
 
 ---


### PR DESCRIPTION
## Summary
Completes stabilization task S-014: All examples runnable.

## Changes
- Fixed incorrect expected output in `docs/getting-started/beginners-guide.md`
  - Was: `Ast required (mm^2): 942` (wrong)
  - Now: `Ast required (mm^2): 882` (correct)
- Updated stabilization checklist

## Verification
Tested all key doc examples - they run correctly:
- Python quickstart examples ✓
- Cookbook recipes (flexure, shear, detailing, serviceability) ✓
- API reference examples ✓
- Verification examples (F1, etc.) ✓

## Files Changed
- docs/getting-started/beginners-guide.md
- docs/planning/v0.20-stabilization-checklist.md