### PR TITLE
fix(automation): close governance and control gaps

### DIFF
--- a/.github/agents/agent-evolver.agent.md
+++ b/.github/agents/agent-evolver.agent.md
@@ -59,14 +59,16 @@ require the minimum collected-session threshold enforced by the evolution script
 ### Scheduled Review Workflow
 
 ```bash
+SESSION_ID="<session-id>"
+
 # Step 1: Collect artifacts from this session
-.venv/bin/python scripts/agent_session_collector.py
+.venv/bin/python scripts/agent_session_collector.py --session-id "$SESSION_ID"
 
 # Step 2: Quick score for agents active this session
-.venv/bin/python scripts/agent_scorer.py --session-latest
+.venv/bin/python scripts/agent_scorer.py --session "$SESSION_ID"
 
-# Step 3: Check for drift violations
-.venv/bin/python scripts/agent_drift_detector.py --session-latest
+# Step 3: Check for drift violations (read-only unless --write is explicit)
+.venv/bin/python scripts/agent_drift_detector.py --session "$SESSION_ID"
 
 # Step 4: Log findings
 ./run.sh feedback log --agent agent-evolver

--- a/.github/skills/agent-evolution/SKILL.md
+++ b/.github/skills/agent-evolution/SKILL.md
@@ -28,6 +28,9 @@ Choose a stable session ID and agent name:
 .venv/bin/python scripts/agent_compliance_checker.py --session <session-id> --agent <agent>
 ```
 
+Drift and compliance checks are read-only. Add `--write` to the drift command
+only when a persisted report is an intentional output of the review.
+
 Do not use nonexistent bulk flags. Manual scores require the scorer's explicit dimension flags and evidence; do not invent values to complete a record.
 
 ## Proposal Gate
@@ -39,6 +42,9 @@ Instruction proposals require at least 15 collected session records. Before that
 .venv/bin/python scripts/agent_evolve_instructions.py --propose
 .venv/bin/python scripts/agent_evolve_instructions.py --list
 ```
+
+Trend analysis is read-only by default; add `--write` only for an intentional
+managed trend artifact.
 
 Review each proposal against the underlying sessions. Correlation or a single bad run is not a root cause.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -204,27 +204,6 @@ repos:
         pass_filenames: false
         files: ^docs/.*\.md$
         verbose: true
-      - id: check-cost-optimizer-issues
-        name: Check cost optimizer code issues
-        entry: .venv/bin/python scripts/check_cost_optimizer_issues.py
-        language: system
-        pass_filenames: false
-        files: ^streamlit_app/pages/02_.*cost_optimizer\.py$
-        verbose: true
-      - id: check-streamlit-issues
-        name: Check Streamlit app issues (AST scanner)
-        entry: .venv/bin/python scripts/check_streamlit.py --all-pages --fail-on-critical
-        language: system
-        pass_filenames: false
-        files: ^streamlit_app/pages/.*\.py$
-        verbose: true
-      - id: check-fragment-violations
-        name: Check Streamlit fragment API violations
-        entry: .venv/bin/python scripts/check_streamlit.py --fragments
-        language: system
-        pass_filenames: false
-        files: ^streamlit_app/.*\.py$
-        verbose: true
       - id: apptest-smoke
         name: AppTest smoke tests (runtime validation)
         entry: bash -c '.venv/bin/python -m pytest tests/apptest/test_all_pages_smoke.py -v --tb=short -x'
@@ -252,13 +231,6 @@ repos:
         language: system
         pass_filenames: false
         files: ^streamlit_app/utils/.*\.py$
-        verbose: true
-      - id: check-performance-issues
-        name: Check Streamlit performance anti-patterns
-        entry: .venv/bin/python scripts/check_performance_issues.py --fail-threshold 1
-        language: system
-        pass_filenames: false
-        files: ^streamlit_app/.*\.py$
         verbose: true
       - id: check-doc-metadata
         name: Check doc metadata (warning mode)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy (structural_lib)
-        entry: bash -c 'cd Python && ../.venv/bin/python -m mypy structural_lib/'
+        entry: bash -c 'cd Python && ../scripts/python_runtime.sh -m mypy structural_lib/'
         language: system
         types: [python]
         files: ^Python/structural_lib/.*\.py$
@@ -76,7 +76,7 @@ repos:
     hooks:
       - id: contract-tests
         name: API contract tests (prevent breaking changes)
-        entry: bash -c "cd Python && ../.venv/bin/python -m pytest tests/integration/test_contracts.py -m contract -v --tb=short"
+        entry: bash -c "cd Python && ../scripts/python_runtime.sh -m pytest tests/integration/test_contracts.py -m contract -v --tb=short"
         language: system
         pass_filenames: false
         always_run: false
@@ -94,147 +94,147 @@ repos:
         always_run: true
       - id: check-repo-hygiene
         name: Check repo hygiene artifacts
-        entry: .venv/bin/python scripts/check_repo_hygiene.py
+        entry: ./scripts/python_runtime.sh scripts/check_repo_hygiene.py
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-doc-versions
         name: Check doc version drift
-        entry: .venv/bin/python scripts/check_doc_versions.py
+        entry: ./scripts/python_runtime.sh scripts/check_doc_versions.py
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-python-version
         name: Check Python version consistency
-        entry: .venv/bin/python scripts/check_python_version.py --ci
+        entry: ./scripts/python_runtime.sh scripts/check_python_version.py --ci
         language: system
         pass_filenames: false
         files: (pyproject\.toml|setup\.cfg|\.github/workflows/.*\.yml)$
         verbose: true
       - id: check-tasks-format
         name: Check TASKS.md format
-        entry: .venv/bin/python scripts/check_tasks_format.py
+        entry: ./scripts/python_runtime.sh scripts/check_tasks_format.py
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-docs-index
         name: Check docs index structure
-        entry: .venv/bin/python scripts/check_docs.py --index
+        entry: ./scripts/python_runtime.sh scripts/check_docs.py --index
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-release-docs
         name: Check release docs consistency
-        entry: .venv/bin/python scripts/release.py check-docs
+        entry: ./scripts/python_runtime.sh scripts/release.py check-docs
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-session-docs
         name: Check session docs consistency
-        entry: .venv/bin/python scripts/session.py check
+        entry: ./scripts/python_runtime.sh scripts/session.py check
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-api-docs-sync
         name: Check API docs sync
-        entry: .venv/bin/python scripts/check_api.py --sync
+        entry: ./scripts/python_runtime.sh scripts/check_api.py --sync
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-pre-release-checklist
         name: Check pre-release checklist structure
-        entry: .venv/bin/python scripts/release.py checklist
+        entry: ./scripts/python_runtime.sh scripts/release.py checklist
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-api-doc-signatures
         name: Check API doc signatures
-        entry: .venv/bin/python scripts/check_api.py --docs
+        entry: ./scripts/python_runtime.sh scripts/check_api.py --docs
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-api-manifest
         name: Check API manifest
-        entry: .venv/bin/python scripts/generate_api_manifest.py --check
+        entry: ./scripts/python_runtime.sh scripts/generate_api_manifest.py --check
         language: system
         pass_filenames: false
         files: ^Python/structural_lib/api\.py$
         verbose: true
       - id: check-next-session-brief-length
         name: Check next-session brief length
-        entry: .venv/bin/python scripts/check_next_session_brief_length.py
+        entry: ./scripts/python_runtime.sh scripts/check_next_session_brief_length.py
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-cli-reference
         name: Check CLI reference commands
-        entry: .venv/bin/python scripts/check_cli_reference.py
+        entry: ./scripts/python_runtime.sh scripts/check_cli_reference.py
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-scripts-index
         name: Check scripts index
-        entry: .venv/bin/python scripts/check_scripts_index.py
+        entry: ./scripts/python_runtime.sh scripts/check_scripts_index.py
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-docs-index-links
         name: Check docs index links
-        entry: .venv/bin/python scripts/check_docs.py --index-links
+        entry: ./scripts/python_runtime.sh scripts/check_docs.py --index-links
         language: system
         pass_filenames: false
         always_run: true
         verbose: true
       - id: check-markdown-links
         name: Check markdown internal links
-        entry: .venv/bin/python scripts/check_links.py
+        entry: ./scripts/python_runtime.sh scripts/check_links.py
         language: system
         pass_filenames: false
         files: ^docs/.*\.md$
         verbose: true
       - id: apptest-smoke
         name: AppTest smoke tests (runtime validation)
-        entry: bash -c '.venv/bin/python -m pytest tests/apptest/test_all_pages_smoke.py -v --tb=short -x'
+        entry: bash -c './scripts/python_runtime.sh -m pytest tests/apptest/test_all_pages_smoke.py -v --tb=short -x'
         language: system
         pass_filenames: false
         files: ^streamlit_app/pages/.*\.py$
         verbose: true
       - id: check-api-signatures
         name: Check React/FastAPI endpoint contract
-        entry: .venv/bin/python scripts/check_api.py --signatures
+        entry: ./scripts/python_runtime.sh scripts/check_api.py --signatures
         language: system
         pass_filenames: false
         files: ^(react_app/src/.*\.(ts|tsx)|fastapi_app/.*\.py)$
         verbose: true
       - id: pylint-streamlit
         name: Pylint check for Streamlit app
-        entry: bash -c '.venv/bin/python -m pylint --rcfile=.pylintrc-streamlit --exit-zero streamlit_app/pages/*.py'
+        entry: bash -c './scripts/python_runtime.sh -m pylint --rcfile=.pylintrc-streamlit --exit-zero streamlit_app/pages/*.py'
         language: system
         pass_filenames: false
         files: ^streamlit_app/pages/.*\.py$
         verbose: true
       - id: check-type-annotations
         name: Check type annotations (Streamlit utils)
-        entry: .venv/bin/python scripts/check_type_annotations.py --lenient
+        entry: ./scripts/python_runtime.sh scripts/check_type_annotations.py --lenient
         language: system
         pass_filenames: false
         files: ^streamlit_app/utils/.*\.py$
         verbose: true
       - id: check-doc-metadata
         name: Check doc metadata (warning mode)
-        entry: .venv/bin/python scripts/check_docs.py --metadata
+        entry: ./scripts/python_runtime.sh scripts/check_docs.py --metadata
         language: system
         pass_filenames: false
         files: ^docs/.*\.md$

--- a/Python/tests/test_agent_governance_automation.py
+++ b/Python/tests/test_agent_governance_automation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
+import subprocess
 import sys
 from datetime import date
 from pathlib import Path
@@ -23,8 +25,40 @@ agent_data = importlib.import_module("_lib.agent_data")
 agent_drift = importlib.import_module("agent_drift_detector")
 agent_trends = importlib.import_module("agent_trends")
 audit_permissions = importlib.import_module("audit_permissions")
+check_all = importlib.import_module("check_all")
+cli_smoke = importlib.import_module("test_cli_smoke")
 tool_permissions = importlib.import_module("tool_permissions")
 tool_registry = importlib.import_module("tool_registry")
+
+
+def test_python_runtime_launcher_uses_explicit_interpreter():
+    launcher = SCRIPTS_DIR / "python_runtime.sh"
+    env = os.environ.copy()
+    env["STRUCTURAL_LIB_PYTHON"] = sys.executable
+
+    result = subprocess.run(
+        [str(launcher), "-c", "import sys; print(sys.executable)"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()).resolve() == Path(sys.executable).resolve()
+
+
+def test_control_paths_use_python_runtime_launcher():
+    launcher = str(SCRIPTS_DIR / "python_runtime.sh")
+    run_sh = (REPO_ROOT / "run.sh").read_text(encoding="utf-8")
+    pre_commit = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    entry_lines = [line for line in pre_commit.splitlines() if "entry:" in line]
+
+    assert check_all.VENV_PYTHON == launcher
+    assert cli_smoke.VENV == launcher
+    assert 'VENV="$SCRIPTS/python_runtime.sh"' in run_sh
+    assert all(".venv/bin/python" not in line for line in entry_lines)
 
 
 def test_current_session_ids_uses_injected_date_and_ignores_malformed_ids():

--- a/Python/tests/test_agent_governance_automation.py
+++ b/Python/tests/test_agent_governance_automation.py
@@ -1,0 +1,244 @@
+"""Regression tests for agent-governance automation controls."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_only
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+agent_compliance = importlib.import_module("agent_compliance_checker")
+agent_context = importlib.import_module("agent_context")
+agent_data = importlib.import_module("_lib.agent_data")
+agent_drift = importlib.import_module("agent_drift_detector")
+agent_trends = importlib.import_module("agent_trends")
+audit_permissions = importlib.import_module("audit_permissions")
+tool_permissions = importlib.import_module("tool_permissions")
+tool_registry = importlib.import_module("tool_registry")
+
+
+def test_current_session_ids_uses_injected_date_and_ignores_malformed_ids():
+    sessions = [
+        "2026-04-07T19:07",
+        "not-a-session",
+        "2026-08-09T09:00",
+        "2026-08-09T18:00",
+    ]
+
+    assert agent_data.current_session_ids(sessions, today=date(2026, 8, 9)) == [
+        "2026-08-09T09:00",
+        "2026-08-09T18:00",
+    ]
+
+
+def test_agent_context_uses_all_registry_agents():
+    registry = agent_context.load_agent_registry()
+
+    assert len(registry) == 16
+    assert {
+        "structural-math",
+        "security",
+        "library-expert",
+        "innovator",
+        "agent-evolver",
+    } <= set(registry)
+
+
+def test_agent_context_commands_are_root_stable():
+    source = (SCRIPTS_DIR / "agent_context.py").read_text(encoding="utf-8")
+
+    assert "cd Python && .venv/bin/python" not in source
+    assert ".venv/bin/python scripts/archive_old_files.sh" not in source
+    assert "./run.sh frontend build" in source
+
+
+def test_compliance_filter_without_attribution_fails_evidence():
+    result = agent_compliance.check_compliance(
+        {"session_id": "2026-08-09T10:00", "agents_active": ["backend"]},
+        "orchestrator",
+    )
+
+    assert result["evidence_available"] is False
+    assert result["compliance_results"] == {}
+    assert "not attributed" in result["no_evidence_reason"]
+
+
+def test_compliance_default_rejects_stale_latest_session(monkeypatch):
+    monkeypatch.setattr(agent_compliance, "list_sessions", lambda: ["2026-04-07T19:07"])
+    monkeypatch.setattr(sys, "argv", ["agent_compliance_checker.py"])
+
+    assert agent_compliance.main() == 1
+
+
+def _ops_session() -> dict:
+    return {
+        "session_id": "2026-04-07T19:07",
+        "agents_active": ["ops"],
+        "commits": [{"message": "ci: inspect checks"}],
+        "files_changed": {},
+    }
+
+
+def test_drift_filter_without_attribution_fails_evidence():
+    result = agent_drift.detect_drift(_ops_session(), agent_filter="frontend")
+
+    assert result["evidence_available"] is False
+    assert result["agents_analyzed"] == []
+    assert "not attributed" in result["no_evidence_reason"]
+
+
+def test_drift_default_is_read_only(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["agent_drift_detector.py", "--session", "old"])
+    monkeypatch.setattr(agent_drift, "load_session", lambda _session: _ops_session())
+
+    def unexpected_write(*_args, **_kwargs):
+        raise AssertionError("read-only drift analysis attempted to write")
+
+    monkeypatch.setattr(agent_drift, "save_drift_report", unexpected_write)
+
+    assert agent_drift.main() == 0
+
+
+def test_drift_write_mode_is_explicit(monkeypatch, tmp_path):
+    written: list[dict] = []
+    monkeypatch.setattr(
+        sys, "argv", ["agent_drift_detector.py", "--session", "old", "--write"]
+    )
+    monkeypatch.setattr(agent_drift, "load_session", lambda _session: _ops_session())
+    monkeypatch.setattr(
+        agent_drift,
+        "save_drift_report",
+        lambda data, output_path=None: written.append(data) or tmp_path / "drift.json",
+    )
+
+    assert agent_drift.main() == 0
+    assert len(written) == 1
+
+
+def _trend_session(score: float) -> dict:
+    return {"agent_scores": {"ops": {"composite": score}}}
+
+
+def test_trends_default_is_read_only(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["agent_trends.py", "--weekly"])
+    monkeypatch.setattr(agent_trends, "list_sessions", lambda: ["s1", "s2", "s3"])
+    scores = iter([6.0, 7.0, 8.0])
+    monkeypatch.setattr(
+        agent_trends, "load_session", lambda _session: _trend_session(next(scores))
+    )
+
+    def unexpected_write(*_args, **_kwargs):
+        raise AssertionError("read-only trend analysis attempted to write")
+
+    monkeypatch.setattr(agent_trends, "save_trends", unexpected_write)
+
+    assert agent_trends.main() == 0
+
+
+def test_trends_missing_agent_fails_before_write(monkeypatch):
+    monkeypatch.setattr(
+        sys, "argv", ["agent_trends.py", "--weekly", "--agent", "frontend"]
+    )
+    monkeypatch.setattr(agent_trends, "list_sessions", lambda: ["s1"])
+    monkeypatch.setattr(
+        agent_trends, "load_session", lambda _session: _trend_session(8.0)
+    )
+
+    assert agent_trends.main() == 1
+
+
+@pytest.mark.parametrize(
+    ("operation", "mode", "expected"),
+    [
+        ("project health", None, "ReadOnly"),
+        ("project health", "--fix", "WorkspaceWrite"),
+        ("session summary", "--write", "WorkspaceWrite"),
+        ("model usage checkpoint", None, "ReadOnly"),
+        ("unknown task", None, "DangerFullAccess"),
+        ("project health", "--unknown", "DangerFullAccess"),
+    ],
+)
+def test_operation_permissions_are_explicit_and_fail_closed(operation, mode, expected):
+    assert (
+        tool_permissions.resolve_required_permission(operation, mode=mode) == expected
+    )
+
+
+def test_abstract_permission_operations_remain_compatible():
+    assert tool_permissions.resolve_required_permission("read") == "ReadOnly"
+    assert tool_permissions.resolve_required_permission("edit") == "WorkspaceWrite"
+    assert tool_permissions.resolve_required_permission("delete") == "DangerFullAccess"
+
+
+def test_agent_permission_check_uses_declared_task_mode():
+    default = tool_permissions.check_permission("reviewer", "project health")
+    mutating = tool_permissions.check_permission(
+        "reviewer", "project health", mode="--fix"
+    )
+
+    assert default.allowed is True
+    assert default.required_level == "ReadOnly"
+    assert mutating.allowed is False
+    assert mutating.required_level == "WorkspaceWrite"
+
+
+def test_undeclared_operation_is_denied_even_to_danger_level_agent(monkeypatch):
+    monkeypatch.setattr(
+        tool_permissions,
+        "_load_registry",
+        lambda: [
+            {
+                "name": "danger-agent",
+                "permission_level": "DangerFullAccess",
+                "file_scope": None,
+            }
+        ],
+    )
+
+    result = tool_permissions.check_permission("danger-agent", "unknown task")
+    unknown_mode = tool_permissions.check_permission(
+        "danger-agent", "project health", mode="--unknown"
+    )
+
+    assert result.allowed is False
+    assert result.required_level == "DangerFullAccess"
+    assert "no explicit permission declaration" in result.reason
+    assert unknown_mode.allowed is False
+
+
+def test_tool_registry_does_not_infer_permission_from_git_text():
+    registry = tool_registry.load_registry()
+
+    assert registry["check git state"].permission == "ReadOnly"
+    assert registry["project health"].permission_modes == {"--fix": "WorkspaceWrite"}
+    assert registry["governance health score"].permission is None
+
+
+def test_permission_metadata_audit_accepts_current_declarations():
+    assert audit_permissions.audit_automation_permission_metadata() == []
+
+
+def test_permission_metadata_audit_rejects_modes_without_default(tmp_path, monkeypatch):
+    automation_map = tmp_path / "automation-map.json"
+    automation_map.write_text(
+        json.dumps(
+            {"tasks": {"broken": {"permission_modes": {"--fix": "WorkspaceWrite"}}}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(audit_permissions, "_AUTOMATION_MAP", automation_map)
+
+    anomalies = audit_permissions.audit_automation_permission_metadata()
+
+    assert len(anomalies) == 1
+    assert "explicit default" in anomalies[0].message

--- a/docs/audit/automation-scripts-audit-2026-08-09.md
+++ b/docs/audit/automation-scripts-audit-2026-08-09.md
@@ -13,8 +13,9 @@ tags: [automation, scripts, audit, maintenance, archive, maint-008]
 
 The active automation surface was audited one item at a time. The baseline
 inventory contained **113 top-level scripts**. After two P0 implementation
-batches and the five-script P1 governance batch, the active surface contains
-**106 top-level scripts**: **89 Python** and **17 shell**, totaling **40,239
+batches, the five-script P1 governance batch, and the worktree-runtime repair,
+the active surface contains **107 top-level scripts**: **89 Python** and **18
+shell**, totaling **40,284
 lines**. The extended control surface also
 contains the root `run.sh` dispatcher, four GitHub Actions workflows, zero
 repository-enforcement Git hook entrypoints, three non-Git Python hook-framework
@@ -25,11 +26,11 @@ disposition is:
 
 | Disposition | Count | Meaning |
 |---|---:|---|
-| Keep | 61 | Supported role, including the repaired API/reference, agent-governance, permission, and runtime controls |
+| Keep | 62 | Supported role, including the repaired API/reference, agent-governance, permission, and runtime controls |
 | Update | 30 | Active or useful, but a confirmed non-P0 defect, stale contract, or metadata problem still needs repair |
 | Review | 12 | Low-use, overlapping, or specialized; prove a current consumer before keeping or archiving |
 | Archive candidate | 3 | Strong evidence of replacement or one-time use; still requires safe-delete preview and owner acceptance |
-| **Total active** | **106** | Current inventory after eight retirements and one addition: the Codex workflow guard |
+| **Total active** | **107** | Current inventory after eight retirements and two additions: the Codex workflow guard and Python worktree resolver |
 
 The original audit was read-only. The user then authorized a P0 implementation
 pass over five named scripts and directed that Git/GitHub work move to Codex.
@@ -106,6 +107,19 @@ that metadata. Two bounded read-only reviewers inspected the independent
 evidence-selection and permission designs. Both used Terra; no Sol agent was
 used.
 
+## Terminal/worktree runtime repair — 2026-08-09
+
+`run.sh`, `check_all.py`, `test_cli_smoke.py`, and 23 active pre-commit entries
+assumed that every linked Git worktree contained its own `.venv`. That made the
+first clean-worktree gate and commit hooks fail before their Python checks ran.
+
+`scripts/python_runtime.sh` is now the single internal resolver. It uses, in
+order, an explicit `STRUCTURAL_LIB_PYTHON`, the current checkout's `.venv`, the
+primary Git worktree's `.venv`, or an active `VIRTUAL_ENV`; otherwise it exits
+with an actionable error. The dispatcher, check orchestrator, smoke suite, and
+pre-commit entries call this resolver. A linked worktree with no local `.venv`
+now runs repository checks without a temporary link.
+
 ## Snapshot and scope
 
 | Field | Value |
@@ -116,7 +130,7 @@ used.
 | Baseline subject | `ci(maint-008): consolidate GitHub workflow lanes` |
 | Audit date | 2026-08-09 |
 | Baseline active top-level scripts | 113 |
-| Current active top-level scripts | 106 |
+| Current active top-level scripts | 107 |
 | Existing archived scripts | 101: 68 Python and 33 shell |
 | Shared support modules | 7 under `scripts/_lib/` |
 | Hook framework modules | 3 non-Git modules under `scripts/hooks/` |
@@ -185,13 +199,25 @@ Batch 3 verification was performed after the five-script P1 implementation:
 | Governance compliance | pass; explicit permission metadata check included |
 | Script index | 106/106 pass |
 | Active script target validation | 0 runtime breaks; 24 informational historical references |
-| CLI smoke | 12/13 pass; known `find_automation.py beam` P1 remains |
+| CLI smoke | 12/13 at initial Batch 3 verification; resolved to 13/13 in the worktree follow-up below |
 | Quick gate | 9/9 pass |
 | Full gate in isolated worktree | 29/29 pass |
 
 The clean Codex worktree removed the unrelated API-manifest/OpenAPI drift seen
 in the shared release worktree. The complete gate then passed without
 regenerating or overwriting those concurrent owner-controlled artifacts.
+
+The runtime follow-up was then verified in the same linked worktree after
+removing its temporary `.venv` link:
+
+| Worktree runtime check | Result |
+|---|---|
+| Runtime resolution | primary-worktree Python 3.11.15 selected without local `.venv` |
+| Focused governance/runtime tests | 108/108 pass |
+| Script index and automation map | 107/107 pass |
+| CLI smoke | 13/13 pass using a guaranteed registered automation task |
+| Quick gate without local `.venv` | 9/9 pass |
+| Full gate without local `.venv` | 29/29 pass |
 
 ### Terminal issues encountered
 
@@ -210,11 +236,11 @@ regenerating or overwriting those concurrent owner-controlled artifacts.
 | Installed Git hook shell syntax | 3/3 pass |
 | Safe help probes | 82/82 pass |
 | Static-only scripts without recognized safe help path | 31 |
-| Script index coverage | 113/113 pass at baseline; 106/106 current |
-| Automation-map physical coverage | 113/113 pass at baseline; 106/106 current |
+| Script index coverage | 113/113 pass at baseline; 107/107 current |
+| Automation-map physical coverage | 113/113 pass at baseline; 107/107 current |
 | Canonical full gate | 29/29 pass |
 | Focused script/infrastructure tests | 218/218 pass |
-| CLI smoke suite | 12/13 pass; `find_automation.py beam` fails |
+| CLI smoke suite | 13/13 pass |
 | Token-efficiency policy | pass |
 | Skill assignment validation | pass |
 | Workflow YAML parse | 4/4 pass |
@@ -226,7 +252,7 @@ regenerating or overwriting those concurrent owner-controlled artifacts.
 The green 29/29 gate is useful but incomplete. It now detects missing active
 script targets, vacuous API signature scanning, and malformed declared
 permission metadata, but it does not yet detect automation-map category drift,
-undeclared-operation coverage, or the failing CLI smoke case.
+undeclared-operation coverage, or require the standalone CLI smoke suite.
 
 ## Highest-priority confirmed issues
 
@@ -288,20 +314,21 @@ across nine production files matched against 62 OpenAPI paths.
 
 ### P1 — Automation discovery is physically complete but semantically stale
 
-`automation-map.json` currently has 118 task entries and 17 legacy categories.
-It maps all 106 physical scripts, but its semantic integrity has drifted:
+`automation-map.json` currently has 119 task entries and 17 legacy categories.
+It maps all 107 physical scripts, but its semantic integrity has drifted:
 
 - 13 category members still name retired or otherwise absent tasks;
-- 14 task entries are not present in any legacy category;
+- 15 task entries are not present in any legacy category;
 - `test vba adapter` says its target was removed but is not marked deprecated;
 - Streamlit and VBA categories still produce removed-product results;
 - `_tmp_add_groups.py` is still exposed as a supported tool; and
 - `find_automation.py` still claims 87 tasks/16 categories.
 
-The CLI smoke test fails because `find_automation.py beam` returns no result.
-Either change the smoke query to a guaranteed automation task or add a truthful
-beam-workflow mapping. Do not keep a failing test merely to prove the runner can
-fail.
+The CLI smoke false failure is resolved: `find_automation.py` is an
+automation-task finder, so its smoke case now queries the guaranteed registered
+task `run tests`; product-domain beam routing remains covered separately by
+`prompt_router.py`. The finder still needs truthful task/category counts and
+stale-category cleanup.
 
 ### P1 — Permission labels do not match operation behavior — RESOLVED FOR DECLARED OPERATIONS
 
@@ -341,7 +368,7 @@ agent behavior.
 
 ### P1 — `check_scripts_index.py` protects counts, not supported behavior
 
-The index checker passes 106/106 while the semantic discovery P1 finding above
+The index checker passes 107/107 while the semantic discovery P1 finding above
 remains. Expand it or add a narrow control-surface validator that checks:
 
 1. every active `run.sh`, pre-commit, workflow, and hook script target exists;
@@ -475,6 +502,7 @@ not a certification of every branch or an instruction to skip normal tests.
 | `preflight.py` | Session | UPDATE | Add `--help` and “When to use” contract. |
 | `project_health.py` | Governance | KEEP (UPDATED) | Canonical role retained; automation metadata now declares read-only default versus WorkspaceWrite `--fix`. |
 | `prompt_router.py` | Infrastructure | UPDATE | Registry labels normal read-only routing as WorkspaceWrite. |
+| `python_runtime.sh` | Infrastructure | KEEP (NEW) | Resolves an approved Python interpreter across primary and linked Git worktrees without creating or copying environments. |
 | `recover_git_state.sh` | Git | RETIRED | Unclear Git state now stops for Codex inspection; no automated destructive recovery. |
 | `release.py` | Release | KEEP | Canonical release CLI and focused tests passed; publishing still requires approval. |
 | `repo_health_check.sh` | Governance | REVIEW | Manual disk/file diagnostic overlaps health and diagnostics tools. |
@@ -488,7 +516,7 @@ not a certification of every branch or an instruction to skip normal tests.
 | `sync_numbers.py` | Session | KEEP | Preview versus `--fix` is explicit; retain. |
 | `test_api_parity.py` | Testing | UPDATE | Current parity is useful; remove stale Streamlit/VBA framing and alias. |
 | `test_changed.py` | Testing | UPDATE | Add help/“When to use” contract and keep root-stable pytest paths. |
-| `test_cli_smoke.py` | Testing | UPDATE | 12/13 pass; beam lookup fails and suite is absent from canonical gates. |
+| `test_cli_smoke.py` | Testing | UPDATE | 13/13 pass after using a registered automation query; decide whether to add the standalone suite to a canonical gate. |
 | `test_import_pipeline.py` | Testing | UPDATE | Add help and explicit live-server prerequisite; retain as maintained E2E path. |
 | `test_sample_endpoint.py` | Testing | ARCHIVE CANDIDATE | Standalone subset of `test_import_pipeline.py`; no active caller/help. |
 | `tool_permissions.py` | Infrastructure | KEEP (UPDATED) | Explicit operation/mode resolver applies agent ceilings and file scope and fails closed on undeclared input. |
@@ -583,8 +611,8 @@ issue closure, release, and history rewriting retain explicit approval gates.
 4. **Completed for permission truth:** declared operation/mode permissions are
    enforced without keyword guessing. Temp/removed discovery aliases remain in
    the automation-discovery P1 item.
-5. **Pending:** repair the CLI smoke case and make it part of repository
-   validation.
+5. **Partially completed:** the CLI smoke case is repaired at 13/13; canonical
+   gate integration remains pending.
 
 ### Packet C4 — Archive/consolidate the proven candidates
 
@@ -691,10 +719,20 @@ No release or publication workflow was triggered.
 - ⚠️ TERMINAL ISSUE: `tool_registry.py` uses mutually exclusive query flags, so
   a combined `--permission Unspecified --stats` probe was rejected -> the two
   read-only queries were rerun separately and passed.
-- ⚠️ TERMINAL ISSUE: the first clean-worktree gate could not find a local
-  `.venv` and stopped before running most checks -> a validated temporary link
-  to the existing project environment produced 9/9 and 29/29 passes, then the
-  link was removed before staging.
+- ✅ RESOLVED TERMINAL ISSUE: the first clean-worktree gate and commit hooks
+  could not find a local `.venv` and stopped before running Python checks ->
+  `python_runtime.sh` now resolves the primary worktree environment, and the
+  same linked worktree runs without a temporary link.
+- ⚠️ TERMINAL ISSUE: a repository-wide `pre-commit --all-files` probe exposed
+  pre-existing YAML/JSONC/Bandit/EOF debt and reformatted unrelated legacy and
+  vendor files -> the exact hook-only edits were reversed, the intended 12-file
+  scope was preserved, and pre-commit was rerun only against that scope.
+- ⚠️ TERMINAL ISSUE: the first audit-index refresh used the absent pluralized
+  `generate_folder_indexes.py` name -> the active
+  `generate_enhanced_index.py docs/audit` command regenerated both indexes.
+- ⚠️ TERMINAL ISSUE: a focused pytest command guessed two split test filenames
+  that do not exist -> the repository's combined
+  `test_agent_governance_automation.py` suite was run directly.
 - ⚠️ TERMINAL ISSUE: the first automated transfer used standard Git range hunk
   headers that the patch tool did not accept -> the same exact-file patch was
   reapplied with supported hunk headers and verified with formatting, tests,
@@ -704,8 +742,8 @@ No release or publication workflow was triggered.
 
 Both confirmed P0 automation batches and the five-script P1 agent-governance
 batch are complete. The next batch should address the remaining P1
-automation-discovery/control-validation scripts, beginning with the failing
-`find_automation.py` CLI smoke path and stale categories, not bulk archiving.
+automation-discovery/control-validation scripts, beginning with stale
+categories and advertised task counts, not bulk archiving.
 Preserve this report as the decision ledger and refresh caller/live-run evidence
 immediately before edits. Do not merge a PR, publish a release, close
 historical issues, or delete remote branches without separate owner approval.

--- a/docs/audit/automation-scripts-audit-2026-08-09.md
+++ b/docs/audit/automation-scripts-audit-2026-08-09.md
@@ -12,9 +12,10 @@ tags: [automation, scripts, audit, maintenance, archive, maint-008]
 ## Outcome
 
 The active automation surface was audited one item at a time. The baseline
-inventory contained **113 top-level scripts**. After the first P0 implementation
-pass, the active surface contains **106 top-level scripts**: **89 Python** and
-**17 shell**, totaling **39,811 lines**. The extended control surface also
+inventory contained **113 top-level scripts**. After two P0 implementation
+batches and the five-script P1 governance batch, the active surface contains
+**106 top-level scripts**: **89 Python** and **17 shell**, totaling **40,239
+lines**. The extended control surface also
 contains the root `run.sh` dispatcher, four GitHub Actions workflows, zero
 repository-enforcement Git hook entrypoints, three non-Git Python hook-framework
 modules, and seven shared Python support modules.
@@ -24,17 +25,21 @@ disposition is:
 
 | Disposition | Count | Meaning |
 |---|---:|---|
-| Keep | 53 | Supported role, including the repaired API contract checker and new Codex workflow guard |
-| Update | 37 | Active or useful, but a confirmed defect, stale contract, unsafe behavior, or metadata problem still needs repair |
-| Review | 13 | Low-use, overlapping, or specialized; prove a current consumer before keeping or archiving |
+| Keep | 61 | Supported role, including the repaired API/reference, agent-governance, permission, and runtime controls |
+| Update | 30 | Active or useful, but a confirmed non-P0 defect, stale contract, or metadata problem still needs repair |
+| Review | 12 | Low-use, overlapping, or specialized; prove a current consumer before keeping or archiving |
 | Archive candidate | 3 | Strong evidence of replacement or one-time use; still requires safe-delete preview and owner acceptance |
-| **Total active** | **106** | Current top-level script inventory after seven wrapper retirements |
+| **Total active** | **106** | Current inventory after eight retirements and one addition: the Codex workflow guard |
 
 The original audit was read-only. The user then authorized a P0 implementation
 pass over five named scripts and directed that Git/GitHub work move to Codex.
+The second authorized P0 batch removed five missing-script control targets and
+closed the remaining P0 finding. The third authorized batch repaired five P1
+agent-governance and permission scripts plus their direct shared controls.
 No independent commit, push, PR mutation, merge, issue action, release, or
-publication was performed during the bounded P0 implementation; its changes
-were integrated into the parent `LIB-IS456-V1` branch for native Git closeout.
+publication was performed during the bounded implementation passes themselves.
+The follow-up closeout isolated their still-uncommitted changes from concurrent
+product work before using the Codex-native Git/GitHub lifecycle.
 
 ## P0 implementation update — 2026-08-09
 
@@ -62,12 +67,51 @@ boundary. During verification, the repaired API checker found and enabled the
 fix of a real production contract defect: the React SSE batch client used
 `/api/v1/stream/batch-design`, while FastAPI exposes `/stream/batch-design`.
 
+## P0 Batch 2 implementation update — 2026-08-09
+
+The second batch addressed the five missing script targets individually:
+
+| Missing target | Result | Outcome |
+|---|---|---|
+| `scripts/run_vba_smoke_tests.py` | Dead entrypoint removed | `run.sh` no longer exposes an unsupported `test --vba` lane. |
+| `scripts/test_vba_adapter.py` | Dead entrypoint removed | The second failing command behind `test --vba` is no longer reachable. |
+| `scripts/check_cost_optimizer_issues.py` | Dead hook removed | The archived cost-optimizer scanner is no longer an active pre-commit target. |
+| `scripts/check_streamlit.py` | Two dead hooks removed | Both Streamlit AST/fragment hook entrypoints were removed. |
+| `scripts/check_performance_issues.py` | Dead hook removed | The archived Streamlit performance scanner is no longer an active target. |
+
+The missing files were already absent, so Batch 2 deleted no additional files.
+`validate_script_refs.py` now scans `run.sh`, pre-commit, GitHub workflows, and
+active top-level scripts for missing runtime targets, including `$SCRIPTS/...`
+dispatcher calls. It fails on executable missing references while preserving
+historical comments and consolidation docstrings as informational evidence.
+
+## P1 Batch 3 implementation update — 2026-08-09
+
+The next five individual scripts were repaired as an agent-governance and
+permission-truth batch:
+
+| Requested script | Result | Outcome |
+|---|---|---|
+| `scripts/agent_compliance_checker.py` | Repaired | Defaults to current-session evidence and returns failure when the session, agent attribution, or evidence set is absent. Historical selection remains explicit. |
+| `scripts/agent_context.py` | Repaired | Loads the canonical 16-agent registry, validates its metadata, accepts every registered agent, and prints root-stable commands. |
+| `scripts/agent_drift_detector.py` | Repaired | Current-session/no-evidence cases fail closed; the default is read-only and files are written only with `--write` or `--output`. |
+| `scripts/agent_trends.py` | Repaired | Historical trend analysis is read-only by default, missing agents fail instead of receiving synthetic zero-score results, and writes are explicit. |
+| `scripts/tool_permissions.py` | Repaired | Resolves explicit task and mode permissions, respects agent ceilings and file scope, and fails closed for unknown tasks or modes. |
+
+Direct support changes made the five fixes enforceable: the shared agent-data
+helper now identifies current dated sessions; the tool registry stopped
+guessing permissions from keywords; automation-map entries declare the repaired
+operations and mutating modes; and the permission/governance audits validate
+that metadata. Two bounded read-only reviewers inspected the independent
+evidence-selection and permission designs. Both used Terra; no Sol agent was
+used.
+
 ## Snapshot and scope
 
 | Field | Value |
 |---|---|
 | Repository | `structural_engineering_lib` |
-| Branch | `task/LIB-IS456-V1` |
+| Branch at Batch 3 closeout | `codex/automation-governance-batches-2-3` |
 | Baseline commit | `8bfdac09564995a04bd0fb249b90934cd4c80011` |
 | Baseline subject | `ci(maint-008): consolidate GitHub workflow lanes` |
 | Audit date | 2026-08-09 |
@@ -79,12 +123,12 @@ fix of a real production contract defect: the React SSE batch client used
 | Repository-enforcement Git hook entrypoints | 0 under `scripts/git-hooks/` |
 | Active workflows | 4 under `.github/workflows/` |
 | Root dispatcher | `run.sh` |
-| Subagents used | 0 |
+| Subagents used | 2 read-only Terra reviewers in Batch 3; 0 in the earlier audit/P0 batches |
 
 The 101 files already under `scripts/_archive/` were not re-reviewed as active
 automation. Their boundary was checked instead: `validate_script_refs.py`
-found no active runtime call to an archived-only script. Its 13 results were
-informational consolidation comments/docstrings only.
+found no active runtime call to an archived-only or otherwise missing script.
+Its 25 results were informational consolidation comments/docstrings only.
 
 ## Method
 
@@ -116,15 +160,38 @@ was then verified separately:
 | Current script index and automation map | 106/106 pass |
 | API contract validation | 24 call sites / 9 files / 62 OpenAPI paths pass |
 | API zero-coverage behavior | expected failure confirmed |
-| Focused Python automation tests | 21/21 pass |
+| Focused Python automation tests | 23/23 pass |
+| Active script target validation | 0 runtime breaks; 25 informational historical references at P0 |
+| Pre-commit configuration validation | pass |
 | Focused React batch-design tests | 10/10 pass |
 | Non-Git hook-framework self-test | 1/1 pass |
-| Link validation | 1,048 links checked; 0 broken |
+| Link validation | 1,050 links checked; 0 broken |
 | Quick gate | 9/9 pass |
 | Integrated full gate after P0 and library-first work | 29/29 pass |
 
 The earlier generated-manifest and OpenAPI drift was resolved by the owning
 library-first work before the final integrated gate.
+
+Batch 3 verification was performed after the five-script P1 implementation:
+
+| P1 Batch 3 check | Result |
+|---|---|
+| Canonical agent registry | 16/16 agents listed; `structural-math` focused context returned rc 0 |
+| Current evidence defaults | compliance and drift returned expected rc 1 because only stale historical sessions were available |
+| Read/write permission modes | reviewer read-only health allowed; `--fix` denied; undeclared operation denied |
+| Focused governance/evolver tests | 106/106 pass |
+| Formatting, lint, and compile | pass for all changed Python implementation/test files |
+| Permission declaration audit | pass; no anomalies |
+| Governance compliance | pass; explicit permission metadata check included |
+| Script index | 106/106 pass |
+| Active script target validation | 0 runtime breaks; 24 informational historical references |
+| CLI smoke | 12/13 pass; known `find_automation.py beam` P1 remains |
+| Quick gate | 9/9 pass |
+| Full gate in isolated worktree | 29/29 pass |
+
+The clean Codex worktree removed the unrelated API-manifest/OpenAPI drift seen
+in the shared release worktree. The complete gate then passed without
+regenerating or overwriting those concurrent owner-controlled artifacts.
 
 ### Terminal issues encountered
 
@@ -132,6 +199,8 @@ library-first work before the final integrated gate.
 - ⚠️ TERMINAL ISSUE: `generate_enhanced_index.py` rejected multiple folder arguments → each affected folder was regenerated in a separate supported invocation.
 - ⚠️ TERMINAL ISSUE: Vitest launched from the repository root missed the React jsdom configuration (`window is not defined`) → rerunning from `react_app/` passed 10/10 tests.
 - ⚠️ TERMINAL ISSUE: a diagnostic zsh loop used the reserved `path` variable and temporarily hid `git` inside that one process → the verification was rerun in a clean shell with non-reserved names.
+- ⚠️ TERMINAL ISSUE: an `rg` command placed `--glob` filters after the `--` pattern terminator, so ripgrep treated them as paths → the search was rerun with filters before `--`.
+- ⚠️ TERMINAL ISSUE: the first Black check reported that `validate_script_refs.py` needed formatting → Black was applied and the final format check passed.
 
 | Check | Result |
 |---|---|
@@ -141,8 +210,8 @@ library-first work before the final integrated gate.
 | Installed Git hook shell syntax | 3/3 pass |
 | Safe help probes | 82/82 pass |
 | Static-only scripts without recognized safe help path | 31 |
-| Script index coverage | 113/113 pass at baseline; 106/106 after P0 retirement |
-| Automation-map physical coverage | 113/113 pass at baseline; 106/106 after P0 retirement |
+| Script index coverage | 113/113 pass at baseline; 106/106 current |
+| Automation-map physical coverage | 113/113 pass at baseline; 106/106 current |
 | Canonical full gate | 29/29 pass |
 | Focused script/infrastructure tests | 218/218 pass |
 | CLI smoke suite | 12/13 pass; `find_automation.py beam` fails |
@@ -154,10 +223,10 @@ library-first work before the final integrated gate.
 | ShellCheck | not installed; syntax only |
 | actionlint | not installed; YAML parse only |
 
-The green 29/29 gate is useful but incomplete. It does not currently detect
-missing `run.sh`/pre-commit targets, automation-map category drift, vacuous API
-signature scanning, behavior-inaccurate permission metadata, or the failing CLI
-smoke case.
+The green 29/29 gate is useful but incomplete. It now detects missing active
+script targets, vacuous API signature scanning, and malformed declared
+permission metadata, but it does not yet detect automation-map category drift,
+undeclared-operation coverage, or the failing CLI smoke case.
 
 ## Highest-priority confirmed issues
 
@@ -187,20 +256,20 @@ instructions assign normal Git/GitHub closeout to Codex, preserve standard
 validation, fail closed on unclear repository state, and keep destructive
 actions behind explicit user confirmation.
 
-### P0 — Five active control paths point to missing scripts
+### P0 — Five active control paths point to missing scripts — RESOLVED
 
-| Surface | Missing target | Current behavior |
+| Surface | Missing target | Resolution |
 |---|---|---|
-| `run.sh` | `scripts/run_vba_smoke_tests.py` | `./run.sh test --vba` fails |
-| `run.sh` | `scripts/test_vba_adapter.py` | `./run.sh test --vba` fails |
-| `.pre-commit-config.yaml` | `scripts/check_cost_optimizer_issues.py` | Dead hook filtered to removed Streamlit path |
-| `.pre-commit-config.yaml` | `scripts/check_streamlit.py` | Two dead hooks filtered to removed Streamlit path |
-| `.pre-commit-config.yaml` | `scripts/check_performance_issues.py` | Dead hook filtered to removed Streamlit path |
+| `run.sh` | `scripts/run_vba_smoke_tests.py` | Removed the unsupported `test --vba` dispatch branch. |
+| `run.sh` | `scripts/test_vba_adapter.py` | Removed with the same unsupported dispatch lane. |
+| `.pre-commit-config.yaml` | `scripts/check_cost_optimizer_issues.py` | Removed the dead archived-product hook. |
+| `.pre-commit-config.yaml` | `scripts/check_streamlit.py` | Removed both dead Streamlit hooks. |
+| `.pre-commit-config.yaml` | `scripts/check_performance_issues.py` | Removed the dead archived-product hook. |
 
 `streamlit_app/`, `VBA/`, `Excel/`, `tests/apptest/`, and
-`.pylintrc-streamlit` are also absent. Remove these dead entrypoints rather than
-restoring removed product trees. The existing `validate_script_refs.py` did not
-find them because it only compares active scripts against names present in
+`.pylintrc-streamlit` remain absent; no removed product tree was restored.
+`validate_script_refs.py` now guards active control surfaces generically, so a
+future missing target fails even when its name is not present in
 `scripts/_archive/`.
 
 ### P0 — `check_api.py --signatures` passes without checking the React calls — RESOLVED
@@ -219,15 +288,14 @@ across nine production files matched against 62 OpenAPI paths.
 
 ### P1 — Automation discovery is physically complete but semantically stale
 
-`automation-map.json` has 125 task entries and 17 legacy categories. The file
-maps all 113 physical scripts, but its semantic integrity has drifted:
+`automation-map.json` currently has 118 task entries and 17 legacy categories.
+It maps all 106 physical scripts, but its semantic integrity has drifted:
 
-- seven category members do not exist as tasks;
+- 13 category members still name retired or otherwise absent tasks;
 - 14 task entries are not present in any legacy category;
-- three duplicate-command groups represent compatibility aliases;
 - `test vba adapter` says its target was removed but is not marked deprecated;
 - Streamlit and VBA categories still produce removed-product results;
-- `_tmp_add_groups.py` is exposed as a supported WorkspaceWrite tool; and
+- `_tmp_add_groups.py` is still exposed as a supported tool; and
 - `find_automation.py` still claims 87 tasks/16 categories.
 
 The CLI smoke test fails because `find_automation.py beam` returns no result.
@@ -235,45 +303,46 @@ Either change the smoke query to a guaranteed automation task or add a truthful
 beam-workflow mapping. Do not keep a failing test merely to prove the runner can
 fail.
 
-### P1 — Permission labels do not match operation behavior
+### P1 — Permission labels do not match operation behavior — RESOLVED FOR DECLARED OPERATIONS
 
-`audit_permissions.py --check` reports no anomalies, but it checks registry
-consistency, not the script's real side effects. Examples:
+The keyword-based classifier was removed. The resolver now uses explicit task
+and mode metadata, applies the registered agent ceiling and file scope, and
+denies unknown task/mode combinations even when an agent has
+`DangerFullAccess`. The permission audit and canonical governance gate reject
+malformed declarations.
 
-- `generate_enhanced_index.py`, `pipeline_state.py`, and `session_store.py` are
-  labeled ReadOnly even though normal subcommands write files/state;
-- `prompt_router.py` and `config_precedence.py` are labeled WorkspaceWrite even
-  though their normal route/audit modes are read-only;
-- check-only utilities inherit DangerFullAccess from the assigned agent; and
-- one script with both read-only and mutating modes receives only one permission
-  label.
+Fourteen high-value operations now have explicit defaults and ten declare
+mutating modes. Examples verified in this batch include read-only `project
+health` versus WorkspaceWrite `--fix`, and read-only drift/trends versus
+WorkspaceWrite `--write`/`--output`. Undeclared task aliases are reported as
+`Unspecified` instead of receiving invented labels; permission enforcement
+rejects an undeclared operation or mode until metadata is added.
 
-Model permissions per operation/subcommand, or conservatively use the maximum
-side effect while documenting a safe read-only invocation. Extend the
-permission audit to compare declared metadata with observed/static behavior.
+This resolves the misleading-label root cause. Future script batches should add
+explicit metadata when an undeclared operation becomes an enforced entrypoint;
+the audit does not claim that static inspection can prove every runtime side
+effect.
 
-### P1 — Agent governance automation can be false-green or unexpectedly write
+### P1 — Agent governance automation can be false-green or unexpectedly write — RESOLVED
 
-- `agent_context.py --list` exposes only 11 of the current 16 agents. It rejects
-  `structural-math`, `security`, `library-expert`, `innovator`, and
-  `agent-evolver`, even though `AGENTS.md` claims all 16 are supported.
-- four commands printed by `agent_context.py` use
-  `cd Python && .venv/bin/python ...`, which points to a nonexistent venv.
-- `agent_compliance_checker.py --agent orchestrator` selected a stale
-  2026-04-07 session, produced an empty result set, returned zero, and then
-  printed “All compliance checks passed.”
-- `agent_drift_detector.py` and `agent_trends.py` wrote ignored local report
-  files during their default analysis invocations. Their output was based on
-  stale April session data rather than the current task.
+- `agent_context.py --list` now exposes and accepts all 16 canonical agents,
+  validates the registry count/names, and emits root-stable commands.
+- default compliance/drift checks require a current dated session and return
+  nonzero for missing sessions, absent agent attribution, or empty evidence;
+  historical sessions remain available only through explicit selectors.
+- drift and trend reports are read-only by default; managed or custom output
+  requires `--write` or `--output`.
+- trend lookup for an absent agent returns failure instead of manufacturing a
+  zero-score record.
 
-Prefer the dynamic registry-backed `agent_brief.sh`, which successfully handled
-all five newer agents in focused checks. Make no-evidence cases fail closed and
-make report-only/no-write behavior explicit.
+Focused tests cover evidence availability, current-session selection, all 16
+agents, root-stable commands, no-write defaults, explicit writes, and missing
+agent behavior.
 
 ### P1 — `check_scripts_index.py` protects counts, not supported behavior
 
-The index checker passes 113/113 while all P0 findings above remain. Expand it
-or add a narrow control-surface validator that checks:
+The index checker passes 106/106 while the semantic discovery P1 finding above
+remains. Expand it or add a narrow control-surface validator that checks:
 
 1. every active `run.sh`, pre-commit, workflow, and hook script target exists;
 2. every automation category member resolves to a task;
@@ -288,13 +357,13 @@ or add a narrow control-surface validator that checks:
 These are lower priority than the P0/P1 items and should be handled in a compact
 documentation/CLI-contract pass, not as 60 separate rewrites:
 
-- 35 of 89 Python scripts lack the catalog's required “When to use” contract.
+- 36 of 89 Python scripts lack the catalog's required “When to use” contract.
 - 31 of the baseline 113 top-level scripts had no safely recognized `--help` path, despite
   the scripts README saying all scripts should support help.
 - 60 scripts contain 309 bare `python scripts/...` command examples instead of
   the root-stable `.venv/bin/python` or `./run.sh` entrypoint.
-- `agent_context.py` contains four specifically broken
-  `cd Python && .venv/bin/python` commands.
+- agent-governance command examples are now root-stable; continue repairing the
+  remaining 309 bare `python scripts/...` examples in later bounded batches.
 - `check_root_file_count.sh` recommends raw `git mv` instead of
   `safe_file_move.py`.
 - `check_circular_imports.py` and `check_type_annotations.py` now scan the
@@ -319,27 +388,27 @@ not a certification of every branch or an instruction to skip normal tests.
 |---|---|---|---|
 | `_tmp_add_groups.py` | Infrastructure | ARCHIVE CANDIDATE | One-time map migration says delete after use; no active caller. |
 | `agent_brief.sh` | Session | KEEP | Dynamic agent brief handled all five newer agents; retain as the compact entrypoint. |
-| `agent_compliance_checker.py` | Governance | UPDATE | Empty compliance set returned rc 0 and “all passed”; fail closed on no evidence. |
-| `agent_context.py` | Session | UPDATE | Only 11/16 agents; four broken `cd Python/.venv` commands; consolidate with dynamic registry. |
-| `agent_drift_detector.py` | Governance | UPDATE | Default run writes ignored reports and selected stale session; add no-write/current selection. |
+| `agent_compliance_checker.py` | Governance | KEEP (UPDATED) | Current-session selection and explicit historical selectors now fail closed on missing session, attribution, or evidence. |
+| `agent_context.py` | Session | KEEP (UPDATED) | Canonical registry validation exposes all 16 agents and emits root-stable commands. |
+| `agent_drift_detector.py` | Governance | KEEP (UPDATED) | Current evidence fails closed; default analysis is read-only and writes require `--write`/`--output`. |
 | `agent_evolve_instructions.py` | Evolution | REVIEW | Manual-only evolution writer; retain only with the current evidence workflow. |
 | `agent_feedback.py` | Governance | KEEP | Active feedback command; no outcome-changing defect found. |
 | `agent_mistakes_report.sh` | Governance | KEEP | Session-start consumer works; no outcome-changing defect found. |
 | `agent_scorer.py` | Governance | REVIEW | Review fallback scoring and stale-session inputs before operational use. |
 | `agent_session_collector.py` | Governance | REVIEW | Manual-only collector; verify current Codex session source before keeping. |
-| `agent_start.sh` | Session | UPDATE | Depends on incomplete `agent_context.py` for named-agent deep context. |
-| `agent_trends.py` | Evolution | REVIEW | Writes output by default and selected stale April data during audit. |
+| `agent_start.sh` | Session | KEEP (UPDATED) | Its named-agent deep-context dependency now uses the complete canonical registry. |
+| `agent_trends.py` | Evolution | KEEP (UPDATED) | Historical analysis is read-only by default; absent agents fail and output writes are explicit. |
 | `ai_commit.sh` | Git | RETIRED | Codex owns scoped commit, push, and connected GitHub PR work. |
 | `archive_old_files.sh` | Docs | UPDATE | Uses raw `mv` instead of link-aware safe file operations. |
 | `audit_error_handling.py` | Quality | KEEP | Safe audit/help path passed; retain. |
 | `audit_input_validation.py` | Quality | KEEP | Safe audit/help path passed; retain. |
-| `audit_permissions.py` | Infrastructure | KEEP | Retain registry-consistency audit, but do not treat it as behavior validation. |
+| `audit_permissions.py` | Infrastructure | KEEP (UPDATED) | Validates explicit automation permission levels and mode declarations; static metadata is not runtime side-effect proof. |
 | `audit_readiness_report.py` | Generation | KEEP | Canonical audit consumer works; retain. |
 | `batch_migrate_runner.py` | Migration | UPDATE | `--dry-run` still creates logs; rollback script emits raw `rm`/`cp`. |
 | `benchmark_api.py` | Testing | KEEP | Supported benchmark with explicit modes; retain. |
 | `bump_version.py` | Release | UPDATE | Remove stale missing Excel/VBA doc targets and normalize commands. |
 | `check_all.py` | Quality | KEEP | Canonical 29-check orchestrator works; expand coverage through focused validators, not ad hoc duplication. |
-| `check_api.py` | Discovery | KEEP (UPDATED) | Validates 24 production React call sites against 60 live OpenAPI paths and fails closed on zero coverage. |
+| `check_api.py` | Discovery | KEEP (UPDATED) | Validates 24 production React call sites against 62 live OpenAPI paths and fails closed on zero coverage. |
 | `check_api_compat.py` | Quality | UPDATE | Add missing “When to use”/CLI contract; underlying check is distinct and useful. |
 | `check_architecture_boundaries.py` | Quality | KEEP | Focused and canonical architecture check passed. |
 | `check_bootstrap_freshness.py` | Quality | KEEP | Canonical freshness check passed. |
@@ -404,7 +473,7 @@ not a certification of every branch or an instruction to skip normal tests.
 | `pipeline_state.py` | Infrastructure | UPDATE | State-changing commands are labeled ReadOnly in registry. |
 | `pre_commit_check.sh` | Git | ARCHIVE CANDIDATE | Manual-only duplicate of installed pre-commit and canonical quick checks. |
 | `preflight.py` | Session | UPDATE | Add `--help` and “When to use” contract. |
-| `project_health.py` | Governance | UPDATE | Preserve canonical role; make no-write versus `--fix` permissions explicit. |
+| `project_health.py` | Governance | KEEP (UPDATED) | Canonical role retained; automation metadata now declares read-only default versus WorkspaceWrite `--fix`. |
 | `prompt_router.py` | Infrastructure | UPDATE | Registry labels normal read-only routing as WorkspaceWrite. |
 | `recover_git_state.sh` | Git | RETIRED | Unclear Git state now stops for Codex inspection; no automated destructive recovery. |
 | `release.py` | Release | KEEP | Canonical release CLI and focused tests passed; publishing still requires approval. |
@@ -422,14 +491,14 @@ not a certification of every branch or an instruction to skip normal tests.
 | `test_cli_smoke.py` | Testing | UPDATE | 12/13 pass; beam lookup fails and suite is absent from canonical gates. |
 | `test_import_pipeline.py` | Testing | UPDATE | Add help and explicit live-server prerequisite; retain as maintained E2E path. |
 | `test_sample_endpoint.py` | Testing | ARCHIVE CANDIDATE | Standalone subset of `test_import_pipeline.py`; no active caller/help. |
-| `tool_permissions.py` | Infrastructure | UPDATE | Audit does not compare permissions with actual script side effects. |
-| `tool_registry.py` | Infrastructure | UPDATE | Exposes temp/stale aliases and behavior-inaccurate permissions. |
+| `tool_permissions.py` | Infrastructure | KEEP (UPDATED) | Explicit operation/mode resolver applies agent ceilings and file scope and fails closed on undeclared input. |
+| `tool_registry.py` | Infrastructure | UPDATE | Keyword permission inference is gone, but temp/stale discovery aliases still need cleanup. |
 | `update_test_stats.py` | Testing | KEEP | Report versus write modes are explicit; retain. |
 | `validate_api_contracts.py` | Quality | KEEP | Canonical contract check passed. |
 | `validate_git_state.sh` | Git | KEEP | Canonical read-only validation passed. |
 | `validate_imports.py` | Quality | KEEP | Canonical import validation passed. |
 | `validate_schema_snapshots.py` | Quality | KEEP | Canonical snapshot validation passed. |
-| `validate_script_refs.py` | Quality | UPDATE | Only checks archived names; misses five active references to nonexistent scripts. |
+| `validate_script_refs.py` | Quality | KEEP (UPDATED) | Scans active CLI, pre-commit, workflow, and script surfaces and fails on any executable missing target. |
 | `watch_tests.sh` | Testing | UPDATE | Uses bare `pytest`/ambiguous default path and legacy Streamlit message; `fswatch` is absent locally. |
 
 ## Extended control-surface disposition
@@ -438,9 +507,9 @@ not a certification of every branch or an instruction to skip normal tests.
 
 | Item | Disposition | Evidence and next action |
 |---|---|---|
-| `run.sh` | UPDATE | Remove broken `test --vba` branch, keep help aligned, and add target-existence validation. |
-| `.pre-commit-config.yaml` | UPDATE | Remove dead Streamlit hooks and their missing targets; retain current React/FastAPI/Python hooks. |
-| `scripts/automation-map.json` | UPDATE | Remove stale categories/aliases/temp tool and align permissions/deprecation metadata. |
+| `run.sh` | KEEP (UPDATED) | Broken `test --vba` dispatch/help/completion entries removed; supported test lanes retained. |
+| `.pre-commit-config.yaml` | KEEP (UPDATED) | Missing-target Streamlit hooks removed; current React/FastAPI/Python hooks retained. |
+| `scripts/automation-map.json` | UPDATE | Operation/mode permissions are explicit for the repaired controls; remove remaining stale categories/aliases/temp tool and align deprecation metadata. |
 | `scripts/index.json` / `index.md` | KEEP/REGENERATE | Physical inventory is truthful now; regenerate only after approved script changes. |
 | `scripts/README.md` | UPDATE | Replace stale PR/deprecation guidance and make help/dry-run claims match reality. |
 
@@ -473,7 +542,7 @@ parts of agent data, registry, and scoring behavior.
 | Item | Disposition |
 |---|---|
 | `scripts/_lib/__init__.py` | KEEP |
-| `scripts/_lib/agent_data.py` | UPDATE with agent evidence/no-write fixes |
+| `scripts/_lib/agent_data.py` | KEEP (UPDATED); shared current-session selection is covered by focused tests |
 | `scripts/_lib/agent_registry.py` | KEEP; use it to eliminate hard-coded agent lists |
 | `scripts/_lib/ast_helpers.py` | KEEP |
 | `scripts/_lib/output.py` | KEEP |
@@ -493,10 +562,10 @@ parts of agent data, registry, and scoring behavior.
 
 ### Packet C1 — Fail-closed control paths
 
-1. Remove the five missing-script entrypoints from `run.sh` and pre-commit.
+1. **Completed:** remove the five missing-script entrypoints from `run.sh` and pre-commit.
 2. **Completed:** replace the vacuous API lane with the live React/OpenAPI contract check.
-3. Extend target/category/smoke validation so the remaining defects cannot return.
-4. Run focused checks, `./run.sh check --quick`, and inspect the live `PR Gate`.
+3. **Completed for P0:** active-target validation now fails closed; category and CLI-smoke improvements remain P1.
+4. **Completed locally:** focused checks and `./run.sh check --quick`; connected CI review belongs to Codex closeout.
 
 ### Packet C2 — Git data-preservation repair
 
@@ -507,12 +576,15 @@ issue closure, release, and history rewriting retain explicit approval gates.
 
 ### Packet C3 — Registry and agent truth
 
-1. Make the dynamic 16-agent registry the source for context and permission
-   discovery.
-2. Fail closed on missing/stale agent evidence.
-3. Add explicit no-write modes to drift/trend/report commands.
-4. Normalize operation-level permissions and remove temp/removed aliases.
-5. Repair the CLI smoke case and make it part of repository validation.
+1. **Completed:** the canonical 16-agent registry now drives agent context.
+2. **Completed:** compliance and drift fail closed on missing/current evidence.
+3. **Completed:** drift and trend analysis is read-only unless writing is
+   explicitly requested.
+4. **Completed for permission truth:** declared operation/mode permissions are
+   enforced without keyword guessing. Temp/removed discovery aliases remain in
+   the automation-discovery P1 item.
+5. **Pending:** repair the CLI smoke case and make it part of repository
+   validation.
 
 ### Packet C4 — Archive/consolidate the proven candidates
 
@@ -603,23 +675,39 @@ No release or publication workflow was triggered.
   audit did not start/alter the development stack.
 - Migration, Git, file-operation, release, auto-fix, and archive modes were not
   executed.
-- `agent_drift_detector.py` and `agent_trends.py` unexpectedly wrote ignored
-  local evidence files during their default analysis modes. They did not change
-  the tracked worktree; the side effect is retained as a finding rather than
-  deleted.
-- `./run.sh session end --agent orchestrator` completed its read-only checks but
-  returned exit 1 because three documentation paths were uncommitted: this audit
-  report plus two out-of-scope planning changes. Its handoff, link, session-log,
-  task-archive, and governance checks all passed. No `--fix` mode was run.
+- The baseline audit observed default writes from drift/trends. Batch 3 removed
+  that behavior and focused tests prove no output directory is created by the
+  default commands.
+- The original `./run.sh session end --agent orchestrator` returned exit 1 for
+  three uncommitted documentation paths. The later Git closeout used a clean,
+  isolated worktree so concurrent project changes were not staged. No `--fix`
+  mode was run.
 - **TERMINAL ISSUE:** an early `awk` inventory expression failed with a quoting
   error -> simpler `git ls-files`, Perl, and Python path-based counts produced
   the reconciled 113-script inventory.
+- ⚠️ TERMINAL ISSUE: Ruff caught `required_level` inserted into the wrong
+  permission helper during the first patch -> it was moved into
+  `check_permission`, then formatting, lint, compile, and focused tests passed.
+- ⚠️ TERMINAL ISSUE: `tool_registry.py` uses mutually exclusive query flags, so
+  a combined `--permission Unspecified --stats` probe was rejected -> the two
+  read-only queries were rerun separately and passed.
+- ⚠️ TERMINAL ISSUE: the first clean-worktree gate could not find a local
+  `.venv` and stopped before running most checks -> a validated temporary link
+  to the existing project environment produced 9/9 and 29/29 passes, then the
+  link was removed before staging.
+- ⚠️ TERMINAL ISSUE: the first automated transfer used standard Git range hunk
+  headers that the patch tool did not accept -> the same exact-file patch was
+  reapplied with supported hunk headers and verified with formatting, tests,
+  and `git diff --check`.
 
 ## Handoff
 
-The next session should start at Packet C1, not with archiving. Preserve this
-report as the decision ledger, refresh caller/live-run evidence immediately
-before edits, and update each row only when a focused change has been verified.
-Do not merge PR #691, publish v0.21.7, close historical issues, or delete remote
-branches as part of the script-maintenance packets without separate owner
-approval.
+Both confirmed P0 automation batches and the five-script P1 agent-governance
+batch are complete. The next batch should address the remaining P1
+automation-discovery/control-validation scripts, beginning with the failing
+`find_automation.py` CLI smoke path and stale categories, not bulk archiving.
+Preserve this report as the decision ledger and refresh caller/live-run evidence
+immediately before edits. Do not merge a PR, publish a release, close
+historical issues, or delete remote branches without separate owner approval.
+The batch is isolated on its own Codex branch; preserve that separation during
+review and do not pull concurrent release/product changes into its PR.

--- a/docs/audit/index.json
+++ b/docs/audit/index.json
@@ -33,10 +33,10 @@
     {
       "name": "automation-scripts-audit-2026-08-09.md",
       "type": "documentation",
-      "size_lines": 714,
+      "size_lines": 752,
       "last_updated": "2026-08-09",
       "description": "The active automation surface was audited one item at a time. The baseline inventory contained **113 top-level scripts**. After two P0 implementation",
-      "content_hash": "217addb4d034"
+      "content_hash": "0da99be84fc5"
     },
     {
       "name": "comprehensive-library-audit-2026-04-04.md",
@@ -86,5 +86,5 @@
       "file_count": 1
     }
   ],
-  "content_hash": "cc5284ec2b735a09"
+  "content_hash": "a902d102bd4940f1"
 }

--- a/docs/audit/index.json
+++ b/docs/audit/index.json
@@ -9,7 +9,7 @@
       "name": "README.md",
       "type": "documentation",
       "size_lines": 83,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "title": "Audit Evidence & Readiness",
       "description": "This folder contains audit evidence templates, checklists, and generated reports for demonstrating software quality, security posture, and compliance readiness. - NIST SSDF (SP 800-218) — Secure Softw",
       "content_hash": "7910666b6c36"
@@ -33,16 +33,16 @@
     {
       "name": "automation-scripts-audit-2026-08-09.md",
       "type": "documentation",
-      "size_lines": 625,
+      "size_lines": 714,
       "last_updated": "2026-08-09",
-      "description": "The active automation surface was audited one item at a time. The baseline inventory contained **113 top-level scripts**. After the first P0 implementation",
-      "content_hash": "8aeb4d67ea45"
+      "description": "The active automation surface was audited one item at a time. The baseline inventory contained **113 top-level scripts**. After two P0 implementation",
+      "content_hash": "217addb4d034"
     },
     {
       "name": "comprehensive-library-audit-2026-04-04.md",
       "type": "documentation",
       "size_lines": 1069,
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-09",
       "description": "| Workstream | Agent | Score | Key Finding | |-----------|-------|-------|-------------|",
       "content_hash": "7fa83524aff8"
     },
@@ -58,7 +58,7 @@
       "name": "git-workflow-audit-pr436.md",
       "type": "documentation",
       "size_lines": 260,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-09",
       "description": "Living audit of the git workflow. Originally based on PR #436 (TASK-500: Unified CLI + onboarding audit) which was deliberately used as a full workflow test. Now expanded with deep analysis of all 11 ",
       "content_hash": "9ff9dd0e831d"
     },
@@ -74,7 +74,7 @@
       "name": "onboarding-audit-session93.md",
       "type": "documentation",
       "size_lines": 146,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-09",
       "description": "Fresh-agent onboarding test: followed all documented steps exactly as a new AI agent would, and logged every friction point, error, and inconsistency encountered. Then conducted a deep audit of archiv",
       "content_hash": "9277bbf0b154"
     }
@@ -86,5 +86,5 @@
       "file_count": 1
     }
   ],
-  "content_hash": "291ad829d4334e02"
+  "content_hash": "cc5284ec2b735a09"
 }

--- a/docs/audit/index.md
+++ b/docs/audit/index.md
@@ -11,7 +11,7 @@
 | [README.md](README.md) | Audit Evidence & Readiness | This folder contains audit evidence templates, checklists, a | 83 |
 | [agent-testing-audit-2026-03-28.md](agent-testing-audit-2026-03-28.md) |  | > Archived from docs/_active/ on 2026-08-07. Counts and open | 292 |
 | [audit-readiness.md](audit-readiness.md) |  | This checklist defines the minimum evidence requirements for | 144 |
-| [automation-scripts-audit-2026-08-09.md](automation-scripts-audit-2026-08-09.md) |  | The active automation surface was audited one item at a time | 714 |
+| [automation-scripts-audit-2026-08-09.md](automation-scripts-audit-2026-08-09.md) |  | The active automation surface was audited one item at a time | 752 |
 | [comprehensive-library-audit-2026-04-04.md](comprehensive-library-audit-2026-04-04.md) |  | | Workstream | Agent | Score | Key Finding | |-----------|-- | 1069 |
 | [evidence-bundle-template.md](evidence-bundle-template.md) |  | | Field | Value | |-------|-------| | 214 |
 | [git-workflow-audit-pr436.md](git-workflow-audit-pr436.md) |  | Living audit of the git workflow. Originally based on PR #43 | 260 |

--- a/docs/audit/index.md
+++ b/docs/audit/index.md
@@ -11,7 +11,7 @@
 | [README.md](README.md) | Audit Evidence & Readiness | This folder contains audit evidence templates, checklists, a | 83 |
 | [agent-testing-audit-2026-03-28.md](agent-testing-audit-2026-03-28.md) |  | > Archived from docs/_active/ on 2026-08-07. Counts and open | 292 |
 | [audit-readiness.md](audit-readiness.md) |  | This checklist defines the minimum evidence requirements for | 144 |
-| [automation-scripts-audit-2026-08-09.md](automation-scripts-audit-2026-08-09.md) |  | The active automation surface was audited one item at a time | 625 |
+| [automation-scripts-audit-2026-08-09.md](automation-scripts-audit-2026-08-09.md) |  | The active automation surface was audited one item at a time | 714 |
 | [comprehensive-library-audit-2026-04-04.md](comprehensive-library-audit-2026-04-04.md) |  | | Workstream | Agent | Score | Key Finding | |-----------|-- | 1069 |
 | [evidence-bundle-template.md](evidence-bundle-template.md) |  | | Field | Value | |-------|-------| | 214 |
 | [git-workflow-audit-pr436.md](git-workflow-audit-pr436.md) |  | Living audit of the git workflow. Originally based on PR #43 | 260 |

--- a/docs/governance/maintenance-playbook.md
+++ b/docs/governance/maintenance-playbook.md
@@ -237,10 +237,10 @@ After structural changes (file moves, renames, new modules):
 .venv/bin/python scripts/agent_scorer.py --agent backend
 
 # Drift detection
-.venv/bin/python scripts/agent_drift_detector.py --latest
+.venv/bin/python scripts/agent_drift_detector.py
 
 # Compliance check
-.venv/bin/python scripts/agent_compliance_checker.py --latest
+.venv/bin/python scripts/agent_compliance_checker.py
 
 # Route a task to best agent
 ./run.sh route "task description"

--- a/run.sh
+++ b/run.sh
@@ -315,11 +315,6 @@ _cmd_test() {
             _require_venv
             "$VENV" "$SCRIPTS/test_import_pipeline.py" "${@:2}"
             ;;
-        --vba)
-            _require_venv
-            "$VENV" "$SCRIPTS/run_vba_smoke_tests.py" "${@:2}"
-            "$VENV" "$SCRIPTS/test_vba_adapter.py" "${@:2}"
-            ;;
         --cli)
             _require_venv
             "$VENV" "$SCRIPTS/external_cli_test.py" "${@:2}"
@@ -368,7 +363,6 @@ Options:
   (no args)          Run full pytest suite (default)
   --parity           FastAPI ↔ library parity tests
   --pipeline         Import → Design → 3D integration test
-  --vba              VBA adapter + smoke tests (macOS only)
   --cli              CLI cold-start smoke test
   --benchmark        API endpoint benchmarks
   --ci               Full local CI (black, ruff, mypy, pytest, coverage)
@@ -810,7 +804,7 @@ _run_sh() {
     local -a health_opts=('--fix' '--score' '--quick' '--category' '--json')
     local -a feedback_subs=('log' 'summary' 'pending' 'resolve' 'stats')
     local -a evolve_opts=('--fix' '--review' '--status' '--report' '--json')
-    local -a test_opts=('--parity' '--pipeline' '--vba' '--cli' '--benchmark' '--ci' '--stats')
+    local -a test_opts=('--parity' '--pipeline' '--cli' '--benchmark' '--ci' '--stats')
     local -a audit_opts=('--score' '--errors' '--inputs' '--diagnostics')
     local -a release_subs=('preflight' 'run' 'verify' 'check-docs' 'checklist')
     local -a efficiency_subs=('check' 'prompt')

--- a/run.sh
+++ b/run.sh
@@ -26,8 +26,8 @@ set -euo pipefail
 
 # Resolve repo root from this script's location
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VENV="$REPO_ROOT/.venv/bin/python"
 SCRIPTS="$REPO_ROOT/scripts"
+VENV="$SCRIPTS/python_runtime.sh"
 
 # ── Colors ─────────────────────────────────────────────────────────────────
 RED='\033[0;31m'
@@ -55,7 +55,7 @@ _hint() {
 
 _require_venv() {
     if [[ ! -x "$VENV" ]]; then
-        _error "Python venv not found at $VENV"
+        _error "Python runtime launcher not found at $VENV"
         echo "  Run: python3 -m venv .venv && .venv/bin/pip install -e Python/"
         exit 1
     fi

--- a/scripts/_lib/agent_data.py
+++ b/scripts/_lib/agent_data.py
@@ -6,8 +6,9 @@ Handles reading/writing session data, trends, scorecards, and evolution logs.
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 from .utils import REPO_ROOT
 
@@ -82,6 +83,27 @@ def list_sessions() -> list[str]:
 
     session_files = sorted(SESSIONS_DIR.glob("*.json"))
     return [f.stem for f in session_files]
+
+
+def current_session_ids(
+    session_ids: Sequence[str], *, today: date | None = None
+) -> list[str]:
+    """Return session IDs whose ISO date prefix matches the current date.
+
+    The helper is intentionally pure so callers can fail closed on stale
+    evidence without creating performance-data directories or files.
+    """
+    expected = today or date.today()
+    current: list[str] = []
+    for session_id in session_ids:
+        date_prefix = session_id.split("T", 1)[0]
+        try:
+            session_date = date.fromisoformat(date_prefix)
+        except ValueError:
+            continue
+        if session_date == expected:
+            current.append(session_id)
+    return current
 
 
 def save_scorecard_index(data: dict[str, Any]) -> Path:

--- a/scripts/agent_compliance_checker.py
+++ b/scripts/agent_compliance_checker.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _lib.agent_data import list_sessions, load_session
+from _lib.agent_data import current_session_ids, list_sessions, load_session
 from _lib.output import StatusLine, print_json, print_table
 from _lib.utils import REPO_ROOT
 
@@ -318,11 +318,23 @@ def check_compliance(
             "session_id": session_data.get("session_id", "unknown"),
             "compliance_results": {},
             "overall_compliance_rate": 0.0,
+            "evidence_available": False,
+            "no_evidence_reason": "Session has no attributed active agents",
         }
 
     # Filter to specific agent if requested
     if agent_name:
-        agents_active = [agent_name] if agent_name in agents_active else []
+        if agent_name not in agents_active:
+            return {
+                "session_id": session_data.get("session_id", "unknown"),
+                "compliance_results": {},
+                "overall_compliance_rate": 0.0,
+                "evidence_available": False,
+                "no_evidence_reason": (
+                    f"Agent '{agent_name}' is not attributed to this session"
+                ),
+            }
+        agents_active = [agent_name]
 
     compliance_results = {}
 
@@ -388,6 +400,8 @@ def check_compliance(
         "session_id": session_data.get("session_id", "unknown"),
         "compliance_results": compliance_results,
         "overall_compliance_rate": round(overall_rate, 3),
+        "evidence_available": all_checked > 0,
+        "no_evidence_reason": None if all_checked > 0 else "No applicable rules found",
     }
 
 
@@ -462,26 +476,39 @@ def main() -> int:
     elif args.summary:
         session_ids = list_sessions()
     else:
-        # Default: check most recent session
+        # Default means current evidence, not merely the newest historical file.
         all_sessions = list_sessions()
-        session_ids = [all_sessions[-1]] if all_sessions else []
+        current_sessions = current_session_ids(all_sessions)
+        session_ids = [current_sessions[-1]] if current_sessions else []
 
     if not session_ids:
-        StatusLine.fail("No sessions found")
+        StatusLine.fail(
+            "No current session evidence found; use --session, --last, or "
+            "--summary for an explicit historical analysis"
+        )
         return 1
 
     # Check compliance for each session
     results_list = []
+    evidence_failure = False
     for session_id in session_ids:
         session_data = load_session(session_id)
         if not session_data:
             StatusLine.warn(f"Session not found: {session_id}")
+            evidence_failure = True
             continue
 
         result = check_compliance(session_data, args.agent)
+        if not result.get("evidence_available", False):
+            StatusLine.fail(
+                f"No compliance evidence for {session_id}: "
+                f"{result.get('no_evidence_reason', 'unknown reason')}"
+            )
+            evidence_failure = True
+            continue
         results_list.append(result)
 
-    if not results_list:
+    if evidence_failure or not results_list:
         StatusLine.fail("No valid sessions to check")
         return 1
 

--- a/scripts/agent_context.py
+++ b/scripts/agent_context.py
@@ -6,6 +6,7 @@ Usage:
     .venv/bin/python scripts/agent_context.py --list
 """
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -15,6 +16,7 @@ ROOT = Path(__file__).resolve().parent.parent
 # ── Agent registry ──────────────────────────────────────────────────────
 
 AGENTS: dict[str, dict] = {}
+AGENT_REGISTRY = ROOT / "agents" / "agent_registry.json"
 
 
 def agent(name: str, description: str):
@@ -25,6 +27,37 @@ def agent(name: str, description: str):
         return func
 
     return decorator
+
+
+def load_agent_registry() -> dict[str, dict]:
+    """Load the canonical agent registry and fail closed on invalid metadata."""
+    try:
+        data = json.loads(AGENT_REGISTRY.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Agent registry not found: {AGENT_REGISTRY}") from exc
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"Agent registry is unreadable: {exc}") from exc
+
+    entries = data.get("agents")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Agent registry has no agent entries")
+
+    registry: dict[str, dict] = {}
+    for entry in entries:
+        name = entry.get("name") if isinstance(entry, dict) else None
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("Agent registry contains an entry without a valid name")
+        normalized = name.lower().strip()
+        if normalized in registry:
+            raise ValueError(f"Agent registry contains duplicate agent: {normalized}")
+        registry[normalized] = entry
+
+    expected_count = data.get("_meta", {}).get("agent_count")
+    if expected_count is not None and expected_count != len(registry):
+        raise ValueError(
+            f"Agent registry count mismatch: metadata={expected_count}, actual={len(registry)}"
+        )
+    return registry
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────
@@ -160,7 +193,7 @@ def ctx_backend():
 
     section("KEY COMMANDS")
     bullet("API signatures: .venv/bin/python scripts/discover_api_signatures.py <func>")
-    bullet("Tests: cd Python && .venv/bin/python -m pytest tests/ -v")
+    bullet("Tests: .venv/bin/python -m pytest Python/tests/ -v")
     bullet(
         "Import check: .venv/bin/python scripts/validate_imports.py --scope structural_lib"
     )
@@ -286,7 +319,7 @@ def ctx_structural_engineer():
     bullet("beam_to_3d_geometry() — 3D visualization positions")
 
     section("VERIFICATION COMMANDS")
-    bullet("cd Python && .venv/bin/python -m pytest tests/ -v -k 'is456'")
+    bullet(".venv/bin/python -m pytest Python/tests/ -v -k 'is456'")
     bullet(".venv/bin/python scripts/discover_api_signatures.py <func>")
     bullet("Param names: b_mm (not width), fck (not concrete_grade), d_mm (not depth)")
 
@@ -329,8 +362,8 @@ def ctx_reviewer():
     section("COMMANDS")
     bullet(".venv/bin/python scripts/check_architecture_boundaries.py")
     bullet(".venv/bin/python scripts/validate_imports.py --scope structural_lib")
-    bullet("cd react_app && npm run build")
-    bullet("cd Python && .venv/bin/python -m pytest tests/ -v")
+    bullet("./run.sh frontend build")
+    bullet(".venv/bin/python -m pytest Python/tests/ -v")
 
 
 @agent("tester", "Test creation, coverage, regression testing, benchmarks")
@@ -356,7 +389,7 @@ def ctx_tester():
     bullet("Never mock structural_lib internals — test real math")
 
     section("COMMANDS")
-    bullet("cd Python && .venv/bin/python -m pytest tests/ -v")
+    bullet(".venv/bin/python -m pytest Python/tests/ -v")
     bullet(".venv/bin/python -m pytest tests/ --cov=structural_lib --cov-report=term")
     bullet("Skill: /is456-verification — run IS 456 tests by category")
 
@@ -474,7 +507,7 @@ def ctx_governance():
     bullet(
         "Generate indexes: .venv/bin/python scripts/generate_enhanced_index.py --all"
     )
-    bullet("Archive old docs: .venv/bin/python scripts/archive_old_files.sh")
+    bullet("Archive old docs: ./scripts/archive_old_files.sh")
 
     section("SUSTAINABILITY CHECKS")
     bullet("Version consistency: .venv/bin/python scripts/check_doc_versions.py")
@@ -518,32 +551,66 @@ def ctx_ui_designer():
 # ── Main ────────────────────────────────────────────────────────────────
 
 
+def print_registry_context(agent_name: str, metadata: dict) -> None:
+    """Print useful context for a registered agent without a tailored function."""
+    print_status()
+
+    section("ROLE")
+    bullet(metadata.get("description", "No role description provided"))
+    bullet(f"Permission: {metadata.get('permission_level', 'unspecified')}")
+    scope = metadata.get("file_scope")
+    bullet(f"File scope: {scope or 'read-only or unrestricted by registry scope'}")
+
+    section("ASSIGNED SKILLS AND SCRIPTS")
+    skills = metadata.get("skills") or []
+    scripts = metadata.get("scripts") or []
+    bullet("Skills: " + (", ".join(skills) if skills else "none assigned"))
+    bullet("Scripts: " + (", ".join(scripts) if scripts else "none assigned"))
+
+    section("HANDOFF TARGETS")
+    handoffs = metadata.get("handoff_targets") or []
+    bullet(", ".join(handoffs) if handoffs else "Return findings to orchestrator")
+
+
 def main():
+    try:
+        registry = load_agent_registry()
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)
+
     if len(sys.argv) < 2 or sys.argv[1] in ("--help", "-h"):
         print("Usage: .venv/bin/python scripts/agent_context.py <agent_name>")
         print("       .venv/bin/python scripts/agent_context.py --list")
-        print(f"\nAvailable agents: {', '.join(sorted(AGENTS.keys()))}")
+        print(f"\nAvailable agents: {', '.join(sorted(registry))}")
         sys.exit(0)
 
     if sys.argv[1] == "--list":
         print("Available agents:\n")
-        for name in sorted(AGENTS.keys()):
-            desc = AGENTS[name]["description"]
+        for name in sorted(registry):
+            desc = registry[name].get("description", "")
             print(f"  {name:25s} {desc}")
         sys.exit(0)
 
     agent_name = sys.argv[1].lower().strip()
-    if agent_name not in AGENTS:
+    if agent_name not in registry:
         print(f"Unknown agent: {agent_name}")
-        print(f"Available: {', '.join(sorted(AGENTS.keys()))}")
+        print(f"Available: {', '.join(sorted(registry))}")
         sys.exit(1)
+
+    metadata = registry[agent_name]
+    description = metadata.get("description", "")
 
     print(f"╔{'═' * 58}╗")
     print(f"║  Agent: {agent_name:48s} ║")
-    print(f"║  {AGENTS[agent_name]['description']:56s} ║")
+    print(f"║  {description[:56]:56s} ║")
     print(f"╚{'═' * 58}╝")
 
-    AGENTS[agent_name]["func"]()
+    context = AGENTS.get(agent_name)
+    if context:
+        context["func"]()
+    else:
+        print_registry_context(agent_name, metadata)
 
     # Self-evolving system context
     section("PROJECT HEALTH")

--- a/scripts/agent_drift_detector.py
+++ b/scripts/agent_drift_detector.py
@@ -21,7 +21,13 @@ from datetime import datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _lib.agent_data import DRIFT_DIR, ensure_dirs, list_sessions, load_session
+from _lib.agent_data import (
+    DRIFT_DIR,
+    current_session_ids,
+    ensure_dirs,
+    list_sessions,
+    load_session,
+)
 from _lib.output import StatusLine, print_table
 
 # Drift rules for each agent type
@@ -211,10 +217,16 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Show all-time drift summary",
     )
-    parser.add_argument(
+    write_group = parser.add_mutually_exclusive_group()
+    write_group.add_argument(
+        "--write",
+        action="store_true",
+        help="Write to the managed drift-report directory",
+    )
+    write_group.add_argument(
         "--output",
         type=Path,
-        help="Output path (defaults to logs/agent-performance/drift/<session_id>.json)",
+        help="Write to an explicit output path",
     )
     return parser.parse_args()
 
@@ -322,13 +334,67 @@ def detect_drift(session_data: dict, agent_filter: str | None = None) -> dict:
         Drift analysis dict with events and scores.
     """
     session_id = session_data.get("session_id", "unknown")
-    agents_active = session_data.get("agents_active", [])
+    attributed_agents = session_data.get("agents_active", [])
     commits = session_data.get("commits", [])
     files_changed = session_data.get("files_changed", {})
 
+    if not attributed_agents:
+        return {
+            "session_id": session_id,
+            "analysis_timestamp": datetime.now().isoformat(),
+            "agents_analyzed": [],
+            "unmeasured_agents": [],
+            "drift_events": [],
+            "agent_drift_scores": {},
+            "summary": {"total_events": 0, "critical": 0, "warning": 0},
+            "evidence_available": False,
+            "no_evidence_reason": "Session has no attributed active agents",
+        }
+
     # Filter agents if requested
     if agent_filter:
-        agents_active = [a for a in agents_active if a == agent_filter]
+        if agent_filter not in attributed_agents:
+            return {
+                "session_id": session_id,
+                "analysis_timestamp": datetime.now().isoformat(),
+                "agents_analyzed": [],
+                "unmeasured_agents": [],
+                "drift_events": [],
+                "agent_drift_scores": {},
+                "summary": {"total_events": 0, "critical": 0, "warning": 0},
+                "evidence_available": False,
+                "no_evidence_reason": (
+                    f"Agent '{agent_filter}' is not attributed to this session"
+                ),
+            }
+        attributed_agents = [agent_filter]
+
+    agents_active = []
+    unmeasured_agents = []
+    for agent in attributed_agents:
+        rules = DRIFT_RULES.get(agent)
+        rule_count = 0
+        if rules:
+            rule_count = len(rules.get("prescribed", [])) + len(
+                rules.get("forbidden", [])
+            )
+        if rule_count:
+            agents_active.append(agent)
+        else:
+            unmeasured_agents.append(agent)
+
+    if not agents_active:
+        return {
+            "session_id": session_id,
+            "analysis_timestamp": datetime.now().isoformat(),
+            "agents_analyzed": [],
+            "unmeasured_agents": unmeasured_agents,
+            "drift_events": [],
+            "agent_drift_scores": {},
+            "summary": {"total_events": 0, "critical": 0, "warning": 0},
+            "evidence_available": False,
+            "no_evidence_reason": "No configured drift rules for attributed agents",
+        }
 
     all_drift_events: list[dict] = []
     agent_drift_scores: dict[str, float] = {}
@@ -362,9 +428,12 @@ def detect_drift(session_data: dict, agent_filter: str | None = None) -> dict:
         "session_id": session_id,
         "analysis_timestamp": datetime.now().isoformat(),
         "agents_analyzed": agents_active,
+        "unmeasured_agents": unmeasured_agents,
         "drift_events": all_drift_events,
         "agent_drift_scores": agent_drift_scores,
         "summary": summary,
+        "evidence_available": True,
+        "no_evidence_reason": None,
     }
 
 
@@ -490,14 +559,23 @@ def main() -> int:
         all_sessions = list_sessions()
         sessions_to_analyze = all_sessions[-args.last :]
     else:
-        # Default: analyze latest session
+        # Default means current evidence, not merely the newest historical file.
         all_sessions = list_sessions()
-        if not all_sessions:
-            StatusLine.fail("No sessions found in logs/agent-performance/sessions/")
+        current_sessions = current_session_ids(all_sessions)
+        if not current_sessions:
+            StatusLine.fail(
+                "No current session evidence found; use --session or --last "
+                "for an explicit historical analysis"
+            )
             return 1
-        sessions_to_analyze = [all_sessions[-1]]
+        sessions_to_analyze = [current_sessions[-1]]
+
+    if not sessions_to_analyze:
+        StatusLine.fail("No sessions selected for analysis")
+        return 1
 
     # Analyze each session
+    evidence_failure = False
     for session_id in sessions_to_analyze:
         StatusLine.ok(f"Analyzing session {session_id}...")
 
@@ -505,14 +583,25 @@ def main() -> int:
         session_data = load_session(session_id)
         if not session_data:
             StatusLine.fail(f"Session {session_id} not found")
+            evidence_failure = True
             continue
 
         # Detect drift
         drift_data = detect_drift(session_data, agent_filter=args.agent)
 
-        # Save report
-        output_path = save_drift_report(drift_data, output_path=args.output)
-        StatusLine.ok(f"Drift report saved to {output_path}")
+        if not drift_data.get("evidence_available", False):
+            StatusLine.fail(
+                f"No drift evidence for {session_id}: "
+                f"{drift_data.get('no_evidence_reason', 'unknown reason')}"
+            )
+            evidence_failure = True
+            continue
+
+        if args.output or args.write:
+            output_path = save_drift_report(drift_data, output_path=args.output)
+            StatusLine.ok(f"Drift report saved to {output_path}")
+        else:
+            StatusLine.info("Read-only analysis; pass --write or --output to save")
 
         # Print summary
         summary = drift_data["summary"]
@@ -552,7 +641,7 @@ def main() -> int:
                 rows.append([agent, f"{score:.2f}", status])
             print_table(["Agent", "Score", "Status"], rows)
 
-    return 0
+    return 1 if evidence_failure else 0
 
 
 if __name__ == "__main__":

--- a/scripts/agent_trends.py
+++ b/scripts/agent_trends.py
@@ -9,6 +9,7 @@ Usage:
     .venv/bin/python scripts/agent_trends.py --monthly
     .venv/bin/python scripts/agent_trends.py --agent ops
     .venv/bin/python scripts/agent_trends.py --alert
+    .venv/bin/python scripts/agent_trends.py --weekly --write
 """
 
 from __future__ import annotations
@@ -122,7 +123,10 @@ def compute_trends(
                 agent_scores[agent].append(composite)
 
     trends: dict[str, dict] = {}
-    all_agents = [agent_name] if agent_name else sorted(agent_scores.keys())
+    if agent_name:
+        all_agents = [agent_name] if agent_name in agent_scores else []
+    else:
+        all_agents = sorted(agent_scores.keys())
 
     for agent in all_agents:
         scores = agent_scores.get(agent, [])
@@ -298,9 +302,13 @@ def main() -> int:
     parser.add_argument(
         "--alert", action="store_true", help="Flag agents with degrading performance"
     )
-    parser.add_argument(
-        "--output", type=Path, help="Save output to file (default: TRENDS_DIR)"
+    write_group = parser.add_mutually_exclusive_group()
+    write_group.add_argument(
+        "--write",
+        action="store_true",
+        help="Write to the managed trends directory",
     )
+    write_group.add_argument("--output", type=Path, help="Write to an explicit path")
     parser.add_argument(
         "--json", action="store_true", help="Output JSON only (no table)"
     )
@@ -309,8 +317,6 @@ def main() -> int:
 
     if not args.weekly and not args.monthly and not args.alert:
         args.weekly = True
-
-    ensure_dirs()
 
     all_sessions = list_sessions()
     if not all_sessions:
@@ -342,13 +348,15 @@ def main() -> int:
         "alerts": alerts,
     }
 
-    # Save to file
+    # Default analysis is read-only. Writes require an explicit mode.
     if args.output:
         args.output.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
         StatusLine.ok(f"Saved trends to {args.output}")
-    else:
+    elif args.write:
         output_path = save_trends(period, output, agent_name=args.agent)
         StatusLine.ok(f"Saved trends to {output_path.relative_to(Path.cwd())}")
+    else:
+        StatusLine.info("Read-only analysis; pass --write or --output to save")
 
     # Display output
     if args.json:

--- a/scripts/audit_permissions.py
+++ b/scripts/audit_permissions.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -65,6 +66,8 @@ class AuditReport:
 # Write-capable tool keywords
 _WRITE_TOOLS = {"editFiles", "edit", "write", "create"}
 _RUN_TOOLS = {"runInTerminal", "run", "terminal"}
+_AUTOMATION_MAP = Path(__file__).resolve().parent / "automation-map.json"
+_KNOWN_LEVELS = {"ReadOnly", "ReadOnlyTerminal", "WorkspaceWrite", "DangerFullAccess"}
 
 
 def _has_write_tools(tools: list[str]) -> bool:
@@ -75,6 +78,75 @@ def _has_write_tools(tools: list[str]) -> bool:
 def _has_run_tools(tools: list[str]) -> bool:
     """Check if tool list contains terminal/run tools."""
     return bool(set(tools) & _RUN_TOOLS)
+
+
+def audit_automation_permission_metadata() -> list[Anomaly]:
+    """Validate only explicitly declared automation permission metadata."""
+    try:
+        data = json.loads(_AUTOMATION_MAP.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        return [
+            Anomaly(
+                agent="automation-map",
+                severity="CONFLICT",
+                message=f"Cannot load automation permission metadata: {exc}",
+            )
+        ]
+
+    anomalies: list[Anomaly] = []
+    for task_name, task in data.get("tasks", {}).items():
+        if not isinstance(task, dict):
+            continue
+        default_level = task.get("permission")
+        modes = task.get("permission_modes")
+        subject = f"automation:{task_name}"
+
+        if default_level is not None and default_level not in _KNOWN_LEVELS:
+            anomalies.append(
+                Anomaly(
+                    agent=subject,
+                    severity="CONFLICT",
+                    message=f"Unknown default permission level: {default_level}",
+                )
+            )
+
+        if modes is None:
+            continue
+        if default_level is None:
+            anomalies.append(
+                Anomaly(
+                    agent=subject,
+                    severity="CONFLICT",
+                    message="permission_modes requires an explicit default permission",
+                )
+            )
+        if not isinstance(modes, dict):
+            anomalies.append(
+                Anomaly(
+                    agent=subject,
+                    severity="CONFLICT",
+                    message="permission_modes must be an object",
+                )
+            )
+            continue
+        for mode, level in modes.items():
+            if not isinstance(mode, str) or not mode.strip():
+                anomalies.append(
+                    Anomaly(
+                        agent=subject,
+                        severity="CONFLICT",
+                        message="permission mode names must be non-empty strings",
+                    )
+                )
+            if level not in _KNOWN_LEVELS:
+                anomalies.append(
+                    Anomaly(
+                        agent=subject,
+                        severity="CONFLICT",
+                        message=f"Mode '{mode}' has unknown permission level: {level}",
+                    )
+                )
+    return anomalies
 
 
 # ---------------------------------------------------------------------------
@@ -207,6 +279,8 @@ def audit_permissions() -> AuditReport:
                 anomalies=anomalies,
             )
         )
+
+    all_anomalies.extend(audit_automation_permission_metadata())
 
     return AuditReport(
         agents=agent_infos,

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -31,6 +31,10 @@
       "group": "Quality",
       "script": ".venv/bin/python scripts/check_all.py",
       "description": "Run all 29 validation checks across 8 categories in parallel (also: ./run.sh check)",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      },
       "options": {
         "--quick": "Run 9 quick checks only (<30s)",
         "--category X": "Run checks for specific category",
@@ -49,6 +53,10 @@
       "group": "Quality",
       "script": ".venv/bin/python scripts/diagnose_ci.py",
       "description": "Diagnose, reproduce, and auto-fix CI failures locally or for a specific PR",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--local --fix": "WorkspaceWrite"
+      },
       "options": {
         "--pr N": "Check specific PR CI status",
         "--local": "Run checks locally",
@@ -159,17 +167,29 @@
     "end session": {
       "group": "Session",
       "script": ".venv/bin/python scripts/session.py end",
-      "description": "Validate handoff and update session docs"
+      "description": "Validate session closeout without hidden writes",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      }
     },
     "session summary": {
       "group": "Session",
-      "script": ".venv/bin/python scripts/session.py summary --write",
-      "description": "Auto-generate session summary from git log — detects new hooks, endpoints, components"
+      "script": ".venv/bin/python scripts/session.py summary",
+      "description": "Preview a session summary from repository history",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--write": "WorkspaceWrite"
+      }
     },
     "sync doc numbers": {
       "group": "Session",
-      "script": ".venv/bin/python scripts/sync_numbers.py --fix",
-      "description": "Scan codebase metrics and update stale counts across 5 doc files",
+      "script": ".venv/bin/python scripts/sync_numbers.py",
+      "description": "Scan codebase metrics and report stale documentation counts",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      },
       "options": {
         "(no flag)": "Dry run — scan and report only",
         "--fix": "Apply updates to files",
@@ -189,7 +209,8 @@
     "check git state": {
       "group": "Git",
       "script": "./scripts/validate_git_state.sh",
-      "description": "Validate git state before any git operation"
+      "description": "Validate git state before any git operation",
+      "permission": "ReadOnly"
     },
     "check api signatures": {
       "group": "Discovery",
@@ -581,7 +602,10 @@
       "script": "./run.sh session usage",
       "description": "Record or summarize model, reasoning, elapsed time, agents, manual dashboard usage, verification, and Git state without estimating billing tokens",
       "agent": "doc-master",
-      "permission": "WorkspaceWrite",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--checkpoint start|milestone|closeout": "WorkspaceWrite"
+      },
       "options": {
         "--checkpoint start|milestone|closeout": "Append a local checkpoint",
         "--summary": "Aggregate checkpoints by model/reasoning profile",
@@ -593,6 +617,7 @@
       "group": "Session",
       "script": ".venv/bin/python scripts/agent_context.py <agent_name>",
       "description": "Load tailored startup context for a specific agent",
+      "permission": "ReadOnly",
       "options": {
         "--list": "List available agents"
       }
@@ -609,7 +634,11 @@
     "self evolve": {
       "group": "Evolution",
       "script": ".venv/bin/python scripts/evolve.py",
-      "description": "Self-evolution cycle: health scan + feedback analysis + auto-fixes",
+      "description": "Preview the self-evolution health and feedback analysis cycle",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      },
       "options": {
         "--fix": "Apply fixes and commit",
         "--review weekly": "Weekly auto-maintenance review"
@@ -619,6 +648,10 @@
       "group": "Governance",
       "script": ".venv/bin/python scripts/project_health.py",
       "description": "Unified project health scanner across 5 categories (0-100 score)",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      },
       "options": {
         "--fix": "Auto-fix fixable issues",
         "--category <name>": "Scan specific category only"
@@ -627,12 +660,18 @@
     "agent compliance check": {
       "group": "Governance",
       "script": ".venv/bin/python scripts/agent_compliance_checker.py",
-      "description": "Verify agents followed their .agent.md rules"
+      "description": "Verify agents followed their .agent.md rules",
+      "permission": "ReadOnly"
     },
     "agent drift detection": {
       "group": "Governance",
       "script": ".venv/bin/python scripts/agent_drift_detector.py",
-      "description": "Detect when agents deviate from prescribed behavior"
+      "description": "Detect when agents deviate from prescribed behavior",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--write": "WorkspaceWrite",
+        "--output": "WorkspaceWrite"
+      }
     },
     "agent evolve instructions": {
       "group": "Evolution",
@@ -652,7 +691,12 @@
     "agent trends": {
       "group": "Evolution",
       "script": ".venv/bin/python scripts/agent_trends.py",
-      "description": "Time series analysis and degradation detection for agent performance"
+      "description": "Time series analysis and degradation detection for agent performance",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--write": "WorkspaceWrite",
+        "--output": "WorkspaceWrite"
+      }
     },
     "export paper data": {
       "group": "Infrastructure",
@@ -667,7 +711,8 @@
     "tool permissions": {
       "group": "Infrastructure",
       "script": ".venv/bin/python scripts/tool_permissions.py",
-      "description": "Manage and validate per-agent tool permission grants"
+      "description": "Resolve and validate explicit per-agent operation permissions",
+      "permission": "ReadOnly"
     },
     "audit permissions": {
       "group": "Infrastructure",

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -2,8 +2,14 @@
   "_comment": "Task-to-script mapping - helps agents find the right automation for their task",
   "_updated": "2026-08-09",
   "_usage": "Run: .venv/bin/python scripts/find_automation.py \"task description\" — or --list for all",
-  "_coverage": "106/106 scripts mapped",
+  "_coverage": "107/107 scripts mapped",
   "tasks": {
+    "resolve python runtime": {
+      "group": "Infrastructure",
+      "script": "./scripts/python_runtime.sh --version",
+      "description": "Resolve the approved Python interpreter across primary and linked Git worktrees",
+      "permission": "ReadOnly"
+    },
     "choose codex model": {
       "group": "Agent Infrastructure",
       "script": ".venv/bin/python scripts/model_picker.py \"task description\"",

--- a/scripts/check_all.py
+++ b/scripts/check_all.py
@@ -34,8 +34,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lib.utils import REPO_ROOT
 from _lib.output import StatusLine, print_json
 
-VENV_PYTHON = str(REPO_ROOT / ".venv" / "bin" / "python")
 SCRIPTS_DIR = REPO_ROOT / "scripts"
+VENV_PYTHON = str(SCRIPTS_DIR / "python_runtime.sh")
 
 # Detect sensible default workers based on system
 _default_workers = min(4, max(1, (os.cpu_count() or 2)))

--- a/scripts/check_governance.py
+++ b/scripts/check_governance.py
@@ -39,6 +39,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lib.utils import REPO_ROOT
+from audit_permissions import audit_automation_permission_metadata
 
 # ═══════════════════════════════════════════════════════════════════════════
 # GOVERNANCE RULES
@@ -873,6 +874,20 @@ def check_redirect_stubs(report: GovernanceReport) -> None:
         report.add_pass("No redirect stubs")
 
 
+def check_automation_permissions(report: GovernanceReport) -> None:
+    """Fail when explicitly declared task/mode permissions are malformed."""
+    anomalies = audit_automation_permission_metadata()
+    if not anomalies:
+        report.add_pass("Automation permission metadata")
+        return
+    for anomaly in anomalies:
+        report.add_error(
+            anomaly.message,
+            location="scripts/automation-map.json",
+            rule=f"Permission metadata ({anomaly.agent})",
+        )
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # CLI & OUTPUT
 # ═══════════════════════════════════════════════════════════════════════════
@@ -897,6 +912,7 @@ def run_compliance(report: GovernanceReport) -> None:
     check_docs_agents_structure(report)
     check_governance_location(report)
     check_redirect_stubs(report)
+    check_automation_permissions(report)
 
 
 def print_report(report: GovernanceReport) -> None:

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3,7 +3,7 @@
   "type": "python-package",
   "description": "> Development, validation, discovery, release-preparation, and maintenance tools.",
   "last_updated": "2026-08-09",
-  "file_count": 108,
+  "file_count": 109,
   "files": [
     {
       "name": "README.md",
@@ -924,7 +924,7 @@
         "tasks",
         "categories"
       ],
-      "content_hash": "0791be4382d5"
+      "content_hash": "e9cbe6b9c577"
     },
     {
       "name": "batch_migrate_runner.py",
@@ -1119,10 +1119,10 @@
         }
       ],
       "constants": [
-        "VENV_PYTHON",
-        "SCRIPTS_DIR"
+        "SCRIPTS_DIR",
+        "VENV_PYTHON"
       ],
-      "content_hash": "359bdcc4ab7f"
+      "content_hash": "b6fb6466b69f"
     },
     {
       "name": "check_api.py",
@@ -4002,6 +4002,14 @@
       "content_hash": "cb3f2a21c85e"
     },
     {
+      "name": "python_runtime.sh",
+      "type": "shell-script",
+      "size_lines": 46,
+      "last_updated": "2026-08-09",
+      "description": "Resolve the repository Python interpreter across primary and linked worktrees.",
+      "content_hash": "e6f453bee035"
+    },
+    {
       "name": "release.py",
       "type": "python",
       "size_lines": 1054,
@@ -4698,7 +4706,7 @@
         "REPO_ROOT",
         "VENV"
       ],
-      "content_hash": "b68d1be5207b"
+      "content_hash": "874696adcb60"
     },
     {
       "name": "test_import_pipeline.py",
@@ -5298,5 +5306,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "efd73c8c9400da30"
+  "content_hash": "61538440bbe0cbff"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -18,7 +18,7 @@
       "name": "_tmp_add_groups.py",
       "type": "python",
       "size_lines": 168,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "Temporary script to add group fields to automation-map.json. Delete after use.",
       "constants": [
         "GROUP_MAP"
@@ -36,7 +36,7 @@
     {
       "name": "agent_compliance_checker.py",
       "type": "python",
-      "size_lines": 514,
+      "size_lines": 541,
       "last_updated": "2026-08-09",
       "description": "Agent compliance checker — verify agents followed their .agent.md rules.",
       "functions": [
@@ -125,12 +125,12 @@
       "constants": [
         "COMPLIANCE_RULES"
       ],
-      "content_hash": "d4c42039968a"
+      "content_hash": "9f2469f15690"
     },
     {
       "name": "agent_context.py",
       "type": "python",
-      "size_lines": 577,
+      "size_lines": 644,
       "last_updated": "2026-08-09",
       "description": "Agent Context Loader — gives each agent its tailored startup context.",
       "functions": [
@@ -141,6 +141,10 @@
             "name",
             "description"
           ]
+        },
+        {
+          "name": "load_agent_registry",
+          "description": "Load the canonical agent registry and fail closed on invalid metadata."
         },
         {
           "name": "run",
@@ -210,18 +214,27 @@
           "name": "ctx_ui_designer"
         },
         {
+          "name": "print_registry_context",
+          "description": "Print useful context for a registered agent without a tailored function.",
+          "params": [
+            "agent_name",
+            "metadata"
+          ]
+        },
+        {
           "name": "main"
         }
       ],
       "constants": [
-        "ROOT"
+        "ROOT",
+        "AGENT_REGISTRY"
       ],
-      "content_hash": "caf69d529423"
+      "content_hash": "c84c694b88a5"
     },
     {
       "name": "agent_drift_detector.py",
       "type": "python",
-      "size_lines": 560,
+      "size_lines": 649,
       "last_updated": "2026-08-09",
       "description": "Agent drift detector — detect when agents deviate from prescribed behavior.",
       "functions": [
@@ -289,7 +302,7 @@
       "constants": [
         "DRIFT_RULES"
       ],
-      "content_hash": "7b5619351642"
+      "content_hash": "4f0b56092c88"
     },
     {
       "name": "agent_evolve_instructions.py",
@@ -378,7 +391,7 @@
       "name": "agent_feedback.py",
       "type": "python",
       "size_lines": 423,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Agent feedback collection and analysis.",
       "functions": [
         {
@@ -439,7 +452,7 @@
       "name": "agent_scorer.py",
       "type": "python",
       "size_lines": 548,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "Agent scorer — score agents on 11 performance dimensions.",
       "functions": [
         {
@@ -511,7 +524,7 @@
       "name": "agent_session_collector.py",
       "type": "python",
       "size_lines": 320,
-      "last_updated": "2026-04-01",
+      "last_updated": "2026-08-09",
       "description": "Agent session collector — gather all session artifacts for scoring.",
       "functions": [
         {
@@ -584,8 +597,8 @@
     {
       "name": "agent_trends.py",
       "type": "python",
-      "size_lines": 375,
-      "last_updated": "2026-04-01",
+      "size_lines": 383,
+      "last_updated": "2026-08-09",
       "description": "Agent trends — time series analysis and degradation detection.",
       "functions": [
         {
@@ -638,7 +651,7 @@
           "description": "Main entry point."
         }
       ],
-      "content_hash": "6f27242e26dc"
+      "content_hash": "95cc0fd4d1f6"
     },
     {
       "name": "archive_old_files.sh",
@@ -652,7 +665,7 @@
       "name": "audit_error_handling.py",
       "type": "python",
       "size_lines": 286,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Audit error handling compliance across structural_lib modules.",
       "classes": [
         {
@@ -700,7 +713,7 @@
       "name": "audit_input_validation.py",
       "type": "python",
       "size_lines": 393,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Audit Input Validation Coverage for structural_lib.",
       "classes": [
         {
@@ -762,8 +775,8 @@
     {
       "name": "audit_permissions.py",
       "type": "python",
-      "size_lines": 394,
-      "last_updated": "2026-04-02",
+      "size_lines": 468,
+      "last_updated": "2026-08-09",
       "description": "Permission audit report for all agents.",
       "classes": [
         {
@@ -781,6 +794,10 @@
       ],
       "functions": [
         {
+          "name": "audit_automation_permission_metadata",
+          "description": "Validate only explicitly declared automation permission metadata."
+        },
+        {
           "name": "audit_permissions",
           "description": "Run full permission audit across all agents."
         },
@@ -793,9 +810,11 @@
       ],
       "constants": [
         "_WRITE_TOOLS",
-        "_RUN_TOOLS"
+        "_RUN_TOOLS",
+        "_AUTOMATION_MAP",
+        "_KNOWN_LEVELS"
       ],
-      "content_hash": "56009c60f71f"
+      "content_hash": "eb0554d88a5b"
     },
     {
       "name": "audit_readiness_report.py",
@@ -905,13 +924,13 @@
         "tasks",
         "categories"
       ],
-      "content_hash": "b44dd6a36da8"
+      "content_hash": "0791be4382d5"
     },
     {
       "name": "batch_migrate_runner.py",
       "type": "python",
       "size_lines": 442,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Batch migration runner with per-operation rollback logs.",
       "classes": [
         {
@@ -1044,7 +1063,7 @@
       "name": "bump_version.py",
       "type": "python",
       "size_lines": 451,
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-09",
       "description": "Version Bump Script — Single Source of Truth",
       "functions": [
         {
@@ -1103,7 +1122,7 @@
         "VENV_PYTHON",
         "SCRIPTS_DIR"
       ],
-      "content_hash": "2e6ebf4e62a3"
+      "content_hash": "359bdcc4ab7f"
     },
     {
       "name": "check_api.py",
@@ -1151,7 +1170,7 @@
       "name": "check_api_compat.py",
       "type": "python",
       "size_lines": 152,
-      "last_updated": "2026-03-29",
+      "last_updated": "2026-08-09",
       "description": "Check API backward compatibility.",
       "functions": [
         {
@@ -1278,7 +1297,7 @@
       "name": "check_bootstrap_freshness.py",
       "type": "python",
       "size_lines": 290,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Check if bootstrap docs are stale compared to actual codebase.",
       "functions": [
         {
@@ -1321,7 +1340,7 @@
       "name": "check_circular_imports.py",
       "type": "python",
       "size_lines": 464,
-      "last_updated": "2026-03-28",
+      "last_updated": "2026-08-09",
       "description": "Circular Import Detector for Streamlit Application",
       "classes": [
         {
@@ -1376,7 +1395,7 @@
       "name": "check_clause_coverage.py",
       "type": "python",
       "size_lines": 486,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "IS 456 clause coverage gap detection.",
       "functions": [
         {
@@ -1452,7 +1471,7 @@
       "name": "check_cli_reference.py",
       "type": "python",
       "size_lines": 48,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Ensure CLI reference includes required commands.",
       "functions": [
         {
@@ -1469,7 +1488,7 @@
     {
       "name": "check_codex_git_workflow.py",
       "type": "python",
-      "size_lines": 89,
+      "size_lines": 97,
       "last_updated": "2026-08-09",
       "description": "Guard the Codex-native Git/GitHub workflow contract.",
       "functions": [
@@ -1483,13 +1502,13 @@
         "RETIRED_PATHS",
         "LIVE_FILES_WITHOUT_WRAPPER_CALLS"
       ],
-      "content_hash": "7c77e2eb783c"
+      "content_hash": "e6c08dc72756"
     },
     {
       "name": "check_doc_versions.py",
       "type": "python",
       "size_lines": 72,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Doc Version Drift Check — Validate no stale *library* version references in docs.",
       "functions": [
         {
@@ -1513,7 +1532,7 @@
       "name": "check_docker_config.py",
       "type": "python",
       "size_lines": 295,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Docker Configuration Validator.",
       "functions": [
         {
@@ -1617,7 +1636,7 @@
       "name": "check_fastapi_issues.py",
       "type": "python",
       "size_lines": 450,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "FastAPI Issues AST Scanner.",
       "classes": [
         {
@@ -1674,7 +1693,7 @@
       "name": "check_function_quality.py",
       "type": "python",
       "size_lines": 668,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "12-point quality checklist for IS 456 functions.",
       "classes": [
         {
@@ -1759,8 +1778,8 @@
     {
       "name": "check_governance.py",
       "type": "python",
-      "size_lines": 1026,
-      "last_updated": "2026-04-04",
+      "size_lines": 1042,
+      "last_updated": "2026-08-09",
       "description": "Unified governance checker — folder structure + compliance validation.",
       "classes": [
         {
@@ -1870,6 +1889,13 @@
           ]
         },
         {
+          "name": "check_automation_permissions",
+          "description": "Fail when explicitly declared task/mode permissions are malformed.",
+          "params": [
+            "report"
+          ]
+        },
+        {
           "name": "run_structure",
           "description": "Run all structure checks.",
           "params": [
@@ -1907,13 +1933,13 @@
         "DEFAULT_RULES",
         "RULES"
       ],
-      "content_hash": "cab3464da4cb"
+      "content_hash": "451b50e738a1"
     },
     {
       "name": "check_instruction_drift.py",
       "type": "python",
       "size_lines": 219,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Check for content drift between .github/instructions/ and .claude/rules/.",
       "functions": [
         {
@@ -1942,7 +1968,7 @@
       "name": "check_links.py",
       "type": "python",
       "size_lines": 351,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Check and fix broken internal links in markdown files.",
       "functions": [
         {
@@ -1969,7 +1995,7 @@
       "name": "check_new_element_completeness.py",
       "type": "python",
       "size_lines": 622,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "Check structural element completeness across all 7 layers.",
       "functions": [
         {
@@ -2082,7 +2108,7 @@
       "name": "check_next_session_brief_length.py",
       "type": "python",
       "size_lines": 31,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Ensure next-session-brief.md stays concise.",
       "functions": [
         {
@@ -2099,14 +2125,14 @@
       "name": "check_not_main.sh",
       "type": "shell-script",
       "size_lines": 15,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "content_hash": "515811cfdcae"
     },
     {
       "name": "check_openapi_drift.py",
       "type": "python",
       "size_lines": 193,
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-09",
       "description": "Check OpenAPI spec for drift against baseline.",
       "functions": [
         {
@@ -2142,7 +2168,7 @@
       "name": "check_openapi_snapshot.py",
       "type": "python",
       "size_lines": 231,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Check OpenAPI spec against baseline snapshot to detect API drift.",
       "functions": [
         {
@@ -2206,7 +2232,7 @@
       "name": "check_repo_hygiene.py",
       "type": "python",
       "size_lines": 44,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Fail if tracked hygiene artifacts exist in the repository.",
       "functions": [
         {
@@ -2222,7 +2248,7 @@
       "name": "check_root_file_count.sh",
       "type": "shell-script",
       "size_lines": 58,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Check Root File Count",
       "content_hash": "f47b4c4c9802"
     },
@@ -2230,7 +2256,7 @@
       "name": "check_scripts_index.py",
       "type": "python",
       "size_lines": 180,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Ensure scripts/index.json and automation-map.json match the scripts folder contents.",
       "functions": [
         {
@@ -2250,7 +2276,7 @@
       "name": "check_tasks_format.py",
       "type": "python",
       "size_lines": 161,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Validate docs/TASKS.md structure and WIP rules.",
       "functions": [
         {
@@ -2293,7 +2319,7 @@
       "name": "check_type_annotations.py",
       "type": "python",
       "size_lines": 543,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Type Annotation Checker for Streamlit Application",
       "classes": [
         {
@@ -2352,7 +2378,7 @@
       "name": "check_version_consistency.sh",
       "type": "shell-script",
       "size_lines": 66,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "check_version_consistency.sh - Verify version strings are consistent",
       "content_hash": "a53b8cf40cc9"
     },
@@ -2360,7 +2386,7 @@
       "name": "check_wip_limits.sh",
       "type": "shell-script",
       "size_lines": 77,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "check_wip_limits.sh - Enforce WIP (Work In Progress) limits",
       "content_hash": "8503ec531801"
     },
@@ -2368,7 +2394,7 @@
       "name": "ci_local.sh",
       "type": "shell-script",
       "size_lines": 41,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "shellcheck source=/dev/null",
       "content_hash": "ced9df5e7129"
     },
@@ -2376,7 +2402,7 @@
       "name": "cleanup_stale_branches.py",
       "type": "python",
       "size_lines": 187,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Cleanup stale remote branches.",
       "functions": [
         {
@@ -2429,7 +2455,7 @@
       "name": "collect_diagnostics.py",
       "type": "python",
       "size_lines": 123,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Collect a compact diagnostics bundle for debugging and support.",
       "functions": [
         {
@@ -2451,7 +2477,7 @@
       "name": "collect_metrics.sh",
       "type": "shell-script",
       "size_lines": 275,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Metrics Collection Script",
       "content_hash": "1dc72fa2661b"
     },
@@ -2459,7 +2485,7 @@
       "name": "config_precedence.py",
       "type": "python",
       "size_lines": 562,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "Configuration precedence auditing for instruction files.",
       "classes": [
         {
@@ -2582,7 +2608,7 @@
       "name": "create_test_scaffold.py",
       "type": "python",
       "size_lines": 238,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Test Scaffold Generator (Solution 2)",
       "functions": [
         {
@@ -2613,7 +2639,7 @@
       "name": "diagnose_ci.py",
       "type": "python",
       "size_lines": 339,
-      "last_updated": "2026-04-04",
+      "last_updated": "2026-08-09",
       "description": "CI failure diagnosis — check, reproduce, and fix CI failures locally.",
       "functions": [
         {
@@ -2763,7 +2789,7 @@
       "name": "dxf_render.py",
       "type": "python",
       "size_lines": 141,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Render DXF drawings to PNG or PDF using ezdxf + matplotlib.",
       "functions": [
         {
@@ -2876,7 +2902,7 @@
       "name": "export_paper_data.py",
       "type": "python",
       "size_lines": 388,
-      "last_updated": "2026-04-01",
+      "last_updated": "2026-08-09",
       "description": "Export agent performance data for academic paper.",
       "functions": [
         {
@@ -2964,7 +2990,7 @@
       "name": "find_automation.py",
       "type": "python",
       "size_lines": 208,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "Find the right automation script for a task.",
       "functions": [
         {
@@ -3034,7 +3060,7 @@
       "name": "fix_broken_links.py",
       "type": "python",
       "size_lines": 268,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "Fix broken internal links in markdown files.",
       "functions": [
         {
@@ -3089,7 +3115,7 @@
       "name": "generate_all_indexes.sh",
       "type": "shell-script",
       "size_lines": 51,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Generate index.json + index.md for all research-relevant folders",
       "content_hash": "32dbf76b936d"
     },
@@ -3097,7 +3123,7 @@
       "name": "generate_api_manifest.py",
       "type": "python",
       "size_lines": 159,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Generate or validate the public API manifest for structural_lib.api.",
       "functions": [
         {
@@ -3113,7 +3139,7 @@
       "name": "generate_client_sdks.py",
       "type": "python",
       "size_lines": 531,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Generate client SDKs from FastAPI OpenAPI specification.",
       "functions": [
         {
@@ -3166,7 +3192,7 @@
       "name": "generate_docs_index.py",
       "type": "python",
       "size_lines": 246,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Generate machine-readable JSON index of documentation.",
       "functions": [
         {
@@ -3312,7 +3338,7 @@
       "name": "generate_error_docs.py",
       "type": "python",
       "size_lines": 139,
-      "last_updated": "2026-03-29",
+      "last_updated": "2026-08-09",
       "description": "Generate docs/reference/error-codes.md from core/errors.py.",
       "functions": [
         {
@@ -3346,7 +3372,7 @@
       "name": "governance_health_score.py",
       "type": "python",
       "size_lines": 515,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Governance Health Score - TASK-289",
       "classes": [
         {
@@ -3390,7 +3416,7 @@
     {
       "name": "migrate_python_module.py",
       "type": "python",
-      "size_lines": 517,
+      "size_lines": 516,
       "last_updated": "2026-08-09",
       "description": "Migrate a Python module to a new location with import updates.",
       "functions": [
@@ -3456,12 +3482,12 @@
         "SEARCH_DIRS",
         "SKIP_PATTERNS"
       ],
-      "content_hash": "53901c3c583f"
+      "content_hash": "9f1b4f49006e"
     },
     {
       "name": "migrate_react_component.py",
       "type": "python",
-      "size_lines": 478,
+      "size_lines": 475,
       "last_updated": "2026-08-09",
       "description": "Migrate a React component to a new feature-grouped folder.",
       "functions": [
@@ -3537,7 +3563,7 @@
         "SEARCH_EXTENSIONS",
         "SKIP_PATTERNS"
       ],
-      "content_hash": "72c75b894821"
+      "content_hash": "bb321cbd8ce2"
     },
     {
       "name": "model_picker.py",
@@ -3621,7 +3647,7 @@
       "name": "pipeline_state.py",
       "type": "python",
       "size_lines": 868,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "Pipeline state tracking for multi-step agent workflows.",
       "classes": [
         {
@@ -3776,7 +3802,7 @@
       "name": "pre_commit_check.sh",
       "type": "shell-script",
       "size_lines": 36,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Pre-flight checks before committing",
       "content_hash": "3d2f4a8c9b58"
     },
@@ -3943,7 +3969,7 @@
       "name": "prompt_router.py",
       "type": "python",
       "size_lines": 492,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "Prompt router — routes natural language queries to the best agent + skills.",
       "classes": [
         {
@@ -4034,13 +4060,13 @@
       "name": "repo_health_check.sh",
       "type": "shell-script",
       "size_lines": 31,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "content_hash": "16279b27ac11"
     },
     {
       "name": "safe_file_delete.py",
       "type": "python",
-      "size_lines": 355,
+      "size_lines": 350,
       "last_updated": "2026-08-09",
       "description": "Safe file delete script with reference checking.",
       "functions": [
@@ -4079,12 +4105,12 @@
           "name": "main"
         }
       ],
-      "content_hash": "e87d642121c1"
+      "content_hash": "c2dea6869d7b"
     },
     {
       "name": "safe_file_move.py",
       "type": "python",
-      "size_lines": 505,
+      "size_lines": 500,
       "last_updated": "2026-08-09",
       "description": "Safe file move script with automatic link updates.",
       "functions": [
@@ -4133,7 +4159,7 @@
           "name": "main"
         }
       ],
-      "content_hash": "c72572fc8159"
+      "content_hash": "ec229eb024cf"
     },
     {
       "name": "session.py",
@@ -4248,7 +4274,7 @@
       "name": "session_store.py",
       "type": "python",
       "size_lines": 372,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "JSON-based session state persistence for AI agent sessions.",
       "classes": [
         {
@@ -4522,7 +4548,7 @@
       "name": "test_api_parity.py",
       "type": "python",
       "size_lines": 457,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "API Parity Testing Script (V3 Preparation)",
       "classes": [
         {
@@ -4613,7 +4639,7 @@
       "name": "test_changed.py",
       "type": "python",
       "size_lines": 216,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Smart test runner — run only tests related to changed files.",
       "functions": [
         {
@@ -4646,7 +4672,7 @@
       "name": "test_cli_smoke.py",
       "type": "python",
       "size_lines": 294,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-09",
       "description": "CLI Smoke Tests — validate all key scripts work correctly.",
       "functions": [
         {
@@ -4796,8 +4822,8 @@
     {
       "name": "tool_permissions.py",
       "type": "python",
-      "size_lines": 346,
-      "last_updated": "2026-04-02",
+      "size_lines": 437,
+      "last_updated": "2026-08-09",
       "description": "Tool permission enforcement for agent operations.",
       "classes": [
         {
@@ -4806,6 +4832,13 @@
         }
       ],
       "functions": [
+        {
+          "name": "resolve_required_permission",
+          "description": "Resolve the required level for an abstract op or declared script mode.",
+          "params": [
+            "operation"
+          ]
+        },
         {
           "name": "check_terminal_command",
           "description": "Check if *command* is allowed for agent's terminal_allowlist.",
@@ -4840,14 +4873,15 @@
       ],
       "constants": [
         "_PERMISSION_LEVELS",
-        "_REGISTRY_PATH"
+        "_REGISTRY_PATH",
+        "_AUTOMATION_MAP_PATH"
       ],
-      "content_hash": "f2805fec9167"
+      "content_hash": "0642c1206c41"
     },
     {
       "name": "tool_registry.py",
       "type": "python",
-      "size_lines": 575,
+      "size_lines": 556,
       "last_updated": "2026-08-09",
       "description": "Unified tool registry — connects agents, skills, scripts, and operations.",
       "classes": [
@@ -4857,15 +4891,6 @@
         }
       ],
       "functions": [
-        {
-          "name": "classify_permission",
-          "description": "Classify tool permission level based on keywords.",
-          "params": [
-            "script",
-            "task_name",
-            "description"
-          ]
-        },
         {
           "name": "extract_keywords",
           "description": "Extract keywords from name and description.",
@@ -4958,13 +4983,13 @@
         "TOOL_ALIASES",
         "STOPWORDS"
       ],
-      "content_hash": "c416c0197a3f"
+      "content_hash": "f17589315903"
     },
     {
       "name": "update_test_stats.py",
       "type": "python",
       "size_lines": 211,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "description": "Update Test Stats — Dynamic test count updater.",
       "functions": [
         {
@@ -5003,7 +5028,7 @@
       "name": "validate_api_contracts.py",
       "type": "python",
       "size_lines": 620,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "API Contract Validator.",
       "classes": [
         {
@@ -5153,7 +5178,7 @@
       "name": "validate_schema_snapshots.py",
       "type": "python",
       "size_lines": 257,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "description": "Schema Snapshot Validator.",
       "functions": [
         {
@@ -5204,9 +5229,9 @@
     {
       "name": "validate_script_refs.py",
       "type": "python",
-      "size_lines": 178,
+      "size_lines": 235,
       "last_updated": "2026-08-09",
-      "description": "Validate that active scripts don't reference archived scripts at runtime.",
+      "description": "Validate that active control paths reference existing scripts.",
       "functions": [
         {
           "name": "get_archived_names",
@@ -5221,11 +5246,22 @@
         },
         {
           "name": "check_file",
-          "description": "Check a single file for stale references to archived scripts.",
+          "description": "Check a single file for stale references to known archived scripts.",
           "params": [
             "filepath",
             "archived_names"
           ]
+        },
+        {
+          "name": "check_missing_targets",
+          "description": "Return references whose top-level ``scripts/`` target does not exist.",
+          "params": [
+            "filepath"
+          ]
+        },
+        {
+          "name": "scan_files",
+          "description": "Return executable repository surfaces that may invoke scripts."
         },
         {
           "name": "main"
@@ -5235,28 +5271,26 @@
         "REPO_ROOT",
         "SCRIPTS_DIR",
         "ARCHIVE_DIR",
+        "WORKFLOWS_DIR",
+        "CONTROL_FILES",
         "RETIRED_NAMES",
         "DOC_PATTERNS",
         "RUNTIME_PATTERNS_PY",
-        "RUNTIME_PATTERNS_SH"
+        "RUNTIME_PATTERNS_SH",
+        "SCRIPT_REFERENCE_RE"
       ],
-      "content_hash": "5908e0ccf849"
+      "content_hash": "37d7df67276e"
     },
     {
       "name": "watch_tests.sh",
       "type": "shell-script",
       "size_lines": 87,
-      "last_updated": "2026-03-27",
+      "last_updated": "2026-08-09",
       "description": "Watch Mode (Solution 5 - Dev Automation)",
       "content_hash": "2de61ff23fb0"
     }
   ],
   "subfolders": [
-    {
-      "name": "git-hooks",
-      "path": "git-hooks/",
-      "file_count": 0
-    },
     {
       "name": "hooks",
       "path": "hooks/",
@@ -5264,5 +5298,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "c205108703232375"
+  "content_hash": "efd73c8c9400da30"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -21,17 +21,17 @@
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
 | [_tmp_add_groups.py](_tmp_add_groups.py) | Temporary script to add group fields to automation-map.json. | 0 | 0 | 168 |
-| [agent_compliance_checker.py](agent_compliance_checker.py) | Agent compliance checker — verify agents followed their .age | 0 | 12 | 514 |
-| [agent_context.py](agent_context.py) | Agent Context Loader — gives each agent its tailored startup | 0 | 18 | 577 |
-| [agent_drift_detector.py](agent_drift_detector.py) | Agent drift detector — detect when agents deviate from presc | 0 | 9 | 560 |
+| [agent_compliance_checker.py](agent_compliance_checker.py) | Agent compliance checker — verify agents followed their .age | 0 | 12 | 541 |
+| [agent_context.py](agent_context.py) | Agent Context Loader — gives each agent its tailored startup | 0 | 20 | 644 |
+| [agent_drift_detector.py](agent_drift_detector.py) | Agent drift detector — detect when agents deviate from presc | 0 | 9 | 649 |
 | [agent_evolve_instructions.py](agent_evolve_instructions.py) | Agent instruction evolver — self-improving agent customizati | 0 | 12 | 550 |
 | [agent_feedback.py](agent_feedback.py) | Agent feedback collection and analysis. | 0 | 6 | 423 |
 | [agent_scorer.py](agent_scorer.py) | Agent scorer — score agents on 11 performance dimensions. | 0 | 9 | 548 |
 | [agent_session_collector.py](agent_session_collector.py) | Agent session collector — gather all session artifacts for s | 0 | 9 | 320 |
-| [agent_trends.py](agent_trends.py) | Agent trends — time series analysis and degradation detectio | 0 | 7 | 375 |
+| [agent_trends.py](agent_trends.py) | Agent trends — time series analysis and degradation detectio | 0 | 7 | 383 |
 | [audit_error_handling.py](audit_error_handling.py) | Audit error handling compliance across structural_lib module | 2 | 3 | 286 |
 | [audit_input_validation.py](audit_input_validation.py) | Audit Input Validation Coverage for structural_lib. | 2 | 5 | 393 |
-| [audit_permissions.py](audit_permissions.py) | Permission audit report for all agents. | 3 | 2 | 394 |
+| [audit_permissions.py](audit_permissions.py) | Permission audit report for all agents. | 3 | 3 | 468 |
 | [audit_readiness_report.py](audit_readiness_report.py) | Audit Readiness Report Generator | 2 | 11 | 783 |
 | [batch_migrate_runner.py](batch_migrate_runner.py) | Batch migration runner with per-operation rollback logs. | 1 | 2 | 442 |
 | [benchmark_api.py](benchmark_api.py) | API Performance Benchmark Script. | 4 | 9 | 837 |
@@ -44,13 +44,13 @@
 | [check_circular_imports.py](check_circular_imports.py) | Circular Import Detector for Streamlit Application | 5 | 1 | 464 |
 | [check_clause_coverage.py](check_clause_coverage.py) | IS 456 clause coverage gap detection. | 0 | 8 | 486 |
 | [check_cli_reference.py](check_cli_reference.py) | Ensure CLI reference includes required commands. | 0 | 1 | 48 |
-| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 1 | 89 |
+| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 1 | 97 |
 | [check_doc_versions.py](check_doc_versions.py) | Doc Version Drift Check — Validate no stale *library* versio | 0 | 2 | 72 |
 | [check_docker_config.py](check_docker_config.py) | Docker Configuration Validator. | 0 | 6 | 295 |
 | [check_docs.py](check_docs.py) | Unified documentation checker — consolidates 4 doc validatio | 0 | 6 | 675 |
 | [check_fastapi_issues.py](check_fastapi_issues.py) | FastAPI Issues AST Scanner. | 3 | 4 | 450 |
 | [check_function_quality.py](check_function_quality.py) | 12-point quality checklist for IS 456 functions. | 3 | 6 | 668 |
-| [check_governance.py](check_governance.py) | Unified governance checker — folder structure + compliance v | 2 | 18 | 1026 |
+| [check_governance.py](check_governance.py) | Unified governance checker — folder structure + compliance v | 2 | 19 | 1042 |
 | [check_instruction_drift.py](check_instruction_drift.py) | Check for content drift between .github/instructions/ and .c | 0 | 2 | 219 |
 | [check_links.py](check_links.py) | Check and fix broken internal links in markdown files. | 0 | 2 | 351 |
 | [check_new_element_completeness.py](check_new_element_completeness.py) | Check structural element completeness across all 7 layers. | 0 | 14 | 622 |
@@ -82,8 +82,8 @@
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 10 | 816 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
-| [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 517 |
-| [migrate_react_component.py](migrate_react_component.py) | Migrate a React component to a new feature-grouped folder. | 0 | 9 | 478 |
+| [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |
+| [migrate_react_component.py](migrate_react_component.py) | Migrate a React component to a new feature-grouped folder. | 0 | 9 | 475 |
 | [model_picker.py](model_picker.py) | Recommend a GPT-5.6 model and reasoning effort for a reposit | 1 | 2 | 295 |
 | [parity_dashboard.py](parity_dashboard.py) | Parity Dashboard — coverage/parity across IS 456, API, endpo | 0 | 6 | 517 |
 | [pipeline_state.py](pipeline_state.py) | Pipeline state tracking for multi-step agent workflows. | 2 | 17 | 868 |
@@ -91,8 +91,8 @@
 | [project_health.py](project_health.py) | Unified project health scanner with auto-fix capability. | 3 | 9 | 903 |
 | [prompt_router.py](prompt_router.py) | Prompt router — routes natural language queries to the best  | 1 | 3 | 492 |
 | [release.py](release.py) | Unified release management CLI. | 0 | 7 | 1054 |
-| [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
-| [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 505 |
+| [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 350 |
+| [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
 | [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2259 |
 | [session_store.py](session_store.py) | JSON-based session state persistence for AI agent sessions. | 1 | 14 | 372 |
 | [skill_tiers.py](skill_tiers.py) | Skill tier classification and management for AI agents. | 1 | 11 | 485 |
@@ -102,13 +102,13 @@
 | [test_cli_smoke.py](test_cli_smoke.py) | CLI Smoke Tests — validate all key scripts work correctly. | 0 | 3 | 294 |
 | [test_import_pipeline.py](test_import_pipeline.py) | End-to-end test of all import paths. | 0 | 20 | 406 |
 | [test_sample_endpoint.py](test_sample_endpoint.py) | Quick test of the sample data endpoint. | 0 | 1 | 72 |
-| [tool_permissions.py](tool_permissions.py) | Tool permission enforcement for agent operations. | 1 | 4 | 346 |
-| [tool_registry.py](tool_registry.py) | Unified tool registry — connects agents, skills, scripts, an | 1 | 13 | 575 |
+| [tool_permissions.py](tool_permissions.py) | Tool permission enforcement for agent operations. | 1 | 5 | 437 |
+| [tool_registry.py](tool_registry.py) | Unified tool registry — connects agents, skills, scripts, an | 1 | 12 | 556 |
 | [update_test_stats.py](update_test_stats.py) | Update Test Stats — Dynamic test count updater. | 0 | 5 | 211 |
 | [validate_api_contracts.py](validate_api_contracts.py) | API Contract Validator. | 2 | 9 | 620 |
 | [validate_imports.py](validate_imports.py) | Validate Python imports across the project after migration. | 0 | 6 | 380 |
 | [validate_schema_snapshots.py](validate_schema_snapshots.py) | Schema Snapshot Validator. | 0 | 6 | 257 |
-| [validate_script_refs.py](validate_script_refs.py) | Validate that active scripts don't reference archived script | 0 | 4 | 178 |
+| [validate_script_refs.py](validate_script_refs.py) | Validate that active control paths reference existing script | 0 | 6 | 235 |
 
 ## Shell Script Files
 
@@ -134,5 +134,4 @@
 
 | Folder | Files | Description |
 |--------|-------|-------------|
-| [git-hooks/](git-hooks/) | 0 |  |
 | [hooks/](hooks/) 📦 | 3 |  |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -4,7 +4,7 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-09
-**Files:** 108
+**Files:** 109
 
 ## Config Files
 
@@ -126,6 +126,7 @@
 - [generate_all_indexes.sh](generate_all_indexes.sh) — Generate index.json + index.md for all research-relevant folders
 - [launch_stack.sh](launch_stack.sh) — launch_stack.sh — Full-stack development launcher for structural_engineering_lib
 - [pre_commit_check.sh](pre_commit_check.sh) — Pre-flight checks before committing
+- [python_runtime.sh](python_runtime.sh) — Resolve the repository Python interpreter across primary and linked worktrees.
 - [repo_health_check.sh](repo_health_check.sh)
 - [validate_git_state.sh](validate_git_state.sh) — Read-only Git workflow validator for Codex
 - [watch_tests.sh](watch_tests.sh) — Watch Mode (Solution 5 - Dev Automation)

--- a/scripts/python_runtime.sh
+++ b/scripts/python_runtime.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Resolve the repository Python interpreter across primary and linked worktrees.
+#
+# When to use: internal launcher for run.sh, pre-commit, and Python subprocess
+# orchestration. Callers pass normal Python arguments after this script.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+run_python_candidate() {
+    local candidate="$1"
+    shift
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+        exec "$candidate" "$@"
+    fi
+}
+
+if [[ -n "${STRUCTURAL_LIB_PYTHON:-}" ]]; then
+    if [[ ! -x "$STRUCTURAL_LIB_PYTHON" ]]; then
+        echo "ERROR: STRUCTURAL_LIB_PYTHON is not executable: $STRUCTURAL_LIB_PYTHON" >&2
+        exit 1
+    fi
+    run_python_candidate "$STRUCTURAL_LIB_PYTHON" "$@"
+fi
+
+run_python_candidate "$REPO_ROOT/.venv/bin/python" "$@"
+
+git_common_dir="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [[ -n "$git_common_dir" ]]; then
+    primary_worktree="$(dirname "$git_common_dir")"
+    if [[ "$primary_worktree" != "$REPO_ROOT" ]]; then
+        run_python_candidate "$primary_worktree/.venv/bin/python" "$@"
+    fi
+fi
+
+if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+    run_python_candidate "$VIRTUAL_ENV/bin/python" "$@"
+fi
+
+echo "ERROR: No project Python interpreter found." >&2
+echo "Checked STRUCTURAL_LIB_PYTHON, this worktree's .venv, the primary worktree's .venv, and VIRTUAL_ENV." >&2
+echo "Create .venv in the primary checkout or set STRUCTURAL_LIB_PYTHON to an executable interpreter." >&2
+exit 1

--- a/scripts/test_cli_smoke.py
+++ b/scripts/test_cli_smoke.py
@@ -27,7 +27,7 @@ from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
-VENV = str(REPO_ROOT / ".venv" / "bin" / "python")
+VENV = str(SCRIPT_DIR / "python_runtime.sh")
 
 # ---------------------------------------------------------------------------
 # Test definitions
@@ -105,8 +105,9 @@ SMOKE_TESTS: list[dict[str, Any]] = [
     # Existing tools (regression)
     {
         "name": "find_automation",
-        "cmd": [VENV, "scripts/find_automation.py", "beam"],
+        "cmd": [VENV, "scripts/find_automation.py", "run tests"],
         "expect_rc": 0,
+        "expect_output": "run tests",
     },
     {
         "name": "discover_api",

--- a/scripts/tool_permissions.py
+++ b/scripts/tool_permissions.py
@@ -5,9 +5,8 @@ Checks whether an agent is allowed to perform an operation based on
 agent_registry.json permission_level and file_scope.
 
 Usage as CLI:
-    python scripts/tool_permissions.py check --agent backend --op edit --path Python/structural_lib/api.py
-    python scripts/tool_permissions.py check --agent reviewer --op edit --path Python/structural_lib/api.py
-    python scripts/tool_permissions.py --agent ops --op delete --path scripts/old.py
+    .venv/bin/python scripts/tool_permissions.py check --agent backend --op edit --path Python/structural_lib/api.py
+    .venv/bin/python scripts/tool_permissions.py check --agent governance --op "project health" --mode=--fix
 
 Usage as module:
     from tool_permissions import check_permission, check_file_scope
@@ -103,6 +102,7 @@ def _level_rank(level: str) -> int:
 # ---------------------------------------------------------------------------
 
 _REGISTRY_PATH = REPO_ROOT / "agents" / "agent_registry.json"
+_AUTOMATION_MAP_PATH = REPO_ROOT / "scripts" / "automation-map.json"
 
 
 def _load_registry() -> list[dict]:
@@ -128,6 +128,63 @@ def _find_agent(agents: list[dict], name: str) -> dict | None:
     return None
 
 
+def _load_automation_tasks() -> dict[str, dict]:
+    """Load explicit operation metadata from the automation map."""
+    try:
+        data = json.loads(_AUTOMATION_MAP_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    tasks = data.get("tasks", {})
+    return tasks if isinstance(tasks, dict) else {}
+
+
+def resolve_required_permission(operation: str, *, mode: str | None = None) -> str:
+    """Resolve the required level for an abstract op or declared script mode.
+
+    Automation tasks must declare their default ``permission`` and any mutating
+    ``permission_modes`` explicitly. Unknown tasks and modes fail closed.
+    """
+    normalized = operation.lower().strip()
+    if mode is None and normalized in READ_OPS | WRITE_OPS | DANGER_OPS:
+        return _LEVEL_FOR_CATEGORY[_op_category(normalized)]
+
+    task = _load_automation_tasks().get(normalized)
+    if not isinstance(task, dict):
+        return "DangerFullAccess"
+
+    default_level = task.get("permission")
+    if default_level not in _PERMISSION_LEVELS:
+        return "DangerFullAccess"
+    if mode is None:
+        return default_level
+
+    modes = task.get("permission_modes", {})
+    if not isinstance(modes, dict):
+        return "DangerFullAccess"
+    required = modes.get(mode.strip())
+    return required if required in _PERMISSION_LEVELS else "DangerFullAccess"
+
+
+def _is_declared_operation(operation: str, *, mode: str | None = None) -> bool:
+    """Return whether an abstract operation or exact task/mode is declared."""
+    normalized = operation.lower().strip()
+    if mode is None and normalized in READ_OPS | WRITE_OPS | DANGER_OPS:
+        return True
+
+    task = _load_automation_tasks().get(normalized)
+    if not isinstance(task, dict) or task.get("permission") not in _PERMISSION_LEVELS:
+        return False
+    if mode is None:
+        return True
+
+    modes = task.get("permission_modes", {})
+    return (
+        isinstance(modes, dict)
+        and mode.strip() in modes
+        and modes[mode.strip()] in _PERMISSION_LEVELS
+    )
+
+
 # ---------------------------------------------------------------------------
 # Permission result
 # ---------------------------------------------------------------------------
@@ -141,8 +198,10 @@ class PermissionResult:
     reason: str
     agent: str
     operation: str
+    mode: str | None
     target_path: str | None
     permission_level: str
+    required_level: str
     file_scope: str | None
 
 
@@ -197,6 +256,8 @@ def check_permission(
     agent: str,
     operation: str,
     target_path: str | None = None,
+    *,
+    mode: str | None = None,
 ) -> PermissionResult:
     """Check whether *agent* may perform *operation* on *target_path*.
 
@@ -205,6 +266,7 @@ def check_permission(
     """
     agents = _load_registry()
     agent_data = _find_agent(agents, agent)
+    required_level = resolve_required_permission(operation, mode=mode)
 
     if agent_data is None:
         return PermissionResult(
@@ -212,16 +274,32 @@ def check_permission(
             reason=f"Agent '{agent}' not found in registry",
             agent=agent,
             operation=operation,
+            mode=mode,
             target_path=target_path,
             permission_level="unknown",
+            required_level=required_level,
             file_scope=None,
+        )
+
+    if not _is_declared_operation(operation, mode=mode):
+        return PermissionResult(
+            allowed=False,
+            reason=(
+                f"Operation '{operation}'"
+                + (f" mode '{mode}'" if mode else "")
+                + " has no explicit permission declaration"
+            ),
+            agent=agent,
+            operation=operation,
+            mode=mode,
+            target_path=target_path,
+            permission_level=agent_data.get("permission_level", "ReadOnly"),
+            required_level=required_level,
+            file_scope=agent_data.get("file_scope"),
         )
 
     perm_level: str = agent_data.get("permission_level", "ReadOnly")
     file_scope: str | None = agent_data.get("file_scope")
-
-    category = _op_category(operation)
-    required_level = _LEVEL_FOR_CATEGORY[category]
 
     # 1. Check permission level is sufficient
     if _level_rank(perm_level) < _level_rank(required_level):
@@ -233,14 +311,16 @@ def check_permission(
             ),
             agent=agent,
             operation=operation,
+            mode=mode,
             target_path=target_path,
             permission_level=perm_level,
+            required_level=required_level,
             file_scope=file_scope,
         )
 
-    # 2. For write/danger ops with a target path, check file scope
+    # 2. For write/danger requirements with a target path, check file scope
     if (
-        category in ("write", "danger")
+        _level_rank(required_level) >= _level_rank("WorkspaceWrite")
         and target_path is not None
         and file_scope is not None
     ):
@@ -254,8 +334,10 @@ def check_permission(
                 ),
                 agent=agent,
                 operation=operation,
+                mode=mode,
                 target_path=target_path,
                 permission_level=perm_level,
+                required_level=required_level,
                 file_scope=file_scope,
             )
 
@@ -264,8 +346,10 @@ def check_permission(
         reason="Permitted",
         agent=agent,
         operation=operation,
+        mode=mode,
         target_path=target_path,
         permission_level=perm_level,
+        required_level=required_level,
         file_scope=file_scope,
     )
 
@@ -285,6 +369,7 @@ def _build_parser() -> argparse.ArgumentParser:
     check_p = sub.add_parser("check", help="Check a single permission")
     check_p.add_argument("--agent", required=True, help="Agent name")
     check_p.add_argument("--op", required=True, help="Operation (read/edit/delete/...)")
+    check_p.add_argument("--mode", default=None, help="Exact declared task mode")
     check_p.add_argument("--path", default=None, help="Target file path")
     check_p.add_argument(
         "--json", action="store_true", dest="as_json", help="JSON output"
@@ -293,6 +378,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # Allow top-level flags as shorthand (no subcommand)
     parser.add_argument("--agent", default=None, help="Agent name")
     parser.add_argument("--op", default=None, help="Operation")
+    parser.add_argument("--mode", default=None, help="Exact declared task mode")
     parser.add_argument("--path", default=None, help="Target file path")
     parser.add_argument(
         "--json", action="store_true", dest="as_json", help="JSON output"
@@ -308,6 +394,7 @@ def main(argv: list[str] | None = None) -> int:
     # Support both `check --agent ...` and `--agent ...` forms
     agent = args.agent
     op = args.op
+    mode = args.mode
     path = args.path
     as_json = args.as_json
 
@@ -315,7 +402,7 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 1
 
-    result = check_permission(agent, op, path)
+    result = check_permission(agent, op, path, mode=mode)
 
     if as_json:
         print_json(
@@ -324,17 +411,21 @@ def main(argv: list[str] | None = None) -> int:
                 "reason": result.reason,
                 "agent": result.agent,
                 "operation": result.operation,
+                "mode": result.mode,
                 "target_path": result.target_path,
                 "permission_level": result.permission_level,
+                "required_level": result.required_level,
                 "file_scope": result.file_scope,
             }
         )
     else:
         icon = "✅" if result.allowed else "🚫"
         print(f"{icon} {result.agent} → {result.operation}", end="")
+        if result.mode:
+            print(f" {result.mode}", end="")
         if result.target_path:
             print(f" on {result.target_path}", end="")
-        print(f"  [{result.permission_level}]")
+        print(f"  [agent={result.permission_level}, required={result.required_level}]")
         if not result.allowed:
             print(f"   Reason: {result.reason}")
 

--- a/scripts/tool_registry.py
+++ b/scripts/tool_registry.py
@@ -4,7 +4,7 @@ Unified tool registry — connects agents, skills, scripts, and operations.
 
 Loads from:
 - agents/agent_registry.json (16 agents)
-- scripts/automation-map.json (113 mapped scripts)
+- scripts/automation-map.json (task and script operation metadata)
 
 Usage:
     python scripts/tool_registry.py --list
@@ -40,7 +40,8 @@ class ToolEntry:
     agent: str
     category: str
     script: str | None
-    permission: str
+    permission: str | None
+    permission_modes: dict[str, str] = field(default_factory=dict)
     keywords: list[str] = field(default_factory=list)
     skill: str | None = None
     aliases: list[str] = field(default_factory=list)
@@ -94,37 +95,6 @@ STOPWORDS = {
     "if",
     "any",
 }
-
-
-def classify_permission(script: str, task_name: str, description: str) -> str:
-    """Classify tool permission level based on keywords."""
-    danger_keywords = ["git", "push", "delete", "cleanup", "merge", "force", "rm"]
-    readonly_keywords = [
-        "check",
-        "validate",
-        "find",
-        "discover",
-        "audit",
-        "benchmark",
-        "context",
-        "list",
-        "show",
-    ]
-
-    text = f"{script} {task_name} {description}".lower()
-
-    # Danger zone
-    for keyword in danger_keywords:
-        if keyword in text:
-            return "DangerFullAccess"
-
-    # Read-only operations
-    for keyword in readonly_keywords:
-        if keyword in text:
-            return "ReadOnly"
-
-    # Default to workspace write
-    return "WorkspaceWrite"
 
 
 def extract_keywords(name: str, description: str) -> list[str]:
@@ -238,10 +208,8 @@ def load_registry() -> dict[str, ToolEntry]:
             description = task_info.get("description", "")
             group = task_info.get("group", "Uncategorized")
 
-            # Classify permission
-            permission = task_info.get("permission") or classify_permission(
-                script, task_name, description
-            )
+            permission = task_info.get("permission")
+            permission_modes = task_info.get("permission_modes", {})
 
             # Extract keywords
             keywords = extract_keywords(task_name, description)
@@ -258,6 +226,7 @@ def load_registry() -> dict[str, ToolEntry]:
                 category=group,
                 script=script,
                 permission=permission,
+                permission_modes=permission_modes,
                 keywords=keywords,
                 skill=None,
                 aliases=[],
@@ -363,7 +332,12 @@ def get_tools_by_permission(
     level: str, registry: dict[str, ToolEntry]
 ) -> list[ToolEntry]:
     """Get all tools with a specific permission level."""
-    return [tool for tool in registry.values() if tool.permission == level]
+    normalized_level = level.lower()
+    return [
+        tool
+        for tool in registry.values()
+        if (tool.permission or "Unspecified").lower() == normalized_level
+    ]
 
 
 def resolve_alias(alias: str) -> str | None:
@@ -375,11 +349,12 @@ def print_tool(tool: ToolEntry, show_score: bool = False, score: float = 0.0):
     """Print a tool entry."""
     agent_tag = f"[@{tool.agent}]" if tool.agent else ""
     category_tag = f"[{tool.category}]" if tool.category else ""
+    permission_label = tool.permission or "Unspecified"
     permission_icon = {
         "ReadOnly": "🔍",
         "WorkspaceWrite": "✏️",
         "DangerFullAccess": "⚠️",
-    }.get(tool.permission, "")
+    }.get(permission_label, "❓")
 
     score_tag = f" (score: {score:.1f})" if show_score and score > 0 else ""
 
@@ -388,6 +363,12 @@ def print_tool(tool: ToolEntry, show_score: bool = False, score: float = 0.0):
 
     if tool.script:
         print(f"     Script: {tool.script}")
+    print(f"     Permission: {permission_label}")
+    if tool.permission_modes:
+        modes = ", ".join(
+            f"{mode}={level}" for mode, level in tool.permission_modes.items()
+        )
+        print(f"     Modes: {modes}")
 
     if tool.aliases:
         aliases_str = ", ".join(tool.aliases)
@@ -436,7 +417,7 @@ def show_stats(registry: dict[str, ToolEntry]):
     # By permission
     by_permission: dict[str, int] = {}
     for tool in registry.values():
-        permission = tool.permission
+        permission = tool.permission or "Unspecified"
         by_permission[permission] = by_permission.get(permission, 0) + 1
 
     # Scripts vs skills vs agents

--- a/scripts/validate_script_refs.py
+++ b/scripts/validate_script_refs.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Validate that active scripts don't reference archived scripts at runtime.
+"""Validate that active control paths reference existing scripts.
 
-Scans scripts/*.py and scripts/*.sh for references to scripts in scripts/_archive/.
-Distinguishes between documentation comments (OK) and actual runtime calls (broken).
+Scans the unified CLI, pre-commit configuration, GitHub workflows, and active
+top-level scripts. References to archived, retired, or otherwise missing script
+targets fail when they occur in an executable control path.
 
 Usage:
     python scripts/validate_script_refs.py          # Check only
@@ -16,6 +17,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = REPO_ROOT / "scripts"
 ARCHIVE_DIR = SCRIPTS_DIR / "_archive"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+CONTROL_FILES = {
+    REPO_ROOT / "run.sh",
+    REPO_ROOT / ".pre-commit-config.yaml",
+}
 RETIRED_NAMES = {
     "ai_commit.sh",
     "safe_push.sh",
@@ -47,8 +53,12 @@ RUNTIME_PATTERNS_PY = [
 ]
 
 RUNTIME_PATTERNS_SH = [
-    r"scripts/\S+\.(py|sh)",  # Direct script invocation in bash
+    r"(?:scripts|\$SCRIPTS|\$\{SCRIPTS\})/\S+\.(py|sh)",
 ]
+
+SCRIPT_REFERENCE_RE = re.compile(
+    r"(?:scripts|\$SCRIPTS|\$\{SCRIPTS\})/([A-Za-z0-9_.-]+\.(?:py|sh))"
+)
 
 
 def get_archived_names() -> set[str]:
@@ -73,8 +83,33 @@ def is_doc_line(line: str) -> bool:
     return False
 
 
+def _is_control_surface(filepath: Path) -> bool:
+    """Return whether every script reference in *filepath* is executable."""
+    if filepath in CONTROL_FILES:
+        return True
+    try:
+        filepath.relative_to(WORKFLOWS_DIR)
+    except ValueError:
+        return False
+    return filepath.suffix in {".yml", ".yaml"}
+
+
+def _reference_severity(filepath: Path, line: str) -> str:
+    """Classify a missing target reference by how the containing line is used."""
+    if _is_control_surface(filepath):
+        return "error"
+
+    patterns = RUNTIME_PATTERNS_PY if filepath.suffix == ".py" else RUNTIME_PATTERNS_SH
+    severity = (
+        "error" if any(re.search(pattern, line) for pattern in patterns) else "info"
+    )
+    if "echo " in line or "print(" in line:
+        return "warning"
+    return severity
+
+
 def check_file(filepath: Path, archived_names: set[str]) -> list[dict]:
-    """Check a single file for stale references to archived scripts."""
+    """Check a single file for stale references to known archived scripts."""
     issues = []
     try:
         content = filepath.read_text(encoding="utf-8")
@@ -88,29 +123,12 @@ def check_file(filepath: Path, archived_names: set[str]) -> list[dict]:
             if is_doc_line(line):
                 continue
 
-            # Determine severity
-            severity = "info"
-            if filepath.suffix == ".py":
-                for pattern in RUNTIME_PATTERNS_PY:
-                    if re.search(pattern, line):
-                        severity = "error"
-                        break
-            elif filepath.suffix == ".sh":
-                for pattern in RUNTIME_PATTERNS_SH:
-                    if re.search(pattern, line):
-                        severity = "error"
-                        break
-
-            # Echo/print references are warnings (misleading output)
-            if "echo " in line or "print(" in line:
-                severity = "warning"
-
             issues.append(
                 {
                     "file": str(filepath.relative_to(REPO_ROOT)),
                     "line": i,
-                    "archived": name,
-                    "severity": severity,
+                    "target": name,
+                    "severity": _reference_severity(filepath, line),
                     "text": line.strip()[:120],
                 }
             )
@@ -118,31 +136,70 @@ def check_file(filepath: Path, archived_names: set[str]) -> list[dict]:
     return issues
 
 
+def check_missing_targets(filepath: Path) -> list[dict]:
+    """Return references whose top-level ``scripts/`` target does not exist."""
+    issues = []
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return issues
+
+    for line_number, line in enumerate(content.splitlines(), 1):
+        if is_doc_line(line):
+            continue
+        code = line.split("#", 1)[0]
+        for match in SCRIPT_REFERENCE_RE.finditer(code):
+            name = match.group(1)
+            if (SCRIPTS_DIR / name).is_file():
+                continue
+            issues.append(
+                {
+                    "file": str(filepath.relative_to(REPO_ROOT)),
+                    "line": line_number,
+                    "target": name,
+                    "severity": _reference_severity(filepath, line),
+                    "text": line.strip()[:120],
+                }
+            )
+    return issues
+
+
+def scan_files() -> list[Path]:
+    """Return executable repository surfaces that may invoke scripts."""
+    files = set(CONTROL_FILES)
+    files.update(SCRIPTS_DIR.glob("*.py"))
+    files.update(SCRIPTS_DIR.glob("*.sh"))
+    if WORKFLOWS_DIR.is_dir():
+        files.update(WORKFLOWS_DIR.glob("*.yml"))
+        files.update(WORKFLOWS_DIR.glob("*.yaml"))
+    return sorted(filepath for filepath in files if filepath.is_file())
+
+
 def main() -> int:
     show_fix = "--fix" in sys.argv
     archived_names = get_archived_names()
-    if not archived_names:
-        print("No archived scripts found.")
-        return 0
-
     all_issues: list[dict] = []
 
-    # Scan active scripts only
-    for ext in ("*.py", "*.sh"):
-        for filepath in SCRIPTS_DIR.glob(ext):
-            if filepath.parent == ARCHIVE_DIR:
-                continue
-            all_issues.extend(check_file(filepath, archived_names))
+    for filepath in scan_files():
+        all_issues.extend(check_file(filepath, archived_names))
+        all_issues.extend(check_missing_targets(filepath))
+
+    # A known archived name may also be found by the generic missing-target scan.
+    unique_issues = {}
+    for issue in all_issues:
+        key = (issue["file"], issue["line"], issue["target"])
+        unique_issues[key] = issue
+    all_issues = list(unique_issues.values())
 
     if not all_issues:
-        print("✅ No stale references to archived scripts found.")
+        print("✅ All active script control-path targets exist.")
         return 0
 
     errors = [i for i in all_issues if i["severity"] == "error"]
     warnings = [i for i in all_issues if i["severity"] == "warning"]
     infos = [i for i in all_issues if i["severity"] == "info"]
 
-    print(f"Found {len(all_issues)} stale reference(s) to archived scripts:")
+    print(f"Found {len(all_issues)} reference(s) to missing scripts:")
     print(f"  ❌ {len(errors)} runtime breaks (actual calls to missing scripts)")
     print(f"  ⚠️  {len(warnings)} misleading output (echo/print of missing scripts)")
     print(f"  ℹ️  {len(infos)} informational (comments, docstrings)")
@@ -151,7 +208,7 @@ def main() -> int:
     if errors:
         print("❌ RUNTIME BREAKS (will fail when called):")
         for issue in errors:
-            print(f"  {issue['file']}:{issue['line']} → {issue['archived']}")
+            print(f"  {issue['file']}:{issue['line']} → {issue['target']}")
             if show_fix:
                 print(f"    {issue['text']}")
         print()
@@ -159,7 +216,7 @@ def main() -> int:
     if warnings:
         print("⚠️  MISLEADING OUTPUT (references non-existent scripts):")
         for issue in warnings:
-            print(f"  {issue['file']}:{issue['line']} → {issue['archived']}")
+            print(f"  {issue['file']}:{issue['line']} → {issue['target']}")
             if show_fix:
                 print(f"    {issue['text']}")
         print()
@@ -167,7 +224,7 @@ def main() -> int:
     if show_fix and infos:
         print("ℹ️  INFORMATIONAL (documentation references — low priority):")
         for issue in infos:
-            print(f"  {issue['file']}:{issue['line']} → {issue['archived']}")
+            print(f"  {issue['file']}:{issue['line']} → {issue['target']}")
         print()
 
     return 1 if errors else 0

--- a/tests/test_evolver_infrastructure.py
+++ b/tests/test_evolver_infrastructure.py
@@ -625,13 +625,13 @@ class TestDriftDetector:
         assert drift_score(10, 5) == 0.0
 
     def test_detect_commit_drift_forbidden_ops(self):
-        """ops agent with 'git push' in commit -> violation."""
+        """ops agent with a verification bypass in commit -> violation."""
         from agent_drift_detector import detect_commit_drift
 
-        commits = [{"message": "git push origin main"}]
+        commits = [{"message": "used --no-verify for the push"}]
         violations = detect_commit_drift(commits, "ops")
         assert len(violations) > 0
-        assert any(v["rule_id"] == "OPS-004" for v in violations)
+        assert any(v["rule_id"] == "OPS-005" for v in violations)
 
     def test_detect_commit_drift_forbidden_force(self):
         """ops agent with '--force' -> violation."""
@@ -690,7 +690,7 @@ class TestDriftDetector:
         session_data = {
             "session_id": "2026-04-01T14-30",
             "agents_active": ["ops"],
-            "commits": [{"message": "git push origin main"}],
+            "commits": [{"message": "used --no-verify for the push"}],
             "files_changed": {},
         }
 


### PR DESCRIPTION
## Summary

- remove five dead VBA/Streamlit control entrypoints from `run.sh` and pre-commit configuration
- expand active script-reference validation across the dispatcher, hooks, workflows, and scripts
- make agent context use the canonical 16-agent registry
- make compliance and drift fail closed on missing or stale evidence
- make drift and trend reporting read-only unless a write mode is explicit
- replace keyword-inferred permissions with explicit operation/mode metadata and fail-closed enforcement
- add a single Python runtime resolver for primary and linked Git worktrees
- route `run.sh`, pre-commit, the check orchestrator, and CLI smoke tests through that resolver
- add focused governance/runtime regressions and update the one-by-one automation audit

## Why

The remaining automation controls could report false success, select stale evidence, write during report-only invocations, or advertise permissions inferred from descriptive text rather than actual modes. Some control surfaces also referenced scripts that no longer exist.

The clean linked worktree also exposed a root cause in the terminal workflow: repository commands and commit hooks assumed every worktree had its own `.venv`. The new resolver uses an explicitly selected interpreter, the current checkout environment, the primary Git worktree environment, or an active virtual environment, and otherwise fails with an actionable error.

This branch is based on `main` after PR #693, so the already-merged first automation batch is not repeated. Concurrent release, Node-runtime, and structural-library work is intentionally excluded.

## Validation

- all scoped repository pre-commit hooks passed without a local linked-worktree `.venv`
- focused governance/runtime tests: 108/108
- CLI smoke: 13/13
- quick gate: 9/9
- complete repository gate: 29/29
- automation-map/index coverage: 107/107 scripts
- active script references: 0 runtime breaks
- permission audit and governance compliance: pass
- GitHub PR checks: all required checks passed