### PR TITLE
chore: add release verification + CLI test workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,6 +44,9 @@ jobs:
           python -m structural_lib bbs ../artifacts/results.json -o ../artifacts/schedule.csv
           python -m structural_lib dxf ../artifacts/results.json -o ../artifacts/drawings.dxf
           python -m structural_lib job examples/sample_job_is456.json -o ../artifacts/job_out
+          python -m structural_lib critical ../artifacts/job_out --top 5 --format csv -o ../artifacts/critical.csv
+          python -m structural_lib report ../artifacts/job_out --format html -o ../artifacts/report.html
+          python -m structural_lib report ../artifacts/results.json --format html -o ../artifacts/report_design --batch-threshold 1
 
       - name: Summarize results
         run: |
@@ -76,6 +79,9 @@ jobs:
             artifacts/results.json
             artifacts/schedule.csv
             artifacts/drawings.dxf
+            artifacts/critical.csv
+            artifacts/report.html
+            artifacts/report_design
             artifacts/job_out
           if-no-files-found: warn
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -34,6 +34,11 @@ Entries here represent "locked" versions that have been verified and approved.
    python -c "from structural_lib import api; print(api.get_library_version())"
    ```
 
+6. **Recommended: clean-venv verification**
+   ```bash
+   python scripts/verify_release.py --version X.Y.Z --source pypi
+   ```
+
 ### TestPyPI (for testing before release)
 
 Use workflow_dispatch with `testpypi` target:

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -1378,6 +1378,7 @@ Before tagging a release or distributing an add-in/wheel:
     - `python -m black --check .`
     - `python -m ruff check .`
     - `python -m mypy`
+ - [ ] Clean-venv release verification: `python scripts/verify_release.py --version X.Y.Z --source pypi`
     - `python -m pytest`
     - `python -m build`
     - wheel smoke test: `python -m pip install --force-reinstall dist/*.whl && python -c "import structural_lib"`

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -54,7 +54,7 @@ Target: Private beta with 2–3 structural engineers
 - [x] **Document results** in `docs/verification/validation-pack.md` with source refs
 - [ ] **One external engineer tries CLI cold** — note friction points
 - [ ] **All tests pass** (run `pytest` in Python/ directory)
-- [ ] **PyPI install verified in clean venv** — `pip install structural-lib-is456==X.Y.Z` + `api.get_library_version()`
+- [ ] **PyPI install verified in clean venv** — `scripts/verify_release.py --version X.Y.Z --source pypi`
 
 ### Nice-to-Have Before Beta
 

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -9,6 +9,7 @@ Benchmark examples and verification packs for validating library calculations.
 | [Validation Pack](validation-pack.md) | 5 benchmark beams with IS 456 references |
 | [Examples](examples.md) | Detailed worked examples with hand calculations |
 | [Verification Pack](pack.md) | Test vectors for regression testing |
+| [External CLI Test](external-cli-test.md) | S-007 checklist for a fresh user run |
 
 ## Quick Start
 

--- a/docs/verification/external-cli-test.md
+++ b/docs/verification/external-cli-test.md
@@ -1,0 +1,58 @@
+# External CLI Test (S-007)
+
+Purpose: capture a repeatable, human-run CLI test from a fresh user.
+
+---
+
+## Tester Info
+- **Name/Role:**
+- **OS + Version:**
+- **Python Version:**
+- **Shell:**
+- **Install method:** `pip install` / `pipx` / other
+
+## Checklist (Run in Order)
+
+1) **Install (clean venv)**
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install "structural-lib-is456[dxf]"
+```
+
+2) **Version check**
+```bash
+python -c "from structural_lib import api; print(api.get_library_version())"
+```
+
+3) **Run job**
+```bash
+python -m structural_lib job Python/examples/sample_job_is456.json -o ./job_out
+```
+
+4) **Critical set**
+```bash
+python -m structural_lib critical ./job_out --top 5 --format=csv
+```
+
+5) **Report HTML**
+```bash
+python -m structural_lib report ./job_out --format=html -o report.html
+```
+
+6) **Optional: design pipeline**
+```bash
+python -m structural_lib design Python/examples/sample_beam_design.csv -o results.json
+python -m structural_lib bbs results.json -o schedule.csv
+python -m structural_lib dxf results.json -o drawings.dxf
+```
+
+## What Happened (Notes)
+- **Any errors?** (copy full traceback/output)
+- **Anything unclear?**
+- **Anything slow?** (approx timings)
+- **Missing docs?** (which link would help)
+
+## Verdict
+- [ ] PASS — all steps worked
+- [ ] FAIL — blocked (list why)

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Release verification helper.
+
+Creates a clean virtual environment, installs the package, and runs a small
+smoke check to confirm version and CLI entrypoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _bin_path(venv_dir: Path, name: str) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / f"{name}.exe"
+    return venv_dir / "bin" / name
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None) -> None:
+    print(f"+ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def _find_wheel(wheel_dir: Path, version: str | None) -> Path:
+    if version:
+        pattern = f"structural_lib_is456-{version}*.whl"
+    else:
+        pattern = "structural_lib_is456-*.whl"
+    wheels = sorted(wheel_dir.glob(pattern))
+    if not wheels:
+        raise FileNotFoundError(f"No wheel found in {wheel_dir} (pattern: {pattern})")
+    return wheels[-1]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify release in a clean venv")
+    parser.add_argument("--version", help="Version to verify (e.g., 0.11.0)")
+    parser.add_argument(
+        "--source",
+        choices=["wheel", "pypi"],
+        default="wheel",
+        help="Install source (default: wheel)",
+    )
+    parser.add_argument(
+        "--wheel-dir",
+        default="Python/dist",
+        help="Directory containing built wheels (default: Python/dist)",
+    )
+    parser.add_argument(
+        "--job",
+        default="Python/examples/sample_job_is456.json",
+        help="Job spec for CLI smoke test",
+    )
+    parser.add_argument(
+        "--skip-cli",
+        action="store_true",
+        help="Skip CLI smoke checks (version check still runs)",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    wheel_dir = repo_root / args.wheel_dir
+    job_path = repo_root / args.job
+
+    with tempfile.TemporaryDirectory(prefix="verify_release_") as tmp:
+        venv_dir = Path(tmp) / "venv"
+        _run([sys.executable, "-m", "venv", str(venv_dir)])
+
+        pip = _bin_path(venv_dir, "pip")
+        python = _bin_path(venv_dir, "python")
+
+        _run([str(pip), "install", "--upgrade", "pip"])
+
+        if args.source == "wheel":
+            wheel = _find_wheel(wheel_dir, args.version)
+            _run([str(pip), "install", str(wheel)])
+        else:
+            if not args.version:
+                print("error: --version is required when using --source pypi")
+                return 2
+            _run([str(pip), "install", f"structural-lib-is456=={args.version}"])
+
+        _run(
+            [
+                str(python),
+                "-c",
+                "from structural_lib import api; print(api.get_library_version())",
+            ]
+        )
+
+        if not args.skip_cli:
+            if not job_path.exists():
+                print(f"error: job file not found: {job_path}")
+                return 2
+
+            out_dir = Path(tmp) / "job_out"
+            _run(
+                [
+                    str(python),
+                    "-m",
+                    "structural_lib",
+                    "job",
+                    str(job_path),
+                    "-o",
+                    str(out_dir),
+                ]
+            )
+            _run(
+                [
+                    str(python),
+                    "-m",
+                    "structural_lib",
+                    "critical",
+                    str(out_dir),
+                    "--top",
+                    "1",
+                    "--format",
+                    "csv",
+                ]
+            )
+            _run(
+                [
+                    str(python),
+                    "-m",
+                    "structural_lib",
+                    "report",
+                    str(out_dir),
+                    "--format",
+                    "html",
+                    "-o",
+                    str(out_dir / "report.html"),
+                ]
+            )
+
+        print("Release verification OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add scripts/verify_release.py for clean-venv release verification
- Add S-007 checklist doc for external CLI test
- Extend nightly QA with critical + report smoke checks
- Update release/process docs to reference verification steps

## Testing
- Not run (docs/workflow + script additions)