### PR TITLE
fix(ci): use active interpreter in release tests

### DIFF
--- a/Python/tests/test_token_efficiency.py
+++ b/Python/tests/test_token_efficiency.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -26,7 +27,7 @@ def test_project_codex_defaults_are_low_token() -> None:
 def test_token_efficiency_checker_passes() -> None:
     result = subprocess.run(
         [
-            str(REPO_ROOT / ".venv" / "bin" / "python"),
+            sys.executable,
             "scripts/check_token_efficiency.py",
         ],
         cwd=REPO_ROOT,
@@ -43,7 +44,7 @@ def test_token_efficiency_checker_passes() -> None:
 def test_low_token_prompt_is_bounded_and_actionable() -> None:
     result = subprocess.run(
         [
-            str(REPO_ROOT / ".venv" / "bin" / "python"),
+            sys.executable,
             "scripts/check_token_efficiency.py",
             "--prompt",
         ],


### PR DESCRIPTION
## Summary

- replace two repository `.venv/bin/python` assumptions with `sys.executable`
- keep token-efficiency subprocess tests on the interpreter selected by the active environment
- repair Publish Release run 31331989251 without weakening its test scope

## Root cause

The publish workflow installs the package into the GitHub Actions Python 3.12 environment and intentionally does not create a repository `.venv`. Two tests bypassed that active interpreter and attempted to execute a nonexistent `.venv/bin/python` path.

## Verification

- `.venv/bin/pytest Python/tests/test_token_efficiency.py -q` — 5 passed
- Ruff and Black checks passed
- `./run.sh check --quick` — 9/9 passed
- failed TestPyPI run stopped before build or publication