### PR TITLE
feat: add bar marks to DXF callouts

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -36,6 +36,7 @@ No active tasks. Pick from "Up Next" and move here when starting.
 | **TASK-098** | Define BBS/DXF contracts + bar mark spec | DOCS | ✅ Done |
 | **TASK-099** | Deterministic bar mark generator + wire into BBS | DEV | ✅ Done |
 | **TASK-100** | BBS cut-length + hook/bend updates + weight rules | DEV | ✅ Done |
+| **TASK-101** | DXF callouts include bar marks + zone labels | DEV | ✅ Done |
 
 ## Recently Completed (Public API Maintenance)
 
@@ -182,7 +183,6 @@ No active tasks. Pick from "Up Next" and move here when starting.
 
 | ID | Task | Agent | Est. | Priority | Bundle |
 |----|------|-------|------|----------|--------|
-| **TASK-101** | DXF callouts include bar marks + zone labels | DEV | 4 hrs | 🟡 Medium | D |
 | **TASK-102** | DXF/BBS consistency checker (mark diff) | DEV | 4 hrs | 🟡 Medium | E |
 | **TASK-103** | DXF content tests (layers + text) | TESTER | 3 hrs | 🟡 Medium | D |
 | **TASK-083** | DXF deliverable layout polish | DEV | 2 hrs | 🟡 Medium | F |


### PR DESCRIPTION
## Summary
- Add bar mark + zone labels to DXF reinforcement callouts
- Scale annotation text/offsets based on beam size
- Close TASK-101

## Testing
- python -m pytest -q tests/test_dxf_export_smoke.py