### PR TITLE
docs: add version warning to Colab insights examples

### DIFF
--- a/docs/getting-started/colab-workflow.ipynb
+++ b/docs/getting-started/colab-workflow.ipynb
@@ -281,7 +281,7 @@
   {
    "cell_type": "markdown",
    "id": "owqc0cp049s",
-   "source": "## Insights Module (v0.13+) - Smart Features\n\nThe insights module provides three advisory features:\n1. **Quick Precheck** - Heuristic validation before full design\n2. **Sensitivity Analysis** - Identify critical parameters\n3. **Constructability Scoring** - Ease of construction assessment",
+   "source": "## Insights Module (v0.13+) - Smart Features\n\n**⚠️ Note:** Insights module requires `structural-lib-is456 >= 0.13.0` (unreleased as of 2025-12-31).\nOnce released, install with: `!pip install -U \"structural-lib-is456[dxf]>=0.13.0\"`\n\nThe insights module provides three advisory features:\n1. **Quick Precheck** - Heuristic validation before full design\n2. **Sensitivity Analysis** - Identify critical parameters\n3. **Constructability Scoring** - Ease of construction assessment",
    "metadata": {}
   }
  ],


### PR DESCRIPTION
## Summary

Adds version warning to Colab notebook insights section to prevent `ModuleNotFoundError` confusion.

## Issue

Users running the Colab notebook encounter:
```
ModuleNotFoundError: No module named 'structural_lib.insights'
```

The insights module is in the codebase but not yet released on PyPI (v0.13.0 unreleased).

## Solution

Added clear warning in markdown header:
```markdown
⚠️ Note: Insights module requires structural-lib-is456 >= 0.13.0 (unreleased as of 2025-12-31).
Once released, install with: !pip install -U "structural-lib-is456[dxf]>=0.13.0"
```

## Changes

- Updated cell `owqc0cp049s` (Insights Module header) with version requirement note
- Clarifies that examples will only work after v0.13.0 release

## Related

- PR #230: Merged sensitivity fixes and Colab examples
- PR #231: Merged blog posts

## Impact

- Prevents user confusion when running insights examples before release
- Makes expectations clear about version requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)