### PR TITLE
chore(ci): guard main commits via PR check

### DIFF
--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -1,0 +1,35 @@
+name: Main Branch Guard
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  block-direct-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require PR for main commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: sha,
+            });
+
+            if (!prs || prs.length === 0) {
+              core.setFailed(`Direct commit to main detected (${sha}). Use a PR.`);
+              return;
+            }
+
+            const prList = prs.map(pr => `#${pr.number}`).join(", ");
+            core.info(`Commit is associated with PR(s): ${prList}`);

--- a/docs/contributing/repo-professionalism.md
+++ b/docs/contributing/repo-professionalism.md
@@ -40,6 +40,7 @@ Canonical sources:
 - Squash merge after CI passes: `gh pr merge <PR> --squash --delete-branch`.
 - Delete branches after merge (the command above does this automatically).
 - Local guardrail: pre-commit blocks commits on `main` (see `.pre-commit-config.yaml`).
+- CI guardrail: pushes to `main` must be associated with a PR (see `.github/workflows/main-branch-guard.yml`).
 
 ### PR discipline
 - Use the PR template in `.github/pull_request_template.md`.


### PR DESCRIPTION
## Summary
- Add a CI guard that fails if a commit lands on `main` without an associated PR.
- Document the server-side guardrail alongside the local pre-commit hook.

## Files
- `.github/workflows/main-branch-guard.yml`
- `docs/contributing/repo-professionalism.md`
