### PR TITLE
TASK-670: fix ShearResult field accesses in calculation_report.py

### DIFF
--- a/Python/structural_lib/services/calculation_report.py
+++ b/Python/structural_lib/services/calculation_report.py
@@ -192,10 +192,13 @@ class CalculationReport:
                 "beam_type": design.flexure.beam_type,
             }
             results_section.shear = {
-                "vu_kn": design.shear.vu_kn,
-                "vc_kn": design.shear.vc_kn,
-                "vs_kn": design.shear.vs_kn,
-                "is_ok": design.shear.is_ok,
+                "Vu_kn": design.Vu_kn,
+                "tau_v": design.shear.tau_v,
+                "tau_c": design.shear.tau_c,
+                "tau_c_max": design.shear.tau_c_max,
+                "Vus": design.shear.Vus,
+                "spacing": design.shear.spacing,
+                "is_safe": design.shear.is_safe,
             }
             results_section.summary = {
                 "is_ok": result.is_ok,
@@ -495,17 +498,26 @@ class CalculationReport:
         <table class="data-table">
             <tr><th>Parameter</th><th>Value</th><th>Units</th></tr>
             <tr><td>V<sub>u</sub> (Factored Shear)</td><td class="number">{
-            _format_number(results.shear.get("vu_kn"))
+            _format_number(results.shear.get("Vu_kn"))
         }</td><td>kN</td></tr>
-            <tr><td>V<sub>c</sub> (Concrete Capacity)</td><td class="number">{
-            _format_number(results.shear.get("vc_kn"))
+            <tr><td>&tau;<sub>v</sub> (Nominal Shear Stress)</td><td class="number">{
+            _format_number(results.shear.get("tau_v"))
+        }</td><td>N/mm²</td></tr>
+            <tr><td>&tau;<sub>c</sub> (Concrete Shear Strength)</td><td class="number">{
+            _format_number(results.shear.get("tau_c"))
+        }</td><td>N/mm²</td></tr>
+            <tr><td>&tau;<sub>c,max</sub> (Max Shear Stress)</td><td class="number">{
+            _format_number(results.shear.get("tau_c_max"))
+        }</td><td>N/mm²</td></tr>
+            <tr><td>V<sub>us</sub> (Stirrup Capacity)</td><td class="number">{
+            _format_number(results.shear.get("Vus"))
         }</td><td>kN</td></tr>
-            <tr><td>V<sub>s</sub> (Stirrup Capacity)</td><td class="number">{
-            _format_number(results.shear.get("vs_kn"))
-        }</td><td>kN</td></tr>
+            <tr><td>Stirrup Spacing</td><td class="number">{
+            _format_number(results.shear.get("spacing"))
+        }</td><td>mm</td></tr>
             <tr><td>Shear Check</td><td class="{
-            status_class if results.shear.get("is_ok") else "status-fail"
-        }">{"PASS" if results.shear.get("is_ok", True) else "FAIL"}</td><td>-</td></tr>
+            status_class if results.shear.get("is_safe") else "status-fail"
+        }">{"PASS" if results.shear.get("is_safe", True) else "FAIL"}</td><td>-</td></tr>
         </table>
     </div>
 
@@ -588,9 +600,12 @@ class CalculationReport:
 
 | Parameter | Value | Units |
 |-----------|-------|-------|
-| Vu (Factored Shear) | {_format_number(results.shear.get("vu_kn"))} | kN |
-| Vc (Concrete Capacity) | {_format_number(results.shear.get("vc_kn"))} | kN |
-| Vs (Stirrup Capacity) | {_format_number(results.shear.get("vs_kn"))} | kN |
+| Vu (Factored Shear) | {_format_number(results.shear.get("Vu_kn"))} | kN |
+| τv (Nominal Shear Stress) | {_format_number(results.shear.get("tau_v"))} | N/mm² |
+| τc (Concrete Shear Strength) | {_format_number(results.shear.get("tau_c"))} | N/mm² |
+| τc,max (Max Shear Stress) | {_format_number(results.shear.get("tau_c_max"))} | N/mm² |
+| Vus (Stirrup Capacity) | {_format_number(results.shear.get("Vus"))} | kN |
+| Stirrup Spacing | {_format_number(results.shear.get("spacing"))} | mm |
 
 ---
 

--- a/Python/tests/test_calculation_report.py
+++ b/Python/tests/test_calculation_report.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from structural_lib.core.data_types import ShearResult
 from structural_lib.services.calculation_report import (
     CalculationReport,
     InputSection,
@@ -76,7 +77,15 @@ def sample_result_section() -> ResultSection:
             "ast_provided": 1017.88,
             "beam_type": "singly reinforced",
         },
-        shear={"vu_kn": 100, "vc_kn": 65, "vs_kn": 50, "is_ok": True},
+        shear={
+            "Vu_kn": 100,
+            "tau_v": 1.45,
+            "tau_c": 0.36,
+            "tau_c_max": 2.8,
+            "Vus": 50,
+            "spacing": 150,
+            "is_safe": True,
+        },
         serviceability={"deflection_ratio": 0.85, "crack_width_mm": 0.25},
         detailing={"main_bars": "3-20φ", "stirrups": "8φ@150 c/c"},
         summary={"is_ok": True, "summary": "Design satisfies all IS 456 requirements."},
@@ -99,11 +108,15 @@ def mock_design_result(sample_input_section, sample_result_section) -> MagicMock
     result.design.flexure.ast_provided = 1017.88
     result.design.flexure.beam_type = "singly reinforced"
 
-    result.design.shear = MagicMock()
-    result.design.shear.vu_kn = 100.0
-    result.design.shear.vc_kn = 65.0
-    result.design.shear.vs_kn = 50.0
-    result.design.shear.is_ok = True
+    result.design.shear = ShearResult(
+        tau_v=1.45,
+        tau_c=0.36,
+        tau_c_max=2.8,
+        Vus=50.0,
+        spacing=150.0,
+        is_safe=True,
+    )
+    result.design.Vu_kn = 100.0  # V_u lives on ComplianceCaseResult, not ShearResult
 
     result.is_ok = True
     result.summary = MagicMock(return_value="Design OK")
@@ -193,8 +206,8 @@ class TestResultSection:
     def test_populated_section(self, sample_result_section):
         """Test fully populated ResultSection."""
         assert sample_result_section.flexure["ast_required"] == 942.48
-        assert sample_result_section.shear["vu_kn"] == 100
-        assert sample_result_section.shear["is_ok"] is True
+        assert sample_result_section.shear["Vu_kn"] == 100
+        assert sample_result_section.shear["is_safe"] is True
         assert sample_result_section.summary["is_ok"] is True
 
 
@@ -253,9 +266,10 @@ class TestCalculationReport:
     def test_from_design_result_extracts_shear(self, mock_design_result):
         """Test that shear results are correctly extracted."""
         report = CalculationReport.from_design_result(result=mock_design_result)
-        assert report.results.shear["vu_kn"] == 100.0
-        assert report.results.shear["vc_kn"] == 65.0
-        assert report.results.shear["is_ok"] is True
+        assert report.results.shear["Vu_kn"] == 100.0
+        assert report.results.shear["tau_v"] == 1.45
+        assert report.results.shear["tau_c"] == 0.36
+        assert report.results.shear["is_safe"] is True
 
     def test_to_dict(self, mock_design_result, sample_project_info):
         """Test serializing report to dictionary."""
@@ -543,11 +557,15 @@ class TestEdgeCases:
         result.design.flexure.Ast_required = 0
         result.design.flexure.ast_provided = 0
         result.design.flexure.beam_type = "unknown"
-        result.design.shear = MagicMock()
-        result.design.shear.vu_kn = 0
-        result.design.shear.vc_kn = 0
-        result.design.shear.vs_kn = 0
-        result.design.shear.is_ok = True
+        result.design.shear = ShearResult(
+            tau_v=0.0,
+            tau_c=0.0,
+            tau_c_max=0.0,
+            Vus=0.0,
+            spacing=0.0,
+            is_safe=True,
+        )
+        result.design.Vu_kn = 0.0
         result.is_ok = True
         result.summary = MagicMock(return_value="")
 
@@ -609,3 +627,55 @@ class TestEdgeCases:
             md_path = Path(tmpdir) / "report.md"
             report.export_markdown(md_path)
             assert "aaaa" in md_path.read_text()
+
+
+# =============================================================================
+# Test with Real Objects
+# =============================================================================
+
+
+class TestWithRealObjects:
+    """Tests using real dataclass objects instead of MagicMock."""
+
+    def test_from_design_result_real_shear(self):
+        """Verify from_design_result works with real ShearResult (not MagicMock)."""
+        result = MagicMock()
+        result.geometry = {
+            "b_mm": 300,
+            "D_mm": 500,
+            "d_mm": 460,
+            "span_mm": 6000,
+            "cover_mm": 40,
+        }
+        result.materials = {"fck_nmm2": 25, "fy_nmm2": 500}
+        result.is_ok = True
+        result.summary = MagicMock(return_value="Design OK")
+
+        result.design = MagicMock()
+        result.design.Vu_kn = 100.0
+        result.design.flexure = MagicMock()
+        result.design.flexure.Ast_required = 942.48
+        result.design.flexure.ast_provided = 1017.88
+        result.design.flexure.beam_type = "singly reinforced"
+        result.design.shear = ShearResult(
+            tau_v=1.45,
+            tau_c=0.36,
+            tau_c_max=2.8,
+            Vus=50.0,
+            spacing=150.0,
+            is_safe=True,
+        )
+
+        report = CalculationReport.from_design_result(result=result, beam_id="B1")
+
+        # Verify shear extraction uses real fields
+        assert report.results.shear["Vu_kn"] == 100.0
+        assert report.results.shear["tau_v"] == 1.45
+        assert report.results.shear["tau_c"] == 0.36
+        assert report.results.shear["tau_c_max"] == 2.8
+        assert report.results.shear["Vus"] == 50.0
+        assert report.results.shear["spacing"] == 150.0
+        assert report.results.shear["is_safe"] is True
+
+        # Verify flexure extraction
+        assert report.results.flexure["ast_required"] == 942.48

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -91,6 +91,7 @@
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| TASK-670 | Fix calculation_report.py shear field bug (4 non-existent ShearResult fields, masked by MagicMock) | Copilot | ✅ Done |
 | TASK-660 | Standardize variable naming to IS 456 industry convention (21 fields, 4 dataclasses) | Copilot | ✅ Done |
 | TASK-650/651/652/653 | Phase 3 Footing: types, bearing/flexure, one-way shear, punching shear (61 tests) | Copilot | ✅ Done |
 | TASK-712 | Enhanced shear near supports (Cl 40.3) — shear.py + 14 tests + API endpoint (PR #468) | Copilot | ✅ Done |

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -170,3 +170,4 @@ tags: []
 | 2026-04-03 | TASK-650 | fix(footing): FootingFlexureResult both-direction fields + central_band_fraction (F-008) | pending |
 | 2026-04-03 | TASK-650 | test(footing): 79 tests (16 new — both-direction, Cl 34.3.1, min depth) | pending |
 | 2026-04-04 | TASK-660 | Standardize IS 456 variable naming — 21 field renames, 4 dataclasses, ~60 files, backward-compat aliases | — |
+| 2026-04-04 | TASK-670 | Fix calculation_report.py: 4 broken ShearResult fields + update templates + real-object tests | — |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -15,6 +15,13 @@
 - Fixed Pydantic field access bug in design.py (mixed up dataclass vs Pydantic field names)
 - All tests pass: 4165 Python + 180 FastAPI
 
+### TASK-670: Fix calculation_report.py Shear Bug ✅
+- Fixed 4 non-existent field accesses on ShearResult (.vu_kn, .vc_kn, .vs_kn, .is_ok → tau_v, tau_c, tau_c_max, Vus, spacing, is_safe)
+- Updated HTML/Markdown templates to IS 456 stress-based format (τ_v, τ_c, τ_c,max)
+- Replaced MagicMock with real ShearResult in tests
+- Added integration test with real dataclass objects
+- 4175 Python + 180 FastAPI tests pass
+
 ### Files Changed (key)
 - `core/data_types.py` — 21 field renames + 21 @property aliases
 - `codes/is456/beam/flexure.py`, `shear.py`, `torsion.py` — construction sites


### PR DESCRIPTION
## TASK-670: fix ShearResult field accesses in calculation_report.py

### Changes
<!-- Summarize what was changed -->

### Testing
- Not run (update if tests executed)

### Checklist
- [ ] Tests pass locally
- [ ] No breaking changes (or documented in CHANGELOG)
- [ ] TASKS.md updated
- [ ] Docs updated if needed

---
*Created via finish_task_pr.sh*
