### PR TITLE
docs: order public API maintenance fixes

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -197,6 +197,16 @@ No active tasks. Pick from "Up Next" and move here when starting.
 | **TASK-116** | Fix serviceability function names in api-stability.md | DOCS | 30 min | 🟢 Low |
 | **TASK-117** | Classify `report`/`report_svg` stability or stop re-exporting | DEV | 45 min | 🟡 Medium |
 | **TASK-118** | Document `get_library_version()` in api.md | DOCS | 20 min | 🟢 Low |
+| **TASK-119** | Add public API helpers overview in api.md | DOCS | 30 min | 🟢 Low |
+
+**Proposed Fix Order (Public API Maintenance):**
+1. TASK-109 → unify units validation (prevents behavior drift).
+2. TASK-110 → fix version fallback (public API correctness).
+3. TASK-111 → align exports vs stability policy (avoids accidental public deps).
+4. TASK-112 + TASK-116 → fix stability doc naming + stable entrypoints.
+5. TASK-115 → decide beam_pipeline exposure in docs.
+6. TASK-117 → classify report/report_svg stability.
+7. TASK-118 + TASK-119 + TASK-114 → fill remaining API doc gaps.
 
 ---
 

--- a/docs/planning/public-api-maintenance-review.md
+++ b/docs/planning/public-api-maintenance-review.md
@@ -98,6 +98,22 @@ does not classify them as stable or experimental.
 
 ---
 
+### API-11 — Missing `api.py` helpers in API reference
+`docs/reference/api.md` documents `check_beam_ductility`, `check_deflection_span_depth`,
+and `check_crack_width`, but does not include `get_library_version()` or a dedicated
+public API overview section. This makes the stable surface harder to discover.
+
+**Fix:** add an "API Helpers" section in `docs/reference/api.md`.
+
+---
+
+### API-12 — Stability doc still lists non-existent deflection helper
+`api-stability.md` refers to `serviceability.check_deflection`, which does not exist.
+
+**Fix:** replace with `check_deflection_span_depth` and `check_deflection_level_b`.
+
+---
+
 ## Recommended Actions (Tasks)
 
 - Centralize unit validation on `beam_pipeline.validate_units`.
@@ -110,3 +126,4 @@ does not classify them as stable or experimental.
 - Fix serviceability function names in `api-stability.md`.
 - Classify `report`/`report_svg` stability or stop re-exporting them.
 - Document `get_library_version()` in `docs/reference/api.md`.
+- Add public API helpers overview to `docs/reference/api.md`.


### PR DESCRIPTION
Summary
- Add additional public API drift findings
- Add TASK-119 and ordered fix sequence for maintenance

Testing
- Not run (docs-only change)