### PR TITLE
docs: add more public API drift findings

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -198,14 +198,16 @@ No active tasks. Pick from "Up Next" and move here when starting.
 | **TASK-117** | Classify `report`/`report_svg` stability or stop re-exporting | DEV | 45 min | 🟡 Medium |
 | **TASK-118** | Document `get_library_version()` in api.md | DOCS | 20 min | 🟢 Low |
 | **TASK-119** | Add public API helpers overview in api.md | DOCS | 30 min | 🟢 Low |
+| **TASK-120** | Fix shear function names in api-stability.md | DOCS | 20 min | 🟢 Low |
+| **TASK-121** | Classify `excel_integration` stability or stop re-exporting | DEV | 30 min | 🟡 Medium |
 
 **Proposed Fix Order (Public API Maintenance):**
 1. TASK-109 → unify units validation (prevents behavior drift).
 2. TASK-110 → fix version fallback (public API correctness).
 3. TASK-111 → align exports vs stability policy (avoids accidental public deps).
-4. TASK-112 + TASK-116 → fix stability doc naming + stable entrypoints.
+4. TASK-112 + TASK-116 + TASK-120 → fix stability doc naming + stable entrypoints.
 5. TASK-115 → decide beam_pipeline exposure in docs.
-6. TASK-117 → classify report/report_svg stability.
+6. TASK-117 + TASK-121 → classify report/report_svg and excel_integration stability.
 7. TASK-118 + TASK-119 + TASK-114 → fill remaining API doc gaps.
 
 ---

--- a/docs/planning/public-api-maintenance-review.md
+++ b/docs/planning/public-api-maintenance-review.md
@@ -114,6 +114,22 @@ public API overview section. This makes the stable surface harder to discover.
 
 ---
 
+### API-13 — Shear function names in stability doc do not match code
+`api-stability.md` lists `shear.check_shear` and `shear.get_stirrup_spacing`,
+but the module exposes `design_shear()` only.
+
+**Fix:** update stability doc to reference the correct function names.
+
+---
+
+### API-14 — `excel_integration` exported but not classified
+`structural_lib.__all__` exports `excel_integration`, but stability docs do not
+classify it as stable/experimental/internal.
+
+**Fix:** classify it explicitly or stop re-exporting it.
+
+---
+
 ## Recommended Actions (Tasks)
 
 - Centralize unit validation on `beam_pipeline.validate_units`.
@@ -127,3 +143,5 @@ public API overview section. This makes the stable surface harder to discover.
 - Classify `report`/`report_svg` stability or stop re-exporting them.
 - Document `get_library_version()` in `docs/reference/api.md`.
 - Add public API helpers overview to `docs/reference/api.md`.
+- Fix shear function names in `api-stability.md`.
+- Classify `excel_integration` stability or stop re-exporting it.


### PR DESCRIPTION
Summary
- Add shear/excel integration stability gaps to review
- Add TASK-120/TASK-121 and update fix order

Testing
- Not run (docs-only change)