### PR TITLE
fix: improve error messages in job_runner (S-006)

### DIFF
--- a/docs/planning/v0.20-stabilization-checklist.md
+++ b/docs/planning/v0.20-stabilization-checklist.md
@@ -21,7 +21,7 @@
 | S-003 | No mypy type errors | DEV | ✅ | Verified 2025-12-28 |
 | S-004 | No ruff lint issues | DEV | ✅ | Verified 2025-12-28 |
 | S-005 | Review 91 skipped tests | TESTER | ✅ | All intentional (comparative tests) |
-| S-006 | Error messages are clear | SUPPORT | ⏳ | User-friendly errors |
+| S-006 | Error messages are clear | SUPPORT | ✅ | Improved job_runner errors |
 
 ### Trust & Validation
 


### PR DESCRIPTION
## Summary
Completes stabilization task S-006: Error messages are clear.

## Changes
Improved error messages in `job_runner.py` to be more user-friendly and actionable:

| Before | After |
|--------|-------|
| `Unsupported code:` (empty) | `Missing required field 'code' in job file. Currently supported: 'IS456'.` |
| `Unsupported schema_version: 0` | `Missing required field 'schema_version' in job file. Expected: 1.` |
| `v1 runner supports only code='IS456'` | `v1 runner supports only code='IS456'. Got: 'ACI318'.` |

## Verification
- All 1810 tests pass
- 14 job-related tests pass specifically

## Files Changed
- Python/structural_lib/job_runner.py
- docs/planning/v0.20-stabilization-checklist.md