### PR TITLE
feat(report): add report.py skeleton and load_job_spec helper (V01)

### DIFF
--- a/Python/structural_lib/__init__.py
+++ b/Python/structural_lib/__init__.py
@@ -34,6 +34,7 @@ from . import detailing
 from . import serviceability
 from . import compliance
 from . import bbs
+from . import report
 
 # DXF export is optional (requires ezdxf)
 dxf_export: Optional[ModuleType]
@@ -57,6 +58,7 @@ __all__ = [
     "excel_integration",
     "flexure",
     "materials",
+    "report",
     "serviceability",
     "shear",
     "tables",

--- a/Python/structural_lib/report.py
+++ b/Python/structural_lib/report.py
@@ -1,0 +1,188 @@
+"""Report generation module for beam design results.
+
+This module generates human-readable reports from job outputs.
+
+Design constraints:
+- Deterministic outputs (same input → same output)
+- stdlib only (no external dependencies)
+- Explicit error handling for missing/malformed inputs
+
+Usage:
+    from structural_lib import report
+
+    # Load from job output folder
+    data = report.load_report_data("./output/")
+
+    # Generate JSON summary
+    json_output = report.export_json(data)
+
+    # Generate HTML report
+    html_output = report.export_html(data)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ReportData:
+    """Container for report input data.
+
+    Combines job spec (geometry/materials) with design results.
+    """
+
+    job_id: str
+    code: str
+    units: str
+    beam: Dict[str, Any]
+    cases: List[Dict[str, Any]]
+    results: Dict[str, Any]
+
+    # Computed fields
+    is_ok: bool = False
+    governing_case_id: str = ""
+    governing_utilization: float = 0.0
+
+
+def load_report_data(
+    output_dir: str | Path,
+    *,
+    job_path: Optional[str | Path] = None,
+    results_path: Optional[str | Path] = None,
+) -> ReportData:
+    """Load report data from job output folder.
+
+    Args:
+        output_dir: Path to job output folder (e.g., "./output/")
+        job_path: Override path to job.json (default: output_dir/inputs/job.json)
+        results_path: Override path to design_results.json
+                     (default: output_dir/design/design_results.json)
+
+    Returns:
+        ReportData with combined job spec and design results
+
+    Raises:
+        FileNotFoundError: If required files are missing
+        ValueError: If files are malformed
+    """
+    out_root = Path(output_dir)
+
+    # Resolve paths
+    job_file = Path(job_path) if job_path else out_root / "inputs" / "job.json"
+    results_file = (
+        Path(results_path)
+        if results_path
+        else out_root / "design" / "design_results.json"
+    )
+
+    # Load job spec
+    if not job_file.exists():
+        raise FileNotFoundError(f"Job file not found: {job_file}")
+
+    try:
+        job_text = job_file.read_text(encoding="utf-8")
+        job = json.loads(job_text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in job file: {e}") from e
+
+    if not isinstance(job, dict):
+        raise ValueError("Job file must contain a JSON object")
+
+    # Validate required job fields
+    beam = job.get("beam")
+    if not isinstance(beam, dict):
+        raise ValueError("Job file missing 'beam' object")
+
+    cases = job.get("cases")
+    if not isinstance(cases, list):
+        raise ValueError("Job file missing 'cases' array")
+
+    # Load design results
+    if not results_file.exists():
+        raise FileNotFoundError(f"Results file not found: {results_file}")
+
+    try:
+        results_text = results_file.read_text(encoding="utf-8")
+        results = json.loads(results_text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in results file: {e}") from e
+
+    if not isinstance(results, dict):
+        raise ValueError("Results file must contain a JSON object")
+
+    # Extract job metadata (prefer from results, fallback to job file)
+    job_meta = results.get("job", {})
+    job_id = str(job_meta.get("job_id", job.get("job_id", "")))
+    code = str(job_meta.get("code", job.get("code", "")))
+    units = str(job_meta.get("units", job.get("units", "")))
+
+    return ReportData(
+        job_id=job_id,
+        code=code,
+        units=units,
+        beam=beam,
+        cases=cases,
+        results=results,
+        is_ok=bool(results.get("is_ok", False)),
+        governing_case_id=str(results.get("governing_case_id", "")),
+        governing_utilization=float(results.get("governing_utilization", 0.0)),
+    )
+
+
+def export_json(data: ReportData, *, indent: int = 2) -> str:
+    """Export report data as JSON string.
+
+    Args:
+        data: ReportData to export
+        indent: JSON indentation (default: 2)
+
+    Returns:
+        JSON string with sorted keys for determinism
+    """
+    output = {
+        "job_id": data.job_id,
+        "code": data.code,
+        "units": data.units,
+        "is_ok": data.is_ok,
+        "governing_case_id": data.governing_case_id,
+        "governing_utilization": data.governing_utilization,
+        "beam": data.beam,
+        "cases": data.results.get("cases", []),
+        "summary": data.results.get("summary", {}),
+    }
+    return json.dumps(output, indent=indent, sort_keys=True, ensure_ascii=False)
+
+
+def export_html(data: ReportData) -> str:
+    """Export report data as HTML string.
+
+    Placeholder implementation for V08.
+
+    Args:
+        data: ReportData to export
+
+    Returns:
+        HTML string
+    """
+    # Minimal placeholder - V08 will implement full HTML
+    status = "✓ PASS" if data.is_ok else "✗ FAIL"
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Beam Design Report - {data.job_id}</title>
+</head>
+<body>
+    <h1>Beam Design Report</h1>
+    <p><strong>Job ID:</strong> {data.job_id}</p>
+    <p><strong>Code:</strong> {data.code}</p>
+    <p><strong>Status:</strong> {status}</p>
+    <p><strong>Governing Utilization:</strong> {data.governing_utilization:.2%}</p>
+    <p><em>Full report implementation in V08.</em></p>
+</body>
+</html>
+"""

--- a/Python/tests/test_report.py
+++ b/Python/tests/test_report.py
@@ -1,0 +1,249 @@
+"""Tests for report module (V01).
+
+Tests the report data loading and export functions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from structural_lib.report import load_report_data, export_json, export_html
+
+
+# Sample test data matching job output structure
+SAMPLE_JOB = {
+    "schema_version": 1,
+    "job_id": "TEST-001",
+    "code": "IS456",
+    "units": "IS456",
+    "beam": {
+        "b_mm": 300,
+        "D_mm": 600,
+        "d_mm": 550,
+        "fck_nmm2": 25,
+        "fy_nmm2": 500,
+        "d_dash_mm": 50,
+        "asv_mm2": 100,
+    },
+    "cases": [
+        {"case_id": "LC1", "Mu_kNm": 150, "Vu_kN": 80},
+        {"case_id": "LC2", "Mu_kNm": 200, "Vu_kN": 100},
+    ],
+}
+
+SAMPLE_RESULTS = {
+    "is_ok": True,
+    "governing_case_id": "LC2",
+    "governing_utilization": 0.85,
+    "cases": [
+        {
+            "case_id": "LC1",
+            "is_ok": True,
+            "governing_utilization": 0.65,
+            "utilizations": {"flexure": 0.65, "shear": 0.40},
+        },
+        {
+            "case_id": "LC2",
+            "is_ok": True,
+            "governing_utilization": 0.85,
+            "utilizations": {"flexure": 0.85, "shear": 0.50},
+        },
+    ],
+    "summary": {"total_cases": 2, "passed": 2, "failed": 0},
+    "job": {
+        "job_id": "TEST-001",
+        "code": "IS456",
+        "units": "IS456",
+    },
+}
+
+
+@pytest.fixture
+def sample_output_dir(tmp_path: Path) -> Path:
+    """Create a sample job output directory structure."""
+    inputs_dir = tmp_path / "inputs"
+    design_dir = tmp_path / "design"
+    inputs_dir.mkdir()
+    design_dir.mkdir()
+
+    # Write job.json
+    (inputs_dir / "job.json").write_text(
+        json.dumps(SAMPLE_JOB, indent=2), encoding="utf-8"
+    )
+
+    # Write design_results.json
+    (design_dir / "design_results.json").write_text(
+        json.dumps(SAMPLE_RESULTS, indent=2), encoding="utf-8"
+    )
+
+    return tmp_path
+
+
+class TestLoadReportData:
+    """Tests for load_report_data function."""
+
+    def test_load_from_output_folder(self, sample_output_dir: Path) -> None:
+        """Test loading report data from standard output folder."""
+        data = load_report_data(sample_output_dir)
+
+        assert data.job_id == "TEST-001"
+        assert data.code == "IS456"
+        assert data.units == "IS456"
+        assert data.is_ok is True
+        assert data.governing_case_id == "LC2"
+        assert data.governing_utilization == 0.85
+        assert data.beam["b_mm"] == 300
+        assert len(data.cases) == 2
+
+    def test_load_with_explicit_paths(self, sample_output_dir: Path) -> None:
+        """Test loading with explicit file paths."""
+        job_path = sample_output_dir / "inputs" / "job.json"
+        results_path = sample_output_dir / "design" / "design_results.json"
+
+        data = load_report_data(
+            sample_output_dir, job_path=job_path, results_path=results_path
+        )
+
+        assert data.job_id == "TEST-001"
+        assert data.is_ok is True
+
+    def test_missing_job_file_raises(self, tmp_path: Path) -> None:
+        """Test that missing job.json raises FileNotFoundError."""
+        design_dir = tmp_path / "design"
+        design_dir.mkdir()
+        (design_dir / "design_results.json").write_text("{}", encoding="utf-8")
+
+        with pytest.raises(FileNotFoundError, match="Job file not found"):
+            load_report_data(tmp_path)
+
+    def test_missing_results_file_raises(self, tmp_path: Path) -> None:
+        """Test that missing design_results.json raises FileNotFoundError."""
+        inputs_dir = tmp_path / "inputs"
+        inputs_dir.mkdir()
+        (inputs_dir / "job.json").write_text(json.dumps(SAMPLE_JOB), encoding="utf-8")
+
+        with pytest.raises(FileNotFoundError, match="Results file not found"):
+            load_report_data(tmp_path)
+
+    def test_malformed_job_json_raises(self, tmp_path: Path) -> None:
+        """Test that malformed job.json raises ValueError."""
+        inputs_dir = tmp_path / "inputs"
+        design_dir = tmp_path / "design"
+        inputs_dir.mkdir()
+        design_dir.mkdir()
+
+        (inputs_dir / "job.json").write_text("not valid json", encoding="utf-8")
+        (design_dir / "design_results.json").write_text("{}", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_report_data(tmp_path)
+
+    def test_missing_beam_raises(self, tmp_path: Path) -> None:
+        """Test that job without 'beam' raises ValueError."""
+        inputs_dir = tmp_path / "inputs"
+        design_dir = tmp_path / "design"
+        inputs_dir.mkdir()
+        design_dir.mkdir()
+
+        bad_job = {"schema_version": 1, "job_id": "X", "cases": []}
+        (inputs_dir / "job.json").write_text(json.dumps(bad_job), encoding="utf-8")
+        (design_dir / "design_results.json").write_text("{}", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="missing 'beam'"):
+            load_report_data(tmp_path)
+
+
+class TestExportJson:
+    """Tests for export_json function."""
+
+    def test_export_json_deterministic(self, sample_output_dir: Path) -> None:
+        """Test that JSON export is deterministic (sorted keys)."""
+        data = load_report_data(sample_output_dir)
+
+        json1 = export_json(data)
+        json2 = export_json(data)
+
+        assert json1 == json2
+
+        # Verify it's valid JSON
+        parsed = json.loads(json1)
+        assert parsed["job_id"] == "TEST-001"
+        assert parsed["is_ok"] is True
+
+    def test_export_json_contains_required_fields(
+        self, sample_output_dir: Path
+    ) -> None:
+        """Test that JSON export contains all required fields."""
+        data = load_report_data(sample_output_dir)
+        output = json.loads(export_json(data))
+
+        assert "job_id" in output
+        assert "code" in output
+        assert "units" in output
+        assert "is_ok" in output
+        assert "governing_case_id" in output
+        assert "governing_utilization" in output
+        assert "beam" in output
+        assert "cases" in output
+
+
+class TestExportHtml:
+    """Tests for export_html function."""
+
+    def test_export_html_basic(self, sample_output_dir: Path) -> None:
+        """Test basic HTML export."""
+        data = load_report_data(sample_output_dir)
+        html = export_html(data)
+
+        assert "<!DOCTYPE html>" in html
+        assert "TEST-001" in html
+        assert "IS456" in html
+        assert "✓ PASS" in html  # is_ok = True
+
+    def test_export_html_fail_status(self, sample_output_dir: Path) -> None:
+        """Test HTML export with failed status."""
+        data = load_report_data(sample_output_dir)
+        data.is_ok = False
+        html = export_html(data)
+
+        assert "✗ FAIL" in html
+
+
+class TestLoadJobSpec:
+    """Tests for load_job_spec in job_runner module."""
+
+    def test_load_job_spec_valid(self, tmp_path: Path) -> None:
+        """Test loading a valid job spec."""
+        from structural_lib.job_runner import load_job_spec
+
+        job_file = tmp_path / "job.json"
+        job_file.write_text(json.dumps(SAMPLE_JOB), encoding="utf-8")
+
+        spec = load_job_spec(job_file)
+
+        assert spec["job_id"] == "TEST-001"
+        assert spec["code"] == "IS456"
+        assert spec["schema_version"] == 1
+        assert spec["beam"]["b_mm"] == 300
+        assert len(spec["cases"]) == 2
+
+    def test_load_job_spec_missing_file(self, tmp_path: Path) -> None:
+        """Test that missing file raises FileNotFoundError."""
+        from structural_lib.job_runner import load_job_spec
+
+        with pytest.raises(FileNotFoundError):
+            load_job_spec(tmp_path / "nonexistent.json")
+
+    def test_load_job_spec_missing_schema_version(self, tmp_path: Path) -> None:
+        """Test that missing schema_version raises ValueError."""
+        from structural_lib.job_runner import load_job_spec
+
+        bad_job = {"job_id": "X", "code": "IS456", "beam": {}, "cases": []}
+        job_file = tmp_path / "job.json"
+        job_file.write_text(json.dumps(bad_job), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="schema_version"):
+            load_job_spec(job_file)

--- a/docs/planning/research-visual-design/README.md
+++ b/docs/planning/research-visual-design/README.md
@@ -1578,10 +1578,26 @@ Documents exact keys needed from each input file for Phase 1 features.
 ### Next Steps
 
 1. ✅ Research complete — move to implementation planning
-2. Create GitHub issues for 8 implementation tasks (see Stage 5)
+2. ✅ GitHub issues created for 9 implementation tasks (Stage 5 complete)
 3. Target milestone: v0.11 (after W08 ships in v0.10)
 4. Phase 2 prerequisites: W08 clause metadata, stable hash rules
 
+### GitHub Issues (v0.11)
+
+| Issue | Title | Effort | Depends On |
+|-------|-------|--------|------------|
+| #134 | V01: report.py skeleton + load_job_spec helper | 2hr | — |
+| #135 | V02: report subcommand in __main__.py | 2hr | V01 |
+| #136 | V03: Critical Set Export (sorted table) | 3hr | V01, V02 |
+| #137 | V04: report_svg.py + cross-section SVG | 4hr | V01 |
+| #138 | V05: Input Sanity Heatmap | 2hr | V01 |
+| #139 | V06: Stability Scorecard | 2hr | V01 |
+| #140 | V07: Units Sentinel | 2hr | V01 |
+| #141 | V08: HTML export + batch packaging | 3hr | V03-V07 |
+| #142 | V09: Golden file tests | 2hr | V08 |
+
+**Total:** 22 hours across 9 tasks
+
 ---
 
-*Research complete. Status: Decided. Implementation planning begins.*
+*Research complete. Status: Decided. Stage 5 handoff complete.*


### PR DESCRIPTION
## Summary
Implements [#134](https://github.com/Pravin-surawase/structural_engineering_lib/issues/134): V01 report.py skeleton + load_job_spec helper

## Changes
- **job_runner.py:** Add `load_job_spec()` helper for shared job file loading
- **report.py:** New module with `ReportData`, `load_report_data`, `export_json`, `export_html`
- **__init__.py:** Add report module to exports
- **test_report.py:** 13 new tests for report module

## Features
- `ReportData` dataclass combining job spec and design results
- `load_report_data()` loads from job output folder structure
- `export_json()` with deterministic output (sorted keys)
- `export_html()` placeholder for V08 implementation

## Test Results
- 13 new tests pass
- Full suite: 1874 passed, 91 skipped

## Closes
Closes #134