### PR TITLE
docs: plan v0.12 and refresh planning docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.0] - Unreleased
+
+### Added
+- BBS/DXF bar mark consistency check (CLI + API helpers).
+- DXF content tests for required layers and callout text.
+- DXF render workflow (PNG/PDF) with optional `render` dependency.
+
+### Changed
+- DXF title block now includes size/cover/span context for deliverables.
+- Colab notebook updated with BBS/DXF + mark-diff workflow.
+
 ## [0.11.0] - 2025-12-29
 
 ### Added

--- a/docs/AI_CONTEXT_PACK.md
+++ b/docs/AI_CONTEXT_PACK.md
@@ -5,6 +5,7 @@
 | Metric | Value |
 |--------|-------|
 | **Current Release** | v0.11.0 (on PyPI) |
+| **Next Planned Release** | v0.12.0 (library APIs + DXF/BBS quality) |
 | **Next Milestone** | v0.20.0 (blocked by S-007) |
 | **Tests** | 1917 passed, 91 skipped |
 | **Coverage** | 92% branch |

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -6,6 +6,29 @@ Append-only record of decisions, PRs, and next actions. For detailed task tracki
 
 ## 2025-12-29 — Session
 
+**Focus:** DXF/BBS consistency + deliverable polish + Colab workflow update
+
+**Completed:**
+- Added BBS/DXF bar mark consistency check (CLI + API helpers).
+- Added DXF content tests (layers + required callouts).
+- Polished DXF title blocks with size/cover/span context.
+- Documented DXF render workflow (PNG/PDF) and optional dependency.
+- Extended Colab notebook with BBS/DXF + mark-diff workflow.
+- Created v0.12 planning doc and updated planning index.
+
+### PRs Merged
+| PR | Summary |
+|----|---------|
+| #185 | BBS/DXF consistency checks, DXF tests, title block polish, render docs |
+| #186 | Colab notebook updates for BBS/DXF workflows |
+
+### Notes
+- v0.12 planning now tracked in `docs/planning/v0.12-plan.md`.
+
+---
+
+## 2025-12-29 — Session
+
 **Focus:** Release polish + visual report v0.11.0, handoff automation, S-007 capture
 
 **Completed:**

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -190,9 +190,9 @@ No active tasks. Pick from "Up Next" and move here when starting.
 
 ---
 
-## Planned (Library API Expansion)
+## Planned (v0.12 Scope)
 
-**Plan doc:** `docs/planning/library-api-expansion.md`
+**Plan doc:** `docs/planning/v0.12-plan.md`
 
 | ID | Task | Agent | Est. | Priority | Bundle |
 |----|------|-------|------|----------|--------|
@@ -201,6 +201,10 @@ No active tasks. Pick from "Up Next" and move here when starting.
 | **TASK-106** | Detailing + BBS APIs + `detail` CLI subcommand | DEV | 4 hrs | 🔴 High | C |
 | **TASK-107** | DXF/report/critical API wrappers (no behavior change) | DEV | 3 hrs | 🟡 Medium | D |
 | **TASK-108** | API/CLI tests + stability labels | TESTER | 3 hrs | 🟡 Medium | E |
+| **TASK-122** | v0.12 release notes (CHANGELOG + RELEASES) | DOCS | 1 hr | 🔴 High | R |
+| **TASK-123** | v0.12 version bump (Python/VBA) | DEVOPS | 15 min | 🔴 High | R |
+| **TASK-124** | v0.12 session log + next-session brief | DOCS | 30 min | 🟡 Medium | R |
+| **TASK-125** | v0.12 release tag + publish | DEVOPS | 20 min | 🔴 High | R |
 
 ---
 

--- a/docs/getting-started/colab-workflow.md
+++ b/docs/getting-started/colab-workflow.md
@@ -371,6 +371,63 @@ IFrame("report.html", width=900, height=600)
 
 ---
 
+## Step 8c: 🆕 BBS + DXF + Mark Consistency (v0.12)
+
+Generate BBS + DXF from a small CSV and verify that bar marks match:
+
+```python
+import csv
+
+rows = [{
+    "BeamID": "B1",
+    "Story": "G",
+    "b": 230,
+    "D": 500,
+    "Span": 4000,
+    "Cover": 40,
+    "fck": 25,
+    "fy": 500,
+    "Mu": 120,
+    "Vu": 80,
+    "Ast_req": 0,
+    "Asc_req": 0,
+    "Stirrup_Dia": 8,
+    "Stirrup_Spacing": 150,
+}]
+
+with open("beams_small.csv", "w", newline="") as f:
+    w = csv.DictWriter(f, fieldnames=rows[0].keys())
+    w.writeheader()
+    w.writerows(rows)
+
+print("Wrote beams_small.csv")
+```
+
+```python
+!python -m structural_lib design beams_small.csv -o results_small.json
+!python -m structural_lib bbs results_small.json -o schedule_small.csv
+!python -m structural_lib dxf results_small.json -o drawings_small.dxf
+!python -m structural_lib mark-diff --bbs schedule_small.csv --dxf drawings_small.dxf --format json -o mark_diff.json
+```
+
+```python
+import json
+import pandas as pd
+
+with open("mark_diff.json", "r", encoding="utf-8") as f:
+    mark_diff = json.load(f)
+
+print(mark_diff)
+pd.read_csv("schedule_small.csv").head(5)
+```
+
+Optional render (PNG/PDF):
+```python
+!python scripts/dxf_render.py drawings_small.dxf -o drawings_small.png
+```
+
+---
+
 ## Step 8b: 🆕 Batch Report Packaging (V08)
 
 When you have a large `design_results.json`, use batch packaging so the report

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -83,6 +83,7 @@ Internal planning documents and research notes.
 | [Project Status Deep Dive](project-status-deep-dive.md) | Module maps, contracts |
 | [Pre-Release Checklist](pre-release-checklist.md) | v1.0 gates |
 | [v0.20 Stabilization](v0.20-stabilization-checklist.md) | Next milestone checklist |
+| [v0.12 Plan](v0.12-plan.md) | v0.12 scope + milestones |
 | [BBS + DXF Improvement Plan](bbs-dxf-improvement-plan.md) | Output contract + DXF/BBS quality plan |
 | [Library API Expansion](library-api-expansion.md) | Library-first APIs + CLI helpers |
 | [Public API Maintenance Review](public-api-maintenance-review.md) | Public API risks + fixes |

--- a/docs/planning/bbs-dxf-improvement-plan.md
+++ b/docs/planning/bbs-dxf-improvement-plan.md
@@ -3,6 +3,8 @@
 Goal: make BBS and DXF outputs fabrication-ready, deterministic, and consistent
 with each other, without changing the current 3-layer architecture.
 
+**Status:** Completed (v0.12 scope via PR #185)
+
 ---
 
 ## Scope (v1.x)

--- a/docs/planning/library-api-expansion.md
+++ b/docs/planning/library-api-expansion.md
@@ -3,6 +3,8 @@
 Goal: make the library easy to embed by exposing stable, composable functions
 and thin CLI wrappers. This is library-first, not product-first.
 
+**Status:** Planned (v0.12)
+
 ---
 
 ## Scope (v1.x)

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -3,26 +3,25 @@
 | Release | Version | Status |
 |---------|---------|--------|
 | **Current** | v0.11.0 | Published on PyPI |
-| **Next** | v0.20.0 | Blocked by S-007 |
+| **Next** | v0.12.0 | Planned (library APIs + DXF/BBS quality) |
 
-**Date:** 2025-12-29 | **PRs:** through #156
+**Date:** 2025-12-29 | **PRs:** through #186
 
 ---
 
 ## 🎯 Immediate Priority
 
-**Only 1 item blocks v0.20.0 release:**
+**v0.12 focus (library-first APIs + DXF/BBS quality):**
 
 | Task | Description | Owner |
 |------|-------------|-------|
-| S-007 | External engineer tries CLI cold | Human (not automatable) |
+| TASK-104 | Define stable API surface + doc updates | DOCS |
+| TASK-105 | Validation APIs + `validate` CLI subcommand | DEV |
+| TASK-106 | Detailing + BBS APIs + `detail` CLI subcommand | DEV |
+| TASK-107 | DXF/report/critical API wrappers | DEV |
+| TASK-108 | API/CLI tests + stability labels | TESTER |
 
-**After S-007 passes:**
-```bash
-python scripts/release.py 0.20.0
-```
-
-**Stabilization status:** 26/31 complete — see `docs/planning/v0.20-stabilization-checklist.md`
+**Plan doc:** `docs/planning/v0.12-plan.md`
 
 ---
 
@@ -40,7 +39,7 @@ python scripts/release.py 0.20.0
 **Quick project summary:**
 - IS 456 RC beam design library (Indian Standard)
 - Python + VBA with matching outputs (parity requirement)
-- CLI: `python -m structural_lib design|bbs|dxf|job|critical|report`
+- CLI: `python -m structural_lib design|bbs|dxf|job|critical|report|mark-diff`
 - PyPI: `pip install structural-lib-is456`
 
 ---
@@ -70,26 +69,18 @@ python scripts/release.py 0.20.0
 
 | PR | Description |
 |----|-------------|
-| #151 | V04 SVG + V05 input sanity heatmap |
-| #153 | V06 stability scorecard |
-| #154 | V07 units sentinel |
-| #155 | V08 report batch packaging + CLI support |
-| #156 | V09 golden report fixtures/tests |
+| #185 | BBS/DXF consistency check + DXF tests + title block polish |
+| #186 | Colab notebook updated for BBS/DXF workflows |
 
-**Outcome:** Visual v0.11 (V03–V09) complete and integrated. ✅
+**Outcome:** DXF/BBS quality gates complete + Colab workflow refreshed.
 
 ---
 
 ## 🎯 What's Next (Priority Order)
 
-### Blocking v0.20.0
+### Long-term milestone (v0.20.0)
 1. **S-007** — External engineer CLI test (requires human)
-
-### After v0.20.0 (Nice to Have)
-2. **S-050** — VBA parity automation
-3. **S-051** — Performance benchmarks (track regression)
-4. **S-052** — Fuzz testing
-5. **S-053** — Security audit
+2. See `docs/planning/v0.20-stabilization-checklist.md`
 
 ### Backlog (v1.0+)
 See `docs/TASKS.md` for full backlog including:

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -1,12 +1,12 @@
 # Pre-Release Checklist
 
-Version: 0.11.0 (beta candidate)
+Version: 0.12.0 (planned)
 Date: 2025-12-29
-Target: Private beta with 2–3 structural engineers
+Target: Public beta with library-first APIs + DXF/BBS quality gates
 
 ---
 
-## Current State
+## Current State (last verified 2025-12-29)
 
 | Area | Status | Evidence |
 |------|--------|----------|

--- a/docs/planning/project-status.md
+++ b/docs/planning/project-status.md
@@ -2,9 +2,9 @@
 
 *Quick summary for agents and contributors*
 
-**Last updated:** 2025-07-11
-**Current release:** v0.10.4 (PyPI)
-**Next milestone:** v0.20.0 (blocked by S-007)
+**Last updated:** 2025-12-29
+**Current release:** v0.11.0 (PyPI)
+**Next milestone:** v0.12.0 (library APIs + DXF/BBS quality)
 
 ---
 
@@ -20,10 +20,10 @@ Professional-grade RC beam design library for IS 456:2000:
 
 | Metric | Value |
 |--------|-------|
-| Python tests | 1810 passed, 91 skipped |
+| Python tests | 1917 passed, 91 skipped |
 | Branch coverage | 92% |
 | VBA parity | Manual (automation planned) |
-| CLI commands | `design`, `bbs`, `dxf`, `job` |
+| CLI commands | `design`, `bbs`, `dxf`, `job`, `critical`, `report`, `mark-diff` |
 
 ## Success Criteria
 

--- a/docs/planning/v0.12-plan.md
+++ b/docs/planning/v0.12-plan.md
@@ -1,0 +1,160 @@
+# v0.12 Plan (Library API Expansion + DXF/BBS Quality)
+
+**Status:** Planned
+**Target version:** v0.12.0
+**Theme:** Library-first APIs + DXF/BBS quality gates
+
+---
+
+## Goals
+- Make the library easier to embed with stable, composable APIs.
+- Add validation and detailing helpers that do not change core math.
+- Provide repeatable DXF/BBS quality checks and optional render workflow.
+- Ship with clean docs, logs, and release hygiene.
+
+---
+
+## Scope (v0.12)
+**In scope**
+- Stable API wrappers (library-first):
+  - `validate_job_spec`, `validate_design_results`
+  - `compute_detailing`, `compute_bbs`, `export_bbs`
+  - `compute_dxf`, `compute_report`, `compute_critical`
+- New CLI helpers (thin wrappers):
+  - `validate` subcommand
+  - `detail` subcommand
+- DXF/BBS quality additions:
+  - Mark-diff consistency check (CLI + API)
+  - DXF content tests (layers + required text)
+  - Title-block polish (sizes/cover/span)
+  - DXF render workflow (PNG/PDF via script + optional dependency)
+- Colab notebook updates for new workflows
+- Documentation and release hygiene for v0.12
+
+**Out of scope**
+- New analysis/solver engine
+- Multi-code plugins or new design codes
+- UI/UX product work (this remains a library)
+- Breaking schema changes (job/results/schedule/dxf contracts stay stable)
+
+---
+
+## Workstreams
+
+### WS1 — API Contract + Docs (Bundle A)
+- Define stable API signatures for v0.12.
+- Update `docs/reference/api.md` + `docs/reference/api-stability.md`.
+- Add recipes in a cookbook or reference section.
+
+**Deliverables**
+- Stable API list (frozen for v0.12+)
+- Updated docs with examples
+
+### WS2 — Validation APIs + CLI (Bundle B)
+- Implement `validate_job_spec` and `validate_design_results`.
+- Add `validate` CLI subcommand.
+- Tests for validation paths.
+
+**Deliverables**
+- Validation API + CLI
+- Unit tests + CLI smoke tests
+
+### WS3 — Detailing + Output APIs (Bundle C)
+- Implement `compute_detailing`, `compute_bbs`, `export_bbs`.
+- Add `detail` CLI subcommand (outputs detailing JSON).
+- Tests for deterministic outputs.
+
+**Deliverables**
+- Detailing/BBS wrappers + CLI
+- Tests for JSON/CSV outputs
+
+### WS4 — DXF + Report Wrappers (Bundle D)
+- Implement `compute_dxf`, `compute_report`, `compute_critical`.
+- Ensure CLI uses wrappers (no behavior change).
+
+**Deliverables**
+- Wrapper APIs with consistent signatures
+- CLI paths aligned to wrappers
+
+### WS5 — DXF/BBS Quality (Bundle E, already delivered)
+- Mark-diff consistency check (API + CLI)
+- DXF content tests
+- Title block polish
+- Render workflow for DXF -> PNG/PDF
+- Colab notebook updated
+
+**Deliverables**
+- Consistency checks + tests
+- Render script guidance
+- Colab notebook workflow
+
+### WS6 — Release Hygiene
+- Update CHANGELOG, RELEASES, SESSION_LOG, next-session-brief.
+- Version bump only at release time.
+- Update docs/README if CLI surface changes.
+
+---
+
+## Milestones
+
+**M1 — API contract + validation**
+Done when:
+- API list frozen
+- `validate` CLI works
+- Tests for validation pass
+
+**M2 — Detailing + output wrappers**
+Done when:
+- `detail` CLI outputs stable JSON
+- BBS/DXF/report wrappers available
+- Tests updated
+
+**M3 — Release prep**
+Done when:
+- CHANGELOG + RELEASES entries prepared
+- Version bump committed
+- Pre-release checklist updated
+- CI green
+
+---
+
+## Definition of Done (v0.12)
+- Library-first APIs documented and tested.
+- `validate` and `detail` CLI commands ship.
+- DXF/BBS quality checks available and documented.
+- Colab notebook demonstrates new workflows.
+- Release notes and logs updated for v0.12.
+
+---
+
+## Release Workflow (v0.12)
+
+**Pre-release checks**
+```bash
+cd Python
+../.venv/bin/python -m pytest -q
+../scripts/ci_local.sh
+```
+
+**Release steps**
+1) Bump version in:
+   - `Python/pyproject.toml`
+   - `Python/structural_lib/api.py`
+   - `VBA/Modules/M08_API.bas`
+2) Update:
+   - `CHANGELOG.md`
+   - `docs/RELEASES.md`
+   - `docs/SESSION_LOG.md`
+   - `docs/planning/next-session-brief.md`
+3) Tag + push release:
+```bash
+git tag -a v0.12.0 -m "v0.12.0"
+git push origin v0.12.0
+```
+
+---
+
+## References
+- `docs/planning/library-api-expansion.md`
+- `docs/planning/bbs-dxf-improvement-plan.md`
+- `docs/TASKS.md`


### PR DESCRIPTION
## Summary
Plan v0.12 in detail and refresh planning/status docs to reflect the next release focus.

## Changes
- New v0.12 plan doc with scope, workstreams, milestones, release workflow
- Update TASKS and next-session brief for v0.12 focus
- Update CHANGELOG with v0.12 Unreleased section
- Refresh session log, project status, pre-release checklist
- Link v0.12 plan in planning index and align related planning docs
- Add BBS/DXF mark-diff section to Colab workflow guide
- Add v0.12 note to AI context pack

## Testing
- Pre-commit hooks (docs/whitespace)
