### PR TITLE
chore(release): record v0.23.0 publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
     defaults:
       run:
         working-directory: Python
@@ -62,7 +63,20 @@ jobs:
             echo "Requested version $requested_version does not match package version $package_version"
             exit 1
           fi
+          prerelease=$(python - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as stream:
+              classifiers = tomllib.load(stream)["project"].get("classifiers", [])
+
+          development_statuses = tuple(
+              f"Development Status :: {level}" for level in range(1, 5)
+          )
+          print(str(any(item.startswith(development_statuses) for item in classifiers)).lower())
+          PY
+          )
           echo "version=$package_version" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
 
       - name: Run release tests
         run: python -m pytest tests -q --tb=short
@@ -376,3 +390,4 @@ jobs:
             release-assets/*
           generate_release_notes: true
           draft: false
+          prerelease: ${{ needs.validate.outputs.prerelease }}

--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -242,6 +242,19 @@ class TestReleaseVerifyDependencies:
         assert 'f"{wheel}[dev]"' in verify_block
 
 
+class TestPublishWorkflow:
+    """The release workflow must preserve package maturity on GitHub."""
+
+    def test_development_status_controls_github_prerelease(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "publish.yml").read_text(
+            encoding="utf-8"
+        )
+
+        assert "prerelease: ${{ steps.version.outputs.prerelease }}" in workflow
+        assert "Development Status :: {level}" in workflow
+        assert "prerelease: ${{ needs.validate.outputs.prerelease }}" in workflow
+
+
 class TestReleasePreflight:
     """Tests for the preflight subcommand."""
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-10 — bounded IS 456 C0-C4 closeout complete; owner-authorized v0.23.0 Alpha release in progress
+**Updated:** 2026-08-10 — v0.23.0 Alpha released; public artifact UAT green
 
 ---
 
@@ -69,10 +69,10 @@
 
 ## Current Release
 
-| **Current candidate** | v0.23.0 | 🚀 ALPHA RELEASE AUTHORIZED — exact CI artifact and publication pending |
+| **Current** | v0.23.0 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
 - **Strategy:** Incremental micro-releases — each focuses on one quality dimension (tests, API, security, performance)
 - **Focus:** API introspection → security hardening → performance baselines → stabilization
-- **Target:** publish v0.23.0 Alpha, then activate later roadmap work separately
+- **Target:** keep later roadmap work inactive until separately activated
 - **Vision:** [democratization-vision.md](planning/democratization-vision.md) — AI chat, automation, library evolution
 - **Architecture:** [unified-architecture-v1.md](architecture/unified-architecture-v1.md) §20 — complete v0.21.5→v1.0 roadmap
 
@@ -89,7 +89,7 @@
 | **v0.21.7** | Security Hardening | ✅ READY FOR RELEASE | Input validation, error sanitization, packaging gates, CI hardening |
 | **v0.21.8** | Performance & Property Testing | 📋 PLANNED | Benchmarks, Hypothesis, performance baselines |
 | **v0.22.0** | Stabilization Release | 📋 PLANNED | API naming convention (Batch 3), provenance, SP:16 verification |
-| **v0.23** | Bounded IS 456 slabs + footing completion | 🚀 ALPHA RELEASE IN PROGRESS | Case-qualified development preview; professional review remains a final stable/engineering-use gate |
+| **v0.23** | Bounded IS 456 slabs + footing completion | ✅ ALPHA RELEASED | Case-qualified development preview; professional review remains a final stable/engineering-use gate |
 | **v0.24** | Multi-Code Infrastructure | 📋 PLANNED | CodeRegistry activation, DesignEnvelope, units.py, API v2 routes |
 | **v0.25** | ACI 318-19 Beam | 📋 PLANNED | ACI beam flexure + shear, PCA Notes ±0.1% benchmarks |
 | **v1.0** | Production Multi-Code | 📋 PLANNED | IS 456 complete, ACI 318 beam+column, EC2 beam, API stability guarantee |

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -337,3 +337,5 @@ tags: []
 | 2026-08-10 | LIB-IS456-C4 | Froze the bounded evidence, limitations and review boundaries on draft PR #696; left qualified review, exact CI publication artifacts, merge, tag and publishing as explicit held gates | — |
 | 2026-08-10 | LIB-IS456-REL-0 | Owner moved qualified review to the final stable/engineering-use gate, retained technical and evidence controls, and authorized the conditioned v0.23.0 Alpha release sequence | — |
 | 2026-08-10 | LIB-IS456-REL-1 | Repaired the release validator state machine so exact-wheel, owner-authorized candidates carry truthful dated metadata while ordinary unpublished candidates still fail closed | — |
+| 2026-08-10 | LIB-IS456-REL-2 | Repaired the publish workflow's runner-local interpreter assumption, merged PRs #696/#697 through green gates, and completed exact TestPyPI rehearsal | 3f880d5b |
+| 2026-08-10 | LIB-IS456-REL-3 | Published v0.23.0 Alpha from tag `v0.23.0`, verified production hashes/SBOM/inventories against PyPI and GitHub assets, and passed exact public-package UAT | 3f880d5b |

--- a/docs/getting-started/releases.md
+++ b/docs/getting-started/releases.md
@@ -80,7 +80,7 @@ Use workflow_dispatch with `testpypi` target:
 
 ## v0.23.0 — Supported IS 456 RC Core (2026-08-10)
 
-**Status:** 🚀 Alpha release authorized on 2026-08-10; publication evidence pending
+**Status:** ✅ Alpha development preview published to PyPI and GitHub Releases on 2026-08-10
 **Source basis:** IS 456:2000 consolidated through Amendment 5, reaffirmed
 2021, with Amendment 6 (June 2024) reviewed by route
 **Scope:** Case-qualified beam, rectangular-column, isolated-footing, and solid
@@ -103,8 +103,10 @@ development preview without a professional-approval claim.
 - Native Codex Git/GitHub workflow with unsafe custom lifecycle wrappers and
   enforcement hooks retired.
 
-**Verification:** 5,452 release-preflight tests passed, 3 skipped, 6 deselected;
-React 147 tests/lint/build passed; canonical gate 29/29; PR #693 gate passed.
+**Verification:** Production run `31332420554` built from tag `v0.23.0` at
+`3f880d5b`; public PyPI UAT passed 5,406 tests, 51 skipped, 6 deselected plus
+installed CLI workflows. React 147 tests/lint/build and canonical gate 29/29
+passed before release.
 
 **Full changelog:** See [CHANGELOG.md](../../CHANGELOG.md#0230--2026-08-10)
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -30,9 +30,9 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
-| `next-session-brief.md` | 2026-08-10 | ✅ Current release handoff |
+| `next-session-brief.md` | 2026-08-10 | ✅ Post-release handoff |
 | `compact-modernization-plan.md` | 2026-08-09 | 📋 Ready after PR #676 |
-| `is456-library-first-master-plan.md` | 2026-08-10 | 🚀 C0-C4 complete; v0.23.0 Alpha release authorized |
+| `is456-library-first-master-plan.md` | 2026-08-10 | ✅ C0-C4 and v0.23.0 Alpha release complete |
 | `professional-library-remediation-plan.md` | 2026-08-10 | ✅ Software remediation evidence ledger; final professional review deferred |
 | `folder-audit.md` | 2026-03-24 | ✅ Complete (11 batches) |
 | `ai-agent-efficiency-and-git-workflow-plan.md` | 2026-03-24 | ✅ Partially implemented |

--- a/docs/planning/is456-library-first-master-plan.md
+++ b/docs/planning/is456-library-first-master-plan.md
@@ -9,12 +9,12 @@ doc_type: spec
 baseline_commit: d4eb9e9dda4a
 release_decision: v0.21.7 deferred
 target_version: v0.23.0
-current_blocker: Exact CI publication-artifact evidence
+current_blocker: Qualified review before stable or engineering-use approval
 ---
 
 **Type:** Plan
 **Audience:** All Agents
-**Status:** C0-C4 Bounded Closeout Complete — Alpha Release Authorized
+**Status:** C0-C4 Complete — v0.23.0 Alpha Released
 **Importance:** Critical
 **Created:** 2026-08-09
 **Last Updated:** 2026-08-10
@@ -57,11 +57,10 @@ owner changes scope through a separate decision.
 ## 2. Relationship to current repository plans
 
 This document is the execution authority and frozen evidence boundary for the
-library-first IS 456 lane activated by the owner. C0-C4 are complete; the
-remaining release gates are exact CI publication-artifact evidence and
-owner-authorized release work. Qualified structural-engineering review is a
-cumulative final gate before stable/engineering-use approval, not a blocker for
-each development packet or Alpha release.
+library-first IS 456 lane activated by the owner. C0-C4 and the v0.23.0 Alpha
+release are complete. Qualified structural-engineering review is a cumulative
+final gate before stable/engineering-use approval, not a blocker for each
+development packet or Alpha release.
 
 It narrows the immediate IS 456 execution order in
 `docs/planning/library-expansion-blueprint-v5.md`. It does not reverse that
@@ -125,10 +124,10 @@ approved or usable for engineering decisions.
 | C3 — Frozen artifact | Complete at `9be6eb35` | Build clean wheel/sdist, inspect contents, record hashes, clean-install supported workflows and CLI | Exact local artifact evidence is reproducible and bound to the frozen source commit |
 | C4 — Evidence freeze | Complete on draft PR #696 | Assemble source IDs, units, benchmarks, limitations, unsafe cases, and unresolved holds without requesting sign-off | The owner's request to finish this bounded plan freezes the intended review scope without authorizing release or professional-use claims |
 
-C0-C4 are complete, so the frozen packet is ready for final qualified-
-engineering review. That review has not been performed. Merge, tag,
-TestPyPI/PyPI, GitHub Release, issue closure, and branch deletion remain
-separate owner-only actions.
+C0-C4 are complete and v0.23.0 was published as an Alpha development preview.
+The cumulative qualified-engineering review has not been performed and remains
+required before any stable or engineering-use approval. Issue closure and
+branch deletion remain separate owner-only actions.
 
 ## 3. Why this plan exists
 
@@ -1325,6 +1324,8 @@ Use existing canonical records. Do not create one log per agent.
 | 2026-08-10 | C3 | Main Agent | COMPLETE | `codex/release-v0.23.0` at `9be6eb35`; draft PR #696 | Package manifest boundary, release skill, optional-DXF test, exact local wheel/sdist | Twine and candidate checks; 181/206 members; zero forbidden/protected content; exact-wheel 5,404 passed; candidate preflight 5,452 passed plus React build | Focused + quick + current-commit PR Gate | Local evidence is not CI publication identity; no upload authorized | C4 |
 | 2026-08-10 | C4 | Main Agent + owner scope instruction | COMPLETE / FROZEN | Draft PR #696; artifact source `9be6eb35` | Master plan, task/session/handoff records, evidence crosswalk and release checklist | Controlled source IDs, units/claims, unsafe cases, limitations, local artifact hashes/SBOM, and held gates reconciled | Documentation/session checks; final PR Gate required on evidence commit | Qualified review and every merge/tag/publish action remain held | Qualified review / owner release decision |
 | 2026-08-10 | REL-0 | Repository owner + Main Agent | APPROVED | Draft PR #696 | Release policy, maintained skills and current release records | Per-packet qualified-review gates removed; technical evidence retained; v0.23.0 remains an Alpha development preview | Documentation + quick + PR Gate | Qualified review remains required before stable/engineering-use approval | P13 release execution |
+| 2026-08-10 | REL-1 | Main Agent | COMPLETE | PR #696 merged at `71e74a7e`; CI fix PR #697 merged at `3f880d5b` | Release metadata, validator state machine, CI interpreter contract | Current-candidate preflight passed 5,454 tests; TestPyPI run `31332187566` published exact clean artifacts and passed installed-wheel UAT | Focused + quick + both PR Gates | Production publication remained conditioned on exact TestPyPI evidence | REL-2 |
+| 2026-08-10 | REL-2 | Repository owner + Main Agent | RELEASED ALPHA | Tag `v0.23.0` at `3f880d5b`; production run `31332420554` | PyPI package, GitHub prerelease, production manifest/SBOM | Production wheel/sdist hashes and inventories match PyPI and GitHub assets; public PyPI verification passed 5,406 tests plus installed CLI workflows | Protected publish workflow green | Qualified review remains the final stable/engineering-use gate | Close release; do not activate v0.24 without owner decision |
 
 ### Required handoff content
 
@@ -1427,7 +1428,7 @@ The first implementation session begins only after the owner clears Phase 0.
 ### Current execution checkpoint
 
 P0-P12, FAPI-1, and remediation packets T0/R1-R8 are implemented. The latest
-source preflight passes 5,452 Python tests (3 skipped, 6 deselected), 349
+source preflight passes 5,454 Python tests (3 skipped, 6 deselected), 349
 FastAPI tests, 147 React tests, frontend lint/build, quick 9/9, full 29/29,
 audit 19/19, and health 100/100. A clean-source v0.23.0 wheel passed package
 version and CLI checks with excluded namespaces absent. Exact-wheel UAT passed
@@ -1442,10 +1443,12 @@ worktree is clean and both Node and Python runtime selectors are retained.
 C2 final product UAT found and repaired the missing local Vite `/stream` proxy;
 source-tree and live safe/unsafe outcomes now agree. C3 froze the exact local
 wheel/sdist at source commit `9be6eb35`, and C4 froze the final bounded evidence
-and limitations on draft PR #696. Do not begin new calculation, multi-code, or
-excluded structural-system work. The owner authorized the v0.23.0 Alpha release
-sequence on 2026-08-10. Exact CI publication-artifact evidence remains required;
-qualified review is deferred to the final stable/engineering-use gate.
+and limitations on PR #696. The owner-authorized v0.23.0 Alpha release was
+published from tag/source `v0.23.0`/`3f880d5b` by production run `31332420554`.
+The exact public package passed 5,406 tests plus installed CLI workflows. Do not
+begin new calculation, multi-code, or excluded structural-system work without a
+separate owner decision. Qualified review is deferred to the final stable/
+engineering-use gate.
 
 ## 21. Final program acceptance checklist
 
@@ -1471,12 +1474,12 @@ qualified review is deferred to the final stable/engineering-use gate.
 - [x] Canonical current-candidate release preflight is green.
 - [x] Local prepublication filenames, sizes, SHA-256 values and inventories are
       recorded against source commit `9be6eb35`.
-- [ ] CI publication-artifact filenames/SHA-256 values are separately recorded.
+- [x] CI publication-artifact filenames/SHA-256 values are separately recorded.
 - [x] Local rehearsal clean-install/CLI UAT is green on the exact wheel.
-- [ ] CI publication-artifact clean-install/CLI UAT is green.
+- [x] CI publication-artifact clean-install/CLI UAT is green.
 - [x] Owner approved the PR #696 merge, TestPyPI rehearsal, v0.23.0 tag, PyPI
       upload, and GitHub Release sequence on 2026-08-10.
-- [ ] Exact published PyPI version passes post-publication UAT.
+- [x] Exact published PyPI version passes post-publication UAT.
 - [ ] Qualified structural-engineering review is recorded before any stable or
       engineering-use approval; this is not an Alpha publication gate.
 - [x] Handoff and execution ledger identify remaining limitations and review

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,147 +4,85 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-10
-- Focus: execute the owner-authorized v0.23.0 Alpha release after completed C0-C4 closeout
+- Focus: v0.23.0 Alpha release complete; later roadmap work remains inactive
 <!-- HANDOFF:END -->
 
-**Current branch:** `codex/release-v0.23.0`
-**Frozen artifact source:** `9be6eb35`
+**Current release:** `v0.23.0` at `3f880d5b`
 **Plan:** [is456-library-first-master-plan.md](is456-library-first-master-plan.md)
 
 ## Required Reading
 
 - [IS 456 library-first master plan](is456-library-first-master-plan.md)
-- [Professional remediation evidence ledger](professional-library-remediation-plan.md)
+- [Release evidence crosswalk](../verification/is456-library-first-evidence.md)
 - [Current task board](../TASKS.md)
 
 | Release state | Version | Decision |
 |---|---|---|
-| **Current** | v0.23.0 | Alpha release authorized; exact CI artifact and publication pending |
-| **Next** | v0.24.0 | Future roadmap only; inactive pending separate owner activation |
+| **Current** | v0.23.0 | Alpha development preview released; exact public UAT green |
+| **Next** | v0.24.0 | Inactive until separately activated by the owner |
 
 ## Outcome
 
-T0 and R1-R8 are implemented; do not repeat them. The owner selected the
-bounded IS 456 product milestone, not the v0.24/v1.0 multi-code roadmap. C0
-plan reconciliation and C1 Git integration are complete. Product remediation
-is checkpointed at `2ff5a42a`, closeout truth at `fbd24350`, and automation
-commit `f812eb3f` is integrated at `d4eb9e9d` without history rewriting or
-lost work.
+C0-C4 and the owner-authorized v0.23.0 Alpha release are complete. PR #696
+merged the bounded product/evidence closeout at `71e74a7e`. PR #697 fixed the
+publish runner's interpreter contract and merged at `3f880d5b`.
 
-C0-C4 are complete on draft PR #696. C2 source/live product UAT repaired the
-missing Vite `/stream` proxy and proved one PASS/one FAIL with the unsafe beam
-left unchanged. C3 froze the exact local v0.23.0 wheel/sdist from source commit
-`9be6eb35` after fixing stale egg-info package leakage at the manifest boundary.
-C4 froze the bounded source, unit, benchmark, limitation, unsafe-case, claim and
-artifact evidence requested by the owner.
+The release is available on PyPI and as a GitHub prerelease. It remains a
+case-qualified development preview, not a whole-standard or professional-
+approval claim. Qualified structural-engineering review is cumulative and is
+required only before stable or engineering-use approval, not per development
+packet or Alpha release.
 
-The owner moved qualified structural-engineering review to the final
-stable/engineering-use gate on 2026-08-10. Development packets and Alpha
-publication no longer require separate qualified sign-off. Every candidate
-remains development software and cannot claim professional approval; its
-source, benchmark, units, unsafe cases and limitations accumulate for the final
-review.
+## Release identity
 
-## Implemented remediation
+- Tag/source: `v0.23.0` / `3f880d5bbc338baefc4aec8ed472cafe840a5c99`
+- TestPyPI run: `31332187566`, green before tag creation.
+- Production run: `31332420554`, green for build, UAT, PyPI, and GitHub Release.
+- Wheel: 478,903 bytes, 181 files, SHA-256
+  `cd56a5301160fc7d62154e9d6e567ba8bf9bb8608827c9454b63161276c5408a`.
+- Sdist: 395,422 bytes, 206 files, SHA-256
+  `fe03a86d6c518a5f293c874e825930bb79de984cb53bebaf63a7610c3f042a73`.
+- Manifest SHA-256:
+  `efadd1e6b0b1e8c3c7e242a057ea83a3bbef19059462a5ccd5ccde5ac2ba9ab5`.
+- CycloneDX 1.6 SBOM SHA-256:
+  `8c76f919df65e913d0d507d0ac824bb2c077fbb530a53732bc65bed68f482686`.
+- Both content allowlist and protected-content gates passed.
+- Exact public PyPI UAT: 5,406 passed, 51 skipped, 6 deselected; installed
+  `job`, `critical`, `report`, and CLI-help workflows passed.
 
-- Supported beam and footing entry points reject booleans, non-real values,
-  NaN, and infinities before arithmetic.
-- Batch completion is separate from engineering safety; unsafe shear is FAIL
-  across Python, SSE, React display/export, and apply-to-store behavior.
-- Reports normalize legacy `is_safe` to canonical `is_ok`; missing status is
-  NOT EVALUATED and unsafe sections override stale overall PASS.
-- Footing flexure requires total thickness for minimum steel, and dowel count
-  is a strict positive integer through Python and FastAPI.
-- Two-way slab output explicitly distinguishes bounded flexure computation,
-  coefficient provenance, qualified acceptance, and complete design approval.
-- A machine-readable semantic contract covers every supported capability,
-  unit, field, alias, status, limitation, and v0.24 report-alias removal.
-- `docs/reference/api-manifest.json` is the only Python API manifest. The stale
-  service manifest was safely removed and is recoverable from
-  `tmp/deleted_backups/api_manifest_20260809_222544.json`.
-- Both API validators share the raw OpenAPI baseline; request-validation 422s
-  use the maintained `{success,data,error}` envelope with field detail.
-- Release checks bind source/docs, wheel filename/METADATA/content, clean
-  installed version, and packaged CLI behavior. Published wording and
-  nonexistent tag-install examples were removed.
-- `MANIFEST.in` now prunes every non-product namespace so stale generated
-  egg-info cannot override the package allowlist.
-- The release-preflight skill distinguishes a future-version positional check
-  from an already-bumped current candidate verified with `--wheel`.
+## Bounded product evidence retained
 
-## Verification evidence
+- Supported beam, rectangular-column, concentric isolated-footing, one-way
+  slab, and bounded two-way slab paths are recorded in the evidence crosswalk.
+- Unsafe beam shear remains FAIL across Python, SSE, React, apply behavior,
+  and export output.
+- Public package contents exclude protected standards and non-product
+  research/migration/code-family namespaces.
+- Runtime, exact-artifact, status-truth, allowlist, protected-content, OIDC,
+  and post-publication verification gates remain mandatory.
 
-- Source candidate preflight: 5,452 passed, 3 skipped, 6 deselected.
-- FastAPI: 349 passed.
-- React: 147 passed; lint and production build passed on Node 24.
-- Quick gate: 9/9; full gate: 29/29.
-- Readiness audit: 19/19; health: 100/100; parity: 93%.
-- API manifest: 73/73 compatible functions.
-- OpenAPI: 62 endpoints, 65 schemas, no drift.
-- Exact local wheel: 478,970 bytes, 181 members, zero excluded namespaces,
-  clean import/CLI passed, SHA-256 `08377c11...2d8875`.
-- Exact local sdist: 398,319 bytes, 206 members, zero excluded namespaces,
-  SHA-256 `f3c6da86...4cbac3`.
-- Exact-wheel UAT: 5,404 passed, 51 skipped, 6 deselected plus job, critical
-  and report CLI workflows. Candidate preflight: 5,452 passed, 3 skipped,
-  6 deselected, clean install and React build green, zero preflight warnings.
-- Local CycloneDX 1.6 SBOM: 196 components, 239,585 bytes, SHA-256
-  `810b1be2...9f0eb7`; CI must regenerate its own release evidence.
-- C2 focused matrix: pure-library/service cases green; 58 FastAPI cases green;
-  16 focused React cases green; Node 24 production build green.
-- C2 live evidence: safe/unsafe SSE `PASS`/`FAIL`, 1 passed/1 failed in React,
-  unsafe beam not applied, standard live 422 envelope, and successful live
-  column, footing and one-way-slab responses.
-- C2 export bytes: BBS 959 bytes (`c34cb245...f8067`), DXF 48,522 bytes
-  (`037a879e...0134`), and unsafe HTML report 8,725 bytes
-  (`1524c1ab...7f8a`).
+## Next action
 
-The exact local artifacts remain ignored under `Python/dist/` for owner review.
-They are prepublication evidence, not the CI publication identity.
-
-## Next actions
-
-1. Merge PR #696 after its current-commit PR Gate passes.
-2. Run the protected CI/TestPyPI rehearsal and capture the exact CI-built wheel,
-   sdist, inventories, hashes, SBOM and clean-install UAT.
-3. If that evidence is green, create v0.23.0 and let the tag-only workflow
-   publish to PyPI and GitHub Releases; then run exact-version PyPI UAT.
-4. Retain accumulated engineering evidence for qualified review before any
-   stable or engineering-use approval.
+No new product lane is active. The owner must separately choose the next
+milestone. Retain the accumulated source, benchmark, unit, unsafe-case,
+limitation, and artifact evidence for one final qualified review before any
+stable or engineering-use approval.
 
 ## Terminal issues recorded
 
-- A contract test initially depended on `PYTHONPATH=Python:.`; it is now
-  repository-root stable under `./run.sh test`.
-- `tool_registry.py --validate` is not a supported flag; the maintained
-  `check_scripts_index.py`, script-reference gate, and full check were used.
-- An unmatched zsh release-doc glob failed before execution; explicit paths
-  and `git diff --name-only | rg` worked.
-- zsh reserves `status`; the deliberate release-failure proof used `rc`.
-- Assigning to zsh-reserved `path` removed command lookup during Git
-  classification; rerunning with `file_path` restored normal execution.
-- The automation finder had no exact C2 mapping; the maintained UAT,
-  release-preflight and quality-gate skills plus exact test paths were used.
-- An unmatched `scripts/dev.*` zsh glob failed before inspection; `rg --files
-  scripts | rg 'dev|server'` found the maintained launcher safely.
-- A first hidden-input file chooser timed out; the visible labelled CSV drop
-  zone opened the documented chooser and imported the fixture successfully.
-- `rg` was given the nonexistent `react_app/src/pages` path; the live route
-  files under `react_app/src/components/pages` were used instead.
-- The first C2 commit attempt crossed the local date boundary and the session
-  hook correctly rejected the missing 2026-08-10 durable entry; the session
-  log and generated indexes were refreshed before retrying.
-- The positional `release preflight 0.23.0` form rejected the already-bumped
-  equal version; the corrected current-candidate form supplied the exact wheel
-  and passed with no warnings.
-- A fresh `Python/build`/`Python/dist` cleanup did not remove stale ignored egg-
-  info, which reintroduced excluded namespaces; generated metadata was moved to
-  Trash, explicit manifest prunes were added, and the final build passed.
-- The first archive inventory snippet used an illegal backslash inside an
-  f-string expression; an intermediate boolean produced the intended read-only
-  evidence on the retry.
-- The archived `check_doc_metadata.py` entrypoint no longer exists and a custom
-  front-matter status was outside the validated enum; `check_docs.py --metadata`
-  and `--frontmatter` were used, with machine status kept `active` while the
-  visible plan status records bounded closeout complete.
-- ⚠️ TERMINAL ISSUE: unsupported link/candidate commands and broad index rewrites → maintained full-link/preflight commands passed and only generated cache diffs were reversed.
+- `check_links.py --modified` is unsupported; the maintained full link check
+  passed with zero broken links.
+- Index generation rewrote unrelated generated caches; only those cache diffs
+  were surgically reversed.
+- A referenced `check_release_candidate.py` entrypoint does not exist; the
+  maintained `./run.sh release candidate-check` command passed.
+- One cleanup assumed `Python/build` existed; the missing directory produced a
+  harmless diagnostic and the fresh build completed. Future cleanup must test
+  each explicit generated path before moving it.
+- The first TestPyPI run failed before upload because tests hard-coded the
+  repository `.venv`; PR #697 uses the active interpreter and the rerun passed.
+- One artifact download retry found the file already present after the first
+  request completed; explicit hash and manifest inspection succeeded.
+- The first evidence commits used descriptive release-row labels; the session
+  contract requires literal `Current` and `Next`, which were restored before
+  retrying.

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -11,11 +11,11 @@
 
 Installed metadata version: 0.23.0
 
-- **Branch:** `codex/release-v0.23.0`
+- **Release source:** tag `v0.23.0` at `3f880d5bbc338baefc4aec8ed472cafe840a5c99`
 - **Implementation PR:** #693 merged at `cc99e610`
-- **Closeout PR:** draft #696; C3 artifact source commit `9be6eb35`
-- **Release target:** v0.23.0 Alpha; publication sequence authorized by the owner on 2026-08-10
-- **Publication state:** C0-C4 bounded software/evidence scope frozen; exact CI artifact evidence and post-PyPI UAT pending
+- **Closeout PR:** #696 merged at `71e74a7e`; CI portability fix #697 merged at `3f880d5b`
+- **Release target:** v0.23.0 Alpha, published 2026-08-10 local time
+- **Publication state:** PyPI and GitHub prerelease published; exact public-version UAT green
 - **Review policy:** qualified structural-engineering review is required before stable/engineering-use approval, not before this Alpha release
 
 ## Beta Readiness Checklist
@@ -40,10 +40,19 @@ Installed metadata version: 0.23.0
 - [x] Wheel/sdist allowlist and exact-artifact UAT encoded in publish CI
 - [x] Exact local wheel/sdist hashes, inventories, protected-content result and SBOM recorded
 - [x] Exact local wheel clean-install tests and CLI UAT pass
-- [ ] CI-built artifact manifest, hashes, inventories and SBOM reviewed
-- [ ] Exact CI-built wheel UAT evidence reviewed
+- [x] CI-built artifact manifest, hashes, inventories and SBOM reviewed
+- [x] Exact CI-built wheel UAT evidence reviewed
 - [x] Owner authorizes the TestPyPI rehearsal
 - [x] Owner authorizes the v0.23.0 tag, production PyPI publication, and GitHub Release after exact CI evidence passes
+
+### v0.23.0 Publication Evidence
+
+- Production run: `31332420554`, source/tag `3f880d5b` / `v0.23.0`
+- Wheel: 478,903 bytes, 181 files, SHA-256 `cd56a5301160fc7d62154e9d6e567ba8bf9bb8608827c9454b63161276c5408a`
+- Sdist: 395,422 bytes, 206 files, SHA-256 `fe03a86d6c518a5f293c874e825930bb79de984cb53bebaf63a7610c3f042a73`
+- Manifest SHA-256: `efadd1e6b0b1e8c3c7e242a057ea83a3bbef19059462a5ccd5ccde5ac2ba9ab5`
+- CycloneDX 1.6 SBOM SHA-256: `8c76f919df65e913d0d507d0ac824bb2c077fbb530a53732bc65bed68f482686`
+- Exact public PyPI verification: 5,406 passed, 51 skipped, 6 deselected; installed `job`, `critical`, `report`, and help workflows green
 
 ### Required Before 1.0
 

--- a/docs/planning/professional-library-remediation-plan.md
+++ b/docs/planning/professional-library-remediation-plan.md
@@ -547,3 +547,15 @@ does not block the v0.23.0 Alpha release. The local hashes are not CI
 publication identities, so exact CI artifact generation and UAT still precede
 tagged production publication. The owner authorized that conditioned release
 sequence on 2026-08-10.
+
+## 11. Alpha release checkpoint — 2026-08-10
+
+PR #696 and the CI portability fix in PR #697 passed their required gates and
+were merged. The exact TestPyPI rehearsal passed before tag creation. Tag
+`v0.23.0` points to `3f880d5b`; protected production run `31332420554`
+published the Alpha package and GitHub prerelease, and exact public PyPI UAT
+passed 5,406 tests plus installed CLI workflows.
+
+This closes the v0.23.0 software/release lane. It does not close the cumulative
+qualified structural-engineering review required before stable or engineering-
+use approval, and it does not activate v0.24 or another feature lane.

--- a/docs/verification/is456-library-first-evidence.md
+++ b/docs/verification/is456-library-first-evidence.md
@@ -7,7 +7,7 @@
 **Created:** 2026-08-09
 **Last Updated:** 2026-08-10
 **Date:** 2026-08-10
-**State:** C0-C4 bounded software/evidence scope frozen; v0.23.0 Alpha release authorized; exact CI publication evidence pending; qualified review deferred to final stable/engineering-use approval
+**State:** C0-C4 complete; v0.23.0 Alpha published with exact CI/public-package evidence; qualified review deferred to final stable/engineering-use approval
 
 ## Controlled sources
 
@@ -70,7 +70,30 @@ validated rather than inferred from HTTP success:
 
 These are source-tree/live-development artifacts, not C3 release identities.
 
-## Release evidence required from CI
+## Production release evidence
+
+The owner-authorized v0.23.0 Alpha release was built from tag `v0.23.0` at
+source commit `3f880d5bbc338baefc4aec8ed472cafe840a5c99` by protected production
+run `31332420554`. The publish workflow, exact-wheel UAT, PyPI upload, and
+GitHub prerelease creation all passed.
+
+| Artifact | Size | SHA-256 | Inventory |
+|---|---:|---|---:|
+| `structural_lib_is456-0.23.0-py3-none-any.whl` | 478,903 | `cd56a5301160fc7d62154e9d6e567ba8bf9bb8608827c9454b63161276c5408a` | 181 files |
+| `structural_lib_is456-0.23.0.tar.gz` | 395,422 | `fe03a86d6c518a5f293c874e825930bb79de984cb53bebaf63a7610c3f042a73` | 206 files |
+
+Both content allowlist and protected-content gates passed. The exact manifest
+SHA-256 is `efadd1e6b0b1e8c3c7e242a057ea83a3bbef19059462a5ccd5ccde5ac2ba9ab5`;
+the CycloneDX 1.6 SBOM SHA-256 is
+`8c76f919df65e913d0d507d0ac824bb2c077fbb530a53732bc65bed68f482686`.
+PyPI and GitHub Release assets match these filenames, byte sizes, and hashes.
+
+The exact public PyPI version passed 5,406 tests with 51 optional-dependency
+skips and 6 deselections, followed by installed `job`, `critical`, `report`,
+and CLI-help workflows. This proves the published artifact identity and
+software behavior; it is not professional design approval.
+
+## Release evidence contract
 
 The production decision must use the exact CI-built artifacts, not a local
 candidate. The `release-evidence` artifact must contain:
@@ -83,8 +106,8 @@ candidate. The `release-evidence` artifact must contain:
 - installed-site-packages UAT for beam, column, footing, slab, capability
   discovery and CLI help.
 
-TestPyPI, the final version, tag, GitHub release and production PyPI upload are
-owner-only actions.
+TestPyPI, version/tag selection, GitHub release and production PyPI upload
+remain owner-only actions for future releases.
 
 ## Local prepublication rehearsal
 


### PR DESCRIPTION
## Outcome

- records the exact v0.23.0 production run, artifact hashes, inventories, SBOM, and public PyPI UAT
- marks the GitHub Release prerelease state from the package Development Status classifier
- closes the Alpha release handoff while retaining qualified review only as the final stable/engineering-use gate

## Verification

- `.venv/bin/pytest Python/tests/test_release_scripts.py -q --tb=short`
- `.venv/bin/ruff check Python/tests/test_release_scripts.py`
- `.venv/bin/black --check Python/tests/test_release_scripts.py`
- `.venv/bin/python scripts/check_links.py --exclude-archive`
- `./run.sh check --quick` (9/9)
- GitHub Release manually verified as prerelease

Production publication is already immutable and green; this PR records that evidence and repairs future release metadata behavior.