### PR TITLE
feat(report): add stability scorecard

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -38,6 +38,7 @@ No active tasks. Pick from "Up Next" and move here when starting.
 | **#136 (V03)** | Critical Set Export (sorted utilization table) | DEV | ✅ Done |
 | **#137 (V04)** | report_svg.py + cross-section SVG | DEV | ✅ Done |
 | **#138 (V05)** | Input Sanity Heatmap | DEV | ✅ Done |
+| **#139 (V06)** | Stability Scorecard | DEV | ✅ Done |
 
 ---
 


### PR DESCRIPTION
## Summary
- add stability scorecard generation from governing case data
- include scorecard in report JSON and HTML output
- expand report tests and mark V06 complete in TASKS

## Testing
- `../.venv/bin/python -m pytest tests/test_report.py -v`
