### PR TITLE
docs: add error schema v1 draft (W03)

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -69,7 +69,7 @@ python -m structural_lib job job.json -o job_out
 |------|----|------|-------|--------|-------|
 | W01 | — | Scope lock + WIP rule | — | ✅ Done | Completed in docs discipline |
 | W02 | S-007 | External engineer CLI test | CLIENT | ⏳ Waiting | Resume when tester available; proceed to W03 if blocked |
-| W03 | RM-W03 | Error schema draft (code/field/hint/severity) | DOCS/DEV | ⏳ Not started | Publish in docs/reference/ |
+| W03 | RM-W03 | Error schema draft (code/field/hint/severity) | DOCS/DEV | ✅ Done | Published in docs/reference/error-schema.md |
 | W04 | RM-W04 | Implement error schema (core + tests) | DEV | ⏳ Not started | Apply to 3 core functions |
 | W05 | RM-W05 | Input validation pass (geometry/materials) | DEV | ⏳ Not started | Ensure is_safe=False with errors |
 | W06 | RM-W06 | Units boundary spec | DEV/DOCS | ⏳ Not started | Update known-pitfalls.md |

--- a/docs/reference/error-schema.md
+++ b/docs/reference/error-schema.md
@@ -1,0 +1,236 @@
+# Error Schema v1
+
+*Structured error format for machine-readable and human-friendly errors*
+
+**Status:** Draft (W03)
+**Last updated:** 2025-12-28
+
+---
+
+## Overview
+
+This document defines the standard error schema for all structural_lib errors. The goal is:
+- **Machine-readable:** Parseable by downstream tools (JSON, CI, dashboards)
+- **Human-friendly:** Clear hints for engineers to fix issues
+- **Traceable:** Links to IS 456 clauses where applicable
+
+---
+
+## Error Schema
+
+### Core Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `code` | string | ✅ | Unique error code (e.g., `E001`, `E_FLEXURE_001`) |
+| `severity` | string | ✅ | One of: `error`, `warning`, `info` |
+| `field` | string | ❌ | Input field that caused the error (e.g., `b`, `fck`, `Mu`) |
+| `message` | string | ✅ | Human-readable error description |
+| `hint` | string | ❌ | Actionable suggestion to fix the error |
+| `clause` | string | ❌ | IS 456 clause reference (e.g., `Cl. 26.5.1.1`) |
+
+### JSON Example
+
+```json
+{
+  "code": "E_FLEXURE_001",
+  "severity": "error",
+  "field": "Mu",
+  "message": "Mu exceeds Mu_lim. Doubly reinforced section required.",
+  "hint": "Use design_doubly_reinforced() or increase section depth.",
+  "clause": "Cl. 38.1"
+}
+```
+
+---
+
+## Error Code Catalog
+
+### Severity Definitions
+
+| Severity | Meaning | Action |
+|----------|---------|--------|
+| `error` | Design fails. Cannot proceed. | Must fix before using result. |
+| `warning` | Design passes but has concerns. | Review and acknowledge. |
+| `info` | Informational only. | No action required. |
+
+### Error Code Prefixes
+
+| Prefix | Module | Examples |
+|--------|--------|----------|
+| `E_INPUT_` | Input validation | `E_INPUT_001` (negative dimension) |
+| `E_FLEXURE_` | Flexure design | `E_FLEXURE_001` (Mu > Mu_lim) |
+| `E_SHEAR_` | Shear design | `E_SHEAR_001` (tv > tc_max) |
+| `E_DUCTILE_` | Ductile detailing | `E_DUCTILE_001` (pt > pt_max) |
+| `E_DETAILING_` | Detailing | `E_DETAILING_001` (spacing too small) |
+| `E_SERVICE_` | Serviceability | `E_SERVICE_001` (deflection limit) |
+| `W_` | Warnings | `W_MIN_STEEL` (near minimum steel) |
+
+### Error Code Registry
+
+#### Input Validation (`E_INPUT_`)
+
+| Code | Field | Message | Hint |
+|------|-------|---------|------|
+| `E_INPUT_001` | `b` | `b must be > 0` | Check beam width input. |
+| `E_INPUT_002` | `d` | `d must be > 0` | Check effective depth input. |
+| `E_INPUT_003` | `d_total` | `d_total must be > d` | Ensure D > d + cover. |
+| `E_INPUT_004` | `fck` | `fck must be > 0` | Use valid concrete grade (15-80 N/mm²). |
+| `E_INPUT_005` | `fy` | `fy must be > 0` | Use valid steel grade (250/415/500/550). |
+| `E_INPUT_006` | `Mu` | `Mu must be >= 0` | Check moment input sign. |
+| `E_INPUT_007` | `Vu` | `Vu must be >= 0` | Check shear input sign. |
+| `E_INPUT_008` | `asv` | `asv must be > 0` | Provide stirrup area. |
+| `E_INPUT_009` | `pt` | `pt must be >= 0` | Check tension steel percentage. |
+
+#### Flexure (`E_FLEXURE_`)
+
+| Code | Field | Message | Hint | Clause |
+|------|-------|---------|------|--------|
+| `E_FLEXURE_001` | `Mu` | `Mu exceeds Mu_lim` | Use doubly reinforced or increase depth. | Cl. 38.1 |
+| `E_FLEXURE_002` | `Ast` | `Ast < Ast_min` | Increase steel to meet minimum. | Cl. 26.5.1.1 |
+| `E_FLEXURE_003` | `Ast` | `Ast > Ast_max` | Reduce steel or increase section. | Cl. 26.5.1.1 |
+| `E_FLEXURE_004` | `d'` | `d' too large for doubly reinforced` | Reduce compression steel cover. | — |
+
+#### Shear (`E_SHEAR_`)
+
+| Code | Field | Message | Hint | Clause |
+|------|-------|---------|------|--------|
+| `E_SHEAR_001` | `tv` | `tv exceeds tc_max` | Increase section size. | Cl. 40.2.3 |
+| `E_SHEAR_002` | `spacing` | `Spacing exceeds maximum` | Reduce stirrup spacing. | Cl. 26.5.1.6 |
+
+#### Ductile Detailing (`E_DUCTILE_`)
+
+| Code | Field | Message | Hint | Clause |
+|------|-------|---------|------|--------|
+| `E_DUCTILE_001` | `pt` | `pt exceeds pt_max for ductile` | Reduce tension steel. | IS 13920 Cl. 6.2.2 |
+| `E_DUCTILE_002` | `stirrup_spacing` | `Stirrup spacing exceeds ductile limit` | Use closer spacing in plastic hinge. | IS 13920 Cl. 6.3.5 |
+
+#### Serviceability (`E_SERVICE_`)
+
+| Code | Field | Message | Hint | Clause |
+|------|-------|---------|------|--------|
+| `E_SERVICE_001` | `deflection` | `Deflection exceeds L/250` | Increase depth or add compression steel. | Cl. 23.2 |
+| `E_SERVICE_002` | `crack_width` | `Crack width exceeds limit` | Reduce bar spacing or diameter. | Cl. 35.3.2 |
+
+#### Warnings (`W_`)
+
+| Code | Field | Message | Hint |
+|------|-------|---------|------|
+| `W_MIN_STEEL` | `Ast` | `Ast near minimum (< 1.1 × Ast_min)` | Consider increasing for safety margin. |
+| `W_HIGH_UTIL` | `utilization` | `Utilization > 95%` | Consider design margin for construction tolerance. |
+| `W_NOMINAL_SHEAR` | `tv` | `tv < tc, minimum shear reinforcement required` | Provide minimum stirrups. |
+
+---
+
+## Integration with Result Dataclasses
+
+### Current State (Inconsistent)
+
+| Module | Field | Format |
+|--------|-------|--------|
+| `flexure.py` | `error_message` | Plain string |
+| `shear.py` | `remarks` | Plain string |
+| CLI | stderr | Plain string |
+
+### Target State (Consistent)
+
+All result dataclasses should include:
+
+```python
+@dataclass
+class DesignError:
+    """Structured error for design results."""
+    code: str
+    severity: str  # "error" | "warning" | "info"
+    message: str
+    field: Optional[str] = None
+    hint: Optional[str] = None
+    clause: Optional[str] = None
+
+@dataclass
+class FlexureResult:
+    # ... existing fields ...
+    errors: List[DesignError] = field(default_factory=list)
+
+    @property
+    def is_safe(self) -> bool:
+        return not any(e.severity == "error" for e in self.errors)
+```
+
+---
+
+## CLI Error Output
+
+### Current
+
+```
+Error: Mu exceeds Mu_lim. Doubly reinforced section required.
+```
+
+### Target
+
+```
+[E_FLEXURE_001] error: Mu exceeds Mu_lim
+  Field: Mu
+  Hint: Use design_doubly_reinforced() or increase section depth.
+  Clause: Cl. 38.1
+```
+
+### JSON Mode (--format json)
+
+```json
+{
+  "success": false,
+  "errors": [
+    {
+      "code": "E_FLEXURE_001",
+      "severity": "error",
+      "field": "Mu",
+      "message": "Mu exceeds Mu_lim",
+      "hint": "Use design_doubly_reinforced() or increase section depth.",
+      "clause": "Cl. 38.1"
+    }
+  ]
+}
+```
+
+---
+
+## Implementation Plan
+
+### W04: Implement in Core (3 functions)
+
+1. Create `structural_lib/errors.py` with `DesignError` dataclass
+2. Update `flexure.design_singly_reinforced()` to use structured errors
+3. Update `shear.design_shear()` to use structured errors
+4. Update `ductile.check_ductility()` to use structured errors
+5. Add tests for error schema compliance
+
+### W05: Input Validation Pass
+
+1. Add `E_INPUT_*` errors to all geometry/material validation
+2. Ensure all `is_safe=False` results have at least one error with code
+
+### Future
+
+- CLI structured output (W40)
+- JSON schema for errors (TASK-090)
+
+---
+
+## Migration Notes
+
+### Backward Compatibility
+
+- `error_message` and `remarks` fields remain for backward compat
+- New `errors` list is the canonical source
+- `error_message = errors[0].message` for simple access
+
+### Breaking Changes (v1.0)
+
+- `is_safe` becomes computed from `errors` list
+- `remarks` deprecated in favor of `errors`
+
+---
+
+*See also: [api.md](api.md), [known-pitfalls.md](known-pitfalls.md)*


### PR DESCRIPTION
## Summary

Roadmap W03 deliverable: Error schema with structured error format for machine-readable and human-friendly errors.

## Error Schema v1

### Core Fields
- `code`: Unique error code (e.g., `E_FLEXURE_001`)
- `severity`: error / warning / info
- `field`: Input field that caused error
- `message`: Human-readable description
- `hint`: Actionable fix suggestion
- `clause`: IS 456 clause reference

### Error Code Prefixes
- `E_INPUT_`: Input validation errors
- `E_FLEXURE_`: Flexure design errors
- `E_SHEAR_`: Shear design errors
- `E_DUCTILE_`: Ductile detailing errors
- `E_SERVICE_`: Serviceability errors
- `W_`: Warnings

### Includes
- Full error catalog with 20+ error codes
- Integration plan for result dataclasses
- CLI output formats (human and JSON)
- Migration notes for backward compatibility

## Files Changed
- docs/reference/error-schema.md (new)
- docs/TASKS.md (W03 marked done)

## Next Steps
- W04: Implement error schema in 3 core functions
- W05: Input validation pass