### PR TITLE
test(task-129-131): harden invariants and mark-diff coverage

### DIFF
--- a/Python/tests/test_api_entrypoints_is456.py
+++ b/Python/tests/test_api_entrypoints_is456.py
@@ -53,6 +53,24 @@ def test_design_beam_is456_returns_case_result_and_records_pt_assumption():
     assert "Computed pt_percent for shear" in res.remarks
 
 
+def test_design_beam_is456_converts_vu_kn_to_tv_nmm2():
+    res = api.design_beam_is456(
+        units="IS456",
+        case_id="C-TV",
+        mu_knm=50.0,
+        vu_kn=80.0,
+        b_mm=200.0,
+        D_mm=450.0,
+        d_mm=400.0,
+        fck_nmm2=25.0,
+        fy_nmm2=500.0,
+        pt_percent=1.0,
+        asv_mm2=100.0,
+    )
+
+    assert res.shear.tv == pytest.approx(1.0, rel=0.0, abs=1e-6)
+
+
 def test_check_beam_is456_runs_multi_case_report():
     cases = [
         {"case_id": "C1", "mu_knm": 80.0, "vu_kn": 60.0},

--- a/Python/tests/test_bbs_dxf_consistency.py
+++ b/Python/tests/test_bbs_dxf_consistency.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import sys
 import tempfile
@@ -52,6 +53,117 @@ class TestBBSDXFConsistency(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["summary"]["missing_in_dxf"], 0)
         self.assertEqual(result["summary"]["extra_in_dxf"], 0)
+
+    def test_mark_diff_missing_in_dxf(self):
+        if not dxf_export.EZDXF_AVAILABLE:
+            self.skipTest("ezdxf is not installed; DXF tests skipped")
+
+        detailing = create_beam_detailing(
+            beam_id="B1",
+            story="S1",
+            b=230,
+            D=450,
+            span=5000,
+            cover=25,
+            fck=25,
+            fy=415,
+            ast_start=900,
+            ast_mid=700,
+            ast_end=900,
+            asc_start=0,
+            asc_mid=0,
+            asc_end=0,
+            stirrup_dia=8,
+            stirrup_spacing_start=100,
+            stirrup_spacing_mid=150,
+            stirrup_spacing_end=100,
+            is_seismic=False,
+        )
+
+        items = bbs.generate_bbs_from_detailing(detailing)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bbs_path = os.path.join(tmpdir, "bbs.csv")
+            dxf_path = os.path.join(tmpdir, "beam.dxf")
+
+            bbs.export_bbs_to_csv(items, bbs_path, include_summary=False)
+            dxf_export.generate_beam_dxf(detailing, dxf_path)
+
+            with open(bbs_path, "r", encoding="utf-8", newline="") as f:
+                reader = csv.DictReader(f)
+                fieldnames = reader.fieldnames
+                rows = list(reader)
+
+            extra_mark = f"{detailing.beam_id}-B-S-D16-99"
+            extra_row = {name: "" for name in (fieldnames or [])}
+            extra_row["bar_mark"] = extra_mark
+            extra_row["member_id"] = detailing.beam_id
+            rows.append(extra_row)
+
+            with open(bbs_path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(rows)
+
+            result = dxf_export.compare_bbs_dxf_marks(bbs_path, dxf_path)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["summary"]["missing_in_dxf"], 1)
+        self.assertEqual(result["summary"]["extra_in_dxf"], 0)
+
+    def test_mark_diff_extra_in_dxf(self):
+        if not dxf_export.EZDXF_AVAILABLE:
+            self.skipTest("ezdxf is not installed; DXF tests skipped")
+
+        detailing = create_beam_detailing(
+            beam_id="B1",
+            story="S1",
+            b=230,
+            D=450,
+            span=5000,
+            cover=25,
+            fck=25,
+            fy=415,
+            ast_start=900,
+            ast_mid=700,
+            ast_end=900,
+            asc_start=0,
+            asc_mid=0,
+            asc_end=0,
+            stirrup_dia=8,
+            stirrup_spacing_start=100,
+            stirrup_spacing_mid=150,
+            stirrup_spacing_end=100,
+            is_seismic=False,
+        )
+
+        items = bbs.generate_bbs_from_detailing(detailing)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bbs_path = os.path.join(tmpdir, "bbs.csv")
+            dxf_path = os.path.join(tmpdir, "beam.dxf")
+
+            bbs.export_bbs_to_csv(items, bbs_path, include_summary=False)
+            dxf_export.generate_beam_dxf(detailing, dxf_path)
+
+            with open(bbs_path, "r", encoding="utf-8", newline="") as f:
+                reader = csv.DictReader(f)
+                fieldnames = reader.fieldnames
+                rows = list(reader)
+
+            removed_mark = items[0].bar_mark
+            rows = [row for row in rows if row.get("bar_mark") != removed_mark]
+
+            with open(bbs_path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(rows)
+
+            result = dxf_export.compare_bbs_dxf_marks(bbs_path, dxf_path)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["summary"]["missing_in_dxf"], 0)
+        self.assertEqual(result["summary"]["extra_in_dxf"], 1)
 
 
 if __name__ == "__main__":

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -6,6 +6,23 @@ Append-only record of decisions, PRs, and next actions. For detailed task tracki
 
 ## 2025-12-30 — Session
 
+**Focus:** TASK-129/130/131 test hardening + start TASK-078
+
+**Completed:**
+- Reworked property-invariant comparisons to remove boundary skips (paired comparisons).
+- Added API and CLI unit-boundary contract checks (kN/kN-m conversion).
+- Added BBS/DXF mark-diff regression tests for missing/extra marks.
+- Validated seismic detailing checks (ductile + lap factor) for TASK-078.
+
+**Started:**
+- TASK-079: VBA parity spot-check (TESTER).
+
+**Tests:**
+- `cd Python && ../.venv/bin/python -m pytest tests/test_property_invariants.py tests/test_api_entrypoints_is456.py tests/test_cli.py tests/test_bbs_dxf_consistency.py`
+- `cd Python && ../.venv/bin/python -m pytest tests/test_ductile.py tests/test_detailing.py tests/test_critical_is456.py -q`
+
+## 2025-12-30 — Session
+
 **Focus:** Repo guardrails + doc consistency automation
 
 **Completed:**

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -24,7 +24,9 @@
 
 ## Active
 
-No active tasks. Move one item from "Up Next" when starting.
+| ID | Task | Agent | Est | Priority | Status |
+|----|------|-------|-----|----------|--------|
+| **TASK-079** | VBA parity spot-check | TESTER | 1 hr | 🟡 Medium | In progress |
 
 ---
 
@@ -32,9 +34,6 @@ No active tasks. Move one item from "Up Next" when starting.
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| **TASK-129** | Reduce property-invariant skips by tightening generators (d > d_min, paired fy inputs) | TESTER | 2 hrs | 🟡 Medium | Ready |
-| **TASK-130** | Add contract tests for units conversion boundaries at API/CLI entrypoints | TESTER | 2 hrs | 🟡 Medium | Ready |
-| **TASK-131** | Add regression fixtures for BBS/DXF mark-diff (missing marks, mismatched counts) | TESTER | 2 hrs | 🟡 Medium | Ready |
 
 ---
 
@@ -45,8 +44,6 @@ No active tasks. Move one item from "Up Next" when starting.
 | ID | Task | Agent | Est | Priority |
 |----|------|-------|-----|----------|
 | **TASK-077** | External user CLI test | CLIENT | 1 hr | 🔴 Critical |
-| **TASK-078** | Seismic detailing validation | TESTER | 45 min | 🟡 Medium |
-| **TASK-079** | VBA parity spot-check | TESTER | 1 hr | 🟡 Medium |
 
 ### Post-v1.0 (beam scope)
 
@@ -66,6 +63,10 @@ No active tasks. Move one item from "Up Next" when starting.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| **TASK-078** | Seismic detailing validation | TESTER | ✅ Done |
+| **TASK-131** | Add regression fixtures for BBS/DXF mark-diff (missing marks, mismatched counts) | TESTER | ✅ Done |
+| **TASK-130** | Add contract tests for units conversion boundaries at API/CLI entrypoints | TESTER | ✅ Done |
+| **TASK-129** | Reduce property-invariant skips by tightening generators (d > d_min, paired fy inputs) | TESTER | ✅ Done |
 | **TASK-126** | Warn on Table 19 fck out-of-range in shear design | DEV | ✅ Done |
 | **TASK-127** | Document Table 19 range warning in known-pitfalls + error schema | DOCS | ✅ Done |
 | **TASK-128** | Add tests for Table 19 range warning | TESTER | ✅ Done |


### PR DESCRIPTION
## Summary
- tighten property-invariant comparisons to remove boundary skips
- add unit-boundary contract checks at API and CLI entrypoints
- add BBS/DXF mark-diff regressions for missing/extra marks
- update TASKS/SESSION_LOG for TASK-078 completion and TASK-079 start

## Testing
- cd Python && ../.venv/bin/python -m pytest tests/test_property_invariants.py tests/test_api_entrypoints_is456.py tests/test_cli.py tests/test_bbs_dxf_consistency.py
- cd Python && ../.venv/bin/python -m pytest tests/test_ductile.py tests/test_detailing.py tests/test_critical_is456.py -q

## Tasks
- TASK-129
- TASK-130
- TASK-131
- TASK-078
- TASK-079