### PR TITLE
test: replace help checks with contract validations

### DIFF
--- a/Python/tests/test_cli.py
+++ b/Python/tests/test_cli.py
@@ -237,23 +237,9 @@ def test_cli_requires_command():
         cli_main.main([])
 
 
-def test_validate_help():
-    """Test validate subcommand help."""
-    with pytest.raises(SystemExit) as exc:
-        cli_main.main(["validate", "--help"])
-    assert exc.value.code == 0
-
-
 # =============================================================================
 # Design Command Tests
 # =============================================================================
-
-
-def test_design_help():
-    """Test design subcommand help."""
-    with pytest.raises(SystemExit) as exc:
-        cli_main.main(["design", "--help"])
-    assert exc.value.code == 0
 
 
 def test_design_missing_args_exit_code():
@@ -490,13 +476,6 @@ def test_design_stdout_output(sample_csv_file, capsys):
 # =============================================================================
 
 
-def test_bbs_help():
-    """Test bbs subcommand help."""
-    with pytest.raises(SystemExit) as exc:
-        cli_main.main(["bbs", "--help"])
-    assert exc.value.code == 0
-
-
 def test_bbs_to_csv(sample_design_results_file, tmp_path):
     """Test bbs command with CSV output."""
     output_file = tmp_path / "bbs.csv"
@@ -571,13 +550,6 @@ def test_bbs_empty_beams(tmp_path):
 # =============================================================================
 # DXF Command Tests
 # =============================================================================
-
-
-def test_dxf_help():
-    """Test dxf subcommand help."""
-    with pytest.raises(SystemExit) as exc:
-        cli_main.main(["dxf", "--help"])
-    assert exc.value.code == 0
 
 
 def test_dxf_requires_output():
@@ -763,13 +735,6 @@ def test_mark_diff_text_fail(tmp_path, monkeypatch, capsys):
 # =============================================================================
 
 
-def test_job_help():
-    """Test job subcommand help."""
-    with pytest.raises(SystemExit) as exc:
-        cli_main.main(["job", "--help"])
-    assert exc.value.code == 0
-
-
 def test_job_requires_output():
     """Test job command requires output argument."""
     with pytest.raises(SystemExit):
@@ -871,13 +836,6 @@ def sample_job_output_dir(tmp_path, sample_job_file):
     return output_dir
 
 
-def test_report_help():
-    """Test report subcommand help."""
-    with pytest.raises(SystemExit) as exc:
-        cli_main.main(["report", "--help"])
-    assert exc.value.code == 0
-
-
 def test_report_missing_output_dir(tmp_path):
     """Test report command with missing output directory."""
     rc = cli_main.main(["report", str(tmp_path / "nonexistent_dir")])
@@ -947,13 +905,6 @@ def test_report_default_format_is_json(sample_job_output_dir, capsys):
 # =============================================================================
 # Critical Command Tests (V03)
 # =============================================================================
-
-
-def test_critical_help():
-    """Test critical subcommand help."""
-    with pytest.raises(SystemExit) as exc:
-        cli_main.main(["critical", "--help"])
-    assert exc.value.code == 0
 
 
 def test_critical_missing_output_dir(tmp_path):

--- a/Python/tests/test_validation_api.py
+++ b/Python/tests/test_validation_api.py
@@ -55,6 +55,52 @@ def test_validate_job_spec_missing_file(tmp_path):
     assert report.errors
 
 
+def test_validate_job_spec_invalid_units(tmp_path):
+    job = {
+        "schema_version": 1,
+        "job_id": "JOB-3",
+        "code": "IS456",
+        "units": "BAD_UNITS",
+        "beam": {
+            "b_mm": 230,
+            "D_mm": 500,
+            "d_mm": 450,
+            "fck_nmm2": 25,
+            "fy_nmm2": 500,
+        },
+        "cases": [{"case_id": "LC1", "mu_knm": 120, "vu_kn": 80}],
+    }
+    path = tmp_path / "job.json"
+    _write_json(path, job)
+
+    report = api.validate_job_spec(path)
+    assert not report.ok
+    assert any("units validation failed" in err for err in report.errors)
+
+
+def test_validate_job_spec_unsupported_schema_version(tmp_path):
+    job = {
+        "schema_version": 2,
+        "job_id": "JOB-4",
+        "code": "IS456",
+        "units": "IS456",
+        "beam": {
+            "b_mm": 230,
+            "D_mm": 500,
+            "d_mm": 450,
+            "fck_nmm2": 25,
+            "fy_nmm2": 500,
+        },
+        "cases": [{"case_id": "LC1", "mu_knm": 120, "vu_kn": 80}],
+    }
+    path = tmp_path / "job.json"
+    _write_json(path, job)
+
+    report = api.validate_job_spec(path)
+    assert not report.ok
+    assert any("Unsupported schema_version" in err for err in report.errors)
+
+
 def test_validate_design_results_ok(tmp_path):
     results = {
         "schema_version": beam_pipeline.SCHEMA_VERSION,
@@ -122,6 +168,20 @@ def test_validate_design_results_missing_units(tmp_path):
     assert report.warnings
 
 
+def test_validate_design_results_missing_beams_list(tmp_path):
+    results = {
+        "schema_version": beam_pipeline.SCHEMA_VERSION,
+        "code": "IS456",
+        "units": "IS456",
+    }
+    path = tmp_path / "results.json"
+    _write_json(path, results)
+
+    report = api.validate_design_results(path)
+    assert not report.ok
+    assert any("beams" in err for err in report.errors)
+
+
 def test_validate_design_results_invalid_schema_version(tmp_path):
     results = {
         "schema_version": "bad",
@@ -143,6 +203,29 @@ def test_validate_design_results_invalid_schema_version(tmp_path):
     report = api.validate_design_results(path)
     assert not report.ok
     assert any("Invalid schema_version" in err for err in report.errors)
+
+
+def test_validate_design_results_unsupported_schema_version(tmp_path):
+    results = {
+        "schema_version": 999,
+        "code": "IS456",
+        "units": "IS456",
+        "beams": [
+            {
+                "beam_id": "B1",
+                "story": "S1",
+                "geometry": {"b_mm": 230, "D_mm": 500, "d_mm": 450},
+                "materials": {"fck_nmm2": 25, "fy_nmm2": 500},
+                "loads": {"mu_knm": 120, "vu_kn": 80},
+            }
+        ],
+    }
+    path = tmp_path / "results.json"
+    _write_json(path, results)
+
+    report = api.validate_design_results(path)
+    assert not report.ok
+    assert any("Unsupported schema_version" in err for err in report.errors)
 
 
 def test_validate_design_results_non_dict_beam(tmp_path):


### PR DESCRIPTION
## Summary
- remove CLI help subcommand tests (low-value coverage)
- add validation API error-path tests (units, schema, missing beams)
- add report design-results error-path tests + html output packaging branches

## Testing
- ../.venv/bin/python -m pytest tests/test_cli.py tests/test_validation_api.py tests/test_report.py -q
- ../.venv/bin/python -m pytest tests -q --cov=structural_lib --cov-branch --cov-fail-under=85