### PR TITLE
feat(report): add critical set export with utilization sorting (V03)

### DIFF
--- a/Python/structural_lib/__main__.py
+++ b/Python/structural_lib/__main__.py
@@ -7,10 +7,11 @@ Usage:
     python -m structural_lib dxf results.json -o drawings.dxf
     python -m structural_lib job job.json -o output/
     python -m structural_lib report ./output/ --format=html
+    python -m structural_lib critical ./output/ --top=10 --format=csv
 
 This module provides a unified command-line interface with subcommands
 for beam design, bar bending schedules, DXF generation, job processing,
-and report generation.
+report generation, and critical set export.
 """
 
 from __future__ import annotations
@@ -678,6 +679,82 @@ def cmd_report(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_critical(args: argparse.Namespace) -> int:
+    """Generate critical set export (sorted utilization table).
+
+    Outputs a table of cases sorted by utilization ratio (highest first).
+    """
+    output_dir = Path(args.output_dir)
+
+    if not output_dir.exists():
+        _print_error(f"Output directory not found: {output_dir}")
+        return 1
+
+    # Resolve optional overrides
+    job_path = Path(args.job) if args.job else None
+    results_path = Path(args.results) if args.results else None
+
+    try:
+        print(f"Loading report data from {output_dir}...", file=sys.stderr)
+
+        data = report.load_report_data(
+            output_dir,
+            job_path=job_path,
+            results_path=results_path,
+        )
+
+        # Get critical set with optional top N filter
+        top_n = args.top if args.top and args.top > 0 else None
+        critical_cases = report.get_critical_set(data, top=top_n)
+
+        if not critical_cases:
+            print("No cases found in results.", file=sys.stderr)
+            return 0
+
+        print(
+            f"Found {len(critical_cases)} case(s) "
+            f"(top={top_n if top_n else 'all'})",
+            file=sys.stderr,
+        )
+
+        # Generate output based on format
+        fmt = args.format.lower()
+        if fmt == "csv":
+            output = report.export_critical_csv(critical_cases)
+        elif fmt == "html":
+            output = report.export_critical_html(critical_cases)
+        else:
+            _print_error(
+                f"Unknown format: {fmt}",
+                hint="Use --format=csv or --format=html",
+            )
+            return 1
+
+        # Write to file or stdout
+        if args.output:
+            out_path = Path(args.output)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(output, encoding="utf-8")
+            print(f"Critical set written to {out_path}", file=sys.stderr)
+        else:
+            print(output)
+
+        return 0
+
+    except FileNotFoundError as e:
+        _print_error(str(e))
+        return 1
+    except ValueError as e:
+        _print_error(str(e))
+        return 1
+    except Exception as e:
+        _print_error(str(e))
+        import traceback
+
+        traceback.print_exc(file=sys.stderr)
+        return 1
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build the main argument parser with subcommands."""
 
@@ -859,6 +936,46 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Override path to design_results.json (default: output_dir/design/design_results.json)",
     )
     report_parser.set_defaults(func=cmd_report)
+
+    # Critical subcommand
+    critical_parser = subparsers.add_parser(
+        "critical",
+        help="Generate critical set (sorted utilization table)",
+        description="""
+        Generate a table of cases sorted by utilization ratio (highest first).
+        Useful for identifying critical load cases that govern the design.
+
+        Examples:
+          python -m structural_lib critical ./output/ --format=csv
+          python -m structural_lib critical ./output/ --format=html -o critical.html
+          python -m structural_lib critical ./output/ --top=10 --format=csv
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    critical_parser.add_argument("output_dir", help="Job output directory to read from")
+    critical_parser.add_argument(
+        "--format",
+        default="csv",
+        choices=["csv", "html"],
+        help="Output format (default: csv)",
+    )
+    critical_parser.add_argument(
+        "-o", "--output", help="Output file path (if omitted, prints to stdout)"
+    )
+    critical_parser.add_argument(
+        "--top",
+        type=int,
+        help="Limit to top N cases by utilization",
+    )
+    critical_parser.add_argument(
+        "--job",
+        help="Override path to job.json",
+    )
+    critical_parser.add_argument(
+        "--results",
+        help="Override path to design_results.json",
+    )
+    critical_parser.set_defaults(func=cmd_critical)
 
     return parser
 

--- a/Python/tests/test_cli.py
+++ b/Python/tests/test_cli.py
@@ -780,6 +780,82 @@ def test_report_default_format_is_json(sample_job_output_dir, capsys):
 
 
 # =============================================================================
+# Critical Command Tests (V03)
+# =============================================================================
+
+
+def test_critical_help():
+    """Test critical subcommand help."""
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["critical", "--help"])
+    assert exc.value.code == 0
+
+
+def test_critical_missing_output_dir(tmp_path):
+    """Test critical command with missing output directory."""
+    rc = cli_main.main(["critical", str(tmp_path / "nonexistent_dir")])
+    assert rc == 1
+
+
+def test_critical_csv_to_stdout(sample_job_output_dir, capsys):
+    """Test critical command outputs CSV to stdout."""
+    rc = cli_main.main(["critical", str(sample_job_output_dir), "--format=csv"])
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    # Should have CSV header and data
+    assert "case_id" in captured.out
+    assert "utilization" in captured.out
+
+
+def test_critical_csv_to_file(sample_job_output_dir, tmp_path):
+    """Test critical command writes CSV to file."""
+    out_file = tmp_path / "critical.csv"
+    rc = cli_main.main(
+        ["critical", str(sample_job_output_dir), "--format=csv", "-o", str(out_file)]
+    )
+    assert rc == 0
+    assert out_file.exists()
+
+    content = out_file.read_text(encoding="utf-8")
+    assert "case_id" in content
+
+
+def test_critical_html_format(sample_job_output_dir, capsys):
+    """Test critical command with HTML format."""
+    rc = cli_main.main(["critical", str(sample_job_output_dir), "--format=html"])
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    assert "<!DOCTYPE html>" in captured.out
+    assert "Critical Set" in captured.out
+
+
+def test_critical_top_filter(sample_job_output_dir, capsys):
+    """Test critical command with --top filter."""
+    rc = cli_main.main(
+        ["critical", str(sample_job_output_dir), "--top=1", "--format=csv"]
+    )
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    lines = captured.out.strip().split("\n")
+    # Header + 1 data row
+    assert len(lines) == 2
+
+
+def test_critical_default_format_is_csv(sample_job_output_dir, capsys):
+    """Test that default format is CSV."""
+    rc = cli_main.main(["critical", str(sample_job_output_dir)])
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    # Should be CSV (default format)
+    assert "case_id" in captured.out
+    assert "utilization" in captured.out
+
+
+# =============================================================================
 # Integration Tests
 # =============================================================================
 
@@ -864,6 +940,7 @@ def test_help_via_subprocess():
     assert "dxf" in result.stdout
     assert "job" in result.stdout
     assert "report" in result.stdout
+    assert "critical" in result.stdout
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
Adds the `critical` subcommand for generating sorted utilization tables (V03).

## Changes
- **`report.py`**: Add CriticalCase dataclass, get_critical_set(), export_critical_csv(), export_critical_html()
- **`__main__.py`**: Add cmd_critical() handler and `critical` subparser
- **`test_report.py`**: Add 14 tests for critical set functions
- **`test_cli.py`**: Add 7 tests for critical CLI command

## Features
- Sort cases by utilization (highest first)
- CSV output with columns: case_id, utilization, flexure_util, shear_util, is_ok, json_path
- HTML output with styled utilization bars and pass/fail badges
- `--top=N` filter to limit results
- `data-source` attribute for traceability to JSON path

## Usage
```bash
# Default (CSV to stdout)
python -m structural_lib critical ./output/

# HTML with top 10 filter
python -m structural_lib critical ./output/ --top=10 --format=html -o critical.html
```

Closes #136