### PR TITLE
fix(shear): warn on Table 19 fck out-of-range

### DIFF
--- a/Python/structural_lib/errors.py
+++ b/Python/structural_lib/errors.py
@@ -267,6 +267,15 @@ E_SHEAR_003 = DesignError(
     clause="Cl. 26.5.1.6",
 )
 
+E_SHEAR_004 = DesignError(
+    code="E_SHEAR_004",
+    severity=Severity.WARNING,
+    message="fck outside Table 19 range (15-40). Using nearest bound values.",
+    field="fck",
+    hint="Use fck within 15-40 for Table 19 or confirm conservative design.",
+    clause="Table 19",
+)
+
 # Ductile Detailing Errors
 E_DUCTILE_001 = DesignError(
     code="E_DUCTILE_001",

--- a/Python/structural_lib/shear.py
+++ b/Python/structural_lib/shear.py
@@ -14,6 +14,7 @@ from .errors import (
     E_INPUT_009,
     E_SHEAR_001,
     E_SHEAR_003,
+    E_SHEAR_004,
 )
 
 
@@ -103,6 +104,10 @@ def design_shear(
             errors=[E_INPUT_009],
         )
 
+    warning_errors = []
+    if fck < 15 or fck > 40:
+        warning_errors.append(E_SHEAR_004)
+
     # 1. Calculate Tv
     tv = calculate_tv(vu_kn, b, d)
 
@@ -119,7 +124,7 @@ def design_shear(
             spacing=0.0,
             is_safe=False,
             remarks="Shear stress exceeds Tc_max. Redesign section.",
-            errors=[E_SHEAR_001],
+            errors=warning_errors + [E_SHEAR_001],
         )
 
     # 3. Get Tc
@@ -128,7 +133,7 @@ def design_shear(
     # 4. Calculate Vus and Spacing
     vu_n = abs(vu_kn) * 1000.0
     vc_n = tc * b * d
-    design_errors = []
+    design_errors = list(warning_errors)
 
     if tv <= tc:
         # Nominal shear < Design strength

--- a/Python/tests/test_error_schema.py
+++ b/Python/tests/test_error_schema.py
@@ -23,6 +23,7 @@ from structural_lib.errors import (
     E_INPUT_016,
     E_FLEXURE_001,
     E_SHEAR_001,
+    E_SHEAR_004,
     E_DUCTILE_001,
     make_error,
 )
@@ -179,6 +180,11 @@ class TestPredefinedErrors:
         assert E_SHEAR_001.severity == Severity.ERROR
         assert E_SHEAR_001.clause == "Cl. 40.2.3"
 
+    def test_shear_error_004(self):
+        assert E_SHEAR_004.code == "E_SHEAR_004"
+        assert E_SHEAR_004.severity == Severity.WARNING
+        assert E_SHEAR_004.field == "fck"
+
     def test_ductile_error_001(self):
         assert E_DUCTILE_001.code == "E_DUCTILE_001"
         assert E_DUCTILE_001.severity == Severity.ERROR
@@ -274,6 +280,11 @@ class TestShearErrorsIntegration:
     def test_valid_shear_design(self):
         result = design_shear(vu_kn=50, b=230, d=450, fck=25, fy=415, asv=157, pt=0.5)
         assert result.is_safe is True
+
+    def test_fck_out_of_range_adds_warning(self):
+        result = design_shear(vu_kn=50, b=230, d=450, fck=50, fy=415, asv=157, pt=0.5)
+        assert result.is_safe is True
+        assert any(e.code == "E_SHEAR_004" for e in result.errors)
 
 
 class TestDuctileErrorsIntegration:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -29,6 +29,14 @@ See also: `docs/_internal/AGENT_WORKFLOW.md`
 
 No active tasks. Pick from "Up Next" and move here when starting.
 
+## Recently Completed (Quality Hardening)
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-126** | Warn on Table 19 fck out-of-range in shear design | DEV | ✅ Done |
+| **TASK-127** | Document Table 19 range warning in known-pitfalls + error schema | DOCS | ✅ Done |
+| **TASK-128** | Add tests for Table 19 range warning | TESTER | ✅ Done |
+
 ## Recently Completed (BBS + DXF Improvement Program)
 
 | ID | Task | Agent | Status |

--- a/docs/reference/error-schema.md
+++ b/docs/reference/error-schema.md
@@ -107,6 +107,8 @@ This document defines the standard error schema for all structural_lib errors. T
 |------|-------|---------|------|--------|
 | `E_SHEAR_001` | `tv` | `tv exceeds tc_max` | Increase section size. | Cl. 40.2.3 |
 | `E_SHEAR_002` | `spacing` | `Spacing exceeds maximum` | Reduce stirrup spacing. | Cl. 26.5.1.6 |
+| `E_SHEAR_003` | `tv` | `Nominal shear < Tc. Provide minimum shear reinforcement.` | Minimum stirrups per Cl. 26.5.1.6. | Cl. 26.5.1.6 |
+| `E_SHEAR_004` | `fck` | `fck outside Table 19 range (15-40). Using nearest bound values.` | Use fck within 15-40 or confirm conservative design. | Table 19 |
 
 #### Ductile Detailing (`E_DUCTILE_`)
 

--- a/docs/reference/known-pitfalls.md
+++ b/docs/reference/known-pitfalls.md
@@ -16,6 +16,7 @@ Use this as a checklist to avoid common mistakes when implementing or reviewing 
 
 ## Table 19/20 Usage
 - Table 19: Clamp pt to 0.15–3.0%; use nearest lower concrete grade column (no fck interpolation).
+- Table 19 range: fck is 15–40 only; values outside are clamped to bounds with a warning.
 - Table 20: If τv > τc,max, section is inadequate — do not proceed to stirrup design.
 - Test exact table points exactly; use bounds for interpolation cases.
 


### PR DESCRIPTION
## Summary
- Add a warning when fck is outside Table 19 range (15–40) in shear design.
- Surface the warning in the error schema and known pitfalls.
- Add a focused test for the new warning.

## Testing
- `../.venv/bin/python -m pytest tests/test_error_schema.py -q`
