### PR TITLE
docs: polish solo git workflow

### DIFF
--- a/docs/_internal/GIT_GOVERNANCE.md
+++ b/docs/_internal/GIT_GOVERNANCE.md
@@ -116,16 +116,18 @@ Solo default:
 **Branch:** `main`
 
 **Rules Enabled:**
-- ✅ Required status checks must pass before push:
-  - `Lint` — Ruff linting
+- ✅ Required status checks must pass on `main` (CI runs after push):
+    - `Lint / Typecheck` — Black, Ruff, MyPy, docs checks
   - `pytest (3.9)` — Python 3.9 tests
   - `pytest (3.10)` — Python 3.10 tests
   - `pytest (3.11)` — Python 3.11 tests
   - `pytest (3.12)` — Python 3.12 tests
-  - `CodeQL` — Security analysis
 - ✅ Force pushes disabled
 - ✅ Branch deletion disabled
 - ⚠️ Pull requests OPTIONAL (not required)
+
+Notes:
+- `CodeQL` runs on pushes and PRs, but is not currently configured as a required status check for `main`.
 
 **CI Workflow:** `.github/workflows/python-tests.yml`
 - Triggers on: push to `main`, pull requests to `main`
@@ -184,20 +186,20 @@ See `.github/copilot-instructions.md` for agent-specific workflow rules.
 
 ---
 
-### 2.6 Local Workflow Guardrails (PR-Only Repos)
+### 2.6 Local Workflow Guardrails (When PRs are required)
 
 These are the rules that prevent rebase pain and “why can’t I push?” surprises.
 
 **Golden rules:**
-- **Never commit on `main`.** Always branch first.
-- **If you accidentally commit on `main`:**
+- If a ruleset requires PRs for `main` (collaboration mode), **never commit on `main`**. Always branch first.
+- **If you accidentally commit on `main` under PR-required rules:**
   1) `git switch -c <branch>`
   2) `git push -u origin <branch>`
   3) Open a PR and merge it normally
 - **Sync `main` only after PR merge:** `git fetch origin` + `git rebase origin/main`
 - **Delete local branches after merge:** `git branch -d <branch>`
 
-**Why this matters:** Rulesets require PRs. Committing on `main` triggers rejected pushes and messy rebases.
+**Why this matters:** When PRs are required, committing on `main` triggers rejected pushes and messy rebases.
 
 ---
 

--- a/scripts/quick_push.sh
+++ b/scripts/quick_push.sh
@@ -1,27 +1,49 @@
 #!/bin/bash
 # Quick push script for solo development
-# Usage: ./scripts/quick_push.sh "commit message"
+# Usage:
+#   ./scripts/quick_push.sh "commit message"          # runs ./scripts/quick_check.sh
+#   ./scripts/quick_push.sh "commit message" docs     # runs ./scripts/quick_check.sh docs
+#   ./scripts/quick_push.sh "commit message" --cov    # runs ./scripts/quick_check.sh --cov
 
-set -e
+set -euo pipefail
 
-if [ -z "$1" ]; then
-    echo "Usage: ./scripts/quick_push.sh 'commit message'"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+COMMIT_MESSAGE="${1-}"
+CHECK_MODE="${2-}"
+
+if [[ -z "$COMMIT_MESSAGE" ]]; then
+    echo "Usage: ./scripts/quick_push.sh 'commit message' [docs|--cov]"
     exit 1
 fi
 
 # Ensure on main
-git checkout main
+git switch main
 
 # Pull latest
 git pull --rebase
 
 # Run quick checks
 echo "Running quick checks..."
-./scripts/quick_check.sh
+if [[ -n "$CHECK_MODE" ]]; then
+    ./scripts/quick_check.sh "$CHECK_MODE"
+else
+    ./scripts/quick_check.sh
+fi
 
 # Commit and push
 git add .
-git commit -m "$1"
+
+echo "Staged changes:"
+git status -sb
+
+if git diff --cached --quiet; then
+    echo "No staged changes. Nothing to commit."
+    exit 0
+fi
+
+git commit -m "$COMMIT_MESSAGE"
 git push
 
 echo "✅ Pushed to main. CI running at:"


### PR DESCRIPTION
Tightens the solo-dev workflow docs and makes quick_push safer and more flexible.

Changes:
- Clarify main ruleset behavior (required checks run after push)
- Remove PR-only wording contradiction
- quick_push: run from any cwd, support docs/--cov mode, print status, no-op if nothing staged

Verification:
- bash -n scripts/quick_push.sh
- .venv/bin/python scripts/check_links.py