### PR TITLE
docs: add visual outputs quick start

### DIFF
--- a/Python/examples/sample_job_report.json
+++ b/Python/examples/sample_job_report.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "code": "IS456",
+  "units": "IS456",
+  "job_id": "example_report_001",
+  "beam": {
+    "b_mm": 230,
+    "D_mm": 500,
+    "d_mm": 450,
+    "fck_nmm2": 25,
+    "fy_nmm2": 500,
+    "cover_mm": 40
+  },
+  "cases": [
+    {"case_id": "C1", "mu_knm": 120, "vu_kn": 90},
+    {"case_id": "C2", "mu_knm": 150, "vu_kn": 110}
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ python -m structural_lib design input.csv -o results.json
 python -m structural_lib bbs results.json -o schedule.csv
 python -m structural_lib dxf results.json -o drawings.dxf
 python -m structural_lib job job.json -o ./output
+python -m structural_lib critical ./output --top 10 --format=csv -o critical.csv
+python -m structural_lib report ./output --format=html -o report.html
 ```
 For VS Code AI-agent work, start with:
 - [AI_CONTEXT_PACK.md](AI_CONTEXT_PACK.md)
@@ -25,6 +27,22 @@ For VS Code AI-agent work, start with:
 3) **Full API surface:** [reference/api.md](reference/api.md)
 4) **IS 456 formula cheat sheet:** [reference/is456-formulas.md](reference/is456-formulas.md)
 5) **Problems & fixes:** [reference/troubleshooting.md](reference/troubleshooting.md)
+
+---
+
+## Visual Outputs (v0.10.7+)
+
+Generate human-readable summaries from job outputs:
+
+```bash
+# Critical set table (CSV/HTML)
+python -m structural_lib critical ./output --top 10 --format=csv -o critical.csv
+
+# Report summary (HTML/JSON)
+python -m structural_lib report ./output --format=html -o report.html
+```
+
+Input for both commands is the job output folder created by `python -m structural_lib job`.
 
 ---
 


### PR DESCRIPTION
## Summary
Document the new visual output commands and add a sample job for quick testing.

## Changes
- Add Visual Outputs section with report/critical commands in docs index
- Add Python/examples/sample_job_report.json for quick report testing

## Testing
- Not run (docs + sample JSON)