### PR TITLE
docs: add report/critical usage to guides

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -41,6 +41,10 @@ python -m structural_lib dxf results.json -o drawings.dxf
 
 # Run complete job from specification
 python -m structural_lib job job.json -o output/
+
+# Critical set + report from job outputs
+python -m structural_lib critical output/ --top 10 --format=csv -o critical.csv
+python -m structural_lib report output/ --format=html -o report.html
 ```
 
 Run `python -m structural_lib --help` for more options.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ See [CHANGELOG.md](CHANGELOG.md) for full release history.
 | Detail drawings | DXF | CAD-ready bar layouts |
 | Compliance reports | JSON | Strength + serviceability checks |
 | Bar bending schedules | CSV | Per IS 2502 with cutting lengths |
+| Critical set tables | CSV/HTML | Sorted utilization table from job outputs |
+| Report summaries (preview) | JSON/HTML | Human-readable summary from job outputs |
 
 ## Who it helps
 
@@ -199,6 +201,12 @@ JSON
 
 # Run the job
 python3 -m structural_lib job job.json -o ./out_demo
+```
+
+Generate a critical set and report from the job outputs:
+```bash
+python3 -m structural_lib critical ./out_demo --top 10 --format=csv -o critical.csv
+python3 -m structural_lib report ./out_demo --format=html -o report.html
 ```
 
 ## Features

--- a/docs/getting-started/colab-workflow.md
+++ b/docs/getting-started/colab-workflow.md
@@ -239,6 +239,14 @@ with open("job.json", "w") as f:
 
 ---
 
+## Step 6b: Critical set + report (from job outputs)
+```python
+!python -m structural_lib critical ./job_out --top 10 --format=csv -o critical.csv
+!python -m structural_lib report ./job_out --format=html -o report.html
+```
+
+---
+
 ## Step 7: Download outputs (optional)
 ```python
 import shutil


### PR DESCRIPTION
## Summary
Adds report + critical CLI usage examples to user guides so new visual outputs are easy to try.

## Changes
- Update root README outputs list + job runner example
- Add report/critical CLI usage to Python README
- Add Colab step for critical/report outputs from job runs

## Testing
- Not run (doc-only changes)