### PR TITLE
chore(docs): add session length + CLI guards

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -70,6 +70,14 @@ jobs:
         run: |
           python scripts/check_pre_release_checklist.py
 
+      - name: Next-session brief length check
+        run: |
+          python scripts/check_next_session_brief_length.py
+
+      - name: CLI reference check
+        run: |
+          python scripts/check_cli_reference.py
+
   pytest:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,20 @@ repos:
         pass_filenames: false
         always_run: true
         verbose: true
+      - id: check-next-session-brief-length
+        name: Check next-session brief length
+        entry: python3 scripts/check_next_session_brief_length.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
+      - id: check-cli-reference
+        name: Check CLI reference commands
+        entry: python3 scripts/check_cli_reference.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
 
 # CI note: pre-commit hooks run locally only.
 # CI has separate lint/format checks in .github/workflows/python-tests.yml

--- a/docs/contributing/repo-professionalism.md
+++ b/docs/contributing/repo-professionalism.md
@@ -52,6 +52,8 @@ Canonical sources:
 - Session docs consistency is enforced locally and in CI: `scripts/check_session_docs.py`.
 - API docs sync is enforced locally and in CI: `scripts/check_api_docs_sync.py`.
 - Pre-release checklist structure is enforced locally and in CI: `scripts/check_pre_release_checklist.py`.
+- Next-session brief length is enforced locally and in CI: `scripts/check_next_session_brief_length.py`.
+- CLI reference completeness is enforced locally and in CI: `scripts/check_cli_reference.py`.
 
 ### PR discipline
 - Use the PR template in `.github/pull_request_template.md`.

--- a/docs/cookbook/cli-reference.md
+++ b/docs/cookbook/cli-reference.md
@@ -24,6 +24,21 @@ python -m structural_lib dxf results.json -o drawings.dxf
 
 # Run complete job
 python -m structural_lib job job.json -o ./output/
+
+# Validate inputs/results
+python -m structural_lib validate job.json
+
+# Generate detailing JSON
+python -m structural_lib detail results.json -o detailing.json
+
+# Generate critical set table
+python -m structural_lib critical ./output --top 10 --format=csv -o critical.csv
+
+# Generate report
+python -m structural_lib report ./output --format=html -o report.html
+
+# Compare BBS and DXF marks
+python -m structural_lib mark-diff --bbs schedule.csv --dxf drawings.dxf
 ```
 
 ---

--- a/scripts/check_cli_reference.py
+++ b/scripts/check_cli_reference.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Ensure CLI reference includes required commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+CLI_REF = Path("docs/cookbook/cli-reference.md")
+
+REQUIRED_COMMANDS = {
+    "design",
+    "bbs",
+    "detail",
+    "dxf",
+    "job",
+    "validate",
+    "critical",
+    "report",
+    "mark-diff",
+}
+
+CMD_RE = re.compile(r"python\s+-m\s+structural_lib\s+(\S+)")
+
+
+def main() -> int:
+    if not CLI_REF.exists():
+        print("ERROR: docs/cookbook/cli-reference.md not found")
+        return 1
+
+    text = CLI_REF.read_text(encoding="utf-8")
+    commands = set(match.group(1) for match in CMD_RE.finditer(text))
+
+    missing = sorted(REQUIRED_COMMANDS - commands)
+    if missing:
+        print("ERROR: CLI reference missing commands:")
+        for cmd in missing:
+            print(f"  - {cmd}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_next_session_brief_length.py
+++ b/scripts/check_next_session_brief_length.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Ensure next-session-brief.md stays concise."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+BRIEF_PATH = Path("docs/planning/next-session-brief.md")
+MAX_LINES = 150
+
+
+def main() -> int:
+    if not BRIEF_PATH.exists():
+        print("ERROR: docs/planning/next-session-brief.md not found")
+        return 1
+
+    lines = BRIEF_PATH.read_text(encoding="utf-8").splitlines()
+    line_count = len(lines)
+
+    if line_count > MAX_LINES:
+        print(
+            f"ERROR: next-session-brief.md is {line_count} lines (max {MAX_LINES})."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a next-session brief length check and CLI reference completeness check.
- Wire the checks into pre-commit and CI.
- Document the guardrails in repo professionalism guidance.
- Update CLI reference quick start to include all stable commands.

## Testing
- `python3 scripts/check_next_session_brief_length.py`
- `python3 scripts/check_cli_reference.py`
