### PR TITLE
TASK-215: docs-only direct commit workflow

### DIFF
--- a/docs/GIT_WORKFLOW_AI_AGENTS.md
+++ b/docs/GIT_WORKFLOW_AI_AGENTS.md
@@ -19,10 +19,11 @@ Run:
 - If it recommends a PR, use the PR workflow below.
 - If it recommends direct commit, use the direct workflow below.
 
-### 2) Direct Commit (Docs-only or very small changes)
+### 2) Direct Commit (Docs-only, any size)
 ```bash
 ./scripts/ai_commit.sh "docs: update guide"
 ```
+Docs-only (including research notebooks) go direct; PRs are reserved for code/CI/deps.
 This script stages changes, enforces PR rules, and delegates to safe_push.sh.
 
 ### 3) PR Workflow (Code/CI/Dependencies)
@@ -63,7 +64,7 @@ It prints the exact recovery command for your current state.
 ## FAQ
 
 **Q: Can I commit directly on main?**
-A: Only for very small docs-only changes. Otherwise use PR.
+A: Yes for docs/research-only changes. Otherwise use PR.
 
 **Q: Do I need to `git add` manually?**
 A: No. `ai_commit.sh` and `safe_push.sh` stage changes for you.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -121,6 +121,7 @@ _TASK-191 (test restructuring), TASK-192 (coverage + benchmarks), TASK-193-196 (
 
 | ID | Task | Completed | Agent |
 |----|------|-----------|-------|
+| **TASK-215** | Update workflow to allow docs/research direct commits (no PR) with checks intact | 2026-01-06 | DEVOPS |
 | **TASK-200** | **Research: Professional Python Library API Patterns** (Study NumPy, SciPy, Pandas, Requests, Pydantic, scikit-learn patterns) | 2026-01-07 | RESEARCHER |
 | **TASK-199** | Sync Colab notebooks (root + docs) and document output review findings | 2026-01-06 | DOCS |
 | **TASK-198** | Update Colab workflow notebook for v0.15 smart design + comparison testing | 2026-01-06 | DOCS |

--- a/docs/_internal/GIT_GOVERNANCE.md
+++ b/docs/_internal/GIT_GOVERNANCE.md
@@ -25,7 +25,7 @@ We use a simplified **Trunk-Based Development** model suitable for a small, high
     *   Contains only tested, verified code.
     *   **Rule (Solo Dev):** Direct pushes allowed for maintainer, but CI must pass.
         *   Use PRs for significant changes (breaking changes, new features, risky refactors).
-        *   Use direct push for routine work (docs, fixes, tests, minor updates).
+        *   Use direct push for docs/research updates (any size) and routine fixes/tests.
         *   CI runs on every push — if it fails, fix immediately.
         *   Release tags are created on the merge commit or on main after direct push.
 *   **`feat/task-ID-description`:**
@@ -44,7 +44,7 @@ We use a simplified **Trunk-Based Development** model suitable for a small, high
 
 ### 2.2.1 Solo Developer Workflow (Simplified)
 
-**For docs-only, low-risk changes:**
+**For docs-only changes (any size):**
 
 1.  **Direct on main** (fastest)
     ```bash
@@ -69,7 +69,7 @@ If CI fails on main:
 1.  `git revert HEAD` (immediate rollback)
 2.  Fix in branch, test locally, then push fix
 
-**Rule of thumb:** Docs-only and tiny → direct push. Everything else → PR.
+**Rule of thumb:** Docs-only → direct push. Everything else → PR.
 
 ### 2.3 Branch Protection Baseline (GitHub Settings)
 
@@ -111,7 +111,7 @@ Notes:
 - OS: ubuntu-latest
 
 **Workflow:**
-- Direct push allowed only for docs-only or very small changes
+- Direct push allowed for docs/research-only changes (any size)
 - All commits trigger CI (fast checks + full tests after merge)
 - Failed CI = immediate notification
 - PRs required for production code, CI changes, and dependencies
@@ -476,13 +476,13 @@ If `main` breaks:
 
 ### 🎯 Recommended Workflow (Solo Dev):
 
-**For routine docs-only changes (<20 lines, low-risk):**
+**For docs-only changes (any size):**
 ```bash
 # make changes
 ./scripts/ai_commit.sh "docs: update guide"
 ```
 
-**For significant changes (>20 lines, risky):**
+**For significant changes (code/CI/deps):**
 ```bash
 ./scripts/create_task_pr.sh TASK-142 "implement feature"
 # make changes


### PR DESCRIPTION
## Summary
Updated the workflow so docs/research changes never require a PR, while keeping pre-commit + CI checks intact.

## Changes
- **scripts/should_use_pr.sh**: Now treats docs-only work as direct-commit eligible (includes .md, .ipynb, .txt, .cff, docs/ content, and LICENSE/NOTICE/COPYING).
- **docs/GIT_WORKFLOW_AI_AGENTS.md**: Updated to reflect the new docs-only policy.
- **docs/_internal/GIT_GOVERNANCE.md**: Updated to reflect the new docs-only policy.
- **docs/TASKS.md**: Logged as TASK-215.

## Testing
- ai_commit.sh ran the full pre-commit suite.
- Verified logic covers all docs file types.