### PR TITLE
fix(ci): pin mypy before 2.x migration

### DIFF
--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
   "pytest-cov",
   "pytest-benchmark",
   "black",
-  "mypy",
+  "mypy>=1.19,<2",
   "pre-commit",
   "ruff==0.15.8",
   "bandit",

--- a/Python/tests/test_release_environment.py
+++ b/Python/tests/test_release_environment.py
@@ -6,6 +6,7 @@ import importlib
 import os
 import subprocess
 import sys
+import tomllib
 import zipfile
 from pathlib import Path
 
@@ -19,6 +20,22 @@ if str(REPO_ROOT) not in sys.path:
 
 release = importlib.import_module("scripts.release")
 node_runtime = importlib.import_module("scripts.node_runtime")
+
+
+def test_mypy_major_upgrade_requires_explicit_migration():
+    """Do not let CI silently cross the Mypy 2.x compatibility boundary."""
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "Python" / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    dev_requirements = pyproject["project"]["optional-dependencies"]["dev"]
+    root_requirements = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8")
+    locked_requirements = (REPO_ROOT / "requirements-lock.txt").read_text(
+        encoding="utf-8"
+    )
+
+    assert "mypy>=1.19,<2" in dev_requirements
+    assert "mypy>=1.19,<2" in root_requirements.splitlines()
+    assert any(line.startswith("mypy==1.") for line in locked_requirements.splitlines())
 
 
 def test_available_ram_uses_memory_pressure_percentage(

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -76,7 +76,7 @@ mkdocs-material==9.7.7
 mkdocs-material-extensions==1.3.1
 mkdocstrings==1.0.6
 mkdocstrings-python==2.0.5
-mypy==2.3.0
+mypy==1.20.2
 mypy_extensions==1.1.0
 narwhals==2.24.0
 nh3==0.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pytest-asyncio>=1.3,<2.0
 pytest-cov>=7.0
 pytest-benchmark>=5.0
 black>=26.0
-mypy>=1.19
+mypy>=1.19,<2
 pre-commit>=4.5
 ruff==0.15.8
 bandit>=1.9


### PR DESCRIPTION
## Root cause

Weekly Verification floated the unbounded Mypy dev dependency to 2.3.0. With the project intentionally targeting Python 3.11 types under a Python 3.12 runner, Mypy 2.3 parsed NumPy 2.4.6's Python 3.12-only stub syntax and stopped before the test lanes. Mypy 2.x also exposes additional adapter typing changes that need an intentional migration.

## Fix

- cap Mypy to the maintained 1.x line in both dependency surfaces
- align the reproducible lock to Mypy 1.20.2
- add a regression requiring an explicit migration before crossing the Mypy 2.x boundary

## Verification

- `Python/tests/test_release_environment.py`: 13 passed
- Black and Ruff: pass
- local Mypy: 179 source files, zero issues
- canonical quick gate: 10/10
- failure evidence: Weekly run 31333731714; Docker, clean-wheel/CLI, and locked dependency lanes passed; only the floated Mypy step failed