### PR TITLE
docs: fix broken internal links

### DIFF
--- a/docs/getting-started/insights-guide.md
+++ b/docs/getting-started/insights-guide.md
@@ -77,7 +77,8 @@ python -m structural_lib design beams.csv -o results.json --insights
 
 # Creates two files:
 # - results.json (design results)
-# - results_insights.json (advisory insights)
+# - <output_stem>_insights.json (advisory insights)
+#   Example: -o results.json -> results_insights.json
 ```
 
 ---
@@ -516,8 +517,8 @@ See [insights-api.md](../reference/insights-api.md) for detailed API documentati
 
 ## Further Reading
 
-- [Sensitivity Analysis Blog Post](../publications/blog-posts/03-sensitivity-analysis/BLOG-SENSITIVITY-ANALYSIS.md)
-- [Constructability Scoring Research](../publications/findings/CONSTRUCTABILITY_RESEARCH.md)
+- [Sensitivity Analysis Blog Post (draft)](../publications/blog-posts/03-sensitivity-analysis/draft.md)
+- [Constructability Scoring Research](../publications/findings/00-research-summary-FINAL.md)
 - [IS 456 Formula Reference](../reference/is456-formulas.md)
 
 ---

--- a/docs/publications/blog-posts/01-smart-library/outline.md
+++ b/docs/publications/blog-posts/01-smart-library/outline.md
@@ -515,9 +515,9 @@ print(pre['warnings'])  # Instant feedback!
 ```
 
 **Read more:**
-- GitHub: [structural_engineering_lib](https://github.com/...)
-- Research doc: [research-smart-library.md](...)
-- Implementation plan: [v0.13-v0.14-implementation-plan.md](...)
+- GitHub: [structural_engineering_lib](https://github.com/Pravin-surawase/structural_engineering_lib)
+- Research doc: [research-smart-library.md](../../../planning/research-smart-library.md)
+- Implementation plan: [v0.13-v0.14-implementation-plan.md](../../../planning/v0.13-v0.14-implementation-plan.md)
 
 **Questions? Comments?** Let's discuss in the comments!
 

--- a/docs/publications/blog-posts/02-deterministic-ml/outline.md
+++ b/docs/publications/blog-posts/02-deterministic-ml/outline.md
@@ -497,8 +497,8 @@ ml_result = neural_network_approach(X_train, y_train)
 ```
 
 **Read more:**
-- [Optimization without ML: A Practical Guide](...)
-- [When to NOT Use Machine Learning](...)
+- Optimization without ML: A Practical Guide (draft TBD)
+- When to NOT Use Machine Learning (draft TBD)
 
 **Discuss:** What classical methods have you used successfully?
 

--- a/docs/publications/blog-posts/03-sensitivity-analysis/outline.md
+++ b/docs/publications/blog-posts/03-sensitivity-analysis/outline.md
@@ -637,9 +637,9 @@ print(robustness)     # Robustness score (0-1)
 ```
 
 **Read more:**
-- [Implementation guide](...)
-- [API reference](...)
-- [Validation cases](...)
+- [Implementation guide](../../../getting-started/insights-guide.md)
+- [API reference](../../../reference/insights-api.md)
+- [Validation cases](../../../verification/insights-verification-pack.md)
 
 ---
 


### PR DESCRIPTION
Fixes broken internal markdown links found by scripts/check_links.py.

- Updates insights guide links to point to existing docs
- Replaces/removes placeholder links in blog outlines

Verification:
- .venv/bin/python scripts/check_links.py (Broken links: 0)