### PR TITLE
feat(tests): W6 unit boundary conversion tests + docs

### DIFF
--- a/Python/tests/test_units_boundary.py
+++ b/Python/tests/test_units_boundary.py
@@ -1,0 +1,47 @@
+import math
+import sys
+import os
+
+import pytest
+
+# Add parent directory to path to import structural_lib
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from structural_lib import flexure, shear, materials
+
+
+def test_calculate_tv_converts_kn_to_n():
+    # Vu in kN should be converted to N inside shear.calculate_tv
+    tv = shear.calculate_tv(vu_kn=100.0, b=200.0, d=400.0)
+    expected = (100.0 * 1000.0) / (200.0 * 400.0)
+    assert tv == pytest.approx(expected, rel=1e-9)
+
+
+def test_calculate_ast_required_uses_knm_conversion():
+    # Validate mu_knm -> N·mm conversion (x1,000,000)
+    b, d = 300.0, 500.0
+    fck, fy = 25.0, 500.0
+    mu_knm = 100.0
+
+    mu_nmm = mu_knm * 1_000_000.0
+    term1 = 0.5 * fck / fy
+    term2 = (4.6 * mu_nmm) / (fck * b * d * d)
+    if term2 > 1.0:
+        term2 = 1.0
+    expected = term1 * (1.0 - math.sqrt(1.0 - term2)) * b * d
+
+    ast = flexure.calculate_ast_required(b, d, mu_knm, fck, fy)
+    assert ast == pytest.approx(expected, rel=1e-9)
+
+
+def test_calculate_mu_lim_returns_knm():
+    b, d = 300.0, 500.0
+    fck, fy = 25.0, 500.0
+
+    xu_max_d = materials.get_xu_max_d(fy)
+    k = 0.36 * xu_max_d * (1 - 0.42 * xu_max_d)
+    expected_nmm = k * fck * b * d * d
+    expected_knm = expected_nmm / 1_000_000.0
+
+    mu_lim = flexure.calculate_mu_lim(b, d, fck, fy)
+    assert mu_lim == pytest.approx(expected_knm, rel=1e-9)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -38,6 +38,9 @@ python -m structural_lib design --help
   - Areas (`Ast`, `Asv`): **mm²**
   - Stresses (`fck`, `fy`, `Tv`, `Tc`): **N/mm²** (MPa)
   - Percentages (`pt`): **%** (e.g., 1.2 for 1.2%)
+  - Boundary conversions (public -> internal):
+    - kN -> N (×1,000)
+    - kN·m -> N·mm (×1,000,000)
 - **Sign Conventions:**
   - Inputs are generally treated as absolute values for design checks.
   - UI/Application layer is responsible for handling signs before calling these libraries.

--- a/docs/reference/known-pitfalls.md
+++ b/docs/reference/known-pitfalls.md
@@ -9,6 +9,10 @@ Use this as a checklist to avoid common mistakes when implementing or reviewing 
 - Do not mix kN·m with mm in the same formula; keep internal units as N, N·mm, mm.
 - Shear flow: τv = Vu / (b×d) with Vu in N; convert back to kN only for reporting.
 - Stirrup spacing formulas expect Vus in N; be explicit about conversions.
+- Boundary contract (public -> internal):
+  - kN -> N: multiply by 1,000
+  - kN·m -> N·mm: multiply by 1,000,000
+  - mm stays mm; N/mm² stays N/mm²
 
 ## Table 19/20 Usage
 - Table 19: Clamp pt to 0.15–3.0%; use nearest lower concrete grade column (no fck interpolation).


### PR DESCRIPTION
## Summary
W6: Document and test unit boundary conversions at public API layer.

## Changes
- **test_units_boundary.py**: 3 tests verifying kN→N, kN·m→N·mm conversions
- **known-pitfalls.md**: Added 'Boundary contract' with explicit conversion factors
- **api.md**: Added conversion bullets to Conventions section

## Testing
```bash
PYTHONPATH=Python .venv/bin/python -m pytest Python/tests/test_units_boundary.py -v
# 3 passed
```