### PR TITLE
MAINT-008-A: Add truthful aggregate PR Gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,282 +1,60 @@
-# GitHub Workflows Reference
-
-**Type:** Reference
-**Audience:** All Agents
-**Status:** Production Ready
-**Importance:** High
-**Version:** 1.0.0
-**Created:** 2026-01-13
-**Last Updated:** 2026-01-13
-
----
-
-## Overview
-
-This folder contains 12 GitHub Actions workflows that automate CI/CD for the project.
-
-**For AI Agents:** Understand these workflows to:
-- Know what checks run on your commits/PRs
-- Diagnose CI failures
-- Understand the release process
-
----
-
-## Quick Reference
-
-| Workflow | Trigger | Time | Purpose |
-|----------|---------|------|---------|
-| **fast-checks.yml** | PR + Push | ~3min | Quick validation (Python 3.11) |
-| **python-tests.yml** | Push to main | ~5min | Full test matrix (3.11, 3.12) |
-| **streamlit-validation.yml** | Streamlit changes | ~2min | AST scanner + pylint |
-| **auto-format.yml** | Push | ~2min | Auto-format code |
-| **git-workflow-tests.yml** | Git script changes | ~2min | Test git automation |
-| **publish.yml** | Release tag | ~5min | Publish to PyPI |
-| **security.yml** | Push + Schedule | ~3min | Security scanning |
-| **codeql.yml** | Push + Schedule | ~10min | Code analysis |
-| **nightly.yml** | Schedule (daily) | ~10min | Nightly full checks |
-| **cost-optimizer-analysis.yml** | On demand | ~3min | Cost optimization analysis |
-| **root-file-limit.yml** | Push | ~1min | Root file count check |
-| **leading-indicator-alerts.yml** | Push | ~2min | Quality metric alerts |
-
----
-
-## Workflow Details
-
-### 1. fast-checks.yml (Primary PR Check)
-
-**Purpose:** Quick validation for PRs - provides fast feedback
-
-**Runs on:** Pull requests + Push to main
-
-**What it checks:**
-- Python 3.11 only (single version for speed)
-- Lint with ruff
-- Type check with mypy
-- Unit tests with pytest
-- Format check with black
-
-**Timeout:** 5 minutes
-
-**Agent Action:** If this fails on your PR, fix the issues before merge.
-
----
-
-### 2. python-tests.yml (Full Test Matrix)
-
-**Purpose:** Comprehensive testing after merge to main
-
-**Runs on:** Push to main only
-
-**What it checks:**
-- Full matrix: Python 3.11 and 3.12
-- Lint and typecheck
-- Full test suite
-- Coverage reporting
-
-**Agent Action:** If this fails after merge, create a fix PR immediately.
-
----
-
-### 3. streamlit-validation.yml
-
-**Purpose:** Catch Streamlit runtime errors before they reach production
-
-**Runs on:** Changes to `streamlit_app/**/*.py`
-
-**What it checks:**
-- AST Scanner (`check_streamlit.py`): NameError, ZeroDivisionError, KeyError, etc.
-- Import validation (`check_streamlit_imports.py`)
-- Pylint with Streamlit-specific config
-
-**Agent Action:** Run `python scripts/check_streamlit.py --all-pages` locally before pushing Streamlit changes.
-
----
-
-### 4. auto-format.yml
-
-**Purpose:** Auto-format code that wasn't formatted locally
-
-**Runs on:** Push to main
-
-**What it does:**
-- Runs black on Python code
-- Commits formatting fixes automatically
-
-**Agent Action:** Run `python -m black .` locally to avoid auto-format commits.
-
----
-
-### 5. git-workflow-tests.yml
-
-**Purpose:** Test git automation scripts
-
-**Runs on:** Changes to git scripts (`scripts/*git*.sh`, `scripts/*push*.sh`, etc.)
-
-**What it tests:**
-- safe_push.sh workflow
-- should_use_pr.sh decision logic
-- Recovery scripts
-
-**Agent Action:** Run `./scripts/test_git_workflow.sh` locally if editing git scripts.
-
----
-
-### 6. publish.yml
-
-**Purpose:** Publish package to PyPI
-
-**Runs on:** Release tag creation (v*.*.*)
-
-**What it does:**
-- Build wheel and sdist
-- Publish to PyPI
-- Create GitHub release
-
-**Agent Action:** Use `python scripts/release.py` for releases.
-
----
-
-### 7. security.yml
-
-**Purpose:** Security vulnerability scanning
-
-**Runs on:** Push + Weekly schedule
-
-**What it checks:**
-- Dependency vulnerabilities (pip-audit)
-- Secret scanning
-- SAST scanning
-
-**Agent Action:** Review security alerts in GitHub Security tab.
-
----
-
-### 8. codeql.yml
-
-**Purpose:** Advanced code analysis
-
-**Runs on:** Push + Weekly schedule
-
-**What it checks:**
-- CodeQL analysis for Python
-- Security vulnerabilities
-- Code quality issues
-
-**Agent Action:** Check CodeQL alerts if workflow fails.
-
----
-
-### 9. nightly.yml
-
-**Purpose:** Full validation suite (catches issues that slip through)
-
-**Runs on:** Daily at midnight UTC
-
-**What it checks:**
-- Full test matrix
-- Doc link validation
-- Coverage thresholds
-- Performance benchmarks
-
-**Agent Action:** Check nightly results each morning.
-
----
-
-### 10. cost-optimizer-analysis.yml
-
-**Purpose:** Analyze cost optimization opportunities
-
-**Runs on:** Manual trigger (workflow_dispatch)
-
-**What it does:**
-- Analyzes CI run times
-- Suggests optimizations
-
-**Agent Action:** Trigger manually when investigating CI costs.
-
----
-
-### 11. root-file-limit.yml
-
-**Purpose:** Enforce root directory cleanliness
-
-**Runs on:** Push
-
-**What it checks:**
-- Max 10 files in repo root
-- Prevents root clutter
-
-**Agent Action:** If blocked, move file to appropriate subfolder.
-
----
-
-### 12. leading-indicator-alerts.yml
-
-**Purpose:** Alert on quality metric degradation
-
-**Runs on:** Push
-
-**What it checks:**
-- Test count changes
-- Coverage changes
-- Doc count changes
-
-**Agent Action:** Review alerts for quality regressions.
-
----
-
-## CI Failure Troubleshooting
-
-### Common Issues
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `black check failed` | Code not formatted | Run `python -m black .` locally |
-| `ruff check failed` | Lint errors | Run `ruff check --fix .` |
-| `mypy failed` | Type errors | Fix type annotations |
-| `pytest failed` | Test failure | Run tests locally, fix failures |
-| `AST scanner CRITICAL` | Runtime error risk | Fix the flagged issue |
-
-### Quick Local Validation
-
-```bash
-# Run same checks as fast-checks.yml
-cd Python
-python -m black --check .
-python -m ruff check .
-python -m mypy structural_lib/
-python -m pytest tests/ -v
-```
-
----
-
-## Related Documentation
-
-- [automation-scripts.md](../../docs/git-automation/automation-scripts.md) - All automation scripts
-- [workflow-guide.md](../../docs/git-automation/workflow-guide.md) - Git workflow
-- [CONTRIBUTING.md](../../CONTRIBUTING.md) - Contribution guidelines
-
----
-
-## Workflow Dependencies
-
-```
-PR Created
-    └── fast-checks.yml (3 min)
-            ├── PASS → Ready for review
-            └── FAIL → Fix required
-
-PR Merged
-    └── python-tests.yml (5 min)
-            ├── auto-format.yml (if needed)
-            └── streamlit-validation.yml (if applicable)
-
-Release Tag (v*.*.*)
-    └── publish.yml
-            └── PyPI publish
-
-Daily (midnight)
-    └── nightly.yml
-            ├── security.yml
-            └── Full validation
-```
+# GitHub Workflows
+
+This directory is being consolidated by MAINT-008. Codex owns scoped maintenance,
+diagnosis, implementation, and review; GitHub Actions supplies the independent,
+repeatable evidence required before a merge.
+
+## Pull request gate
+
+`fast-checks.yml` is the only workflow triggered by pull requests. It creates these
+checks:
+
+| Check | When it runs | Evidence |
+|---|---|---|
+| `Detect Changes` | Every PR | Classifies Python, FastAPI, and React inputs |
+| `Repository Validation` | Every PR | YAML, docs, scripts, architecture, and agent-control policy |
+| `Python Validation` | Python inputs | Format, lint, types, contracts, focused core tests, architecture policy |
+| `FastAPI Validation` | API or deployment inputs | Format, lint, API tests, contracts, Docker/OpenAPI configuration |
+| `React Validation` | React inputs | Lint, production build, and Vitest |
+| `PR Gate` | Every PR, with `if: always()` | Rejects any failed or cancelled applicable job |
+
+The component checks may be skipped when their layer is unchanged. `Repository
+Validation` never skips, so a docs-only or control-plane PR still receives real
+validation. `PR Gate` checks each component result against the detected paths; a
+skipped applicable check cannot produce a green gate.
+
+The active main-branch ruleset still requires `Quick Validation (Python 3.11 only)`
+until the owner separately approves switching it to `PR Gate`. Do not rename the
+new check after that switch.
+
+## Legacy check mapping
+
+Packet A removes duplicate pull-request triggers but does not delete workflows.
+Packet B will consolidate the remaining scheduled, main-push, manual, and release
+lanes.
+
+| Previous PR workflow | Packet A disposition |
+|---|---|
+| `auto-format.yml` | Python format and Ruff checks retained in `Python Validation`; old workflow is manual only |
+| `git-workflow-tests.yml` | Shell syntax and migration-script checks retained in `Repository Validation`; main-push lane remains for Packet B |
+| `link-check.yml` | Internal link checks retained in `Repository Validation`; external link scan remains scheduled/main-push for Packet B |
+| `root-file-limit.yml` | Parked from PRs; repository hygiene remains in the local/Codex quick gate |
+| `codeql.yml` | Scheduled/main-push security analysis retained for Packet B |
+| `docker-build.yml` | FastAPI configuration checks retained on PRs; full image build remains main-push/manual for Packet B |
+| `performance.yml` | Expensive benchmark lane retained on main/schedule/manual for Packet B |
+| `security.yml` | Dependency audits retained on main/schedule/manual for Packet B |
+| `leading-indicator-alerts.yml` | Removed from PRs; governance signal remains scheduled/main/manual pending Packet B noise review |
+
+## Current workflow inventory
+
+There are 17 workflow files at the end of Packet A. Only `fast-checks.yml` handles
+pull requests. The intended Packet B end state is four active lanes unless an
+owner-approved main-process reason requires another:
+
+1. pull-request validation;
+2. scheduled and manual full verification;
+3. approved release publication;
+4. documentation deployment.
+
+Use `./run.sh check --quick` before committing and the full `./run.sh check` once at
+MAINT-008 closeout. Do not bypass a failing `PR Gate`.

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,9 +1,7 @@
 name: Format Check
 
 on:
-  pull_request:
-    paths:
-      - 'Python/**/*.py'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,6 @@ name: CodeQL
 on:
   push:
     branches: [ main ]
-  pull_request:
   schedule:
     - cron: "37 3 * * 2" # weekly
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,15 +20,6 @@ on:
       - 'requirements.txt'
       - 'fastapi_app/**'
       - 'Python/structural_lib/**'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'Dockerfile.fastapi'
-      - 'docker-compose*.yml'
-      - '.dockerignore'
-      - 'requirements.txt'
-      - 'fastapi_app/**'
-      - 'Python/structural_lib/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -185,7 +185,7 @@ jobs:
               if any(part in {'.venv', 'node_modules'} for part in path.parts):
                   continue
               with path.open(encoding='utf-8') as stream:
-                  yaml.safe_load(stream)
+                  yaml.compose(stream)
               print(path)
           PY
 

--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -1,62 +1,53 @@
-name: Fast PR Checks
+name: PR Validation
 
 on:
   pull_request:
+    branches: [main]
   push:
-    branches: [ main ]
-
-# Quick checks for PRs - run only essential validations
-# Full test matrix runs after merge to main
-#
-# EFFICIENCY OPTIMIZATION (added 2026-01-24):
-# - Uses dorny/paths-filter to detect what changed
-# - Docs-only changes skip Python tests
-# - Python changes skip doc checks (separate workflow)
-# - Keeps PR feedback under 3-5 minutes
+    branches: [main]
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  # Detect what files changed to optimize job selection
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
       python: ${{ steps.filter.outputs.python }}
-      docs: ${{ steps.filter.outputs.docs }}
-      scripts: ${{ steps.filter.outputs.scripts }}
       fastapi: ${{ steps.filter.outputs.fastapi }}
       react: ${{ steps.filter.outputs.react }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Classify changed paths
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
             python:
               - 'Python/**'
-              - 'pyproject.toml'
-              - 'setup.cfg'
-            docs:
-              - 'docs/**'
-              - '*.md'
-              - 'agents/**'
-            scripts:
-              - 'scripts/**'
+              - 'Python/pyproject.toml'
             fastapi:
               - 'fastapi_app/**'
-              - 'requirements.txt'
+              - 'requirements*.txt'
+              - 'Dockerfile.fastapi'
+              - 'docker-compose*.yml'
             react:
               - 'react_app/**'
+              - '**/package-lock.json'
 
-  # Python validation - only when Python code changes
   python-validation:
     name: Python Validation
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -64,57 +55,44 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
-          cache: 'pip'
+          python-version: '3.11'
+          cache: pip
           cache-dependency-path: Python/pyproject.toml
 
-      - name: Install package (dev)
-        working-directory: Python
+      - name: Install package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          python -m pip install -e 'Python/[dev]'
 
-      - name: Format check (black)
-        working-directory: Python
-        run: python -m black --check .
-
-      - name: Lint check (ruff)
-        working-directory: Python
-        run: python -m ruff check .
-
-      - name: Type check (mypy)
-        working-directory: Python
-        run: python -m mypy
-
-      - name: Contract tests (breaking change detection)
-        working-directory: Python
-        run: python -m pytest tests/integration/test_contracts.py -m contract -v
-
-      - name: Core tests (fast subset)
-        working-directory: Python
-        run: python -m pytest tests/integration/test_flexure_edges_additional.py tests/unit/test_shear.py tests/unit/test_detailing.py -v --strict-markers
-
-      - name: Code quality checks
+      - name: Format and lint
         run: |
-          python scripts/check_type_annotations.py --fail-threshold 50 --json > /dev/null || \
-            (echo "❌ Type annotation rate below 50%" && exit 1)
-          python scripts/check_circular_imports.py || \
-            (echo "❌ Circular imports detected" && exit 1)
-          python scripts/check_performance_issues.py || true
-          echo "✅ Code quality checks passed"
+          python -m black --check Python
+          python -m ruff check Python
 
-      - name: Governance structure gate (stub-only root modules)
+      - name: Type check
+        run: python -m mypy Python/structural_lib
+
+      - name: Contract and core tests
         run: |
+          python -m pytest Python/tests/integration/test_contracts.py -m contract -v
+          python -m pytest \
+            Python/tests/integration/test_flexure_edges_additional.py \
+            Python/tests/unit/test_shear.py \
+            Python/tests/unit/test_detailing.py \
+            -v --strict-markers
+
+      - name: Architecture and code-quality policy
+        run: |
+          python scripts/check_type_annotations.py --fail-threshold 50 --json > /dev/null
+          python scripts/check_circular_imports.py
           python scripts/check_governance.py --structure --json > /tmp/governance-structure.json
-          echo "✅ Governance structure gate passed"
 
-  # FastAPI validation - only when FastAPI code changes
   fastapi-validation:
     name: FastAPI Validation
     needs: changes
     if: needs.changes.outputs.fastapi == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -122,103 +100,39 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
-          cache: 'pip'
-          cache-dependency-path: Python/pyproject.toml
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            Python/pyproject.toml
+            requirements*.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e "Python/[dev]"
-          python -m pip install fastapi uvicorn httpx websockets sse-starlette PyJWT[crypto] pytest-asyncio python-multipart pydantic-settings
+          python -m pip install -e 'Python/[dev]'
+          python -m pip install -r requirements.txt
 
-      - name: Format check (black)
-        run: python -m black --check fastapi_app/
-
-      - name: Lint check (ruff)
-        run: python -m ruff check fastapi_app/
-
-      - name: Type check (mypy)
-        run: python -m mypy fastapi_app/ --ignore-missing-imports || echo "⚠️ mypy has warnings (non-blocking)"
-
-      - name: Run FastAPI tests
-        run: python -m pytest fastapi_app/tests/ -v --tb=short
-
-      - name: Security checks
+      - name: Format and lint
         run: |
-          python -m bandit -r fastapi_app/ -ll || true
-          echo "✅ FastAPI security scan complete"
+          python -m black --check fastapi_app
+          python -m ruff check fastapi_app
 
-      - name: API contract tests
+      - name: FastAPI tests
+        run: python -m pytest fastapi_app/tests -v --tb=short
+
+      - name: API and deployment contracts
         run: |
-          if [ -f "scripts/validate_api_contracts.py" ]; then
-            python scripts/validate_api_contracts.py || true
-          fi
-          echo "✅ FastAPI validation passed"
+          python scripts/validate_api_contracts.py
+          python scripts/check_fastapi_issues.py
+          python scripts/check_docker_config.py
+          python scripts/check_openapi_snapshot.py
 
-      - name: API performance benchmarks
-        run: |
-          python scripts/benchmark_api.py --quick --threshold 50
-          echo "✅ FastAPI performance benchmarks passed"
-
-  # Doc validation - only when docs change
-  docs-validation:
-    name: Docs Validation
-    needs: changes
-    if: needs.changes.outputs.docs == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Doc checks (parallel)
-        run: |
-          python scripts/check_doc_versions.py --ci &
-          python scripts/check_tasks_format.py &
-          python scripts/check_api.py --sync &
-          python scripts/generate_api_manifest.py --check &
-          python scripts/check_links.py &
-          wait
-
-      - name: Governance checks
-        run: |
-          python scripts/check_governance.py
-
-  # Scripts validation - only when scripts change
-  scripts-validation:
-    name: Scripts Validation
-    needs: changes
-    if: needs.changes.outputs.scripts == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 6
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Scripts checks
-        run: |
-          python scripts/check_scripts_index.py
-          python -m pip install --upgrade pip pytest
-          python -m pytest tests/integration/test_migration_scripts.py -q
-
-  # React validation - only when React code changes
   react-validation:
     name: React Validation
     needs: changes
     if: needs.changes.outputs.react == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -227,57 +141,128 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: 'react_app/package-lock.json'
+          cache: npm
+          cache-dependency-path: react_app/package-lock.json
 
       - name: Install dependencies
         working-directory: react_app
         run: npm ci
 
-      - name: Lint
+      - name: Lint, build, and test
         working-directory: react_app
-        run: npm run lint
+        run: |
+          npm run lint
+          npm run build
+          npx vitest run
 
-      - name: Type check and Build
-        working-directory: react_app
-        run: npm run build
-
-      - name: Run tests
-        working-directory: react_app
-        run: npx vitest run
-
-  # Always-run minimal check (for status reporting)
-  quick-validation:
-    name: Quick Validation (Python 3.11 only)
-    needs: changes
-    # Run if nothing specific triggered, or as a safety net
-    if: |
-      needs.changes.outputs.python != 'true' &&
-      needs.changes.outputs.docs != 'true' &&
-      needs.changes.outputs.scripts != 'true' &&
-      needs.changes.outputs.fastapi != 'true' &&
-      needs.changes.outputs.react != 'true'
+  repository-validation:
+    name: Repository Validation
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 6
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-      - name: Minimal validation
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements-lock.txt
+
+      - name: Install validation dependencies
+        run: python -m pip install pytest PyYAML
+
+      - name: Validate YAML syntax
         run: |
-          echo "✅ No code/docs changes detected"
-          echo "📝 Running minimal checks..."
-          # Just verify repo is healthy
-          python --version
-          test -f README.md
-          echo "✅ Minimal validation passed"
+          python - <<'PY'
+          from pathlib import Path
+          import yaml
 
-  full-tests-notification:
-    name: Full Test Info
+          for path in sorted(Path('.').rglob('*.yml')) + sorted(Path('.').rglob('*.yaml')):
+              if any(part in {'.venv', 'node_modules'} for part in path.parts):
+                  continue
+              with path.open(encoding='utf-8') as stream:
+                  yaml.safe_load(stream)
+              print(path)
+          PY
+
+      - name: Validate repository policy
+        run: |
+          python scripts/check_doc_versions.py --ci
+          python scripts/check_tasks_format.py
+          python scripts/check_links.py
+          python scripts/check_scripts_index.py
+          python scripts/validate_script_refs.py
+          python scripts/check_token_efficiency.py
+          python scripts/check_architecture_boundaries.py
+          python scripts/skill_tiers.py validate
+
+      - name: Validate maintenance scripts
+        run: |
+          bash -n scripts/safe_push.sh
+          bash -n scripts/ai_commit.sh
+          bash -n scripts/create_task_pr.sh
+          bash -n scripts/finish_task_pr.sh
+          bash -n scripts/validate_git_state.sh
+          bash -n scripts/recover_git_state.sh
+          python -m pytest tests/integration/test_migration_scripts.py -q
+
+  pr-gate:
+    name: PR Gate
+    if: always()
+    needs:
+      - changes
+      - python-validation
+      - fastapi-validation
+      - react-validation
+      - repository-validation
     runs-on: ubuntu-latest
     steps:
-      - name: Info
+      - name: Verify every applicable validation
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          PYTHON_CHANGED: ${{ needs.changes.outputs.python }}
+          PYTHON_RESULT: ${{ needs.python-validation.result }}
+          FASTAPI_CHANGED: ${{ needs.changes.outputs.fastapi }}
+          FASTAPI_RESULT: ${{ needs.fastapi-validation.result }}
+          REACT_CHANGED: ${{ needs.changes.outputs.react }}
+          REACT_RESULT: ${{ needs.react-validation.result }}
+          REPOSITORY_RESULT: ${{ needs.repository-validation.result }}
         run: |
-          echo "✅ Quick checks passed!"
-          echo "📝 Full test matrix (Python 3.11-3.12) will run after merge to main"
-          echo "⚡ This workflow optimizes PR feedback speed"
+          failed=0
+
+          require_success() {
+            local name="$1"
+            local result="$2"
+            if [[ "$result" != 'success' ]]; then
+              echo "ERROR: $name concluded '$result'"
+              failed=1
+            fi
+          }
+
+          require_component() {
+            local name="$1"
+            local changed="$2"
+            local result="$3"
+            if [[ "$changed" == 'true' ]]; then
+              require_success "$name" "$result"
+            elif [[ "$result" != 'skipped' ]]; then
+              echo "ERROR: $name should be skipped for this change set, got '$result'"
+              failed=1
+            fi
+          }
+
+          require_success 'Detect Changes' "$CHANGES_RESULT"
+          require_success 'Repository Validation' "$REPOSITORY_RESULT"
+          require_component 'Python Validation' "$PYTHON_CHANGED" "$PYTHON_RESULT"
+          require_component 'FastAPI Validation' "$FASTAPI_CHANGED" "$FASTAPI_RESULT"
+          require_component 'React Validation' "$REACT_CHANGED" "$REACT_RESULT"
+
+          if [[ "$failed" -ne 0 ]]; then
+            exit 1
+          fi
+
+          echo 'All required and applicable validation jobs passed.'

--- a/.github/workflows/git-workflow-tests.yml
+++ b/.github/workflows/git-workflow-tests.yml
@@ -11,16 +11,6 @@ on:
       - 'scripts/validate_git_state.sh'
       - 'scripts/recover_git_state.sh'
       - '.github/workflows/git-workflow-tests.yml'
-  pull_request:
-    paths:
-      - 'scripts/safe_push.sh'
-      - 'scripts/ai_commit.sh'
-      - 'scripts/create_task_pr.sh'
-      - 'scripts/finish_task_pr.sh'
-      - 'scripts/validate_git_state.sh'
-      - 'scripts/recover_git_state.sh'
-      - '.github/workflows/git-workflow-tests.yml'
-
 jobs:
   test-git-workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/leading-indicator-alerts.yml
+++ b/.github/workflows/leading-indicator-alerts.yml
@@ -7,8 +7,6 @@ name: Leading Indicator Alerts
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   schedule:
     # Run daily at 9 AM UTC (checks overnight activity)
     - cron: '0 9 * * *'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,10 +7,6 @@ on:
       - 'docs/**'
       - '*.md'
       - '.github/workflows/link-check.yml'
-  pull_request:
-    paths:
-      - 'docs/**'
-      - '*.md'
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday 6am UTC
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -24,13 +24,6 @@ on:
       - 'Python/tests/benchmarks/**'
       - '.github/workflows/performance.yml'
 
-  # Run on PRs to detect regressions
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'Python/structural_lib/**/*.py'
-      - 'Python/tests/benchmarks/**'
-
   # Weekly baseline refresh
   schedule:
     - cron: '0 4 * * 0'  # Sunday 4 AM UTC

--- a/.github/workflows/root-file-limit.yml
+++ b/.github/workflows/root-file-limit.yml
@@ -12,12 +12,6 @@ on:
       - '*.md'
       - '*.txt'
       - '*.sh'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - '*.md'
-      - '*.txt'
-      - '*.sh'
   # Allow manual trigger for testing
   workflow_dispatch:
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,14 +10,6 @@ on:
       - "react_app/package-lock.json"
       - "requirements*.txt"
       - ".github/workflows/security.yml"
-  pull_request:
-    paths:
-      - "Python/**"
-      - "fastapi_app/**"
-      - "react_app/package.json"
-      - "react_app/package-lock.json"
-      - "requirements*.txt"
-      - ".github/workflows/security.yml"
   schedule:
     # Run daily at 6 AM UTC (11:30 AM IST)
     - cron: "0 6 * * *"

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-09 — PR #676 is merged; the isolated MAINT-008 skills control-plane lane is in closeout
+**Updated:** 2026-08-09 — PR #689 is merged; Packet A is live on draft PR #690 and awaits the separate required-check decision
 
 ---
 
@@ -28,7 +28,7 @@
 | MAINT-005 | Restore frontend confidence and define the v0.21.7 finish line | P1 | ✅ DONE | Live import→design→3D→dashboard→export flow and byte-level artifacts pass; v0.21.7 preflight is ready |
 | MAINT-006 | Enforce low-token Codex operation | P1 | ✅ DONE | User-selected parent model is preserved; Luna/Terra advisory routing, bounded worker packets, two-subagent cap, and quick-gate check pass |
 | MAINT-007 | Refresh onboarding, agents, tools, and usage telemetry | P1 | ✅ DONE | Terminal-only PR status, current bootstrap/counts, complete 14-skill discovery, honest usage checkpoints, and focused regressions pass |
-| MAINT-008 | Compact CI, maintenance controls, and agent entry paths | P0 | 🔄 IN PROGRESS | Isolated skills repair passes; later CI packets complete the [implementation plan](planning/compact-modernization-plan.md) with one truthful PR gate and unchanged main-process evidence |
+| MAINT-008 | Compact CI, maintenance controls, and agent entry paths | P0 | 🔄 IN PROGRESS | Skills repair is merged; draft PR #690 has one passing truthful PR gate, with the ruleset decision and later packets still approval-gated |
 
 ### Maintenance evidence captured 2026-08-07
 
@@ -49,6 +49,7 @@
 - MAINT-007 closeout: 32 focused regressions, Ruff/Black, quick 9/9, full 29/29, audit 22/22, and health 100/100 pass; folder indexes and the 282-document global index are current.
 - PR #676 was safely squash-merged and synchronized; clean MAINT-008 baseline commit is `755ac9fb`.
 - MAINT-008 skills lane: all 14 skills have valid frontmatter and current commands, `skill_tiers.json` is the single catalog, registry routing/counts validate, the four-layer architecture checker is green, missing API discovery fails closed, release verification selects exact artifacts, and evolution proposals stop below 15 collected sessions.
+- PR #689 was safely squash-merged at `b611f6b3`; Packet A draft PR #690 now emits one passing `PR Gate`, and only `fast-checks.yml` retains a pull-request trigger. Ruleset `11390214` is unchanged and still requires `Quick Validation (Python 3.11 only)` pending explicit owner approval.
 
 ### Recovery progress
 
@@ -120,13 +121,13 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| MAINT-008 | Execute the [compact modernization plan](planning/compact-modernization-plan.md) | Main Agent | 🔄 Skills lane in closeout on `task/MAINT-008-SKILLS`; CI packets not started |
+| MAINT-008 | Execute the [compact modernization plan](planning/compact-modernization-plan.md) | Main Agent | 🔄 Packet A implemented on draft PR #690; required-check switch awaits owner approval |
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| MAINT-008 | Review the isolated skills PR; after separate owner merge approval, start truthful PR Gate packet A from a clean baseline | ops + owner | bounded packets | P0 | ⏳ AFTER SKILLS PR |
+| MAINT-008 | Review draft PR #690; separately approve the ruleset switch from `Quick Validation (Python 3.11 only)` to `PR Gate` before Packet B | ops + owner | bounded packets | P0 | ⏳ OWNER DECISION |
 | v0.21.7 | Re-run release preflight and obtain a separate release approval after MAINT-008 | ops + owner | <1 session | P1 | ⏸ AFTER MAINT-008 |
 
 ## Backlog

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -34,6 +34,7 @@ tags: []
 
 | Date | Task | Change | Commit |
 |------|------|--------|--------|
+| 2026-08-09 | MAINT-008 | Added a truthful aggregate PR Gate and removed nine superseded pull-request workflow triggers after the live gate passed | 07ecf357 |
 | 2026-08-09 | MAINT-008 | Removed hidden session mutations so summary, sync, and end are read-only unless an explicit write flag is supplied | fc4d0249 |
 | 2026-08-09 | MAINT-008 | Repaired all 14 skill entrypoints, canonicalized tier/route validation, and made supporting evidence commands fail closed | 5ac70ac1 |
 | 2026-08-09 | MAINT-001 | Closed PR #676 CI root causes, added essential-only/root-cause review policy, and verified all local and GitHub gates | 242ba8ce |

--- a/docs/planning/compact-modernization-plan.md
+++ b/docs/planning/compact-modernization-plan.md
@@ -254,7 +254,7 @@ Next packet authorized: yes/no
 
 **Branch:** `task/MAINT-008-SKILLS`
 
-**Status:** implemented; local and CI gates green on draft PR #689, pending owner approval
+**Status:** completed; approved PR #689 was squash-merged and synchronized at `b611f6b3`
 
 **Files in scope:** the 14 `.github/skills/*/SKILL.md` entrypoints, `.github/skills/skill_tiers.json`, cross-agent session instructions, agent skill assignments/metadata, and only the supporting session/discovery/architecture/release/evolution scripts needed to make those instructions truthful.
 
@@ -279,6 +279,8 @@ Make the skill surface safe for lower-cost agents: one canonical catalog, bounde
 Run targeted script validation, `./run.sh check --quick`, and one `./run.sh check` closeout. Commit and push through the safe wrapper, then open an isolated PR. The worker does not merge it. Packet A begins only after explicit owner approval and synchronization to the merged skills baseline.
 
 ## 11. Packet A — Truthful PR gate
+
+**Status:** implemented on draft PR #690; the live `PR Gate` passes, superseded pull-request triggers are removed, and ruleset `11390214` remains unchanged pending explicit owner approval
 
 **Suggested worker:** Terra, normal implementation reasoning
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,18 +4,18 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-09
-- Focus: Close the isolated MAINT-008 skills control-plane repair; leave its merge and all CI/ruleset/release work for separate approval
+- Focus: Review Packet A draft PR #690 and obtain the separate required-check decision; do not merge or change the ruleset implicitly
 <!-- HANDOFF:END -->
 
 **Last Updated:** 2026-08-09
-**Current Session:** PR #676 is merged; MAINT-008 skills repair is implemented on `task/MAINT-008-SKILLS` and is in closeout
+**Current Session:** PR #689 is merged at `b611f6b3`; Packet A is implemented on `task/MAINT-008-A` in draft PR #690
 
 ## Start Here
 
-1. Review the MAINT-008 skills PR and its gate evidence; do not merge it without explicit owner approval.
-2. After that skills PR is merged and synchronized, follow [MAINT-008 — Compact Project Modernization Plan](compact-modernization-plan.md) from packet A on a new clean branch.
-3. Obtain separate explicit decisions for the skills merge, GitHub required-check change, later MAINT-008 CI merge, and v0.21.7 release.
-4. Preserve the recovered Mac baseline and accepted main-process results; do not mix workflow compaction or product work into the skills PR.
+1. Review draft PR #690 and its live `PR Gate`; do not merge it without a later explicit owner approval.
+2. Obtain explicit approval before changing ruleset `11390214` from `Quick Validation (Python 3.11 only)` to `PR Gate`.
+3. Begin Packet B only after the new required check is re-fetched and verified; the later MAINT-008 merge and v0.21.7 release remain separate decisions.
+4. Preserve the recovered main-process baseline; do not mix product code or release work into Packet A.
 
 Full evidence and accepted risks are in
 [maintenance-recovery-audit-2026-08-07.md](../audit/maintenance-recovery-audit-2026-08-07.md).
@@ -39,8 +39,10 @@ Full evidence and accepted risks are in
 - MAINT-007 checkpoint `4d5b9eb5` is pushed to PR #676.
 - PR #676 closeout: its required checks were green before the safe squash merge. React coverage remains an accepted follow-up risk.
 - MAINT-008 skills branch: all 14 skill entrypoints were reviewed and repaired; one JSON catalog now drives tier validation, agent routes and metadata agree, and supporting API/architecture/release/evolution commands fail closed on ambiguous or insufficient evidence.
-- Skills commits: `5ac70ac1` repairs the compact control plane; `fc4d0249` removes hidden session writes. Draft PR #689 is open, clean, and has all applicable GitHub checks passing.
+- Skills commits `5ac70ac1` and `fc4d0249` were merged through approved PR #689 at `b611f6b3`.
 - Skills targeted evidence: tier assignment validation, four-layer architecture scan (119 files, zero violations), API discovery success/missing-function behavior, Python compilation, frontmatter/stale-command scan, and evolution 9/15 burn-in gate pass.
+- Packet A draft PR #690 emits one `PR Gate`; its latest run passed with `Repository Validation` successful and the three unchanged product-layer jobs explicitly skipped. Nine superseded PR triggers were then removed, leaving `fast-checks.yml` as the only pull-request workflow.
+- Packet A baseline remains 17 workflow files; deletion and scheduled/release-lane compaction belong to Packet B. Ruleset `11390214` is unchanged pending owner approval.
 - Recovery checkpoint: `b28ee4e3` pushed on `task/MAINT-001`.
 - MAINT-002: complete and validated with 18/18 live E2E checks and zero broken internal links.
 - Quick canonical gate: 9/9 green; all 3,248 scanned imports resolve.
@@ -58,7 +60,7 @@ Full evidence and accepted risks are in
 - Session summary, sync, and end are read-only; add `--write`, `--fix`, or `--log-cost` only when the task intentionally owns that mutation.
 - Evidence commands must reject missing, ambiguous, or insufficient proof; never accept a convenient first match.
 - Run from the workspace root. Find docs through indexes or `rg --files`; the compact log is `docs/WORKLOG.md`.
-- Do not extend draft PR #689. After an owner-approved merge, synchronize and start packet A on a clean branch; ruleset, later merge, and release decisions remain separate.
+- Do not change ruleset `11390214`, merge draft PR #690, or release v0.21.7 without the corresponding separate owner approval.
 
 ## Maintenance Sequence
 


### PR DESCRIPTION
## Outcome

Packet A replaces the skipped required-check design with one stable aggregate check named `PR Gate` and removes duplicate pull-request workflow fan-out.

## What changed

- `fast-checks.yml` now always runs repository policy validation and conditionally runs Python, FastAPI, and React validation by affected layer
- `PR Gate` uses `if: always()`, depends on every validation job, and explicitly rejects failed, cancelled, or incorrectly skipped applicable jobs
- nine superseded `pull_request` triggers were removed only after the live gate passed
- all 17 legacy workflow files remain for Packet B; no workflow was deleted
- workflow documentation and MAINT-008 handoff records now describe the live state

## Evidence

- live `PR Gate`: passed on three successive PR heads
- latest PR fan-out: one workflow, 3 successful checks, 3 intentionally skipped component checks, 0 failures
- local gate-logic simulation: success path plus five failure/cancellation paths behaved correctly
- YAML: 17 workflow files parsed; changed files pass pre-commit `check-yaml`
- migration-script tests: 7 passed
- `./run.sh check --quick`: 9/9
- internal links: 0 broken
- protected product/calculation/test paths: unchanged

## Baseline and approval boundary

- merged skills baseline: `b611f6b3`
- active ruleset: `11390214`
- current required check: `Quick Validation (Python 3.11 only)`
- proposed required check: `PR Gate`
- workflow files: 17 before and after Packet A

The ruleset is unchanged. Do not switch the required check or merge this draft PR without separate owner approval.