### PR TITLE
docs: define BBS/DXF contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,7 @@ If you want to understand the concepts and the code step by step, start here:
 - Architecture & layering: [architecture/project-overview.md](architecture/project-overview.md)
 - Consolidated architecture/data flow: [architecture/deep-project-map.md](architecture/deep-project-map.md)
 - Library contract (stability promises): [reference/library-contract.md](reference/library-contract.md)
+- BBS + DXF contract: [reference/bbs-dxf-contract.md](reference/bbs-dxf-contract.md)
 - Testing strategy & CI setup: [contributing/testing-strategy.md](contributing/testing-strategy.md)
 - VBA testing guide: [contributing/vba-testing-guide.md](contributing/vba-testing-guide.md)
 - Development practices: [contributing/development-guide.md](contributing/development-guide.md)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -29,6 +29,12 @@ See also: `docs/_internal/AGENT_WORKFLOW.md`
 
 No active tasks. Pick from "Up Next" and move here when starting.
 
+## Recently Completed (BBS + DXF Improvement Program)
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-098** | Define BBS/DXF contracts + bar mark spec | DOCS | ✅ Done |
+
 ## Recently Completed (Public API Maintenance)
 
 | ID | Task | Agent | Status |
@@ -174,7 +180,6 @@ No active tasks. Pick from "Up Next" and move here when starting.
 
 | ID | Task | Agent | Est. | Priority | Bundle |
 |----|------|-------|------|----------|--------|
-| **TASK-098** | Define BBS/DXF contracts + bar mark spec | DOCS | 2 hrs | 🔴 High | A |
 | **TASK-099** | Deterministic bar mark generator + wire into BBS | DEV | 3 hrs | 🔴 High | B |
 | **TASK-100** | BBS cut-length + hook/bend updates + weight rules | DEV | 4 hrs | 🔴 High | C |
 | **TASK-101** | DXF callouts include bar marks + zone labels | DEV | 4 hrs | 🟡 Medium | D |

--- a/docs/planning/bbs-dxf-improvement-plan.md
+++ b/docs/planning/bbs-dxf-improvement-plan.md
@@ -47,6 +47,8 @@ with each other, without changing the current 3-layer architecture.
 - Layer names + minimum content.
 - Text labels include bar marks and zones.
 
+Contract doc: `docs/reference/bbs-dxf-contract.md`
+
 4) **Rounding rules**
 - Length rounding (mm) and weight rounding (kg).
 - Defined once, reused across code + docs.

--- a/docs/reference/bbs-dxf-contract.md
+++ b/docs/reference/bbs-dxf-contract.md
@@ -1,0 +1,91 @@
+# BBS + DXF Contract (v1.x)
+
+This document defines the stable contracts for Bar Bending Schedule (BBS) and
+DXF outputs. It is beam-only (IS 456) and is intended for integrators who need
+predictable outputs across releases.
+
+## 1) Bar Mark Identity (Project-Unique)
+
+Each BBS line item has a `bar_mark` that is unique across the project and is
+used in DXF callouts.
+
+**Format (v1.x target):**
+```
+<beam_id>-<loc>-<zone>-D<dia>-<seq>
+```
+
+**Tokens:**
+- `beam_id`: normalized to uppercase, spaces -> "-", non-alnum stripped.
+- `loc`: `B` (bottom), `T` (top), `S` (stirrup).
+- `zone`: `S` (start), `M` (mid), `E` (end), `F` (full length).
+- `dia`: integer diameter in mm (e.g., `D16`).
+- `seq`: 2-digit sequence number assigned deterministically.
+
+**Deterministic assignment:**
+Sort all line items by:
+`beam_id`, `loc`, `zone`, `diameter_mm`, `shape_code`, `cut_length_mm`,
+then assign `seq` in order. This guarantees stable, project-unique marks.
+
+**Example:**
+```
+B1-B-S-D16-01
+B1-B-M-D16-02
+B1-S-S-D8-01
+```
+
+## 2) BBS Line Item Schema (CSV)
+
+Columns are stable and ordered as follows:
+
+```
+bar_mark,member_id,location,zone,shape_code,diameter_mm,no_of_bars,
+cut_length_mm,total_length_mm,unit_weight_kg,total_weight_kg,remarks
+```
+
+**Units:**
+- Lengths: mm
+- Weights: kg
+
+**Rounding rules (v1.x target):**
+- `cut_length_mm`: round to nearest 1 mm.
+- `total_length_mm`: `no_of_bars * cut_length_mm` (mm).
+- `unit_weight_kg`: round to 0.01 kg.
+- `total_weight_kg`: `no_of_bars * unit_weight_kg`, round to 0.01 kg.
+- Summary totals: round to 0.01 kg after summing.
+
+## 3) DXF Contract
+
+**DXF version:** R2010 (AC1024)
+**Units:** mm
+**Views:** elevation + section (if enabled)
+
+**Required layers (minimum):**
+- `BEAM_OUTLINE`
+- `REBAR_MAIN`
+- `REBAR_STIRRUP`
+- `DIMENSIONS`
+- `TEXT`
+- `CENTERLINE`
+
+**Required text content:**
+- Beam ID + Story (title or header).
+- Bar marks for top/bottom/stirrups.
+- Zone labels for start/mid/end where applicable.
+
+**Callout format (minimum):**
+```
+<bar_mark>  (and zone, if not already encoded)
+```
+
+## 4) Consistency Rules
+
+- Every `bar_mark` in BBS must appear in DXF callouts for the same beam.
+- Every DXF callout mark must exist in the BBS for that beam.
+- Ordering of callouts is deterministic (no random shuffling).
+
+## 5) Change Policy
+
+Breaking changes to this contract require:
+- A `schema_version` bump (where applicable).
+- A migration note in CHANGELOG/RELEASES.
+- Backward-compatibility guidance for consumers.

--- a/docs/specs/v0.7_DATA_MAPPING.md
+++ b/docs/specs/v0.7_DATA_MAPPING.md
@@ -1,8 +1,8 @@
 # v0.7 Data Mapping Specification
 
-**Agent:** INTEGRATION  
-**Task:** TASK-029  
-**Status:** Complete  
+**Agent:** INTEGRATION
+**Task:** TASK-029
+**Status:** Complete
 **Date:** 2025-12-11
 
 ---
@@ -119,23 +119,23 @@ class BeamDetailingResult:
     # Identification
     beam_id: str          # "B1"
     story: str            # "Story1"
-    
+
     # Geometry (mm)
     b: float              # 300
     D: float              # 500
     span: float           # 4000
     cover: float          # 40
-    
+
     # Reinforcement arrangements
     top_bars: List[BarArrangement]     # [start, mid, end]
     bottom_bars: List[BarArrangement]  # [start, mid, end]
     stirrups: List[StirrupArrangement] # [start, mid, end]
-    
+
     # Detailing values
     ld_tension: float      # Development length (mm)
     ld_compression: float  # Compression Ld (mm)
     lap_length: float      # Lap splice length (mm)
-    
+
     # Status
     is_valid: bool
     remarks: str
@@ -167,6 +167,8 @@ def generate_beam_dxf(
 | TEXT | Yellow (2) | Callouts, labels |
 | CENTERLINE | Magenta (6) | CL lines |
 
+Contract reference: `docs/reference/bbs-dxf-contract.md`
+
 ---
 
 ## 6. Integration Code Pattern
@@ -180,7 +182,7 @@ from structural_lib.dxf_export import generate_beam_dxf
 def process_beam_for_dxf(row_data: dict, output_folder: str):
     """
     Process a single beam design row and generate DXF.
-    
+
     Args:
         row_data: Dictionary with tbl_BeamDesign column values
         output_folder: Path to save DXF files
@@ -201,13 +203,13 @@ def process_beam_for_dxf(row_data: dict, output_folder: str):
         stirrup_dia=float(row_data["Stirrup_Dia"]),
         is_seismic=False
     )
-    
+
     # 2. Generate DXF
     filename = f"{row_data['Story']}_{row_data['BeamID']}_detail.dxf"
     output_path = f"{output_folder}/{filename}"
-    
+
     generate_beam_dxf(detailing, output_path)
-    
+
     return output_path
 ```
 
@@ -219,11 +221,11 @@ Sub Generate_DXF_For_Beam(beamId As String)
     Dim pyScript As String
     Dim jsonPath As String
     Dim dxfPath As String
-    
+
     ' Export beam data to JSON
     jsonPath = ExportBeamToJSON(beamId)
     dxfPath = ThisWorkbook.Path & "\beam_" & beamId & ".dxf"
-    
+
     ' Call Python script
     pyScript = "python -m structural_lib dxf " & jsonPath & " -o " & dxfPath
     Shell pyScript, vbNormalFocus
@@ -295,5 +297,5 @@ Lap length: 1357 mm
 
 ---
 
-*Document: v0.7_DATA_MAPPING.md*  
+*Document: v0.7_DATA_MAPPING.md*
 *Version: 1.0*


### PR DESCRIPTION
## Summary
- Add BBS/DXF contract with bar-mark spec, rounding rules, and consistency requirements
- Link the contract from the docs index
- Cross-reference the contract in the data mapping and improvement plan
- Mark TASK-098 complete

## Testing
- scripts/check_doc_versions.py (pre-commit hook)