### PR TITLE
docs: add handoff quick start

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -215,6 +215,7 @@ When working on specific task types, apply these focuses:
 1. Update `docs/planning/next-session-brief.md` with session summary
 2. Ensure TASKS.md reflects current state
 3. Commit any uncommitted doc changes
+4. Use `docs/HANDOFF.md` as the short resume template
 
 ---
 

--- a/docs/AGENT_BOOTSTRAP.md
+++ b/docs/AGENT_BOOTSTRAP.md
@@ -43,8 +43,10 @@ This shows: version, branch, active tasks, blockers, and doc freshness.
 ## 📍 Quick Reference
 
 - **Copilot rules:** [../.github/copilot-instructions.md](../.github/copilot-instructions.md)
+- **Handoff quick start:** [HANDOFF.md](HANDOFF.md)
 - **API docs:** [reference/api.md](reference/api.md)
 - **Known pitfalls:** [reference/known-pitfalls.md](reference/known-pitfalls.md)
+- **Recent issues:** [contributing/session-issues.md](contributing/session-issues.md)
 - **Agent roles:** [../agents/README.md](../agents/README.md)
 - **Project status:** [planning/project-status.md](planning/project-status.md) (quick) or [planning/project-status-deep-dive.md](planning/project-status-deep-dive.md) (detailed)
 

--- a/docs/AI_CONTEXT_PACK.md
+++ b/docs/AI_CONTEXT_PACK.md
@@ -139,6 +139,7 @@ Keep wording precise; no claims about untested tooling.
 | Releases | `docs/RELEASES.md` |
 | ADRs | `docs/adr/README.md` |
 | Archive | `docs/_archive/` |
+| Handoff | `docs/HANDOFF.md` |
 
 ---
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,0 +1,24 @@
+# Handoff Quick Start
+
+Goal: enable the next agent to resume in under 2 minutes.
+
+---
+
+## Resume (next agent)
+1. Run: `.venv/bin/python scripts/start_session.py`
+2. Read:
+   - `docs/planning/next-session-brief.md` (what changed + blockers)
+   - `docs/contributing/session-issues.md` (recent pitfalls + fixes)
+   - `docs/TASKS.md` (active + up next)
+3. If releasing: `./scripts/ci_local.sh` then `python scripts/verify_release.py --version X.Y.Z --source pypi`
+
+## Handoff (ending)
+1. Run: `.venv/bin/python scripts/end_session.py --fix`
+2. Update `docs/planning/next-session-brief.md` with summary + blockers.
+3. Update `docs/TASKS.md` (move items to Done/Active).
+4. Ensure clean tree: `git status -sb`
+
+## Common Traps (fast fixes)
+- CI watch times out: re-run `gh pr checks <num> --watch`.
+- PR behind base: `gh pr update-branch <num>` then re-check CI.
+- PyPI verification: always use a clean venv.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ python -m structural_lib report ./output --format=html -o report.html
 For VS Code AI-agent work, start with:
 - [AI_CONTEXT_PACK.md](AI_CONTEXT_PACK.md)
 - [AI summary](../llms.txt)
+- [Handoff Quick Start](HANDOFF.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a short resume/handoff template for next-session pickup
- Link it from AGENT_BOOTSTRAP, AI context, docs index, and copilot instructions

## Testing
- Not run (docs only)