### PR TITLE
chore(docs): enforce docs index links

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -82,6 +82,10 @@ jobs:
         run: |
           python scripts/check_cli_reference.py
 
+      - name: Docs index links check
+        run: |
+          python scripts/check_docs_index_links.py
+
   pytest:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,13 @@ repos:
         pass_filenames: false
         always_run: true
         verbose: true
+      - id: check-docs-index-links
+        name: Check docs index links
+        entry: python3 scripts/check_docs_index_links.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
 
 # CI note: pre-commit hooks run locally only.
 # CI has separate lint/format checks in .github/workflows/python-tests.yml

--- a/docs/contributing/repo-professionalism.md
+++ b/docs/contributing/repo-professionalism.md
@@ -55,6 +55,7 @@ Canonical sources:
 - API doc signatures are enforced locally and in CI: `scripts/check_api_doc_signatures.py`.
 - Next-session brief length is enforced locally and in CI: `scripts/check_next_session_brief_length.py`.
 - CLI reference completeness is enforced locally and in CI: `scripts/check_cli_reference.py`.
+- Docs index links are enforced locally and in CI: `scripts/check_docs_index_links.py`.
 
 ### PR discipline
 - Use the PR template in `.github/pull_request_template.md`.

--- a/scripts/check_docs_index_links.py
+++ b/scripts/check_docs_index_links.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Ensure docs/README.md links resolve to real files/dirs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+DOCS_INDEX = Path("docs/README.md")
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+FENCE_RE = re.compile(r"^```")
+
+
+def _strip_code_blocks(text: str) -> str:
+    lines = []
+    in_fence = False
+    for line in text.splitlines():
+        if FENCE_RE.match(line.strip()):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def _is_external(link: str) -> bool:
+    return link.startswith("http://") or link.startswith("https://") or link.startswith("mailto:")
+
+
+def main() -> int:
+    if not DOCS_INDEX.exists():
+        print("ERROR: docs/README.md not found")
+        return 1
+
+    text = _strip_code_blocks(DOCS_INDEX.read_text(encoding="utf-8"))
+    base = DOCS_INDEX.parent
+
+    errors: list[str] = []
+    for match in LINK_RE.finditer(text):
+        link = match.group(1).strip()
+        if not link or _is_external(link) or link.startswith("#"):
+            continue
+
+        link_path = link.split("#", 1)[0]
+        if not link_path:
+            continue
+
+        resolved = (base / link_path).resolve()
+        if not resolved.exists():
+            errors.append(f"Missing: {link_path}")
+
+    if errors:
+        print("ERROR: docs/README.md contains broken local links:")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a docs index link check (`scripts/check_docs_index_links.py`).
- Wire the check into pre-commit and CI.
- Document the guardrail in repo professionalism guidance.

## Testing
- `python3 scripts/check_docs_index_links.py`
