### PR TITLE
TASK-457: Add future annotations to core modules (Python 3.11 follow-up)

### DIFF
--- a/Python/structural_lib/api.py
+++ b/Python/structural_lib/api.py
@@ -5,6 +5,8 @@ Module:       api
 Description:  Public facing API functions
 """
 
+from __future__ import annotations
+
 import json
 from collections.abc import Sequence
 from importlib.metadata import PackageNotFoundError, version

--- a/Python/structural_lib/api_results.py
+++ b/Python/structural_lib/api_results.py
@@ -12,6 +12,8 @@ Related:
 - docs/guidelines/result-object-standard.md
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any
 
@@ -128,7 +130,7 @@ class DesignAndDetailResult:
         return json.dumps(self.to_dict(), indent=indent, default=str)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "DesignAndDetailResult":
+    def from_dict(cls, data: dict[str, Any]) -> DesignAndDetailResult:
         """Create instance from dictionary.
 
         Note: This creates a partial reconstruction. The design and detailing

--- a/Python/structural_lib/codes/is456/detailing.py
+++ b/Python/structural_lib/codes/is456/detailing.py
@@ -14,6 +14,8 @@ References:
 - SP 34:1987 (Handbook on Detailing)
 """
 
+from __future__ import annotations
+
 import math
 from dataclasses import dataclass
 

--- a/Python/structural_lib/codes/is456/flexure.py
+++ b/Python/structural_lib/codes/is456/flexure.py
@@ -7,6 +7,8 @@ Description:  Flexural design and analysis functions per IS 456:2000
 Traceability: Functions are decorated with @clause for IS 456 clause references.
 """
 
+from __future__ import annotations
+
 import math
 
 from structural_lib import materials

--- a/Python/structural_lib/costing.py
+++ b/Python/structural_lib/costing.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2024-2026 Pravin Surawase
 """Cost calculation utilities for structural elements."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 STEEL_DENSITY_KG_PER_M3 = 7850.0

--- a/Python/structural_lib/dxf_export.py
+++ b/Python/structural_lib/dxf_export.py
@@ -19,6 +19,8 @@ Usage:
     generate_beam_dxf(detailing_result, "output.dxf")
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any
 
@@ -1345,7 +1347,7 @@ def generate_multi_beam_dxf(
 
 
 def quick_dxf(
-    detailing: "BeamDetailingResult",
+    detailing: BeamDetailingResult,
     output_path: str | None = None,
     include_title_block: bool = True,
     project_name: str = "",
@@ -1413,7 +1415,7 @@ def quick_dxf(
 
 
 def quick_dxf_bytes(
-    detailing: "BeamDetailingResult",
+    detailing: BeamDetailingResult,
     include_title_block: bool = True,
     project_name: str = "",
 ) -> bytes:

--- a/Python/structural_lib/excel_bridge.py
+++ b/Python/structural_lib/excel_bridge.py
@@ -17,6 +17,7 @@ Setup:
     4. Use functions in formulas
 """
 
+from __future__ import annotations
 
 import xlwings as xw
 

--- a/Python/structural_lib/excel_integration.py
+++ b/Python/structural_lib/excel_integration.py
@@ -12,6 +12,8 @@ Usage:
     from structural_lib.excel_integration import process_beam_schedule, batch_generate_dxf
 """
 
+from __future__ import annotations
+
 import csv
 import json
 import logging
@@ -51,7 +53,7 @@ class BeamDesignData:
     status: str  # "OK" or "REVISE"
 
     @classmethod
-    def from_dict(cls, data: dict) -> "BeamDesignData":
+    def from_dict(cls, data: dict) -> BeamDesignData:
         """Create from dictionary (flexible key matching)."""
         # Normalize keys (handle both camelCase and snake_case)
         normalized = {}

--- a/Python/structural_lib/insights/cost_optimization.py
+++ b/Python/structural_lib/insights/cost_optimization.py
@@ -6,6 +6,7 @@ This module provides AI-driven cost optimization that finds the cheapest
 beam design meeting IS 456:2000 requirements.
 """
 
+from __future__ import annotations
 
 from structural_lib.costing import CostProfile
 from structural_lib.optimization import CostOptimizationResult, optimize_beam_cost

--- a/Python/structural_lib/insights/smart_designer.py
+++ b/Python/structural_lib/insights/smart_designer.py
@@ -36,6 +36,8 @@ Example:
     >>> dashboard.to_json("smart_analysis.json")
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/Python/structural_lib/optimization.py
+++ b/Python/structural_lib/optimization.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2024-2026 Pravin Surawase
 """Optimization algorithms for structural design."""
 
+from __future__ import annotations
+
 import time
 from dataclasses import dataclass
 

--- a/Python/structural_lib/validation.py
+++ b/Python/structural_lib/validation.py
@@ -10,6 +10,7 @@ and ensure consistent error handling across the library.
 See docs/research/cs-best-practices-audit.md for design rationale.
 """
 
+from __future__ import annotations
 
 from .errors import (
     E_INPUT_001,


### PR DESCRIPTION
## TASK-457: Add future annotations to core modules (Python 3.11 follow-up)

### Changes
<!-- Summarize what was changed -->

### Testing
- ✅ All 2200 tests passing
- ✅ Mypy type checking clean
- ✅ Pre-commit hooks passing

### Checklist
- [ ] Tests pass locally
- [ ] No breaking changes (or documented in CHANGELOG)
- [ ] TASKS.md updated
- [ ] Docs updated if needed

---
*Created via finish_task_pr.sh*