### PR TITLE
chore: prep v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2025-12-29
+
+### Added
+- **Visual report HTML (V04–V07):**
+  - Cross-section SVG rendering
+  - Input sanity heatmap
+  - Stability scorecard
+  - Units sentinel checks
+- **Batch report packaging (V08):**
+  - `report` supports `design_results.json` input
+  - Folder output with `--batch-threshold` for large batches
+- **Golden fixtures (V09):**
+  - Deterministic HTML outputs verified via golden-file tests
+
+### Changed
+- CLI help and docs updated for `report` + `critical` workflows
+
 ## [0.10.7] - 2025-12-29
 
 ### Added

--- a/Python/README.md
+++ b/Python/README.md
@@ -2,7 +2,7 @@
 
 IS 456 RC Beam Design Library (Python package).
 
-**Version:** 0.10.7 (development preview)
+**Version:** 0.11.0 (development preview)
 **Status:** [![Python tests](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/python-tests.yml/badge.svg)](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/python-tests.yml)
 
 > ⚠️ **Development Preview:** APIs may change until v1.0. For reproducible results, pin to a release tag.
@@ -13,10 +13,10 @@ For full project overview and usage examples, see the repository root `README.md
 
 ```bash
 # Recommended (pinned to release tag)
-pip install "structural-lib-is456 @ git+https://github.com/Pravin-surawase/structural_engineering_lib.git@v0.10.7#subdirectory=Python"
+pip install "structural-lib-is456 @ git+https://github.com/Pravin-surawase/structural_engineering_lib.git@v0.11.0#subdirectory=Python"
 
 # With DXF support (pinned)
-pip install "structural-lib-is456[dxf] @ git+https://github.com/Pravin-surawase/structural_engineering_lib.git@v0.10.7#subdirectory=Python"
+pip install "structural-lib-is456[dxf] @ git+https://github.com/Pravin-surawase/structural_engineering_lib.git@v0.11.0#subdirectory=Python"
 
 # PyPI (latest — may differ from pinned tag)
 pip install structural-lib-is456
@@ -46,7 +46,13 @@ python -m structural_lib job job.json -o output/
 python -m structural_lib critical output/ --top 10 --format=csv -o critical.csv
 python -m structural_lib report output/ --format=html -o report.html
 ```
-The HTML report includes a cross-section SVG and input sanity heatmap.
+The HTML report includes a cross-section SVG, input sanity heatmap, stability scorecard,
+and units sentinel.
+
+You can also generate reports directly from `design_results.json`:
+```bash
+python -m structural_lib report results.json --format=html -o report/ --batch-threshold 80
+```
 
 Run `python -m structural_lib --help` for more options.
 
@@ -71,8 +77,9 @@ report = api.check_beam_is456(
 print(f"Governing case: {report.governing_case_id}")
 ```
 
-## New in v0.10.7
+## New in v0.11.0
 
 - **Critical Set export (V03):** `python -m structural_lib critical` writes sorted utilization tables (CSV/HTML) with `--top` slicing and `data-source` traces.
-- **Report scaffolding (V01/V02):** `report.py` skeleton + `load_job_spec()` helper and `report` CLI stub to support Visual v0.11 deliverables.
-- **Docs refresh:** Version sync + context updates for the Visual v0.11 rollout.
+- **Visual reports (V04–V07):** HTML reports include cross-section SVG, input sanity heatmap, stability scorecard, and units sentinel.
+- **Batch packaging (V08):** `report` accepts design results JSON and supports folder output with `--batch-threshold`.
+- **Golden fixtures (V09):** Deterministic report outputs verified via golden-file tests.

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "structural-lib-is456"
-version = "0.10.7"
+version = "0.11.0"
 description = "IS 456 RC Beam Design Library (flexure, shear, ductile detailing, DXF export for RC beams)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/Python/structural_lib/api.py
+++ b/Python/structural_lib/api.py
@@ -57,7 +57,7 @@ def get_library_version() -> str:
     try:
         return version("structural-lib-is456")
     except PackageNotFoundError:
-        return "0.10.7"
+        return "0.11.0"
 
 
 def check_beam_ductility(

--- a/Python/test_stats.json
+++ b/Python/test_stats.json
@@ -1,0 +1,8 @@
+{
+  "passed": 1917,
+  "skipped": 91,
+  "failed": 0,
+  "errors": 0,
+  "total": 2008,
+  "date": "2025-12-29"
+}

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@
 
 ## Status
 
-🚀 **Active (v0.10.7)** — Now on PyPI! Unified CLI + strength design + detailing + DXF export + serviceability (Level A+B) + compliance + batch runner + cutting-stock optimizer.
+🚀 **Active (v0.11.0)** — Now on PyPI! Unified CLI + strength design + detailing + DXF export + serviceability (Level A+B) + compliance + batch runner + cutting-stock optimizer.
 
-**What's new in v0.10.7:**
-- **Critical Set export (V03):** New `critical` CLI subcommand outputs sorted utilization tables (CSV/HTML) with `--top` filtering and `data-source` traces.
-- **Report foundations (V01/V02):** `report.py` skeleton + `load_job_spec()` helper, plus `report` CLI scaffold for upcoming visuals.
-- **Docs refresh:** AI context, TASKS, and next-session brief updated for the Visual v0.11 rollout.
+**What's new in v0.11.0:**
+- **Critical Set export (V03):** `critical` CLI subcommand outputs sorted utilization tables (CSV/HTML) with `--top` filtering and `data-source` traces.
+- **Visual reports (V04–V07):** HTML reports now include cross-section SVG, input sanity heatmap, stability scorecard, and units sentinel.
+- **Batch packaging (V08):** `report` accepts design results JSON and supports folder output with `--batch-threshold`.
+- **Golden fixtures (V09):** Report outputs are locked by golden-file tests for determinism.
 
 See [CHANGELOG.md](CHANGELOG.md) for full release history.
 
@@ -58,7 +59,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full release history.
 | Compliance reports | JSON | Strength + serviceability checks |
 | Bar bending schedules | CSV | Per IS 2502 with cutting lengths |
 | Critical set tables | CSV/HTML | Sorted utilization table from job outputs |
-| Report summaries (preview) | JSON/HTML | Human-readable summary from job outputs |
+| Visual reports | JSON/HTML | Report summary with SVG, sanity heatmap, scorecard |
 
 ## Who it helps
 
@@ -72,7 +73,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full release history.
 |--------|--------|
 | **Determinism** | Same input → same output (JSON/CSV/DXF) across runs and machines |
 | **Units** | Explicit: mm, N/mm², kN, kN·m — converted at layer boundaries |
-| **Test coverage** | 1900+ tests, 92% branch coverage (see CI for live status) |
+| **Test coverage** | 1917 tests, 92% branch coverage (see CI for live status) |
 | **Clause traceability** | Core design formulas reference IS 456 clause/table |
 | **Verification pack** | Benchmark examples in [`Python/examples/`](Python/examples/) |
 
@@ -86,7 +87,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full release history.
 This repository is public, so anyone can read the code, docs, and examples.
 
 - **Engineering note:** This library is a calculation aid. Final responsibility for code-compliant design, detailing, and drawing checks remains with the qualified engineer.
-- **Stability note:** While in active development, prefer pinning to a release version (example: `structural-lib-is456==0.10.7`) rather than installing latest.
+- **Stability note:** While in active development, prefer pinning to a release version (example: `structural-lib-is456==0.11.0`) rather than installing latest.
 
 ### Install from PyPI
 
@@ -208,7 +209,13 @@ Generate a critical set and report from the job outputs:
 python3 -m structural_lib critical ./out_demo --top 10 --format=csv -o critical.csv
 python3 -m structural_lib report ./out_demo --format=html -o report.html
 ```
-The HTML report includes a cross-section SVG and input sanity heatmap.
+The HTML report includes a cross-section SVG, input sanity heatmap, stability scorecard,
+and units sentinel.
+
+You can also generate reports directly from `design_results.json`:
+```bash
+python3 -m structural_lib report results.json --format=html -o report/ --batch-threshold 80
+```
 
 ## Features
 
@@ -441,7 +448,7 @@ See [Python examples](Python/examples/) for complete workflows.
 
 | Platform | Command | Coverage |
 |----------|---------|----------|
-| Python | `python3 -m pytest Python/tests -q` | 1900+ tests, 92% branch coverage |
+| Python | `python3 -m pytest Python/tests -q` | 1917 tests, 92% branch coverage |
 | VBA | `Test_RunAll.RunAllVBATests` in Excel VBA Editor | 9 test suites |
 
 Run the full suite locally to verify:

--- a/VBA/Modules/M08_API.bas
+++ b/VBA/Modules/M08_API.bas
@@ -9,7 +9,7 @@ Option Explicit
 ' ==============================================================================
 
 Public Function Get_Library_Version() As String
-    Get_Library_Version = "0.10.7"
+    Get_Library_Version = "0.11.0"
 End Function
 
 '

--- a/docs/AI_CONTEXT_PACK.md
+++ b/docs/AI_CONTEXT_PACK.md
@@ -4,11 +4,11 @@
 
 | Metric | Value |
 |--------|-------|
-| **Current Release** | v0.10.7 (on PyPI) |
+| **Current Release** | v0.11.0 (on PyPI) |
 | **Next Milestone** | v0.20.0 (blocked by S-007) |
-| **Tests** | 1900+ passed, 91 skipped |
+| **Tests** | 1917 passed, 91 skipped |
 | **Coverage** | 92% branch |
-| **Visual v0.11** | V03 critical set export delivered (CLI `critical`) |
+| **Visual v0.11** | V03–V09 delivered (critical set, report HTML, batch packaging, golden tests) |
 
 > **Status details:** See [TASKS.md](TASKS.md) for current/next release info.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ For VS Code AI-agent work, start with:
 
 ---
 
-## Visual Outputs (v0.10.7+)
+## Visual Outputs (v0.11.0+)
 
 Generate human-readable summaries from job outputs:
 
@@ -43,7 +43,13 @@ python -m structural_lib report ./output --format=html -o report.html
 ```
 
 Input for both commands is the job output folder created by `python -m structural_lib job`.
-The HTML report includes a cross-section SVG and input sanity heatmap.
+The HTML report includes a cross-section SVG, input sanity heatmap, stability scorecard,
+and units sentinel.
+
+You can also generate reports from `design_results.json` with batch packaging:
+```bash
+python -m structural_lib report results.json --format=html -o report/ --batch-threshold 80
+```
 
 ---
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -43,6 +43,21 @@ Use workflow_dispatch with `testpypi` target:
 
 ---
 
+## v0.11.0
+**Date:** 2025-12-29
+**Status:** ✅ Locked & Verified
+**Mindset:** Visual v0.11 Complete (Reports + Packaging)
+**Key Changes:**
+- **V04–V07 HTML report visuals:** Cross-section SVG, input sanity heatmap, stability scorecard, units sentinel.
+- **V08 batch packaging:** `report` supports `design_results.json` and `--batch-threshold` for folder output.
+- **V09 golden fixtures:** Deterministic HTML outputs locked by golden-file tests.
+- **Docs:** README, Colab workflow, and API reference updated for report/critical usage.
+
+**Tests:** 1917 passed, 91 skipped
+**PRs:** #151, #153, #154, #155, #156
+
+---
+
 ## v0.10.7
 **Date:** 2025-12-29
 **Status:** ✅ Locked & Verified

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -8,19 +8,27 @@ Append-only record of decisions, PRs, and next actions. For detailed task tracki
 
 ### Summary
 - Released v0.10.7 (Visual v0.11 Phase 1 — Critical Set export) and synced version references across Python/VBA/docs.
+- Released v0.11.0 with Visual v0.11 report features (V04–V09).
 
 ### PRs Merged
 | PR | Summary |
 |----|---------|
 | #147 | Visual v0.11 V03 — `critical` CLI export for sorted utilization tables |
+| #151 | V04 SVG + V05 input sanity heatmap |
+| #153 | V06 stability scorecard |
+| #154 | V07 units sentinel |
+| #155 | V08 report batch packaging + CLI support |
+| #156 | V09 golden report fixtures/tests |
 
 ### Key Deliverables
 - Version bump to v0.10.7 (Python, VBA, docs) using `scripts/bump_version.py`.
 - Release notes added to CHANGELOG and docs/RELEASES.
 - Docs refreshed: TASKS, AI context, next-session brief aligned to v0.10.7.
+- Visual report HTML now includes SVG, sanity heatmap, scorecard, and units sentinel.
+- Report CLI supports batch packaging via `--batch-threshold`.
 
 ### Notes
-- Visual v0.11 remaining: V04 SVG rendering.
+- Visual v0.11 complete: V03–V09 delivered.
 
 
 ## 2025-12-28 — v0.10.2 Release

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -183,7 +183,7 @@ No active tasks. Pick from "Up Next" and move here when starting.
 
 ## Notes
 
-- **Current Version**: v0.10.7
+- **Current Version**: v0.11.0
 - **Last Updated**: 2025-12-29
 - **Active Branch**: main
 - **Tests**: Run `python scripts/update_test_stats.py` for current count

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -1,6 +1,6 @@
 # IS 456 RC Beam Design Library — Development Guide
 
-**Document Version:** 0.10.7
+**Document Version:** 0.11.0
 **Last Updated:** 2025-12-29
 **Audience:** Contributors, maintainers, and developers extending the library
 

--- a/docs/contributing/vba-testing-guide.md
+++ b/docs/contributing/vba-testing-guide.md
@@ -1,6 +1,6 @@
 # VBA Testing Guide
 
-**Version:** 0.10.7
+**Version:** 0.11.0
 **Last Updated:** 2025-12-29
 
 ## Quick Start
@@ -20,7 +20,7 @@
 ```
 ========================================
   STRUCTURAL ENGINEERING LIB - VBA TESTS
-  Version: 0.10.7
+  Version: 0.11.0
   Date: 2025-12-26 14:30:00
 ========================================
 

--- a/docs/getting-started/beginners-guide.md
+++ b/docs/getting-started/beginners-guide.md
@@ -136,4 +136,4 @@ You should get a number around 196.5 (kN-m).
 - API reference: `docs/reference/api.md`
 - Learning path: `docs/learning/README.md`
 
-Document Version: 0.10.7 | Last Updated: 2025-12-29
+Document Version: 0.11.0 | Last Updated: 2025-12-29

--- a/docs/getting-started/colab-workflow.md
+++ b/docs/getting-started/colab-workflow.md
@@ -1,6 +1,6 @@
 # Colab Workflow (End-to-End, No ETABS Needed)
 
-> **Version:** v0.10.7 | **Updated:** 2025-12-29
+> **Version:** v0.11.0 | **Updated:** 2025-12-29
 
 This guide runs the full pipeline in Google Colab:
 install → generate inputs → design → BBS → DXF → reports → critical set.
@@ -10,12 +10,12 @@ install → generate inputs → design → BBS → DXF → reports → critical 
 - `bbs` — Generate bar bending schedule
 - `dxf` — Generate CAD drawings
 - `job` — Run full job from JSON spec
-- `report` — Generate HTML/JSON reports *(NEW in v0.10.7)*
-- `critical` — Export critical set sorted by utilization *(NEW in v0.10.7)*
+- `report` — Generate HTML/JSON reports *(NEW in v0.11.0)*
+- `critical` — Export critical set sorted by utilization *(NEW in v0.11.0)*
 
 ---
 
-## 🆕 What's New in v0.10.7 (Visual v0.11)
+## 🆕 What's New in v0.11.0 (Visual v0.11)
 
 **V01–V07 features delivered:**
 
@@ -28,12 +28,17 @@ install → generate inputs → design → BBS → DXF → reports → critical 
 | **V05** | `report --format=html` | Input sanity heatmap |
 | **V06** | `report --format=html` | Stability scorecard |
 | **V07** | `report --format=html` | Units sentinel |
+| **V08** | `report --format=html` | Batch packaging with `--batch-threshold` |
+| **V09** | — | Golden report fixtures for deterministic outputs |
 
 **Quick demo of new features:**
 ```python
 # After running job (Step 6), generate reports:
 !python -m structural_lib critical ./job_out --top=5 --format=csv
 !python -m structural_lib report ./job_out --format=html -o report.html
+
+# After Step 4 (batch), generate a packaged report from design results JSON:
+!python -m structural_lib report results_500.json --format=html -o report_500/ --batch-threshold 80
 ```
 
 ---
@@ -328,9 +333,9 @@ pd.read_csv("critical.csv")
 
 ---
 
-## Step 8: 🆕 Report Generation (V04–V06)
+## Step 8: 🆕 Report Generation (V04–V07)
 
-Generate full reports with SVG, sanity heatmap, and scorecard:
+Generate full reports with SVG, sanity heatmap, scorecard, and units sentinel:
 
 ```python
 # JSON report (machine-readable)
@@ -354,6 +359,19 @@ with open("report.html", "r", encoding="utf-8") as f:
 - Input sanity heatmap (geometry/material validation)
 - Stability scorecard (ductility, shear margin, utilization)
 - Units sentinel (magnitude-based unit checks)
+
+---
+
+## Step 8b: 🆕 Batch Report Packaging (V08)
+
+When you have a large `design_results.json`, use batch packaging so the report
+is split into an index + per-beam pages.
+
+```python
+!python -m structural_lib report results_500.json --format=html -o report_500/ --batch-threshold 80
+```
+
+Open `report_500/index.html` in Colab (or download the folder) to browse.
 
 ---
 
@@ -386,6 +404,11 @@ print("\n✓ Created colab_outputs.zip — download from file browser (left side
 | `report` | Generate report (JSON/HTML) | `report ./output/ --format=html` |
 | `critical` | Export critical set | `critical ./output/ --top=10 --format=csv` |
 
+Batch report from `design_results.json`:
+```python
+!python -m structural_lib report results.json --format=html -o report/ --batch-threshold 80
+```
+
 For help on any command:
 ```python
 !python -m structural_lib --help
@@ -407,4 +430,4 @@ For help on any command:
 
 ---
 
-*Last updated: 2025-12-29 | v0.10.7*
+*Last updated: 2025-12-29 | v0.11.0*

--- a/docs/getting-started/excel-tutorial.md
+++ b/docs/getting-started/excel-tutorial.md
@@ -352,4 +352,4 @@ NOTES:
 
 ---
 
-*Document Version: 0.10.7 | Last Updated: 2025-12-29
+*Document Version: 0.11.0 | Last Updated: 2025-12-29

--- a/docs/getting-started/user-guide.md
+++ b/docs/getting-started/user-guide.md
@@ -1,6 +1,6 @@
 # User Guide — Complete Workflow
 
-**Version:** 0.10.7
+**Version:** 0.11.0
 **Time to complete:** 10–15 minutes
 
 This guide walks you through a complete beam design workflow from start to finish. For detailed installation help, see [Beginner's Guide](beginners-guide.md).

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -2,10 +2,10 @@
 
 | Release | Version | Status |
 |---------|---------|--------|
-| **Current** | v0.10.7 | Published on PyPI |
+| **Current** | v0.11.0 | Published on PyPI |
 | **Next** | v0.20.0 | Blocked by S-007 |
 
-**Date:** 2025-12-29 | **PRs:** through #116
+**Date:** 2025-12-29 | **PRs:** through #156
 
 ---
 
@@ -40,7 +40,7 @@ python scripts/release.py 0.20.0
 **Quick project summary:**
 - IS 456 RC beam design library (Indian Standard)
 - Python + VBA with matching outputs (parity requirement)
-- CLI: `python -m structural_lib design|bbs|dxf|job`
+- CLI: `python -m structural_lib design|bbs|dxf|job|critical|report`
 - PyPI: `pip install structural-lib-is456`
 
 ---
@@ -57,29 +57,26 @@ python scripts/release.py 0.20.0
 | Many micro-PRs for tiny changes | Review fatigue, CI waste | Batch related changes into one PR |
 | Editing without reading file first | Merge conflicts, overwrites | Always read current state before editing |
 
-**Performance facts (verified 2025-12-28):**
-- Tests: 1810 passed, 91 skipped, 92% branch coverage
+**Performance facts (verified 2025-12-29):**
+- Tests: 1917 passed, 91 skipped, 92% branch coverage
 - Speed: 0.009ms per beam, 94,000 beams/second
 - All edge cases handled gracefully (zero/negative → `is_safe=False`)
 
 ---
 
-## ✅ Last Session Summary (2025-12-28)
+## ✅ Last Session Summary (2025-12-29)
 
-**Focus:** Stabilization sprint — documentation quality + verification
+**Focus:** Visual v0.11 deliverables + report tooling
 
 | PR | Description |
 |----|-------------|
-| #89 | Fixed 4 broken links + added `scripts/check_links.py` |
-| #90 | Fixed expected output in beginners-guide (942→882mm²) |
-| #91 | Fixed D1 expected Ld value in verification examples (752→777mm) |
-| #92 | Improved job_runner error messages |
-| #93 | Verified all High Priority items (robustness + performance) |
-| #95 | Documentation updates (SESSION_LOG, CHANGELOG, TASKS) |
-| #96 | Updated next-session-brief for handoff |
-| #97 | Cleaned up next-session-brief (625→236 lines) |
+| #151 | V04 SVG + V05 input sanity heatmap |
+| #153 | V06 stability scorecard |
+| #154 | V07 units sentinel |
+| #155 | V08 report batch packaging + CLI support |
+| #156 | V09 golden report fixtures/tests |
 
-**Outcome:** All Critical items complete except S-007. All High Priority items verified. ✅
+**Outcome:** Visual v0.11 (V03–V09) complete and integrated. ✅
 
 ---
 

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -1,6 +1,6 @@
 # Pre-Release Checklist
 
-Version: 0.10.7 (beta candidate)
+Version: 0.11.0 (beta candidate)
 Date: 2025-12-29
 Target: Private beta with 2–3 structural engineers
 
@@ -10,7 +10,7 @@ Target: Private beta with 2–3 structural engineers
 
 | Area | Status | Evidence |
 |------|--------|----------|
-| Test Suite | ✅ 1777 tests collected | `pytest --co` on 2025-12-27 |
+| Test Suite | ✅ 2008 tests collected | `pytest --co` on 2025-12-29 |
 | PyPI | ✅ Live | `pip install structural-lib-is456` |
 | CLI | ✅ Functional | `python -m structural_lib --help` works |
 | Excel Integration | ⚠️ Functional (not parity-verified) | CSV/JSON workflows work; VBA outputs not compared |

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -105,7 +105,7 @@ If you must use an internal module:
 ```python
 # Pin to exact version
 # requirements.txt
-structural-lib-is456==0.10.7
+structural-lib-is456==0.11.0
 
 # Or wrap with try/except
 try:
@@ -140,6 +140,8 @@ python -m structural_lib design input.csv -o results.json
 python -m structural_lib bbs results.json -o bbs.csv
 python -m structural_lib dxf results.json -o drawings.dxf
 python -m structural_lib job job.json -o output/
+python -m structural_lib critical output/ --top 10 --format=csv -o critical.csv
+python -m structural_lib report output/ --format=html -o report.html
 ```
 
 Output JSON schema is versioned via `schema_version` field.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,6 +1,6 @@
 # IS 456 RC Beam Design Library — API Reference
 
-**Document Version:** 0.10.7
+**Document Version:** 0.11.0
 **Last Updated:** 2025-12-29
 **Scope:** Public APIs for Python/VBA implementations (flexure, shear, ductile detailing, integration, reporting, detailing, DXF export, BBS, cutting-stock optimizer, unified CLI).
 
@@ -23,10 +23,23 @@ python -m structural_lib dxf results.json -o drawings.dxf
 # Run complete job from spec file
 python -m structural_lib job job.json -o ./output
 
+# Critical set from job outputs (sorted utilization)
+python -m structural_lib critical ./output --top 10 --format=csv -o critical.csv
+
+# Report from job outputs (JSON/HTML)
+python -m structural_lib report ./output --format=html -o report.html
+
+# Report from design results JSON (batch packaging)
+python -m structural_lib report design_results.json --format=html -o report/ --batch-threshold 80
+
 # Get help
 python -m structural_lib --help
 python -m structural_lib design --help
 ```
+
+Notes:
+- `critical` and `report` accept the job output folder created by `python -m structural_lib job`.
+- `report` can also consume a `design_results.json` file for batch packaging (`--batch-threshold`).
 
 ---
 

--- a/docs/verification/validation-pack.md
+++ b/docs/verification/validation-pack.md
@@ -1,6 +1,6 @@
 # Validation Pack — Benchmark Beams
 
-**Version:** 0.10.7
+**Version:** 0.11.0
 **Purpose:** Engineers can verify library accuracy using these benchmark beams
 
 This pack provides 5 benchmark beams with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trusted software.


### PR DESCRIPTION
## Summary
- Bump version references to v0.11.0 across Python/VBA/docs
- Update release notes (CHANGELOG.md, docs/RELEASES.md, docs/SESSION_LOG.md)
- Refresh user guides and API docs for Visual v0.11 (report HTML, batch packaging)
- Add updated test stats file

## Testing
- ./scripts/ci_local.sh