### PR TITLE
docs: add 5-stage multi-agent research workflow

### DIFF
--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -16,31 +16,42 @@ Internal planning documents and research notes.
 
 ## Research Process
 
+> **Full workflow:** See [research-workflow.md](research-workflow.md) for the complete 5-stage process.
+
 ### How Features Evolve
 
 ```
-Research → Shape → Decide → Implement → Release
-   ↓         ↓        ↓         ↓          ↓
- Ideas    Scope    TASKS.md   Code      PyPI
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Stage 1        Stage 2        Stage 3        Stage 4        Stage 5    │
+│  ────────       ────────       ────────       ────────       ────────   │
+│  INITIATE  →   EXPLORE    →   EVALUATE   →   DECIDE     →   HANDOFF    │
+│                                                                          │
+│  CLIENT        RESEARCHER     DEV            PM             DOCS        │
+│  PM            TESTER         Review         Owner          DEV         │
+│                               Agents                                     │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Agent Roles in Research
 
-| Agent | Role in Research |
-|-------|------------------|
-| **RESEARCHER** | Explore options, identify constraints |
-| **CLIENT** | Define user problems, validate solutions |
-| **PM** | Scope decisions, prioritize |
-| **DEV** | Feasibility, effort estimates |
-| **TESTER** | Edge cases, validation criteria |
+| Agent | Stage | Role |
+|-------|-------|------|
+| **CLIENT** | 1. Initiate | Define problems, user personas |
+| **PM** | 1. Initiate, 4. Decide | Scope, constraints, final call |
+| **RESEARCHER** | 2. Explore | Options, market analysis |
+| **TESTER** | 2. Explore | Edge cases, validation criteria |
+| **DEV** | 3. Evaluate | Feasibility, effort, architecture |
+| **Review agents** | 3. Evaluate | Critique, find gaps |
+| **DOCS** | 5. Handoff | Create tasks, update roadmap |
 
 ### Starting New Research
 
 1. Copy `_research-template.md` to `research-{topic}/README.md`
-2. Fill in Problem, Constraints, Options
-3. Score options using the rubric
-4. Make a decision (or park for later)
-5. Move approved items to `TASKS.md`
+2. **Stage 1:** CLIENT fills Problem, Personas; PM sets constraints
+3. **Stage 2:** RESEARCHER explores options; TESTER adds edge cases
+4. **Stage 3:** DEV scores feasibility; Review agents critique
+5. **Stage 4:** PM makes decision, defines parking lot
+6. **Stage 5:** DOCS creates tasks, DEV writes implementation spec
 
 ### Research Status Lifecycle
 
@@ -74,10 +85,11 @@ Research → Shape → Decide → Implement → Release
 
 ---
 
-## Templates
+## Templates & Workflow
 
-| Template | Use For |
+| Document | Use For |
 |----------|---------|
+| [research-workflow.md](research-workflow.md) | Full 5-stage process with agent handoffs |
 | [_research-template.md](_research-template.md) | New research topics |
 
 ---

--- a/docs/planning/research-workflow.md
+++ b/docs/planning/research-workflow.md
@@ -1,0 +1,391 @@
+# Multi-Agent Research Workflow
+
+> **Purpose:** Define how AI agents collaborate on research topics from inception to implementation.
+> **Scope:** Any feature that starts as an idea and needs exploration before coding.
+
+---
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        RESEARCH WORKFLOW                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Stage 1        Stage 2        Stage 3        Stage 4        Stage 5    │
+│  ────────       ────────       ────────       ────────       ────────   │
+│  INITIATE  →   EXPLORE    →   EVALUATE   →   DECIDE     →   HANDOFF    │
+│                                                                          │
+│  CLIENT        RESEARCHER     DEV            PM             DOCS        │
+│  PM            TESTER         Review         Owner          DEV         │
+│                               Agents                                     │
+│                                                                          │
+│  1-2 hrs       2-4 hrs        1-2 hrs        30 min         1 hr        │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Stage 1: Initiate (CLIENT + PM)
+
+**Duration:** 1-2 hours
+**Agents:** CLIENT (primary), PM (secondary)
+**Output:** Problem statement + initial constraints
+
+### CLIENT Agent Tasks
+
+1. **Define the problem**
+   - What pain are we solving?
+   - Who feels this pain? (user personas)
+   - How do they work around it today?
+
+2. **Gather requirements**
+   - What does success look like?
+   - What's out of scope?
+   - Any hard constraints from users?
+
+3. **Document in template**
+   - Fill: Problem Statement, Users & Personas, Success Criteria
+   - Leave: Options, Scoring, Decision (for later stages)
+
+### PM Agent Tasks
+
+1. **Check alignment**
+   - Does this fit current roadmap phase?
+   - What's the WIP impact?
+   - Any blockers from other work?
+
+2. **Set boundaries**
+   - Timebox the research (e.g., "2 sessions max")
+   - Define decision date
+   - Assign owner
+
+### Stage 1 Deliverable
+
+```markdown
+## Problem Statement
+[1-2 sentences from CLIENT]
+
+## Users & Personas
+| User | Context | Pain Point |
+|------|---------|------------|
+| ... | ... | ... |
+
+## Constraints (from PM)
+- [ ] Must fit Phase [A/B/C/D]
+- [ ] No new required dependencies
+- [ ] Decision by: [DATE]
+- [ ] Owner: [AGENT/PERSON]
+
+## Success Criteria
+| Metric | Target |
+|--------|--------|
+| ... | ... |
+```
+
+---
+
+## Stage 2: Explore (RESEARCHER + TESTER)
+
+**Duration:** 2-4 hours
+**Agents:** RESEARCHER (primary), TESTER (secondary)
+**Output:** Options explored with pros/cons
+
+### RESEARCHER Agent Tasks
+
+1. **Market analysis**
+   - What do existing tools do?
+   - What's the industry standard?
+   - What's novel/differentiated?
+
+2. **Technical options**
+   - List 2-4 approaches
+   - Pros and cons for each
+   - Dependencies and risks
+
+3. **Constraints check**
+   - Does each option fit our non-negotiables?
+   - Determinism? Dependencies? Units?
+
+### TESTER Agent Tasks
+
+1. **Edge cases**
+   - What could go wrong?
+   - What inputs would break each option?
+   - What's hard to test?
+
+2. **Validation criteria**
+   - How would we verify each option works?
+   - What tests would we need?
+   - Any parity concerns (Python/VBA)?
+
+### Stage 2 Deliverable
+
+```markdown
+## Options Explored
+
+### Option A: [Name]
+**Description:** ...
+**Pros:** ...
+**Cons:** ...
+**Edge cases (from TESTER):** ...
+**Dependencies:** ...
+
+### Option B: [Name]
+**Description:** ...
+**Pros:** ...
+**Cons:** ...
+**Edge cases (from TESTER):** ...
+**Dependencies:** ...
+
+## Constraints Verification
+| Option | Deterministic | No New Deps | Fits Phase | Testable |
+|--------|---------------|-------------|------------|----------|
+| A | ✓/✗ | ✓/✗ | ✓/✗ | ✓/✗ |
+| B | ✓/✗ | ✓/✗ | ✓/✗ | ✓/✗ |
+```
+
+---
+
+## Stage 3: Evaluate (DEV + Review Agents)
+
+**Duration:** 1-2 hours
+**Agents:** DEV (primary), Review agents (critique)
+**Output:** Scored options with feasibility notes
+
+### DEV Agent Tasks
+
+1. **Feasibility assessment**
+   - Can we actually build each option?
+   - What's the effort estimate?
+   - Any hidden complexity?
+
+2. **Architecture fit**
+   - Does it fit our layer model (Core/App/I-O)?
+   - Any schema changes needed?
+   - Integration points?
+
+3. **Score the options**
+   - Use the standard rubric
+   - Add effort estimates
+   - Flag blockers
+
+### Review Agent Tasks
+
+1. **Critique each option**
+   - What's missing?
+   - What assumptions are wrong?
+   - What risks are understated?
+
+2. **Challenge the scores**
+   - Is effort realistic?
+   - Is trust impact justified?
+   - Any blind spots?
+
+### Stage 3 Deliverable
+
+```markdown
+## Feasibility Notes (from DEV)
+
+### Option A
+- Effort: [X days/weeks]
+- Complexity: [Low/Medium/High]
+- Blockers: [None / W08 / Schema freeze / etc.]
+- Architecture notes: ...
+
+### Option B
+- Effort: [X days/weeks]
+- Complexity: [Low/Medium/High]
+- Blockers: [None / W08 / Schema freeze / etc.]
+- Architecture notes: ...
+
+## Scoring (Rubric Applied)
+
+| Option | Trust | Value | Effort | Risk | Align | Total | Rank |
+|--------|-------|-------|--------|------|-------|-------|------|
+| A | /5 | /5 | /5 | /5 | /5 | /25 | |
+| B | /5 | /5 | /5 | /5 | /5 | /25 | |
+
+## Review Findings
+
+| Severity | Finding | Option | Resolution |
+|----------|---------|--------|------------|
+| High | ... | A | ... |
+| Medium | ... | B | ... |
+```
+
+---
+
+## Stage 4: Decide (PM + Owner)
+
+**Duration:** 30 minutes
+**Agents:** PM (primary), designated Owner
+**Output:** Decision + parking lot
+
+### PM Agent Tasks
+
+1. **Synthesize findings**
+   - What does the scoring say?
+   - What do review findings change?
+   - Any new blockers surfaced?
+
+2. **Make the call**
+   - Choose: Approve / Defer / Split / Reject
+   - Document rationale
+   - Assign to roadmap phase
+
+3. **Define parking lot**
+   - What good ideas aren't for now?
+   - When might we revisit?
+
+### Stage 4 Deliverable
+
+```markdown
+## Decision
+
+**Chosen option:** [A / B / Defer / Split]
+**Rationale:** ...
+**Roadmap placement:** [Phase X / v0.Y.Z / Post-v1.0]
+
+## What We Will NOT Do (and why)
+- [Option B]: [reason]
+- [Idea X]: [reason]
+
+## Parking Lot
+
+| Idea | Why Parked | Revisit When |
+|------|------------|--------------|
+| ... | ... | ... |
+
+## Approval
+- [ ] PM: Approved scope
+- [ ] Owner: Accepted assignment
+- [ ] No WIP conflict
+```
+
+---
+
+## Stage 5: Handoff (DOCS + DEV)
+
+**Duration:** 1 hour
+**Agents:** DOCS (primary), DEV (secondary)
+**Output:** TASKS.md entries + implementation spec
+
+### DOCS Agent Tasks
+
+1. **Create task entries**
+   - Add to `docs/TASKS.md`
+   - Link to research doc
+   - Set priority and estimates
+
+2. **Update roadmap if needed**
+   - Does this affect milestones?
+   - Any phase adjustments?
+
+3. **Mark research as Decided**
+   - Update status in research doc
+   - Add to research index
+
+### DEV Agent Tasks
+
+1. **Write implementation spec**
+   - Define file changes
+   - Define function signatures
+   - Define test requirements
+
+2. **Identify dependencies**
+   - What must be done first?
+   - Any external blockers?
+
+### Stage 5 Deliverable
+
+```markdown
+## Next Steps (in TASKS.md)
+
+| ID | Task | Agent | Est. | Priority | Depends On |
+|----|------|-------|------|----------|------------|
+| TASK-XXX | ... | DEV | X hr | High | None |
+| TASK-XXX | ... | TESTER | X hr | Medium | TASK-XXX |
+
+## Implementation Spec
+
+### Files to Create/Modify
+- `Python/structural_lib/xxx.py` — [purpose]
+- `Python/tests/test_xxx.py` — [purpose]
+
+### Key Functions
+```python
+def feature_name(param: Type) -> ReturnType:
+    """[docstring draft]"""
+```
+
+### Test Requirements
+- [ ] Unit tests for [X]
+- [ ] Edge case: [Y]
+- [ ] Golden file: [Z]
+
+## Research Status Update
+- Status: ~~In Review~~ → **Decided**
+- Decision date: YYYY-MM-DD
+- Implementation target: v0.X.Y
+```
+
+---
+
+## Quick Reference: Agent Handoffs
+
+```
+CLIENT → RESEARCHER: "Here's the problem, go explore"
+RESEARCHER → DEV: "Here are the options, assess feasibility"
+DEV → Review: "Here are the scores, critique them"
+Review → PM: "Here are the findings, make the call"
+PM → DOCS: "Here's the decision, create tasks"
+DOCS → DEV: "Here's the spec, start building"
+```
+
+---
+
+## Timing Guidelines
+
+| Research Size | Total Time | Stages |
+|---------------|------------|--------|
+| **Small** (single feature) | 4-6 hours | All 5, compressed |
+| **Medium** (feature set) | 8-12 hours | All 5, full |
+| **Large** (major direction) | 2-3 sessions | Stage 2 may iterate |
+
+---
+
+## Rules
+
+1. **WIP=1 applies:** Research doesn't create parallel implementation work
+2. **Timeboxes are real:** If Stage 2 exceeds 4 hours, force a decision
+3. **Parking lot is real:** Unapproved ideas don't sneak into tasks
+4. **Decisions are final until revisited:** Don't re-debate in implementation
+5. **Each stage has a deliverable:** No "we discussed it" without documentation
+
+---
+
+## Example: Visual Layer Research
+
+| Stage | Agent | Duration | Output |
+|-------|-------|----------|--------|
+| 1. Initiate | CLIENT | 1 hr | Problem: "Engineers can't see critical beams" |
+| 2. Explore | RESEARCHER | 3 hrs | Options: SVG, matplotlib, plotly |
+| 3. Evaluate | DEV + Review | 2 hrs | Scored: SVG wins, deferred features identified |
+| 4. Decide | PM | 30 min | Phase 1: Critical Set + Ledger + SVG |
+| 5. Handoff | DOCS | 1 hr | TASK-100, TASK-101, TASK-102 created |
+
+**Total:** ~7.5 hours across multiple sessions
+
+---
+
+## Templates
+
+- Research template: [`_research-template.md`](_research-template.md)
+- Task template: See `TASKS.md` format
+- Implementation spec: Include in research doc or separate file
+
+---
+
+*This workflow ensures research is thorough, decisions are recorded, and implementation is well-defined.*


### PR DESCRIPTION
## Summary
Define complete workflow for how AI agents collaborate on research from idea to implementation.

## New File: `docs/planning/research-workflow.md`

### The 5 Stages

```
INITIATE → EXPLORE → EVALUATE → DECIDE → HANDOFF
   ↓          ↓          ↓          ↓         ↓
CLIENT    RESEARCHER   DEV         PM       DOCS
  PM       TESTER     Review     Owner       DEV
```

### Stage Details

| Stage | Agents | Duration | Output |
|-------|--------|----------|--------|
| 1. Initiate | CLIENT, PM | 1-2 hrs | Problem + constraints |
| 2. Explore | RESEARCHER, TESTER | 2-4 hrs | Options + edge cases |
| 3. Evaluate | DEV, Review | 1-2 hrs | Scores + feasibility |
| 4. Decide | PM, Owner | 30 min | Decision + parking lot |
| 5. Handoff | DOCS, DEV | 1 hr | TASKS.md + impl spec |

### Includes
- Agent handoff diagram
- Deliverable templates for each stage
- Timing guidelines (4-12 hours total)
- Example: Visual Layer research walkthrough
- Rules for preventing scope creep

## Updated: `docs/planning/README.md`
- Links to workflow doc
- Updated agent role table with stages

## Why This Matters
With AI agents acting as a "team":
- Each agent knows when to act
- Handoffs are explicit
- Decisions are recorded
- No re-debating settled questions