### PR TITLE
chore: release v0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.6] - 2025-12-28
+
+### Added
+- **W5 Structured Validation for Doubly/Flanged Beams:**
+  - New error codes: `E_INPUT_010` (d_dash), `E_INPUT_011` (min_long_bar_dia)
+  - New error codes: `E_INPUT_012-016` for flanged beam inputs (bw, bf, Df, constraints)
+  - New error code: `E_FLEXURE_004` for d' too large in doubly reinforced design
+  - Structured validation in `design_doubly_reinforced()` with error list
+  - Structured validation in `design_flanged_beam()` with error list
+  - Validation for d, fck, fy, min_long_bar_dia in `check_beam_ductility()`
+  - 9 new tests for new error codes
+- **Documentation:**
+  - Solo maintainer operating system guide
+  - Beginner learning path with exercises
+  - Updated error-schema.md with new error codes
+
+### Changed
+- Improved CLI error messages for better user experience
+
+### Fixed
+- Error schema review findings (frozen dataclass, E_INPUT_003a, dynamic messages)
+
 ## [0.10.5] - 2025-12-28
 
 ### Added

--- a/Python/README.md
+++ b/Python/README.md
@@ -2,7 +2,7 @@
 
 IS 456 RC Beam Design Library (Python package).
 
-**Version:** 0.10.5 (development preview)
+**Version:** 0.10.6 (development preview)
 **Status:** [![Python tests](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/python-tests.yml/badge.svg)](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/python-tests.yml)
 
 > ⚠️ **Development Preview:** APIs may change until v1.0. For reproducible results, pin to a release tag.
@@ -13,10 +13,10 @@ For full project overview and usage examples, see the repository root `README.md
 
 ```bash
 # Recommended (pinned to release tag)
-pip install "structural-lib-is456 @ git+https://github.com/Pravin-surawase/structural_engineering_lib.git@v0.10.5#subdirectory=Python"
+pip install "structural-lib-is456 @ git+https://github.com/Pravin-surawase/structural_engineering_lib.git@v0.10.6#subdirectory=Python"
 
 # With DXF support (pinned)
-pip install "structural-lib-is456[dxf] @ git+https://github.com/Pravin-surawase/structural_engineering_lib.git@v0.10.5#subdirectory=Python"
+pip install "structural-lib-is456[dxf] @ git+https://github.com/Pravin-surawase/structural_engineering_lib.git@v0.10.6#subdirectory=Python"
 
 # PyPI (latest — may differ from pinned tag)
 pip install structural-lib-is456
@@ -66,7 +66,7 @@ report = api.check_beam_is456(
 print(f"Governing case: {report.governing_case_id}")
 ```
 
-## New in v0.10.5
+## New in v0.10.6
 
 - **Level B Serviceability:** Curvature-based deflection per IS 456 Cl 23.2 / Annex C
 - **CLI/AI Discoverability:** `llms.txt`, enhanced CLI help with examples

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "structural-lib-is456"
-version = "0.10.5"
+version = "0.10.6"
 description = "IS 456 RC Beam Design Library (flexure, shear, ductile detailing, DXF export for RC beams)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/Python/structural_lib/api.py
+++ b/Python/structural_lib/api.py
@@ -57,7 +57,7 @@ def get_library_version() -> str:
     try:
         return version("structural-lib-is456")
     except PackageNotFoundError:
-        return "0.10.5"
+        return "0.10.6"
 
 
 def check_beam_ductility(

--- a/Python/structural_lib/errors.py
+++ b/Python/structural_lib/errors.py
@@ -144,6 +144,62 @@ E_INPUT_009 = DesignError(
     hint="Check tension steel percentage.",
 )
 
+E_INPUT_010 = DesignError(
+    code="E_INPUT_010",
+    severity=Severity.ERROR,
+    message="d_dash must be > 0",
+    field="d_dash",
+    hint="Check compression steel cover input.",
+)
+
+E_INPUT_011 = DesignError(
+    code="E_INPUT_011",
+    severity=Severity.ERROR,
+    message="min_long_bar_dia must be > 0",
+    field="min_long_bar_dia",
+    hint="Provide smallest longitudinal bar diameter.",
+)
+
+E_INPUT_012 = DesignError(
+    code="E_INPUT_012",
+    severity=Severity.ERROR,
+    message="bw must be > 0",
+    field="bw",
+    hint="Check web width input.",
+)
+
+E_INPUT_013 = DesignError(
+    code="E_INPUT_013",
+    severity=Severity.ERROR,
+    message="bf must be > 0",
+    field="bf",
+    hint="Check flange width input.",
+)
+
+E_INPUT_014 = DesignError(
+    code="E_INPUT_014",
+    severity=Severity.ERROR,
+    message="Df must be > 0",
+    field="Df",
+    hint="Check flange thickness input.",
+)
+
+E_INPUT_015 = DesignError(
+    code="E_INPUT_015",
+    severity=Severity.ERROR,
+    message="bf must be >= bw",
+    field="bf",
+    hint="Ensure flange width is not smaller than web width.",
+)
+
+E_INPUT_016 = DesignError(
+    code="E_INPUT_016",
+    severity=Severity.ERROR,
+    message="Df must be < d",
+    field="Df",
+    hint="Ensure flange thickness is less than effective depth.",
+)
+
 # Flexure Errors
 E_FLEXURE_001 = DesignError(
     code="E_FLEXURE_001",
@@ -170,6 +226,14 @@ E_FLEXURE_003 = DesignError(
     field="Ast",
     hint="Reduce steel or increase section.",
     clause="Cl. 26.5.1.2",
+)
+
+E_FLEXURE_004 = DesignError(
+    code="E_FLEXURE_004",
+    severity=Severity.ERROR,
+    message="d' too large for doubly reinforced design",
+    field="d_dash",
+    hint="Reduce compression steel cover.",
 )
 
 # Shear Errors

--- a/Python/tests/test_error_schema.py
+++ b/Python/tests/test_error_schema.py
@@ -14,6 +14,13 @@ from structural_lib.errors import (
     DesignError,
     Severity,
     E_INPUT_001,
+    E_INPUT_010,
+    E_INPUT_011,
+    E_INPUT_012,
+    E_INPUT_013,
+    E_INPUT_014,
+    E_INPUT_015,
+    E_INPUT_016,
     E_FLEXURE_001,
     E_SHEAR_001,
     E_DUCTILE_001,
@@ -126,6 +133,41 @@ class TestPredefinedErrors:
         assert E_INPUT_001.severity == Severity.ERROR
         assert E_INPUT_001.field == "b"
         assert E_INPUT_001.hint is not None
+
+    def test_input_error_010(self):
+        assert E_INPUT_010.code == "E_INPUT_010"
+        assert E_INPUT_010.severity == Severity.ERROR
+        assert E_INPUT_010.field == "d_dash"
+
+    def test_input_error_011(self):
+        assert E_INPUT_011.code == "E_INPUT_011"
+        assert E_INPUT_011.severity == Severity.ERROR
+        assert E_INPUT_011.field == "min_long_bar_dia"
+
+    def test_input_error_012(self):
+        assert E_INPUT_012.code == "E_INPUT_012"
+        assert E_INPUT_012.severity == Severity.ERROR
+        assert E_INPUT_012.field == "bw"
+
+    def test_input_error_013(self):
+        assert E_INPUT_013.code == "E_INPUT_013"
+        assert E_INPUT_013.severity == Severity.ERROR
+        assert E_INPUT_013.field == "bf"
+
+    def test_input_error_014(self):
+        assert E_INPUT_014.code == "E_INPUT_014"
+        assert E_INPUT_014.severity == Severity.ERROR
+        assert E_INPUT_014.field == "Df"
+
+    def test_input_error_015(self):
+        assert E_INPUT_015.code == "E_INPUT_015"
+        assert E_INPUT_015.severity == Severity.ERROR
+        assert E_INPUT_015.field == "bf"
+
+    def test_input_error_016(self):
+        assert E_INPUT_016.code == "E_INPUT_016"
+        assert E_INPUT_016.severity == Severity.ERROR
+        assert E_INPUT_016.field == "Df"
 
     def test_flexure_error_001(self):
         assert E_FLEXURE_001.code == "E_FLEXURE_001"

--- a/Python/tests/test_flanged_beam.py
+++ b/Python/tests/test_flanged_beam.py
@@ -134,3 +134,4 @@ def test_flanged_beam_invalid_geometry_fails_gracefully():
     )
     assert res.is_safe is False
     assert "bf" in res.error_message.lower()
+    assert any(err.code == "E_INPUT_015" for err in res.errors)

--- a/Python/tests/test_input_validation.py
+++ b/Python/tests/test_input_validation.py
@@ -84,6 +84,7 @@ def test_flexure_design_doubly_reinforced_rejects_nonpositive_d_dash():
     )
     assert res.is_safe is False
     assert "d'" in res.error_message.lower()
+    assert any(err.code == "E_INPUT_010" for err in res.errors)
 
 
 @pytest.mark.parametrize(

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 ## Status
 
-🚀 **Active (v0.10.5)** — Now on PyPI! Unified CLI + strength design + detailing + DXF export + serviceability (Level A+B) + compliance + batch runner + cutting-stock optimizer.
+🚀 **Active (v0.10.6)** — Now on PyPI! Unified CLI + strength design + detailing + DXF export + serviceability (Level A+B) + compliance + batch runner + cutting-stock optimizer.
 
-**What's new in v0.10.5:**
+**What's new in v0.10.6:**
 - 45 critical IS 456 clause-specific tests (Mu_lim, xu/d ratios, T-beam, shear limits)
 - Multi-agent repository review with CI improvements
 - Local CI parity script (`scripts/ci_local.sh`)
@@ -85,7 +85,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full release history.
 This repository is public, so anyone can read the code, docs, and examples.
 
 - **Engineering note:** This library is a calculation aid. Final responsibility for code-compliant design, detailing, and drawing checks remains with the qualified engineer.
-- **Stability note:** While in active development, prefer pinning to a release version (example: `structural-lib-is456==0.10.5`) rather than installing latest.
+- **Stability note:** While in active development, prefer pinning to a release version (example: `structural-lib-is456==0.10.6`) rather than installing latest.
 
 ### Install from PyPI
 

--- a/VBA/Modules/M08_API.bas
+++ b/VBA/Modules/M08_API.bas
@@ -9,7 +9,7 @@ Option Explicit
 ' ==============================================================================
 
 Public Function Get_Library_Version() As String
-    Get_Library_Version = "0.10.5"
+    Get_Library_Version = "0.10.6"
 End Function
 
 '

--- a/docs/AI_CONTEXT_PACK.md
+++ b/docs/AI_CONTEXT_PACK.md
@@ -4,7 +4,7 @@
 
 | Metric | Value |
 |--------|-------|
-| **Current Release** | v0.10.5 (on PyPI) |
+| **Current Release** | v0.10.6 (on PyPI) |
 | **Next Milestone** | v0.20.0 (blocked by S-007) |
 | **Tests** | 1810 passed, 91 skipped |
 | **Coverage** | 92% branch |

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -43,6 +43,25 @@ Use workflow_dispatch with `testpypi` target:
 
 ---
 
+## v0.10.6
+**Date:** 2025-12-28
+**Status:** ✅ Locked & Verified
+**Mindset:** Complete Structured Validation
+**Key Changes:**
+- **W5 Structured Validation:**
+  - New error codes: `E_INPUT_010-016` for d_dash, min_long_bar_dia, and flanged beam inputs
+  - New `E_FLEXURE_004` for d' too large in doubly reinforced design
+  - Structured validation in `design_doubly_reinforced()` and `design_flanged_beam()`
+  - Validation in `check_beam_ductility()` for d, fck, fy, min_long_bar_dia
+- **Docs:** Solo maintainer guide, beginner learning path, improved error schema docs
+- **CLI:** Improved error messages
+
+**Note:** v0.10.5 was not published to PyPI. This release includes all v0.10.5 changes.
+
+**PRs:** #81, #94, #112, #113, #114, #115
+
+---
+
 ## v0.10.5
 **Date:** 2025-12-28
 **Status:** ✅ Locked & Verified

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -1,6 +1,6 @@
 # IS 456 RC Beam Design Library — Development Guide
 
-**Document Version:** 0.10.5
+**Document Version:** 0.10.6
 **Last Updated:** 2025-12-28
 **Audience:** Contributors, maintainers, and developers extending the library
 

--- a/docs/contributing/vba-testing-guide.md
+++ b/docs/contributing/vba-testing-guide.md
@@ -1,6 +1,6 @@
 # VBA Testing Guide
 
-**Version:** 0.10.5
+**Version:** 0.10.6
 **Last Updated:** 2025-12-28
 
 ## Quick Start
@@ -20,7 +20,7 @@
 ```
 ========================================
   STRUCTURAL ENGINEERING LIB - VBA TESTS
-  Version: 0.10.5
+  Version: 0.10.6
   Date: 2025-12-26 14:30:00
 ========================================
 

--- a/docs/getting-started/beginners-guide.md
+++ b/docs/getting-started/beginners-guide.md
@@ -136,4 +136,4 @@ You should get a number around 196.5 (kN-m).
 - API reference: `docs/reference/api.md`
 - Learning path: `docs/learning/README.md`
 
-Document Version: 0.10.5 | Last Updated: 2025-12-28
+Document Version: 0.10.6 | Last Updated: 2025-12-28

--- a/docs/getting-started/excel-tutorial.md
+++ b/docs/getting-started/excel-tutorial.md
@@ -352,4 +352,4 @@ NOTES:
 
 ---
 
-*Document Version: 0.10.5 | Last Updated: 2025-12-28
+*Document Version: 0.10.6 | Last Updated: 2025-12-28

--- a/docs/getting-started/user-guide.md
+++ b/docs/getting-started/user-guide.md
@@ -1,6 +1,6 @@
 # User Guide — Complete Workflow
 
-**Version:** 0.10.5
+**Version:** 0.10.6
 **Time to complete:** 10–15 minutes
 
 This guide walks you through a complete beam design workflow from start to finish. For detailed installation help, see [Beginner's Guide](beginners-guide.md).

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -2,7 +2,7 @@
 
 | Release | Version | Status |
 |---------|---------|--------|
-| **Current** | v0.10.5 | Published on PyPI |
+| **Current** | v0.10.6 | Published on PyPI |
 | **Next** | v0.20.0 | Blocked by S-007 |
 
 **Date:** 2025-12-28 | **PRs:** through #107

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -1,6 +1,6 @@
 # Pre-Release Checklist
 
-Version: 0.10.5 (beta candidate)
+Version: 0.10.6 (beta candidate)
 Date: 2025-12-28
 Target: Private beta with 2–3 structural engineers
 

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -105,7 +105,7 @@ If you must use an internal module:
 ```python
 # Pin to exact version
 # requirements.txt
-structural-lib-is456==0.10.5
+structural-lib-is456==0.10.6
 
 # Or wrap with try/except
 try:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,6 +1,6 @@
 # IS 456 RC Beam Design Library — API Reference
 
-**Document Version:** 0.10.5
+**Document Version:** 0.10.6
 **Last Updated:** 2025-12-28
 **Scope:** Public APIs for Python/VBA implementations (flexure, shear, ductile detailing, integration, reporting, detailing, DXF export, BBS, cutting-stock optimizer, unified CLI).
 

--- a/docs/reference/error-schema.md
+++ b/docs/reference/error-schema.md
@@ -84,6 +84,13 @@ This document defines the standard error schema for all structural_lib errors. T
 | `E_INPUT_007` | `Vu` | `Vu must be >= 0` | Check shear input sign. |
 | `E_INPUT_008` | `asv` | `asv must be > 0` | Provide stirrup area. |
 | `E_INPUT_009` | `pt` | `pt must be >= 0` | Check tension steel percentage. |
+| `E_INPUT_010` | `d_dash` | `d_dash must be > 0` | Check compression steel cover input. |
+| `E_INPUT_011` | `min_long_bar_dia` | `min_long_bar_dia must be > 0` | Provide smallest longitudinal bar diameter. |
+| `E_INPUT_012` | `bw` | `bw must be > 0` | Check web width input. |
+| `E_INPUT_013` | `bf` | `bf must be > 0` | Check flange width input. |
+| `E_INPUT_014` | `Df` | `Df must be > 0` | Check flange thickness input. |
+| `E_INPUT_015` | `bf` | `bf must be >= bw` | Ensure flange width is not smaller than web width. |
+| `E_INPUT_016` | `Df` | `Df must be < d` | Ensure flange thickness is less than effective depth. |
 
 #### Flexure (`E_FLEXURE_`)
 
@@ -92,7 +99,7 @@ This document defines the standard error schema for all structural_lib errors. T
 | `E_FLEXURE_001` | `Mu` | `Mu exceeds Mu_lim` | Use doubly reinforced or increase depth. | Cl. 38.1 |
 | `E_FLEXURE_002` | `Ast` | `Ast < Ast_min` | Increase steel to meet minimum. | Cl. 26.5.1.1 |
 | `E_FLEXURE_003` | `Ast` | `Ast > Ast_max` | Reduce steel or increase section. | Cl. 26.5.1.1 |
-| `E_FLEXURE_004` | `d'` | `d' too large for doubly reinforced` | Reduce compression steel cover. | — |
+| `E_FLEXURE_004` | `d_dash` | `d' too large for doubly reinforced` | Reduce compression steel cover. | — |
 
 #### Shear (`E_SHEAR_`)
 
@@ -105,8 +112,9 @@ This document defines the standard error schema for all structural_lib errors. T
 
 | Code | Field | Message | Hint | Clause |
 |------|-------|---------|------|--------|
-| `E_DUCTILE_001` | `pt` | `pt exceeds pt_max for ductile` | Reduce tension steel. | IS 13920 Cl. 6.2.2 |
-| `E_DUCTILE_002` | `stirrup_spacing` | `Stirrup spacing exceeds ductile limit` | Use closer spacing in plastic hinge. | IS 13920 Cl. 6.3.5 |
+| `E_DUCTILE_001` | `b` | `Width < 200 mm` | Increase beam width to ≥ 200 mm. | IS 13920 Cl. 6.1.1 |
+| `E_DUCTILE_002` | `b/D` | `Width/Depth ratio < 0.3` | Increase width or reduce depth. | IS 13920 Cl. 6.1.2 |
+| `E_DUCTILE_003` | `D` | `Invalid depth` | Depth must be > 0. | IS 13920 Cl. 6.1 |
 
 #### Serviceability (`E_SERVICE_`)
 

--- a/docs/verification/validation-pack.md
+++ b/docs/verification/validation-pack.md
@@ -1,6 +1,6 @@
 # Validation Pack — Benchmark Beams
 
-**Version:** 0.10.5
+**Version:** 0.10.6
 **Purpose:** Engineers can verify library accuracy using these benchmark beams
 
 This pack provides 5 benchmark beams with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trusted software.


### PR DESCRIPTION
## Release v0.10.6

### Summary
This release includes all changes since v0.10.4 (v0.10.5 was not published to PyPI).

### Changes Since v0.10.4

**v0.10.5 (included):**
- Structured error schema (W03-W04)
- `DesignError` dataclass with code/severity/message/field/hint/clause
- Core integration in `design_singly_reinforced()`, `design_shear()`, `check_beam_ductility()`
- 29 new tests for error schema

**v0.10.6 (new):**
- W5 structured validation for doubly/flanged beams
- New error codes: `E_INPUT_010-016`, `E_FLEXURE_004`
- Solo maintainer guide, beginner learning path
- Improved CLI error messages

### Files Changed
- Version bumped in pyproject.toml, api.py, M08_API.bas
- CHANGELOG.md, RELEASES.md updated
- Doc version references synced

### After Merge
Tag and push: `git tag v0.10.6 && git push origin v0.10.6`
This triggers PyPI publish via GitHub Actions.