### PR TITLE
docs: refine workflow template and rules

### DIFF
--- a/docs/planning/_research-template.md
+++ b/docs/planning/_research-template.md
@@ -1,7 +1,7 @@
 # Research: [Topic Name]
 
 > **Template version:** 1.0
-> Copy this file to `research-{topic}/README.md` or `research-{topic}.md`
+> Copy this file to `research-{topic}/README.md`
 
 **Last Updated:** YYYY-MM-DD
 **Status:** Draft | In Review | Decided | Archived

--- a/docs/planning/research-workflow.md
+++ b/docs/planning/research-workflow.md
@@ -73,7 +73,7 @@
 | ... | ... | ... |
 
 ## Constraints (from PM)
-- [ ] Must fit Phase [A/B/C/D]
+- [ ] Must fit Phase [A/B/C/D/E]
 - [ ] No new required dependencies
 - [ ] Decision by: [DATE]
 - [ ] Owner: [AGENT/PERSON]
@@ -359,7 +359,8 @@ DOCS → DEV: "Here's the spec, start building"
 ## Rules
 
 1. **WIP=1 applies:** Research doesn't create parallel implementation work
-2. **Timeboxes are real:** If Stage 2 exceeds 4 hours, force a decision
+2. **Timeboxes are real:** If Stage 2 exceeds 4 hours for small/medium research, force a decision
+   (large research may iterate Stage 2 with PM approval)
 3. **Parking lot is real:** Unapproved ideas don't sneak into tasks
 4. **Decisions are final until revisited:** Don't re-debate in implementation
 5. **Each stage has a deliverable:** No "we discussed it" without documentation


### PR DESCRIPTION
## Summary
Small refinements to research workflow based on review feedback.

## Changes

### `_research-template.md`
- Standardize to folder-only path: `research-{topic}/README.md`
- Removes single-file option for consistency with existing research docs

### `research-workflow.md`
- Add **Phase E** to constraint checklist (future-proofing for post-v1.0)
- Adjust Stage 2 timebox rule:
  - Small/medium research: 4-hour hard limit
  - Large research: May iterate with PM approval
  - Aligns with timing table (large = 2-3 sessions)