### PR TITLE
docs: enforce TASKS structure and archive history

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,13 @@ repos:
         pass_filenames: false
         always_run: true
         verbose: true
+      - id: check-tasks-format
+        name: Check TASKS.md format
+        entry: python3 scripts/check_tasks_format.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
 
 # CI note: pre-commit hooks run locally only.
 # CI has separate lint/format checks in .github/workflows/python-tests.yml

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,276 +1,84 @@
 # Task Board
 
-> How to use: start each session here. Pick a task from "Up Next", move it to "Active", then move to "Done" when finished.
+> Single source of truth for work. Keep it short and current.
 
 ---
 
-## Multi-Agent Workflow
+## Rules (read first)
+- WIP = 1. Move tasks between sections; do not duplicate.
+- Definition of Done: tests pass, docs updated, CHANGELOG/RELEASES updated when needed.
+- Keep "Recently Done" to the last 10-20 items; older history lives in the archive.
+- Use agent roles from `agents/` and the workflow in `docs/_internal/AGENT_WORKFLOW.md`.
 
-When working on tasks, specify which agent role to use:
+---
 
-| Role | Doc | Use For |
-|------|-----|---------|
-| **DEV** | `agents/DEV.md` | Implementation, refactoring, architecture |
-| **TESTER** | `agents/TESTER.md` | Test design, edge cases, validation |
-| **DEVOPS** | `agents/DEVOPS.md` | Repo structure, automation, releases |
-| **PM** | `agents/PM.md` | Scope, prioritization, changelog |
-| **UI** | `agents/UI.md` | Excel layout, UX flow, VBA forms |
-| **CLIENT** | `agents/CLIENT.md` | Requirements, user stories, validation |
-| **RESEARCHER** | `agents/RESEARCHER.md` | IS Codes, algorithms, technical constraints |
-| **INTEGRATION** | `agents/INTEGRATION.md` | Data schemas, ETABS/CSV mapping |
-| **DOCS** | `agents/DOCS.md` | API docs, guides, changelog |
-| **SUPPORT** | `agents/SUPPORT.md` | Troubleshooting, known issues |
+## Current Release
 
-See also: `docs/_internal/AGENT_WORKFLOW.md`
+- Target: v0.12.1 (maintenance)
+- Focus: test hardening + DXF/BBS regression fixtures
+- Blockers: none (update when set)
 
 ---
 
 ## Active
 
-No active tasks. Pick from "Up Next" and move here when starting.
+No active tasks. Move one item from "Up Next" when starting.
 
-## Recently Completed (Quality Hardening)
+---
+
+## Up Next
+
+| ID | Task | Agent | Est | Priority | Status |
+|----|------|-------|-----|----------|--------|
+| **TASK-129** | Reduce property-invariant skips by tightening generators (d > d_min, paired fy inputs) | TESTER | 2 hrs | 🟡 Medium | Ready |
+| **TASK-130** | Add contract tests for units conversion boundaries at API/CLI entrypoints | TESTER | 2 hrs | 🟡 Medium | Ready |
+| **TASK-131** | Add regression fixtures for BBS/DXF mark-diff (missing marks, mismatched counts) | TESTER | 2 hrs | 🟡 Medium | Ready |
+
+---
+
+## Backlog
+
+### v1.0 Readiness (carryover)
+
+| ID | Task | Agent | Est | Priority |
+|----|------|-------|-----|----------|
+| **TASK-077** | External user CLI test | CLIENT | 1 hr | 🔴 Critical |
+| **TASK-078** | Seismic detailing validation | TESTER | 45 min | 🟡 Medium |
+| **TASK-079** | VBA parity spot-check | TESTER | 1 hr | 🟡 Medium |
+
+### Post-v1.0 (beam scope)
+
+| ID | Task | Agent | Est | Priority |
+|----|------|-------|-----|----------|
+| **TASK-081** | Level C Serviceability (creep + shrinkage) | DEV | 1-2 days | 🟡 Medium |
+| **TASK-082** | VBA parity automation harness | DEVOPS | 1-2 days | 🟡 Medium |
+| **TASK-085** | Torsion design + detailing (Cl. 41) | DEV | 2-3 days | 🟡 Medium |
+| **TASK-086** | Side-face reinforcement check (Cl. 26.5.1.3) | DEV | 4 hrs | 🟡 Medium |
+| **TASK-087** | Anchorage space check (Cl. 26.2) | DEV | 1 day | 🟡 Medium |
+| **TASK-088** | Slenderness/stability check (Cl. 23.1.2) | DEV | 4 hrs | 🟡 Medium |
+| **TASK-089** | Flanged effective width helper | INTEGRATION | 1 day | 🟡 Medium |
+
+---
+
+## Recently Done
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
 | **TASK-126** | Warn on Table 19 fck out-of-range in shear design | DEV | ✅ Done |
 | **TASK-127** | Document Table 19 range warning in known-pitfalls + error schema | DOCS | ✅ Done |
 | **TASK-128** | Add tests for Table 19 range warning | TESTER | ✅ Done |
-
-## Recently Completed (BBS + DXF Improvement Program)
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
-| **TASK-098** | Define BBS/DXF contracts + bar mark spec | DOCS | ✅ Done |
-| **TASK-099** | Deterministic bar mark generator + wire into BBS | DEV | ✅ Done |
-| **TASK-100** | BBS cut-length + hook/bend updates + weight rules | DEV | ✅ Done |
-| **TASK-101** | DXF callouts include bar marks + zone labels | DEV | ✅ Done |
-| **TASK-102** | DXF/BBS consistency checker (mark diff) | DEV | ✅ Done |
-| **TASK-103** | DXF content tests (layers + text) | TESTER | ✅ Done |
-| **TASK-083** | DXF deliverable layout polish | DEV | ✅ Done |
-| **TASK-084** | DXF to PDF/PNG export workflow | DEVOPS | ✅ Done |
-
-## Recently Completed (Public API Maintenance)
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
-| **TASK-109** | Centralize units validation in public API | DEV | ✅ Done |
-| **TASK-110** | Fix `get_library_version()` fallback | DEV | ✅ Done |
-| **TASK-111** | Align `__all__` exports with stability policy | DEV | ✅ Done |
-| **TASK-112** | Document `api.py` stable entrypoints in api-stability.md | DOCS | ✅ Done |
-| **TASK-113** | Add return type annotation for `detail_beam_is456()` | DEV | ✅ Done |
-| **TASK-114** | Clarify units for `check_compliance_report()` in docs | DOCS | ✅ Done |
-| **TASK-115** | Document or demote `beam_pipeline` in API docs | DOCS | ✅ Done |
-| **TASK-116** | Fix serviceability function names in api-stability.md | DOCS | ✅ Done |
-| **TASK-117** | Classify `report`/`report_svg` stability or stop re-exporting | DEV | ✅ Done |
-| **TASK-118** | Document `get_library_version()` in api.md | DOCS | ✅ Done |
-| **TASK-119** | Add public API helpers overview in api.md | DOCS | ✅ Done |
-| **TASK-120** | Fix shear function names in api-stability.md | DOCS | ✅ Done |
-| **TASK-121** | Classify `excel_integration` stability or stop re-exporting | DEV | ✅ Done |
-
-## Recently Completed (v0.12)
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
+| **TASK-122** | v0.12 release notes (CHANGELOG + RELEASES) | DOCS | ✅ Done |
+| **TASK-123** | v0.12 version bump (Python/VBA) | DEVOPS | ✅ Done |
+| **TASK-124** | v0.12 session log + next-session brief | DOCS | ✅ Done |
+| **TASK-125** | v0.12 release tag + publish | DEVOPS | ✅ Done |
 | **TASK-104** | Define stable API surface + doc updates | DOCS | ✅ Done |
 | **TASK-105** | Validation APIs + `validate` CLI subcommand | DEV | ✅ Done |
 | **TASK-106** | Detailing + BBS APIs + `detail` CLI subcommand | DEV | ✅ Done |
 | **TASK-107** | DXF/report/critical API wrappers (no behavior change) | DEV | ✅ Done |
 | **TASK-108** | API/CLI tests + stability labels | TESTER | ✅ Done |
-| **TASK-122** | v0.12 release notes (CHANGELOG + RELEASES) | DOCS | ✅ Done |
-| **TASK-123** | v0.12 version bump (Python/VBA) | DEVOPS | ✅ Done |
-| **TASK-124** | v0.12 session log + next-session brief | DOCS | ✅ Done |
-| **TASK-125** | v0.12 release tag + publish | DEVOPS | ✅ Done |
-
-## Recently Completed (Visual v0.11)
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
-| **#134 (V01)** | report.py skeleton + load_job_spec helper | DEV | ✅ Done |
-| **#135 (V02)** | report subcommand in __main__.py | DEV | ✅ Done |
-| **#136 (V03)** | Critical Set Export (sorted utilization table) | DEV | ✅ Done |
-| **#137 (V04)** | report_svg.py + cross-section SVG | DEV | ✅ Done |
-| **#138 (V05)** | Input Sanity Heatmap | DEV | ✅ Done |
-| **#139 (V06)** | Stability Scorecard | DEV | ✅ Done |
-| **#140 (V07)** | Units Sentinel | DEV | ✅ Done |
-| **#141 (V08)** | HTML export + batch packaging | DEV | ✅ Done |
-| **#142 (V09)** | Golden file tests for report module | DEV | ✅ Done |
-
----
-
-## Recently Completed (v0.10.6)
-
-### W03-W05: Structured Error Schema Sprint — ✅ COMPLETE
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
-| **W03** | Design error schema (docs/reference/error-schema.md) | DOCS | ✅ Done |
-| **W04** | Implement DesignError dataclass + integrate in core | DEV | ✅ Done |
-| **W05** | Structured validation for doubly/flanged beams | DEV | ✅ Done |
-
-**Deliverables:**
-- `errors.py` module with frozen `DesignError` dataclass
-- 16+ error codes: `E_INPUT_*`, `E_FLEXURE_*`, `E_SHEAR_*`, `E_DUCTILE_*`
-- Structured errors in all core design functions
-- 38 new tests for error schema
-- Full error catalog in docs/reference/error-schema.md
-
----
-
-## Recently Completed (v0.9.7-dev)
-
-### Level B Serviceability + CLI/AI Discoverability (PR #62) — ✅ COMPLETE
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
-| **TASK-055** | Level B Serviceability (curvature-based deflection) | DEV | ✅ Done |
-| **TASK-069** | Add `llms.txt` (AI summary) | DOCS | ✅ Done |
-| **TASK-070** | CLI help pass | DEV | ✅ Done |
-| **TASK-071** | Sync CLI reference | DOCS | ✅ Done |
-| **TASK-072** | Cross-links from docs | DOCS | ✅ Done |
-
-**Deliverables:**
-- 7 new Level B functions in `serviceability.py`
-- `DeflectionLevelBResult` dataclass
-- 16 new tests (1730 total passing)
-- `llms.txt` for AI discovery
-- Enhanced CLI help text
-
-### Release Automation Sprint (TASK-065 through TASK-068) — ✅ COMPLETE
-
-**Deliverables (PR #59):**
-- `scripts/release.py` — One-command release helper
-- `scripts/check_doc_versions.py` — Validate no stale versions
-- `.pre-commit-config.yaml` — Enhanced with ruff, doc check hooks
-- CI doc drift check step
-
-### Guardrails Hardening (Local CI Parity) — ✅ COMPLETE
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
-| **TASK-097** | Add local CI parity script (`scripts/ci_local.sh`) | DEVOPS | ✅ Done |
-
-### Error Message Review (TASK-080) — ✅ COMPLETE
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
-| **TASK-080** | Error message review | SUPPORT | ✅ Done |
-
-### Multi-Agent Review Remediation (Phase 1/2) — ✅ COMPLETE
-
-| ID | Task | Agent | Status |
-|----|------|-------|--------|
-| **TASK-090** | Add branch coverage gate + pytest timeout in CI | DEVOPS | ✅ Done |
-| **TASK-091** | Add `CODEOWNERS` | DEVOPS | ✅ Done |
-| **TASK-092** | Complete Shear section in `docs/reference/api.md` | DOCS | ✅ Done |
-| **TASK-093** | Document golden/parity vector sources | DOCS | ✅ Done |
-| **TASK-094** | Add explicit `__all__` in `api.py` | DEV | ✅ Done |
-| **TASK-095** | Remove duplicate doc drift check in CI | DEVOPS | ✅ Done |
-| **TASK-096** | Add Mu_lim clause comment + expand `design_shear` docstring | DEV | ✅ Done |
-
----
-
-## Up Next (v0.9.7 Release Sprint)
-
-**Goal:** Prepare for v0.9.7 release with Level B serviceability + polish.
-
-| ID | Task | Agent | Est. | Priority |
-|----|------|-------|------|----------|
-| **TASK-073** | Update CHANGELOG for v0.9.7 | PM | 15 min | 🔴 High |
-| **TASK-074** | Bump version to 0.9.7 | DEVOPS | 10 min | 🔴 High |
-| **TASK-075** | Update next-session-brief | DOCS | 15 min | 🟡 Medium |
-| **TASK-076** | Tag and release v0.9.7 | DEVOPS | 15 min | 🔴 High |
-
----
-
-## Up Next (v1.0 Readiness)
-
-**Goal:** Complete beta gates and prepare for v1.0 stable release.
-
-| ID | Task | Agent | Est. | Priority |
-|----|------|-------|------|----------|
-| **TASK-077** | External user CLI test | CLIENT | 1 hr | 🔴 Critical |
-| **TASK-078** | Seismic detailing validation | TESTER | 45 min | 🟡 Medium |
-| **TASK-079** | VBA parity spot-check | TESTER | 1 hr | 🟡 Medium |
-| **TASK-083** | DXF deliverable layout polish | DEV | 2 hrs | 🟡 Medium |
-| **TASK-084** | DXF to PDF/PNG export workflow | DEVOPS | 2 hrs | 🟡 Medium |
-
-**v1.0 Beta Gates (from pre-release-checklist):**
-- [x] 5 real beam validations documented
-- [ ] One external engineer tries CLI cold
-- [ ] All tests pass (currently: 1956 passed, 91 skipped)
-- [ ] VBA parity verified
-
----
-
-## Planned (BBS + DXF Improvement Program)
-
-**Plan doc:** `docs/planning/bbs-dxf-improvement-plan.md`
-
-| ID | Task | Agent | Est. | Priority | Bundle |
-|----|------|-------|------|----------|--------|
-
----
-
-## Planned (v0.12 Scope)
-
-All v0.12 release tasks completed.
-
----
-
-## Planned (Test Hardening)
-
-| ID | Task | Agent | Est. | Priority |
-|----|------|-------|------|----------|
-| **TASK-126** | Reduce property-invariant skips by tightening generators (d > d_min, paired fy inputs) | TESTER | 2 hrs | 🟡 Medium |
-| **TASK-127** | Add contract tests for units conversion boundaries at API/CLI entrypoints | TESTER | 2 hrs | 🟡 Medium |
-| **TASK-128** | Add regression fixtures for BBS/DXF mark-diff (missing marks, mismatched counts) | TESTER | 2 hrs | 🟡 Medium |
-
----
-
-## Planned (Public API Maintenance)
-
-**Review doc:** `docs/planning/public-api-maintenance-review.md`
-
-All Public API Maintenance tasks are complete.
-
----
-
-## Backlog (Post-v1.0)
-
-| ID | Task | Agent | Description |
-|----|------|-------|-------------|
-| **TASK-081** | Level C Serviceability | DEV | Shrinkage + creep deflection (Annex C full) |
-| **TASK-082** | VBA Parity Automation | DEVOPS | Automated Python vs VBA comparison harness |
-| **TASK-085** | Torsion Design + Detailing | DEV | Equivalent shear/moment + closed stirrups (Cl. 41) |
-| **TASK-086** | Side-Face Reinforcement Check | DEV | D > 750 mm -> 0.1% web area bars (Cl. 26.5.1.3) |
-| **TASK-087** | Anchorage Space Check | DEV | Verify Ld at supports; suggest hooks/bends if short (Cl. 26.2) |
-| **TASK-088** | Slenderness/Stability Check | DEV | L > 60b or 250b^2/d warning (Cl. 23.1.2) |
-| **TASK-089** | Flanged Effective Width Helper | INTEGRATION | Compute bf from slab geometry for T/L beams |
-
----
-
-## Completed (v0.9.6)
-
-- [x] **TASK-059: Shared Beam Pipeline Module** — `beam_pipeline.py` — PR #55
-- [x] **TASK-060: Canonical Result Schema v1** — `BeamDesignOutput`, `MultiBeamOutput` — PR #55
-- [x] **TASK-061: Units Validation at App Layer** — `validate_units()` — PR #55
-- [x] **TASK-062: BBS/DXF Null Detailing Guard** — `or {}` guard in `__main__.py` — PR #56
-- [x] **TASK-063: Canonical Units in job_runner Output** — Use return value of `validate_units()` — PR #56
-- [x] **TASK-064: Case-Insensitive Units Validation** — Normalize to uppercase — PR #56
 
 ---
 
 ## Archive
 
-- Full history: `docs/_archive/TASKS_2025-12-27.md`
-
----
-
-## Notes
-
-- **Current Version**: v0.11.0
-- **Last Updated**: 2025-12-30
-- **Active Branch**: main
-- **Tests**: Run `python scripts/update_test_stats.py` for current count
-- **Target**: v0.20.0 stable release (see `docs/planning/v0.20-stabilization-checklist.md`)
+- Full history: `docs/_archive/TASKS_HISTORY.md`

--- a/docs/_archive/TASKS_HISTORY.md
+++ b/docs/_archive/TASKS_HISTORY.md
@@ -1,0 +1,278 @@
+# Task Board (Archive Snapshot)
+
+> Snapshot of `docs/TASKS.md` before cleanup/restructure. Keep for history only.
+
+> How to use: start each session here. Pick a task from "Up Next", move it to "Active", then move to "Done" when finished.
+
+---
+
+## Multi-Agent Workflow
+
+When working on tasks, specify which agent role to use:
+
+| Role | Doc | Use For |
+|------|-----|---------|
+| **DEV** | `agents/DEV.md` | Implementation, refactoring, architecture |
+| **TESTER** | `agents/TESTER.md` | Test design, edge cases, validation |
+| **DEVOPS** | `agents/DEVOPS.md` | Repo structure, automation, releases |
+| **PM** | `agents/PM.md` | Scope, prioritization, changelog |
+| **UI** | `agents/UI.md` | Excel layout, UX flow, VBA forms |
+| **CLIENT** | `agents/CLIENT.md` | Requirements, user stories, validation |
+| **RESEARCHER** | `agents/RESEARCHER.md` | IS Codes, algorithms, technical constraints |
+| **INTEGRATION** | `agents/INTEGRATION.md` | Data schemas, ETABS/CSV mapping |
+| **DOCS** | `agents/DOCS.md` | API docs, guides, changelog |
+| **SUPPORT** | `agents/SUPPORT.md` | Troubleshooting, known issues |
+
+See also: `docs/_internal/AGENT_WORKFLOW.md`
+
+---
+
+## Active
+
+No active tasks. Pick from "Up Next" and move here when starting.
+
+## Recently Completed (Quality Hardening)
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-126** | Warn on Table 19 fck out-of-range in shear design | DEV | ✅ Done |
+| **TASK-127** | Document Table 19 range warning in known-pitfalls + error schema | DOCS | ✅ Done |
+| **TASK-128** | Add tests for Table 19 range warning | TESTER | ✅ Done |
+
+## Recently Completed (BBS + DXF Improvement Program)
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-098** | Define BBS/DXF contracts + bar mark spec | DOCS | ✅ Done |
+| **TASK-099** | Deterministic bar mark generator + wire into BBS | DEV | ✅ Done |
+| **TASK-100** | BBS cut-length + hook/bend updates + weight rules | DEV | ✅ Done |
+| **TASK-101** | DXF callouts include bar marks + zone labels | DEV | ✅ Done |
+| **TASK-102** | DXF/BBS consistency checker (mark diff) | DEV | ✅ Done |
+| **TASK-103** | DXF content tests (layers + text) | TESTER | ✅ Done |
+| **TASK-083** | DXF deliverable layout polish | DEV | ✅ Done |
+| **TASK-084** | DXF to PDF/PNG export workflow | DEVOPS | ✅ Done |
+
+## Recently Completed (Public API Maintenance)
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-109** | Centralize units validation in public API | DEV | ✅ Done |
+| **TASK-110** | Fix `get_library_version()` fallback | DEV | ✅ Done |
+| **TASK-111** | Align `__all__` exports with stability policy | DEV | ✅ Done |
+| **TASK-112** | Document `api.py` stable entrypoints in api-stability.md | DOCS | ✅ Done |
+| **TASK-113** | Add return type annotation for `detail_beam_is456()` | DEV | ✅ Done |
+| **TASK-114** | Clarify units for `check_compliance_report()` in docs | DOCS | ✅ Done |
+| **TASK-115** | Document or demote `beam_pipeline` in API docs | DOCS | ✅ Done |
+| **TASK-116** | Fix serviceability function names in api-stability.md | DOCS | ✅ Done |
+| **TASK-117** | Classify `report`/`report_svg` stability or stop re-exporting | DEV | ✅ Done |
+| **TASK-118** | Document `get_library_version()` in api.md | DOCS | ✅ Done |
+| **TASK-119** | Add public API helpers overview in api.md | DOCS | ✅ Done |
+| **TASK-120** | Fix shear function names in api-stability.md | DOCS | ✅ Done |
+| **TASK-121** | Classify `excel_integration` stability or stop re-exporting | DEV | ✅ Done |
+
+## Recently Completed (v0.12)
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-104** | Define stable API surface + doc updates | DOCS | ✅ Done |
+| **TASK-105** | Validation APIs + `validate` CLI subcommand | DEV | ✅ Done |
+| **TASK-106** | Detailing + BBS APIs + `detail` CLI subcommand | DEV | ✅ Done |
+| **TASK-107** | DXF/report/critical API wrappers (no behavior change) | DEV | ✅ Done |
+| **TASK-108** | API/CLI tests + stability labels | TESTER | ✅ Done |
+| **TASK-122** | v0.12 release notes (CHANGELOG + RELEASES) | DOCS | ✅ Done |
+| **TASK-123** | v0.12 version bump (Python/VBA) | DEVOPS | ✅ Done |
+| **TASK-124** | v0.12 session log + next-session brief | DOCS | ✅ Done |
+| **TASK-125** | v0.12 release tag + publish | DEVOPS | ✅ Done |
+
+## Recently Completed (Visual v0.11)
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **#134 (V01)** | report.py skeleton + load_job_spec helper | DEV | ✅ Done |
+| **#135 (V02)** | report subcommand in __main__.py | DEV | ✅ Done |
+| **#136 (V03)** | Critical Set Export (sorted utilization table) | DEV | ✅ Done |
+| **#137 (V04)** | report_svg.py + cross-section SVG | DEV | ✅ Done |
+| **#138 (V05)** | Input Sanity Heatmap | DEV | ✅ Done |
+| **#139 (V06)** | Stability Scorecard | DEV | ✅ Done |
+| **#140 (V07)** | Units Sentinel | DEV | ✅ Done |
+| **#141 (V08)** | HTML export + batch packaging | DEV | ✅ Done |
+| **#142 (V09)** | Golden file tests for report module | DEV | ✅ Done |
+
+---
+
+## Recently Completed (v0.10.6)
+
+### W03-W05: Structured Error Schema Sprint — ✅ COMPLETE
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **W03** | Design error schema (docs/reference/error-schema.md) | DOCS | ✅ Done |
+| **W04** | Implement DesignError dataclass + integrate in core | DEV | ✅ Done |
+| **W05** | Structured validation for doubly/flanged beams | DEV | ✅ Done |
+
+**Deliverables:**
+- `errors.py` module with frozen `DesignError` dataclass
+- 16+ error codes: `E_INPUT_*`, `E_FLEXURE_*`, `E_SHEAR_*`, `E_DUCTILE_*`
+- Structured errors in all core design functions
+- 38 new tests for error schema
+- Full error catalog in docs/reference/error-schema.md
+
+---
+
+## Recently Completed (v0.9.7-dev)
+
+### Level B Serviceability + CLI/AI Discoverability (PR #62) — ✅ COMPLETE
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-055** | Level B Serviceability (curvature-based deflection) | DEV | ✅ Done |
+| **TASK-069** | Add `llms.txt` (AI summary) | DOCS | ✅ Done |
+| **TASK-070** | CLI help pass | DEV | ✅ Done |
+| **TASK-071** | Sync CLI reference | DOCS | ✅ Done |
+| **TASK-072** | Cross-links from docs | DOCS | ✅ Done |
+
+**Deliverables:**
+- 7 new Level B functions in `serviceability.py`
+- `DeflectionLevelBResult` dataclass
+- 16 new tests (1730 total passing)
+- `llms.txt` for AI discovery
+- Enhanced CLI help text
+
+### Release Automation Sprint (TASK-065 through TASK-068) — ✅ COMPLETE
+
+**Deliverables (PR #59):**
+- `scripts/release.py` — One-command release helper
+- `scripts/check_doc_versions.py` — Validate no stale versions
+- `.pre-commit-config.yaml` — Enhanced with ruff, doc check hooks
+- CI doc drift check step
+
+### Guardrails Hardening (Local CI Parity) — ✅ COMPLETE
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-097** | Add local CI parity script (`scripts/ci_local.sh`) | DEVOPS | ✅ Done |
+
+### Error Message Review (TASK-080) — ✅ COMPLETE
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-080** | Error message review | SUPPORT | ✅ Done |
+
+### Multi-Agent Review Remediation (Phase 1/2) — ✅ COMPLETE
+
+| ID | Task | Agent | Status |
+|----|------|-------|--------|
+| **TASK-090** | Add branch coverage gate + pytest timeout in CI | DEVOPS | ✅ Done |
+| **TASK-091** | Add `CODEOWNERS` | DEVOPS | ✅ Done |
+| **TASK-092** | Complete Shear section in `docs/reference/api.md` | DOCS | ✅ Done |
+| **TASK-093** | Document golden/parity vector sources | DOCS | ✅ Done |
+| **TASK-094** | Add explicit `__all__` in `api.py` | DEV | ✅ Done |
+| **TASK-095** | Remove duplicate doc drift check in CI | DEVOPS | ✅ Done |
+| **TASK-096** | Add Mu_lim clause comment + expand `design_shear` docstring | DEV | ✅ Done |
+
+---
+
+## Up Next (v0.9.7 Release Sprint)
+
+**Goal:** Prepare for v0.9.7 release with Level B serviceability + polish.
+
+| ID | Task | Agent | Est. | Priority |
+|----|------|-------|------|----------|
+| **TASK-073** | Update CHANGELOG for v0.9.7 | PM | 15 min | 🔴 High |
+| **TASK-074** | Bump version to 0.9.7 | DEVOPS | 10 min | 🔴 High |
+| **TASK-075** | Update next-session-brief | DOCS | 15 min | 🟡 Medium |
+| **TASK-076** | Tag and release v0.9.7 | DEVOPS | 15 min | 🔴 High |
+
+---
+
+## Up Next (v1.0 Readiness)
+
+**Goal:** Complete beta gates and prepare for v1.0 stable release.
+
+| ID | Task | Agent | Est. | Priority |
+|----|------|-------|------|----------|
+| **TASK-077** | External user CLI test | CLIENT | 1 hr | 🔴 Critical |
+| **TASK-078** | Seismic detailing validation | TESTER | 45 min | 🟡 Medium |
+| **TASK-079** | VBA parity spot-check | TESTER | 1 hr | 🟡 Medium |
+| **TASK-083** | DXF deliverable layout polish | DEV | 2 hrs | 🟡 Medium |
+| **TASK-084** | DXF to PDF/PNG export workflow | DEVOPS | 2 hrs | 🟡 Medium |
+
+**v1.0 Beta Gates (from pre-release-checklist):**
+- [x] 5 real beam validations documented
+- [ ] One external engineer tries CLI cold
+- [ ] All tests pass (currently: 1956 passed, 91 skipped)
+- [ ] VBA parity verified
+
+---
+
+## Planned (BBS + DXF Improvement Program)
+
+**Plan doc:** `docs/planning/bbs-dxf-improvement-plan.md`
+
+| ID | Task | Agent | Est. | Priority | Bundle |
+|----|------|-------|------|----------|--------|
+
+---
+
+## Planned (v0.12 Scope)
+
+All v0.12 release tasks completed.
+
+---
+
+## Planned (Test Hardening)
+
+| ID | Task | Agent | Est. | Priority |
+|----|------|-------|------|----------|
+| **TASK-126** | Reduce property-invariant skips by tightening generators (d > d_min, paired fy inputs) | TESTER | 2 hrs | 🟡 Medium |
+| **TASK-127** | Add contract tests for units conversion boundaries at API/CLI entrypoints | TESTER | 2 hrs | 🟡 Medium |
+| **TASK-128** | Add regression fixtures for BBS/DXF mark-diff (missing marks, mismatched counts) | TESTER | 2 hrs | 🟡 Medium |
+
+---
+
+## Planned (Public API Maintenance)
+
+**Review doc:** `docs/planning/public-api-maintenance-review.md`
+
+All Public API Maintenance tasks are complete.
+
+---
+
+## Backlog (Post-v1.0)
+
+| ID | Task | Agent | Description |
+|----|------|-------|-------------|
+| **TASK-081** | Level C Serviceability | DEV | Shrinkage + creep deflection (Annex C full) |
+| **TASK-082** | VBA Parity Automation | DEVOPS | Automated Python vs VBA comparison harness |
+| **TASK-085** | Torsion Design + Detailing | DEV | Equivalent shear/moment + closed stirrups (Cl. 41) |
+| **TASK-086** | Side-Face Reinforcement Check | DEV | D > 750 mm -> 0.1% web area bars (Cl. 26.5.1.3) |
+| **TASK-087** | Anchorage Space Check | DEV | Verify Ld at supports; suggest hooks/bends if short (Cl. 26.2) |
+| **TASK-088** | Slenderness/Stability Check | DEV | L > 60b or 250b^2/d warning (Cl. 23.1.2) |
+| **TASK-089** | Flanged Effective Width Helper | INTEGRATION | Compute bf from slab geometry for T/L beams |
+
+---
+
+## Completed (v0.9.6)
+
+- [x] **TASK-059: Shared Beam Pipeline Module** — `beam_pipeline.py` — PR #55
+- [x] **TASK-060: Canonical Result Schema v1** — `BeamDesignOutput`, `MultiBeamOutput` — PR #55
+- [x] **TASK-061: Units Validation at App Layer** — `validate_units()` — PR #55
+- [x] **TASK-062: BBS/DXF Null Detailing Guard** — `or {}` guard in `__main__.py` — PR #56
+- [x] **TASK-063: Canonical Units in job_runner Output** — Use return value of `validate_units()` — PR #56
+- [x] **TASK-064: Case-Insensitive Units Validation** — Normalize to uppercase — PR #56
+
+---
+
+## Archive
+
+- Full history: `docs/_archive/TASKS_2025-12-27.md`
+
+---
+
+## Notes
+
+- **Current Version**: v0.11.0
+- **Last Updated**: 2025-12-30
+- **Active Branch**: main
+- **Tests**: Run `python scripts/update_test_stats.py` for current count
+- **Target**: v0.20.0 stable release (see `docs/planning/v0.20-stabilization-checklist.md`)

--- a/docs/contributing/repo-professionalism.md
+++ b/docs/contributing/repo-professionalism.md
@@ -42,6 +42,10 @@ Canonical sources:
 - Local guardrail: pre-commit blocks commits on `main` (see `.pre-commit-config.yaml`).
 - CI guardrail: pushes to `main` must be associated with a PR (see `.github/workflows/main-branch-guard.yml`).
 
+### Task hygiene
+- TASKS format is enforced locally: `scripts/check_tasks_format.py`.
+- Keep WIP=1 and move tasks between sections (no duplicates).
+
 ### PR discipline
 - Use the PR template in `.github/pull_request_template.md`.
 - Link a TASK ID in the PR body.

--- a/scripts/check_tasks_format.py
+++ b/scripts/check_tasks_format.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate docs/TASKS.md structure and WIP rules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+TASKS_PATH = Path("docs/TASKS.md")
+
+REQUIRED_HEADINGS = [
+    "## Rules (read first)",
+    "## Current Release",
+    "## Active",
+    "## Up Next",
+    "## Backlog",
+    "## Recently Done",
+    "## Archive",
+]
+
+
+def _find_heading(lines: list[str], heading: str) -> int:
+    for idx, line in enumerate(lines):
+        if line.strip() == heading:
+            return idx
+    return -1
+
+
+def _section(lines: list[str], start_idx: int) -> list[str]:
+    end_idx = len(lines)
+    for idx in range(start_idx + 1, len(lines)):
+        if lines[idx].startswith("## "):
+            end_idx = idx
+            break
+    return lines[start_idx + 1 : end_idx]
+
+
+def _table_rows(section_lines: list[str]) -> list[str]:
+    rows = [line for line in section_lines if line.strip().startswith("|")]
+    if not rows:
+        return []
+    # Drop header + separator if present.
+    data_rows = []
+    for line in rows:
+        if "| ID |" in line and "| Task |" in line:
+            continue
+        if set(line.strip()) <= {"|", "-", " "}:
+            continue
+        data_rows.append(line)
+    return data_rows
+
+
+def main() -> int:
+    if not TASKS_PATH.exists():
+        print(f"ERROR: Missing {TASKS_PATH}")
+        return 1
+
+    lines = TASKS_PATH.read_text(encoding="utf-8").splitlines()
+
+    # Headings present and ordered.
+    positions = []
+    for heading in REQUIRED_HEADINGS:
+        pos = _find_heading(lines, heading)
+        if pos == -1:
+            print(f"ERROR: Missing heading: {heading}")
+            return 1
+        positions.append(pos)
+
+    if positions != sorted(positions):
+        print("ERROR: Headings are out of order.")
+        return 1
+
+    # Rules section contains WIP rule.
+    rules_lines = _section(lines, positions[0])
+    if not any("WIP = 1" in line for line in rules_lines):
+        print("ERROR: Rules section must include 'WIP = 1'.")
+        return 1
+
+    # Active section WIP count.
+    active_lines = _section(lines, positions[2])
+    active_rows = _table_rows(active_lines)
+    if len(active_rows) > 1:
+        print("ERROR: Active section must have at most 1 task (WIP=1).")
+        return 1
+
+    # Up Next table header.
+    up_next_lines = _section(lines, positions[3])
+    if not any("| ID | Task | Agent | Est | Priority | Status |" in line for line in up_next_lines):
+        print("ERROR: Up Next table header missing or malformed.")
+        return 1
+
+    # Recently Done table header.
+    done_lines = _section(lines, positions[5])
+    if not any("| ID | Task | Agent | Status |" in line for line in done_lines):
+        print("ERROR: Recently Done table header missing or malformed.")
+        return 1
+
+    # Archive link.
+    archive_lines = _section(lines, positions[6])
+    if not any("docs/_archive/TASKS_HISTORY.md" in line for line in archive_lines):
+        print("ERROR: Archive link missing (docs/_archive/TASKS_HISTORY.md).")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Clean and simplify `docs/TASKS.md` into a short, professional flow.
- Archive the full historical task list in `docs/_archive/TASKS_HISTORY.md`.
- Add a local format check (`scripts/check_tasks_format.py`) and hook it into pre-commit.
- Document the TASKS guardrail in repo professionalism guidance.

## Testing
- `python3 scripts/check_tasks_format.py`
