### PR TITLE
TASK-437: Move re import to module level in api_wrapper.py

### DIFF
--- a/streamlit_app/utils/api_wrapper.py
+++ b/streamlit_app/utils/api_wrapper.py
@@ -21,6 +21,7 @@ Updated: 2026-01-08
 """
 
 import math
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -688,7 +689,6 @@ def get_library_status() -> dict:
         # Parse import error to identify missing modules
         if "No module named" in _IMPORT_ERROR:
             # Extract module name from error message
-            import re
             match = re.search(r"No module named '([^']+)'", _IMPORT_ERROR)
             if match:
                 status["missing_modules"].append(match.group(1))


### PR DESCRIPTION
Small fix: move `import re` from inside function to module level in api_wrapper.py

Scanner results: 14→13 issues (HIGH: 2→1)

Part of TASK-437 import cleanup.