### PR TITLE
chore(docs): enforce API doc signatures

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -70,6 +70,10 @@ jobs:
         run: |
           python scripts/check_pre_release_checklist.py
 
+      - name: API doc signatures check
+        run: |
+          python scripts/check_api_doc_signatures.py
+
       - name: Next-session brief length check
         run: |
           python scripts/check_next_session_brief_length.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,13 @@ repos:
         pass_filenames: false
         always_run: true
         verbose: true
+      - id: check-api-doc-signatures
+        name: Check API doc signatures
+        entry: python3 scripts/check_api_doc_signatures.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
       - id: check-next-session-brief-length
         name: Check next-session brief length
         entry: python3 scripts/check_next_session_brief_length.py

--- a/docs/contributing/repo-professionalism.md
+++ b/docs/contributing/repo-professionalism.md
@@ -52,6 +52,7 @@ Canonical sources:
 - Session docs consistency is enforced locally and in CI: `scripts/check_session_docs.py`.
 - API docs sync is enforced locally and in CI: `scripts/check_api_docs_sync.py`.
 - Pre-release checklist structure is enforced locally and in CI: `scripts/check_pre_release_checklist.py`.
+- API doc signatures are enforced locally and in CI: `scripts/check_api_doc_signatures.py`.
 - Next-session brief length is enforced locally and in CI: `scripts/check_next_session_brief_length.py`.
 - CLI reference completeness is enforced locally and in CI: `scripts/check_cli_reference.py`.
 

--- a/scripts/check_api_doc_signatures.py
+++ b/scripts/check_api_doc_signatures.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Ensure api.__all__ functions are documented in docs/reference/api.md."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+DOC_PATH = Path("docs/reference/api.md")
+
+
+def _load_api_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root / "Python"))
+    from structural_lib import api  # type: ignore
+
+    return api
+
+
+def _documented_names(doc_text: str) -> set[str]:
+    names: set[str] = set()
+    for match in re.finditer(r"\bapi\.([a-zA-Z_][a-zA-Z0-9_]*)", doc_text):
+        names.add(match.group(1))
+    for match in re.finditer(r"^\s*def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(", doc_text, re.M):
+        names.add(match.group(1))
+    return names
+
+
+def main() -> int:
+    if not DOC_PATH.exists():
+        print("ERROR: docs/reference/api.md not found")
+        return 1
+
+    doc_text = DOC_PATH.read_text(encoding="utf-8")
+    documented = _documented_names(doc_text)
+
+    api = _load_api_module()
+    exported = [name for name in getattr(api, "__all__", []) if not name.startswith("_")]
+
+    missing = [name for name in exported if name not in documented]
+    if missing:
+        print("ERROR: api.__all__ symbols missing from docs/reference/api.md:")
+        for name in missing:
+            print(f"  - {name}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_session_docs.py
+++ b/scripts/check_session_docs.py
@@ -69,14 +69,22 @@ def main() -> int:
 
     # Check session log has matching date header.
     session_heading = f"## {date_str}"
+    first_session_line = None
     session_idx = -1
     for idx, line in enumerate(session_lines):
+        if line.startswith("## ") and first_session_line is None:
+            first_session_line = line
         if line.startswith(session_heading) and "Session" in line:
             session_idx = idx
             break
 
     if session_idx == -1:
         print(f"ERROR: SESSION_LOG.md missing session entry for {date_str}")
+        return 1
+
+    if first_session_line is not None and not first_session_line.startswith(session_heading):
+        print("ERROR: SESSION_LOG.md newest session must be at the top (append-only).")
+        print(f"Expected first session header to start with {session_heading}.")
         return 1
 
     # Ensure Focus appears near the session header.


### PR DESCRIPTION
## Summary
- Add an API doc signature check against `structural_lib.api.__all__`.
- Enforce it via pre-commit and CI.
- Tighten session log guardrail to require newest entry at top.

## Testing
- `python3 scripts/check_api_doc_signatures.py`
- `python3 scripts/check_session_docs.py`
