### PR TITLE
docs(api): Add comprehensive docstrings to api.py (TASK-195)

### DIFF
--- a/Python/structural_lib/api.py
+++ b/Python/structural_lib/api.py
@@ -315,7 +315,42 @@ def compute_detailing(
     *,
     config: Optional[dict[str, Any]] = None,
 ) -> list[detailing.BeamDetailingResult]:
-    """Compute beam detailing results from design results JSON dict."""
+    """Compute beam detailing results from design results JSON dict.
+    
+    Extracts beam geometry, materials, and reinforcement from design results
+    and generates detailed bar schedules, stirrup layouts, and construction notes.
+    
+    Args:
+        design_results: Design results dictionary with 'beams' key containing
+            list of beam designs. Must include geometry (b, D, span, cover),
+            materials (fck, fy), and reinforcement (ast, asc).
+        config: Optional configuration dictionary with keys:
+            - stirrup_dia_mm (float): Stirrup diameter in mm (default: 8)
+            - stirrup_spacing_start_mm (float): Spacing at ends (default: 150)
+            - stirrup_spacing_mid_mm (float): Spacing at midspan (default: 200)
+            - stirrup_spacing_end_mm (float): Spacing at ends (default: 150)
+            - is_seismic (bool): Seismic detailing requirements (default: False)
+    
+    Returns:
+        List of BeamDetailingResult objects containing:
+            - bar_schedule: List of rebar items (mark, diameter, length, count)
+            - stirrup_layout: Stirrup arrangement (zones, spacing, diameter)
+            - construction_notes: Detailing notes per IS 456:2000
+    
+    Raises:
+        TypeError: If design_results is not a dict
+        ValueError: If no beams found in design_results
+        ValueError: If units in design_results are not IS 456 standard (mm, N/mm², kN, kN·m)
+    
+    References:
+        IS 456:2000, Cl. 26 (Detailing)
+    
+    Examples:
+        >>> results = {"beams": [{"beam_id": "B1", "geometry": {...}, ...}]}
+        >>> detailing_list = compute_detailing(results)
+        >>> print(f"Generated {len(detailing_list)} beam details")
+        Generated 1 beam details
+    """
     if not isinstance(design_results, dict):
         raise TypeError("design_results must be a dict")
 
@@ -395,7 +430,30 @@ def compute_bbs(
     *,
     project_name: str = "Beam BBS",
 ) -> bbs.BBSDocument:
-    """Generate a bar bending schedule document from detailing results."""
+    """Generate a bar bending schedule (BBS) document from detailing results.
+    
+    Consolidates reinforcement from multiple beams into a structured BBS document
+    with bar marks, shapes, dimensions, and quantities for steel fabrication.
+    
+    Args:
+        detailing_list: List of BeamDetailingResult objects from compute_detailing()
+        project_name: Project name for BBS document header (default: "Beam BBS")
+    
+    Returns:
+        BBSDocument object containing:
+            - items: List of BBS entries (mark, shape, dimensions, count, weight)
+            - summary: Total steel weight by diameter
+            - project_name: Project identifier
+    
+    References:
+        IS 2502:1963 (Code of practice for bending and fixing of bars for RCC)
+    
+    Examples:
+        >>> detailing_list = compute_detailing(design_results)
+        >>> bbs_doc = compute_bbs(detailing_list, project_name="Tower A")
+        >>> print(f"Total steel: {bbs_doc.summary.total_weight_kg:.1f} kg")
+        Total steel: 1234.5 kg
+    """
     return bbs.generate_bbs_document(detailing_list, project_name=project_name)
 
 
@@ -428,7 +486,44 @@ def compute_dxf(
     title_block_width_mm: float = 120.0,
     title_block_height_mm: float = 40.0,
 ) -> Path:
-    """Generate DXF drawings from detailing results."""
+    """Generate DXF CAD drawings from detailing results.
+    
+    Creates AutoCAD-compatible DXF files with beam elevations, cross-sections,
+    reinforcement layouts, and dimensional annotations. Requires ezdxf package.
+    
+    Args:
+        detailing_list: List of BeamDetailingResult objects from compute_detailing()
+        output: Output DXF file path
+        multi: If True, generate multi-beam layout on single sheet.
+            Auto-enabled if len(detailing_list) > 1 (default: False)
+        include_title_block: If True, add title block to drawing (default: False)
+        title_block: Optional title block data dictionary with keys:
+            - project_name (str): Project name
+            - drawing_number (str): Drawing identifier
+            - drawn_by (str): Designer name
+            - date (str): Drawing date
+        sheet_margin_mm: Sheet margin width in mm (default: 20.0)
+        title_block_width_mm: Title block width in mm (default: 120.0)
+        title_block_height_mm: Title block height in mm (default: 40.0)
+    
+    Returns:
+        Path to generated DXF file
+    
+    Raises:
+        RuntimeError: If ezdxf library not installed (install with: pip install "structural-lib-is456[dxf]")
+        ValueError: If detailing_list is empty
+    
+    Examples:
+        >>> detailing_list = compute_detailing(design_results)
+        >>> dxf_path = compute_dxf(
+        ...     detailing_list,
+        ...     "output/beams.dxf",
+        ...     include_title_block=True,
+        ...     title_block={"project_name": "Tower A", "drawn_by": "John"}
+        ... )
+        >>> print(f"DXF generated: {dxf_path}")
+        DXF generated: output/beams.dxf
+    """
     from . import dxf_export as _dxf_export
 
     if _dxf_export is None:
@@ -481,7 +576,47 @@ def compute_report(
     output_path: Optional[Union[str, Path]] = None,
     batch_threshold: int = 80,
 ) -> Union[str, Path, list[Path]]:
-    """Generate report output from job outputs or design results."""
+    """Generate design report from job outputs or design results.
+    
+    Creates HTML or JSON reports with design calculations, code checks, reinforcement
+    details, and compliance summaries. Supports single-beam and batch reporting.
+    
+    Args:
+        source: Input source - one of:
+            - dict: Design results dictionary (from design_beam_is456())
+            - str/Path: Path to design results JSON file
+            - str/Path: Path to folder with job.json and results/ (for batch jobs)
+        format: Output format - "html" or "json" (default: "html")
+        job_path: Optional job specification path (for folder source)
+        results_path: Optional results folder path (for folder source)
+        output_path: Output file/folder path. If None, returns string (HTML/JSON).
+            For batch reports (>= batch_threshold beams), creates folder package.
+        batch_threshold: Number of beams threshold for batch report mode (default: 80)
+    
+    Returns:
+        - str: HTML or JSON string if output_path is None
+        - Path: Output file path if output_path provided (single report)
+        - list[Path]: List of output paths if batch report with multiple files
+    
+    Raises:
+        ValueError: If format not in {"html", "json"}
+        ValueError: If design results missing 'beams' key
+        ValueError: If batch report (>= batch_threshold) requested without output_path
+    
+    Examples:
+        >>> # Generate HTML report from dict
+        >>> results = design_beam_is456(b_mm=300, D_mm=450, ...)
+        >>> html = compute_report(results, format="html")
+        
+        >>> # Save batch HTML report to folder
+        >>> report_path = compute_report(
+        ...     "results/design_results.json",
+        ...     format="html",
+        ...     output_path="reports/batch_001"
+        ... )
+        >>> print(f"Report saved to: {report_path}")
+        Report saved to: reports/batch_001/index.html
+    """
     fmt = format.lower()
     if fmt not in {"html", "json"}:
         raise ValueError("Unknown format. Use format='html' or format='json'.")


### PR DESCRIPTION
## Summary
Add comprehensive Google Style docstrings to 4 key API functions in api.py.

## Changes

### Functions Enhanced
1. **compute_detailing()** - Generate beam detailing from design results
2. **compute_bbs()** - Create bar bending schedule documents
3. **compute_dxf()** - Generate AutoCAD DXF drawings
4. **compute_report()** - Create HTML/JSON design reports

### Docstring Structure (per Google Style guide)
Each function now includes:
- **Description:** Detailed explanation of functionality
- **Args:** Parameter descriptions with types, units, and defaults
- **Returns:** Return value structure and contents
- **Raises:** Error conditions (TypeError, ValueError, RuntimeError)
- **References:** IS 456:2000 clause citations where applicable
- **Examples:** Realistic usage patterns with expected output

## Impact

### Documentation Quality
✅ 4 key API functions fully documented  
✅ Clear parameter descriptions with units (mm, N/mm², kN)  
✅ Error handling documented  
✅ Usage examples provided  

### Benefits
- **Improved discoverability:** Users can understand API without reading source code
- **Better IDE support:** IntelliSense/autocomplete shows comprehensive help
- **Reduced support burden:** Self-documenting API with clear examples
- **API documentation generation:** Ready for pdoc/Sphinx documentation

## Validation
- All 7 related tests passing
- No functional changes (documentation only)
- Follows docs/contributing/docstring-style-guide.md

## Related
- Closes TASK-195
- Part of Professional Standards & Hygiene Implementation
- Follow-up tasks: TASK-196 (core modules docstrings)