### PR TITLE
docs: add workflow guardrails and quick check

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -6,6 +6,23 @@ Append-only record of decisions, PRs, and next actions. For detailed task tracki
 
 ## 2025-12-29 — Session
 
+**Focus:** Git workflow friction + fast checks
+
+**Issues observed:**
+- PR-only rules blocked direct pushes when commits landed on `main`.
+- Local `main` diverged after PR merge, causing rebase conflicts.
+- Coverage gate in docs mismatched CI (92 vs 85).
+- Running pytest from repo root used the installed package instead of workspace code.
+
+**Fixes / plan:**
+- Added PR-only guardrails + quick check guidance in `docs/_internal/GIT_GOVERNANCE.md`.
+- Added `scripts/quick_check.sh` (code/docs/coverage modes).
+- Aligned `docs/contributing/testing-strategy.md` with the 85% branch-coverage gate.
+
+---
+
+## 2025-12-29 — Session
+
 **Focus:** DXF/BBS consistency + deliverable polish + Colab workflow update
 
 **Completed:**

--- a/docs/_internal/GIT_GOVERNANCE.md
+++ b/docs/_internal/GIT_GOVERNANCE.md
@@ -125,6 +125,42 @@ See `.github/copilot-instructions.md` for agent-specific workflow rules.
 
 ---
 
+### 2.6 Local Workflow Guardrails (PR-Only Repos)
+
+These are the rules that prevent rebase pain and “why can’t I push?” surprises.
+
+**Golden rules:**
+- **Never commit on `main`.** Always branch first.
+- **If you accidentally commit on `main`:**
+  1) `git switch -c <branch>`
+  2) `git push -u origin <branch>`
+  3) Open a PR and merge it normally
+- **Sync `main` only after PR merge:** `git fetch origin` + `git rebase origin/main`
+- **Delete local branches after merge:** `git branch -d <branch>`
+
+**Why this matters:** Rulesets require PRs. Committing on `main` triggers rejected pushes and messy rebases.
+
+---
+
+### 2.7 Quick Local Checks (Before PR)
+
+Use the fast pre-flight checks below to avoid CI failures:
+
+```bash
+# Code (fast)
+./scripts/quick_check.sh
+
+# Code + coverage gate
+./scripts/quick_check.sh --cov
+
+# Docs-only
+./scripts/quick_check.sh docs
+```
+
+For a full run, use `scripts/ci_local.sh`.
+
+---
+
 ## 3. Commit Message Convention (Conventional Commits)
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/) to enable automated changelogs.

--- a/docs/contributing/testing-strategy.md
+++ b/docs/contributing/testing-strategy.md
@@ -26,7 +26,7 @@
 - From `Python/`: `python -m pytest --cov=structural_lib --cov-report=term-missing --cov-report=xml`
 
 **How to run the CI-equivalent check locally (includes coverage gate):**
-- From `Python/`: `python -m pytest --cov=structural_lib --cov-report=term-missing --cov-report=xml --cov-fail-under=92`
+- From `Python/`: `python -m pytest --cov=structural_lib --cov-branch --cov-report=term-missing --cov-report=xml --cov-fail-under=85`
 
 ### CI (GitHub Actions)
 
@@ -39,7 +39,7 @@ Workflow: `.github/workflows/python-tests.yml`
   - Python matrix: 3.9, 3.10, 3.11, 3.12
   - Installs: `pip install -e ".[dev,dxf]"`
   - Runs: pytest with coverage + uploads `coverage.xml`
-  - Coverage gate: `--cov-fail-under=92`
+  - Coverage gate: `--cov-fail-under=85` (branch coverage)
   - Packaging smoke: `python -m build`
 
 **What this gives us:**
@@ -77,7 +77,7 @@ Workflow: `.github/workflows/python-tests.yml`
 Latest verified local run (Dec 2025): **100% total coverage** with `--cov-report=term-missing`.
 
 Notes:
-- CI gate is `--cov-fail-under=92`.
+- CI gate is `--cov-fail-under=85` (branch coverage).
 - Tests that execute modules via `runpy.run_module(...)` clear entries from `sys.modules` to avoid `RuntimeWarning` noise.
 
 ---
@@ -85,7 +85,7 @@ Notes:
 ## 4) Key gaps / risks (senior tester assessment)
 
 1. **Coverage gate is conservative**
-  - CI enforces a minimum total coverage of 80% to prevent silent regressions.
+  - CI enforces a minimum total branch coverage of 85% to prevent silent regressions.
   - This is intentionally low to avoid blocking feature work; raise gradually as coverage improves.
 
 2. **High-risk areas (now covered, still sensitive to change)**
@@ -108,7 +108,7 @@ Notes:
 
 ### P0 — Protect against regression
 
-- Keep the CI **coverage gate** at 92%.
+- Keep the CI **coverage gate** at 85% (current baseline).
 
 ### P1 — Increase confidence where failures are expensive
 

--- a/scripts/quick_check.sh
+++ b/scripts/quick_check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="python"
+fi
+
+if [[ "${1-}" == "docs" ]]; then
+  "$PYTHON_BIN" "$ROOT_DIR/scripts/check_doc_versions.py"
+  "$PYTHON_BIN" "$ROOT_DIR/scripts/check_links.py"
+  exit 0
+fi
+
+if [[ "${1-}" == "--cov" ]]; then
+  cd "$ROOT_DIR/Python"
+  "$PYTHON_BIN" -m pytest --cov=structural_lib --cov-branch --cov-fail-under=85 -q
+  exit 0
+fi
+
+cd "$ROOT_DIR/Python"
+"$PYTHON_BIN" -m pytest -q


### PR DESCRIPTION
## Summary
- add PR-only guardrails and quick-check guidance to git governance
- align testing strategy doc with 85% branch coverage gate
- add scripts/quick_check.sh for fast local checks
- log workflow friction + fixes in session log

## Testing
- not run (docs/script only)