### PR TITLE
chore(docs): enforce docs index structure

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -50,6 +50,10 @@ jobs:
         run: |
           python scripts/check_doc_versions.py --ci
 
+      - name: Docs index structure check
+        run: |
+          python scripts/check_docs_index.py
+
   pytest:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,13 @@ repos:
         pass_filenames: false
         always_run: true
         verbose: true
+      - id: check-docs-index
+        name: Check docs index structure
+        entry: python3 scripts/check_docs_index.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
 
 # CI note: pre-commit hooks run locally only.
 # CI has separate lint/format checks in .github/workflows/python-tests.yml

--- a/docs/contributing/repo-professionalism.md
+++ b/docs/contributing/repo-professionalism.md
@@ -46,6 +46,9 @@ Canonical sources:
 - TASKS format is enforced locally: `scripts/check_tasks_format.py`.
 - Keep WIP=1 and move tasks between sections (no duplicates).
 
+### Docs hygiene
+- Docs index structure is enforced locally and in CI: `scripts/check_docs_index.py`.
+
 ### PR discipline
 - Use the PR template in `.github/pull_request_template.md`.
 - Link a TASK ID in the PR body.

--- a/scripts/check_docs_index.py
+++ b/scripts/check_docs_index.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Validate docs/README.md structure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+DOC_PATH = Path("docs/README.md")
+
+REQUIRED_HEADINGS = [
+    "# Docs Index (Start Here)",
+    "## Quick CLI Reference",
+    "## For Most Users",
+    "## Visual Outputs",
+    "## For Contributors / Maintainers",
+    "## Planning / Research",
+    "## Release History",
+    "## Internal (multi-agent workflow)",
+]
+
+
+def main() -> int:
+    if not DOC_PATH.exists():
+        print("ERROR: docs/README.md not found")
+        return 1
+
+    text = DOC_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    for heading in REQUIRED_HEADINGS:
+        if not any(line.startswith(heading) for line in lines):
+            print(f"ERROR: Missing heading: {heading}")
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a docs index structure check (`scripts/check_docs_index.py`).
- Wire it into pre-commit and CI.
- Document the guardrail in repo professionalism guidance.

## Testing
- `python3 scripts/check_docs_index.py`
