### PR TITLE
docs: update README and docs for v0.10.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
 🚀 **Active (v0.10.6)** — Now on PyPI! Unified CLI + strength design + detailing + DXF export + serviceability (Level A+B) + compliance + batch runner + cutting-stock optimizer.
 
 **What's new in v0.10.6:**
-- 45 critical IS 456 clause-specific tests (Mu_lim, xu/d ratios, T-beam, shear limits)
-- Multi-agent repository review with CI improvements
-- Local CI parity script (`scripts/ci_local.sh`)
-- Pre-commit hooks and governance documentation
+- **Structured error schema:** Machine-readable `DesignError` with code/severity/hint/clause
+- **Full input validation:** 16+ error codes covering all design functions
+- **Doubly/flanged beam validation:** Structured errors in `design_doubly_reinforced()`, `design_flanged_beam()`
+- **Improved CLI:** Better error messages for user-facing feedback
 
 See [CHANGELOG.md](CHANGELOG.md) for full release history.
 

--- a/docs/AI_CONTEXT_PACK.md
+++ b/docs/AI_CONTEXT_PACK.md
@@ -6,7 +6,7 @@
 |--------|-------|
 | **Current Release** | v0.10.6 (on PyPI) |
 | **Next Milestone** | v0.20.0 (blocked by S-007) |
-| **Tests** | 1810 passed, 91 skipped |
+| **Tests** | 1900+ passed, 91 skipped |
 | **Coverage** | 92% branch |
 
 > **Status details:** See [TASKS.md](TASKS.md) for current/next release info.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -31,6 +31,25 @@ See also: `docs/_internal/AGENT_WORKFLOW.md`
 
 ---
 
+## Recently Completed (v0.10.6)
+
+### W03-W05: Structured Error Schema Sprint — ✅ COMPLETE
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **W03** | Design error schema (docs/reference/error-schema.md) | DOCS | ✅ Done |
+| **W04** | Implement DesignError dataclass + integrate in core | DEV | ✅ Done |
+| **W05** | Structured validation for doubly/flanged beams | DEV | ✅ Done |
+
+**Deliverables:**
+- `errors.py` module with frozen `DesignError` dataclass
+- 16+ error codes: `E_INPUT_*`, `E_FLEXURE_*`, `E_SHEAR_*`, `E_DUCTILE_*`
+- Structured errors in all core design functions
+- 38 new tests for error schema
+- Full error catalog in docs/reference/error-schema.md
+
+---
+
 ## Recently Completed (v0.9.7-dev)
 
 ### Level B Serviceability + CLI/AI Discoverability (PR #62) — ✅ COMPLETE

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -5,7 +5,7 @@
 | **Current** | v0.10.6 | Published on PyPI |
 | **Next** | v0.20.0 | Blocked by S-007 |
 
-**Date:** 2025-12-28 | **PRs:** through #107
+**Date:** 2025-12-29 | **PRs:** through #116
 
 ---
 


### PR DESCRIPTION
Post-release doc updates for v0.10.6:

- Update README 'What's new' section with actual v0.10.6 features (error schema)
- Update AI_CONTEXT_PACK test count to 1900+
- Update next-session-brief date (2025-12-29) and PR count (#116)
- Add W03-W05 completion record in TASKS.md