### PR TITLE
docs: complete public API maintenance pass

### DIFF
--- a/Python/structural_lib/__init__.py
+++ b/Python/structural_lib/__init__.py
@@ -21,21 +21,13 @@ except PackageNotFoundError:
     __version__ = "0.0.0-dev"  # Not installed, development mode
 
 # Expose key modules
-from . import constants
-from . import types
-from . import tables
-from . import utilities
-from . import materials
 from . import flexure
 from . import shear
-from . import ductile
 from . import api
 from . import detailing
 from . import serviceability
 from . import compliance
 from . import bbs
-from . import report
-from . import report_svg
 
 # DXF export is optional (requires ezdxf)
 dxf_export: Optional[ModuleType]
@@ -44,26 +36,14 @@ try:
 except ImportError:
     dxf_export = None
 
-# Excel integration module
-from . import excel_integration
-
 __all__ = [
     "__version__",
     "api",
     "bbs",
     "compliance",
-    "constants",
     "detailing",
-    "ductile",
     "dxf_export",
-    "excel_integration",
     "flexure",
-    "materials",
-    "report",
-    "report_svg",
     "serviceability",
     "shear",
-    "tables",
-    "types",
-    "utilities",
 ]

--- a/Python/structural_lib/api.py
+++ b/Python/structural_lib/api.py
@@ -372,7 +372,7 @@ def detail_beam_is456(
     stirrup_spacing_mid_mm: float = 200.0,
     stirrup_spacing_end_mm: float = 150.0,
     is_seismic: bool = False,
-):
+) -> detailing.BeamDetailingResult:
     """Create IS456/SP34 detailing outputs from design Ast/Asc and stirrups.
 
     Args:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -29,6 +29,24 @@ See also: `docs/_internal/AGENT_WORKFLOW.md`
 
 No active tasks. Pick from "Up Next" and move here when starting.
 
+## Recently Completed (Public API Maintenance)
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-109** | Centralize units validation in public API | DEV | ✅ Done |
+| **TASK-110** | Fix `get_library_version()` fallback | DEV | ✅ Done |
+| **TASK-111** | Align `__all__` exports with stability policy | DEV | ✅ Done |
+| **TASK-112** | Document `api.py` stable entrypoints in api-stability.md | DOCS | ✅ Done |
+| **TASK-113** | Add return type annotation for `detail_beam_is456()` | DEV | ✅ Done |
+| **TASK-114** | Clarify units for `check_compliance_report()` in docs | DOCS | ✅ Done |
+| **TASK-115** | Document or demote `beam_pipeline` in API docs | DOCS | ✅ Done |
+| **TASK-116** | Fix serviceability function names in api-stability.md | DOCS | ✅ Done |
+| **TASK-117** | Classify `report`/`report_svg` stability or stop re-exporting | DEV | ✅ Done |
+| **TASK-118** | Document `get_library_version()` in api.md | DOCS | ✅ Done |
+| **TASK-119** | Add public API helpers overview in api.md | DOCS | ✅ Done |
+| **TASK-120** | Fix shear function names in api-stability.md | DOCS | ✅ Done |
+| **TASK-121** | Classify `excel_integration` stability or stop re-exporting | DEV | ✅ Done |
+
 ## Recently Completed (Visual v0.11)
 
 | ID | Task | Agent | Status |
@@ -185,30 +203,7 @@ No active tasks. Pick from "Up Next" and move here when starting.
 
 **Review doc:** `docs/planning/public-api-maintenance-review.md`
 
-| ID | Task | Agent | Est. | Priority |
-|----|------|-------|------|----------|
-| **TASK-109** | Centralize units validation in public API | DEV | 1 hr | 🔴 High |
-| **TASK-110** | Fix `get_library_version()` fallback | DEV | 30 min | 🟡 Medium |
-| **TASK-111** | Align `__all__` exports with stability policy | DEV | 1 hr | 🟡 Medium |
-| **TASK-112** | Document `api.py` stable entrypoints in api-stability.md | DOCS | 45 min | 🟡 Medium |
-| **TASK-113** | Add return type annotation for `detail_beam_is456()` | DEV | 15 min | 🟢 Low |
-| **TASK-114** | Clarify units for `check_compliance_report()` in docs | DOCS | 30 min | 🟢 Low |
-| **TASK-115** | Document or demote `beam_pipeline` in API docs | DOCS | 45 min | 🟡 Medium |
-| **TASK-116** | Fix serviceability function names in api-stability.md | DOCS | 30 min | 🟢 Low |
-| **TASK-117** | Classify `report`/`report_svg` stability or stop re-exporting | DEV | 45 min | 🟡 Medium |
-| **TASK-118** | Document `get_library_version()` in api.md | DOCS | 20 min | 🟢 Low |
-| **TASK-119** | Add public API helpers overview in api.md | DOCS | 30 min | 🟢 Low |
-| **TASK-120** | Fix shear function names in api-stability.md | DOCS | 20 min | 🟢 Low |
-| **TASK-121** | Classify `excel_integration` stability or stop re-exporting | DEV | 30 min | 🟡 Medium |
-
-**Proposed Fix Order (Public API Maintenance):**
-1. TASK-109 → unify units validation (prevents behavior drift).
-2. TASK-110 → fix version fallback (public API correctness).
-3. TASK-111 → align exports vs stability policy (avoids accidental public deps).
-4. TASK-112 + TASK-116 + TASK-120 → fix stability doc naming + stable entrypoints.
-5. TASK-115 → decide beam_pipeline exposure in docs.
-6. TASK-117 + TASK-121 → classify report/report_svg and excel_integration stability.
-7. TASK-118 + TASK-119 + TASK-114 → fill remaining API doc gaps.
+All Public API Maintenance tasks are complete.
 
 ---
 

--- a/docs/contributing/testing-strategy.md
+++ b/docs/contributing/testing-strategy.md
@@ -17,6 +17,11 @@
 **How to run locally (fast):**
 - From `Python/`: `python -m pytest -q`
 
+**Fast checks before commit (pick what changed):**
+- Docs-only: from repo root, `python scripts/check_doc_versions.py`
+- Links touched: from repo root, `python scripts/check_links.py`
+- Code + tests: from `Python/`, `python -m pytest -q`
+
 **How to run with coverage:**
 - From `Python/`: `python -m pytest --cov=structural_lib --cov-report=term-missing --cov-report=xml`
 

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -31,8 +31,7 @@ flexure.design_doubly_reinforced(b, d, d_dash, d_total, mu_knm, fck, fy, ...)
 flexure.design_flanged_beam(bf, bw, Df, d, d_total, mu_knm, fck, fy, ...)
 
 # Shear
-shear.check_shear(b, d, fck, fy, vu_kn, pt_percent, ...)
-shear.get_stirrup_spacing(b, d, fck, fy, vu_kn, pt_percent, asv_mm2, ...)
+shear.design_shear(vu_kn, b, d, fck, fy, asv, pt)
 ```
 
 ### High-Level API
@@ -40,8 +39,17 @@ shear.get_stirrup_spacing(b, d, fck, fy, vu_kn, pt_percent, asv_mm2, ...)
 ```python
 from structural_lib import api
 
+api.get_library_version()
+api.check_beam_ductility(b, D, d, fck, fy, min_long_bar_dia)
+api.check_deflection_span_depth(span_mm, d_mm, support_condition, ...)
+api.check_crack_width(exposure_class, limit_mm, ...)
+api.check_compliance_report(cases, b_mm, D_mm, d_mm, fck_nmm2, fy_nmm2, ...)
+api.design_beam_is456(units, case_id, mu_knm, vu_kn, b_mm, D_mm, d_mm, ...)
 api.check_beam_is456(
     units, cases, b_mm, D_mm, d_mm, fck_nmm2, fy_nmm2, ...
+)
+api.detail_beam_is456(
+    units, beam_id, story, b_mm, D_mm, span_mm, cover_mm, fck_nmm2, fy_nmm2, ...
 )
 ```
 
@@ -60,7 +68,8 @@ beam_pipeline.design_multiple_beams(units, beams, ...)
 ```python
 from structural_lib import serviceability
 
-serviceability.check_deflection(span_mm, d_mm, beam_type, ...)
+serviceability.check_deflection_span_depth(span_mm, d_mm, support_condition, ...)
+serviceability.check_deflection_level_b(...)
 serviceability.check_crack_width(...)
 ```
 
@@ -132,6 +141,9 @@ These modules are implementation details. Do not depend on them directly.
 | `materials.py` | Material properties | May merge with constants |
 | `types.py` | Type definitions | Dataclass fields may change |
 | `ductile.py` | Ductile detailing checks | Under development |
+| `report.py` | Report generation helpers | Experimental; subject to change |
+| `report_svg.py` | SVG rendering helpers | Experimental; subject to change |
+| `excel_integration.py` | Excel batch helpers | Under review |
 
 ### How to Use Internal Modules Safely
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -144,6 +144,91 @@ def detail_beam_is456(
 ) -> BeamDetailingResult
 ```
 
+### 1A.4 API Helpers
+
+```python
+def get_library_version() -> str
+def check_beam_ductility(b: float, D: float, d: float, fck: float, fy: float, min_long_bar_dia: float) -> DuctileBeamResult
+def check_deflection_span_depth(span_mm: float, d_mm: float, support_condition: str = "simply_supported", ...) -> DeflectionResult
+def check_crack_width(exposure_class: str = "moderate", limit_mm: float | None = None, ...) -> CrackWidthResult
+def check_compliance_report(
+    cases: Sequence[dict],
+    b_mm: float,
+    D_mm: float,
+    d_mm: float,
+    fck_nmm2: float,
+    fy_nmm2: float,
+    d_dash_mm: float = 50.0,
+    asv_mm2: float = 100.0,
+    pt_percent: float | None = None,
+    deflection_defaults: dict | None = None,
+    crack_width_defaults: dict | None = None,
+) -> ComplianceReport
+```
+
+Notes:
+- `check_compliance_report()` assumes IS456 units (mm, N/mm², kN, kN·m) and does
+  not accept a `units` argument. Use `check_beam_is456()` when you want explicit
+  unit validation at the API boundary.
+
+---
+
+## 1B. Beam Pipeline (`beam_pipeline.py`)
+
+These helpers power the CLI/job runner and return the canonical output schema
+(`BeamDesignOutput`, `MultiBeamOutput`). Use them when you want a full, structured
+pipeline without building it yourself.
+
+### 1B.1 Units Validation
+
+```python
+def validate_units(units: str) -> str
+```
+
+Returns canonical `"IS456"` or raises `UnitsValidationError`.
+
+### 1B.2 Single Beam Pipeline
+
+```python
+def design_single_beam(
+    *,
+    units: str,
+    beam_id: str,
+    story: str,
+    b_mm: float,
+    D_mm: float,
+    d_mm: float,
+    span_mm: float,
+    cover_mm: float,
+    fck_nmm2: float,
+    fy_nmm2: float,
+    mu_knm: float,
+    vu_kn: float,
+    case_id: str = "CASE-1",
+    d_dash_mm: float = 50.0,
+    asv_mm2: float = 100.0,
+    pt_percent: float | None = None,
+    include_detailing: bool = True,
+    stirrup_dia_mm: float = 8.0,
+    stirrup_spacing_start_mm: float = 150.0,
+    stirrup_spacing_mid_mm: float = 200.0,
+    stirrup_spacing_end_mm: float = 150.0,
+    deflection_params: dict | None = None,
+    crack_width_params: dict | None = None,
+) -> BeamDesignOutput
+```
+
+### 1B.3 Multi-Beam Pipeline
+
+```python
+def design_multiple_beams(
+    *,
+    units: str,
+    beams: Sequence[dict],
+    include_detailing: bool = True,
+) -> MultiBeamOutput
+```
+
 ---
 
 ## 2. Flexure Module (`M06_Flexure` / `flexure.py`)


### PR DESCRIPTION
## Summary\n- Align public exports with stability policy\n- Document api.py helpers + beam_pipeline in API reference\n- Fix stability doc naming (shear/serviceability)\n- Add fast pre-commit checks guidance\n- Mark Public API Maintenance tasks complete\n\n## Testing\n- `scripts/check_doc_versions.py`\n- `python -m pytest -q` (Python/)