### PR TITLE
docs: extend colab notebook with BBS/DXF checks

### DIFF
--- a/docs/getting-started/colab-workflow.ipynb
+++ b/docs/getting-started/colab-workflow.ipynb
@@ -1,130 +1,254 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Structural Lib Colab Demo (Visual Reports)\n",
-        "\n",
-        "This notebook installs the package, runs a small job, and renders the HTML report.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "!pip -q install \"structural-lib-is456[dxf]\"\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from structural_lib import api\n",
-        "print('Version:', api.get_library_version())\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from structural_lib import flexure\n",
-        "\n",
-        "res = flexure.design_singly_reinforced(\n",
-        "    b=300, d=450, d_total=500, mu_knm=150, fck=25, fy=500\n",
-        ")\n",
-        "print('Ast required (mm^2):', round(res.ast_required))\n",
-        "print('Status:', 'OK' if res.is_safe else res.error_message)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "\n",
-        "job = {\n",
-        "    'schema_version': 1,\n",
-        "    'code': 'IS456',\n",
-        "    'units': 'IS456',\n",
-        "    'job_id': 'colab_job_001',\n",
-        "    'beam': {\n",
-        "        'b_mm': 230,\n",
-        "        'D_mm': 500,\n",
-        "        'd_mm': 450,\n",
-        "        'd_dash_mm': 50,\n",
-        "        'fck_nmm2': 25,\n",
-        "        'fy_nmm2': 500,\n",
-        "        'asv_mm2': 100,\n",
-        "    },\n",
-        "    'cases': [\n",
-        "        {'case_id': 'LC1', 'mu_knm': 80, 'vu_kn': 55},\n",
-        "        {'case_id': 'LC2', 'mu_knm': 110, 'vu_kn': 75},\n",
-        "        {'case_id': 'LC3', 'mu_knm': 140, 'vu_kn': 95},\n",
-        "    ],\n",
-        "}\n",
-        "\n",
-        "with open('job.json', 'w', encoding='utf-8') as f:\n",
-        "    json.dump(job, f, indent=2)\n",
-        "\n",
-        "print('Wrote job.json')\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "!python -m structural_lib job job.json -o ./job_out\n",
-        "!python -m structural_lib critical ./job_out --top 5 --format=csv -o critical.csv\n",
-        "!python -m structural_lib report ./job_out --format=html -o report.html\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from IPython.display import HTML, IFrame, display\n",
-        "from pathlib import Path\n",
-        "import pandas as pd\n",
-        "\n",
-        "display(HTML(Path('report.html').read_text(encoding='utf-8')))\n",
-        "pd.read_csv('critical.csv').head(5)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# If inline HTML does not render, use an iframe:\n",
-        "IFrame('report.html', width=900, height=600)\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.x"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Structural Lib Colab Demo (Visual Reports)\n",
+    "\n",
+    "This notebook installs the package, runs a small job, and renders the HTML report.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip -q install \"structural-lib-is456[dxf]\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from structural_lib import api\n",
+    "print('Version:', api.get_library_version())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from structural_lib import flexure\n",
+    "\n",
+    "res = flexure.design_singly_reinforced(\n",
+    "    b=300, d=450, d_total=500, mu_knm=150, fck=25, fy=500\n",
+    ")\n",
+    "print('Ast required (mm^2):', round(res.ast_required))\n",
+    "print('Status:', 'OK' if res.is_safe else res.error_message)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "job = {\n",
+    "    'schema_version': 1,\n",
+    "    'code': 'IS456',\n",
+    "    'units': 'IS456',\n",
+    "    'job_id': 'colab_job_001',\n",
+    "    'beam': {\n",
+    "        'b_mm': 230,\n",
+    "        'D_mm': 500,\n",
+    "        'd_mm': 450,\n",
+    "        'd_dash_mm': 50,\n",
+    "        'fck_nmm2': 25,\n",
+    "        'fy_nmm2': 500,\n",
+    "        'asv_mm2': 100,\n",
+    "    },\n",
+    "    'cases': [\n",
+    "        {'case_id': 'LC1', 'mu_knm': 80, 'vu_kn': 55},\n",
+    "        {'case_id': 'LC2', 'mu_knm': 110, 'vu_kn': 75},\n",
+    "        {'case_id': 'LC3', 'mu_knm': 140, 'vu_kn': 95},\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "with open('job.json', 'w', encoding='utf-8') as f:\n",
+    "    json.dump(job, f, indent=2)\n",
+    "\n",
+    "print('Wrote job.json')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python -m structural_lib job job.json -o ./job_out\n",
+    "!python -m structural_lib critical ./job_out --top 5 --format=csv -o critical.csv\n",
+    "!python -m structural_lib report ./job_out --format=html -o report.html\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import HTML, IFrame, display\n",
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "\n",
+    "display(HTML(Path('report.html').read_text(encoding='utf-8')))\n",
+    "pd.read_csv('critical.csv').head(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If inline HTML does not render, use an iframe:\n",
+    "IFrame('report.html', width=900, height=600)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## BBS + DXF + Mark Consistency (Optional)\n",
+    "\n",
+    "This section generates a small CSV, runs design -> BBS -> DXF, then checks\n",
+    "that bar marks match between the CSV and DXF callouts.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "\n",
+    "rows = [{\n",
+    "    'BeamID': 'B1',\n",
+    "    'Story': 'G',\n",
+    "    'b': 230,\n",
+    "    'D': 500,\n",
+    "    'Span': 4000,\n",
+    "    'Cover': 40,\n",
+    "    'fck': 25,\n",
+    "    'fy': 500,\n",
+    "    'Mu': 120,\n",
+    "    'Vu': 80,\n",
+    "    'Ast_req': 0,\n",
+    "    'Asc_req': 0,\n",
+    "    'Stirrup_Dia': 8,\n",
+    "    'Stirrup_Spacing': 150,\n",
+    "}]\n",
+    "\n",
+    "with open('beams_small.csv', 'w', newline='') as f:\n",
+    "    w = csv.DictWriter(f, fieldnames=rows[0].keys())\n",
+    "    w.writeheader()\n",
+    "    w.writerows(rows)\n",
+    "\n",
+    "print('Wrote beams_small.csv')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!python -m structural_lib design beams_small.csv -o results_small.json\n",
+    "!python -m structural_lib bbs results_small.json -o schedule_small.csv\n",
+    "!python -m structural_lib dxf results_small.json -o drawings_small.dxf\n",
+    "!python -m structural_lib mark-diff --bbs schedule_small.csv --dxf drawings_small.dxf --format json -o mark_diff.json\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pandas as pd\n",
+    "from IPython.display import display\n",
+    "\n",
+    "with open('mark_diff.json', 'r', encoding='utf-8') as f:\n",
+    "    mark_diff = json.load(f)\n",
+    "\n",
+    "print(mark_diff)\n",
+    "display(pd.read_csv('schedule_small.csv').head(5))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "try:\n",
+    "    import ezdxf\n",
+    "    from ezdxf.addons import drawing\n",
+    "    from ezdxf.addons.drawing.matplotlib import MatplotlibBackend\n",
+    "    import matplotlib\n",
+    "\n",
+    "    matplotlib.use('Agg')\n",
+    "    import matplotlib.pyplot as plt\n",
+    "\n",
+    "    doc = ezdxf.readfile('drawings_small.dxf')\n",
+    "    msp = doc.modelspace()\n",
+    "\n",
+    "    fig = plt.figure()\n",
+    "    ax = fig.add_axes([0, 0, 1, 1])\n",
+    "    ax.set_aspect('equal')\n",
+    "    ax.axis('off')\n",
+    "\n",
+    "    ctx = drawing.RenderContext(doc)\n",
+    "    backend = MatplotlibBackend(ax)\n",
+    "    drawing.Frontend(ctx, backend).draw_layout(msp)\n",
+    "    backend.finalize()\n",
+    "    ax.autoscale()\n",
+    "\n",
+    "    out_path = Path('drawings_small.png')\n",
+    "    fig.savefig(out_path, dpi=200, bbox_inches='tight', pad_inches=0.1)\n",
+    "    plt.close(fig)\n",
+    "    print(f'Rendered {out_path}')\n",
+    "except Exception as exc:\n",
+    "    print('Render skipped:', exc)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image, display\n",
+    "from pathlib import Path\n",
+    "\n",
+    "if Path('drawings_small.png').exists():\n",
+    "    display(Image('drawings_small.png'))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
Add a BBS/DXF workflow section to the Colab notebook so users can try mark consistency checks and optional DXF rendering.

## Changes
- Create small CSV -> design -> bbs -> dxf -> mark-diff
- Show mark_diff.json + schedule preview
- Optional render to PNG for quick visual check

## Testing
- Pre-commit hooks (json + eof)