### PR TITLE
chore(docs): enforce release docs consistency

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -54,6 +54,10 @@ jobs:
         run: |
           python scripts/check_docs_index.py
 
+      - name: Release docs consistency check
+        run: |
+          python scripts/check_release_docs.py
+
   pytest:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,13 @@ repos:
         pass_filenames: false
         always_run: true
         verbose: true
+      - id: check-release-docs
+        name: Check release docs consistency
+        entry: python3 scripts/check_release_docs.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
 
 # CI note: pre-commit hooks run locally only.
 # CI has separate lint/format checks in .github/workflows/python-tests.yml

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -235,6 +235,17 @@ Use workflow_dispatch with `testpypi` target:
 
 ---
 
+## v0.9.5
+**Date:** 2025-12-27
+**Status:** ✅ Locked & Verified
+**Mindset:** PyPI launch + docs restructure + release automation
+**Key Changes:**
+- **Published to PyPI:** Trusted Publishing (OIDC) with GitHub Release auto-creation.
+- **Docs restructure:** 7 folders (getting-started, reference, verification, contributing, architecture, planning, cookbook).
+- **Project metadata:** `project.urls` added to `pyproject.toml`.
+
+---
+
 ## v0.9.4
 **Date:** 2025-12-27
 **Status:** ✅ Locked & Verified
@@ -338,6 +349,14 @@ Use workflow_dispatch with `testpypi` target:
 - Flanged Beam Design (T/L Sections)
 - Neutral Axis analysis (Flange vs Web)
 - `Test_Flanged.bas`
+
+## v0.2.1
+**Date:** 2025-12-11
+**Status:** ✅ Locked
+**Key Fixes (Mac VBA Compatibility):**
+- Stack corruption fixes for boolean pass-by-value cases.
+- Wrapped dimension multiplications in `CDbl()` to avoid overflow.
+- Safer test harness assertions in `Test_Structural.bas`.
 
 ## v0.2.0
 **Date:** 2025-12-11

--- a/docs/contributing/repo-professionalism.md
+++ b/docs/contributing/repo-professionalism.md
@@ -48,6 +48,7 @@ Canonical sources:
 
 ### Docs hygiene
 - Docs index structure is enforced locally and in CI: `scripts/check_docs_index.py`.
+- Release docs consistency is enforced locally and in CI: `scripts/check_release_docs.py`.
 
 ### PR discipline
 - Use the PR template in `.github/pull_request_template.md`.

--- a/scripts/check_release_docs.py
+++ b/scripts/check_release_docs.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Validate CHANGELOG.md and docs/RELEASES.md have matching versions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+CHANGELOG = Path("CHANGELOG.md")
+RELEASES = Path("docs/RELEASES.md")
+
+VERSION_RE = re.compile(r"^##\s*\[?v?(\d+\.\d+\.\d+)\b")
+
+
+def _parse_versions(path: Path) -> list[str]:
+    versions: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = VERSION_RE.match(line.strip())
+        if match:
+            versions.append(match.group(1))
+    return versions
+
+
+def _semver_key(version: str) -> tuple[int, int, int]:
+    parts = version.split(".")
+    if len(parts) != 3:
+        return (0, 0, 0)
+    return tuple(int(part) for part in parts)  # type: ignore[return-value]
+
+
+def main() -> int:
+    if not CHANGELOG.exists():
+        print("ERROR: CHANGELOG.md not found")
+        return 1
+    if not RELEASES.exists():
+        print("ERROR: docs/RELEASES.md not found")
+        return 1
+
+    changelog_versions = _parse_versions(CHANGELOG)
+    releases_versions = _parse_versions(RELEASES)
+
+    if not changelog_versions:
+        print("ERROR: No versions found in CHANGELOG.md")
+        return 1
+    if not releases_versions:
+        print("ERROR: No versions found in docs/RELEASES.md")
+        return 1
+
+    missing_in_releases = sorted(
+        set(changelog_versions) - set(releases_versions), key=_semver_key
+    )
+    missing_in_changelog = sorted(
+        set(releases_versions) - set(changelog_versions), key=_semver_key
+    )
+
+    if missing_in_releases:
+        print("ERROR: Versions in CHANGELOG missing from RELEASES:")
+        for version in missing_in_releases:
+            print(f"  - {version}")
+        return 1
+
+    if missing_in_changelog:
+        print("ERROR: Versions in RELEASES missing from CHANGELOG:")
+        for version in missing_in_changelog:
+            print(f"  - {version}")
+        return 1
+
+    latest_changelog = max(changelog_versions, key=_semver_key)
+    latest_releases = max(releases_versions, key=_semver_key)
+    if latest_changelog != latest_releases:
+        print(
+            "ERROR: Latest versions do not match: "
+            f"CHANGELOG={latest_changelog}, RELEASES={latest_releases}"
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a release docs consistency check (`scripts/check_release_docs.py`).
- Wire it into pre-commit and CI.
- Backfill missing v0.9.5 and v0.2.1 entries in `docs/RELEASES.md` to match CHANGELOG.
- Document the guardrail in repo professionalism guidance.

## Testing
- `python3 scripts/check_release_docs.py`
