### PR TITLE
test: add fixture-based CLI regression checks

### DIFF
--- a/Python/tests/fixtures/cli/critical_top1.csv
+++ b/Python/tests/fixtures/cli/critical_top1.csv
@@ -1,0 +1,2 @@
+case_id,utilization,flexure_util,shear_util,is_ok,json_path
+C1,0.6000,0.6000,0.4000,TRUE,cases[0]

--- a/Python/tests/fixtures/cli/job_out_min/design/design_results.json
+++ b/Python/tests/fixtures/cli/job_out_min/design/design_results.json
@@ -1,0 +1,21 @@
+{
+  "job": {
+    "job_id": "cli_job_001",
+    "code": "IS456",
+    "units": "IS456"
+  },
+  "cases": [
+    {
+      "case_id": "C1",
+      "utilizations": {
+        "flexure": 0.6,
+        "shear": 0.4
+      },
+      "governing_utilization": 0.6,
+      "is_ok": true
+    }
+  ],
+  "is_ok": true,
+  "governing_case_id": "C1",
+  "governing_utilization": 0.6
+}

--- a/Python/tests/fixtures/cli/job_out_min/inputs/job.json
+++ b/Python/tests/fixtures/cli/job_out_min/inputs/job.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "code": "IS456",
+  "units": "IS456",
+  "job_id": "cli_job_001",
+  "beam": {
+    "b_mm": 230,
+    "D_mm": 500,
+    "d_mm": 450,
+    "d_dash_mm": 50,
+    "fck_nmm2": 25,
+    "fy_nmm2": 500,
+    "asv_mm2": 100
+  },
+  "cases": [
+    {
+      "case_id": "C1",
+      "mu_knm": 120,
+      "vu_kn": 80
+    }
+  ]
+}

--- a/Python/tests/test_cli_report_regression.py
+++ b/Python/tests/test_cli_report_regression.py
@@ -1,0 +1,64 @@
+"""CLI regression tests for report/critical commands (fixture-based)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+REPORT_FIXTURES = FIXTURES / "report"
+CLI_FIXTURES = FIXTURES / "cli"
+
+
+def _run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def test_cli_report_from_design_results(tmp_path: Path) -> None:
+    design_results = REPORT_FIXTURES / "design_results_1.json"
+    out_html = tmp_path / "report.html"
+
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "structural_lib",
+            "report",
+            str(design_results),
+            "--format",
+            "html",
+            "-o",
+            str(out_html),
+            "--batch-threshold",
+            "80",
+        ]
+    )
+
+    expected = (REPORT_FIXTURES / "report_single_1.html").read_text(encoding="utf-8")
+    assert out_html.read_text(encoding="utf-8") == expected
+
+
+def test_cli_critical_from_job_output(tmp_path: Path) -> None:
+    job_out = CLI_FIXTURES / "job_out_min"
+    out_csv = tmp_path / "critical.csv"
+
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "structural_lib",
+            "critical",
+            str(job_out),
+            "--top",
+            "1",
+            "--format",
+            "csv",
+            "-o",
+            str(out_csv),
+        ]
+    )
+
+    expected = (CLI_FIXTURES / "critical_top1.csv").read_text(encoding="utf-8")
+    assert out_csv.read_text(encoding="utf-8") == expected


### PR DESCRIPTION
## Summary
- Add CLI regression tests for report (design_results.json) and critical (job_out fixture)
- Add minimal job_out fixture and expected CSV output

## Testing
- ../.venv/bin/python -m pytest tests/test_cli_report_regression.py -v