### PR TITLE
fix(ci): constrain numpy for Python 3.11 typing

### DIFF
--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
   "pytest-benchmark",
   "black",
   "mypy>=1.19,<2",
+  "numpy>=2.0,<2.5",
   "pre-commit",
   "ruff==0.15.8",
   "bandit",

--- a/Python/tests/test_release_environment.py
+++ b/Python/tests/test_release_environment.py
@@ -22,8 +22,8 @@ release = importlib.import_module("scripts.release")
 node_runtime = importlib.import_module("scripts.node_runtime")
 
 
-def test_mypy_major_upgrade_requires_explicit_migration():
-    """Do not let CI silently cross the Mypy 2.x compatibility boundary."""
+def test_type_check_toolchain_requires_explicit_migration():
+    """Do not let CI silently cross known Mypy/NumPy stub boundaries."""
     pyproject = tomllib.loads(
         (REPO_ROOT / "Python" / "pyproject.toml").read_text(encoding="utf-8")
     )
@@ -34,8 +34,11 @@ def test_mypy_major_upgrade_requires_explicit_migration():
     )
 
     assert "mypy>=1.19,<2" in dev_requirements
+    assert "numpy>=2.0,<2.5" in dev_requirements
     assert "mypy>=1.19,<2" in root_requirements.splitlines()
+    assert "numpy>=2.0,<2.5" in root_requirements.splitlines()
     assert any(line.startswith("mypy==1.") for line in locked_requirements.splitlines())
+    assert "numpy==2.4.6" in locked_requirements.splitlines()
 
 
 def test_available_ram_uses_memory_pressure_percentage(

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ stpyvista>=0.1.4
 # Data & Scientific (project-wide, not in pyproject.toml)
 # ===========================================
 pandas>=2.0
-numpy>=2.0
+numpy>=2.0,<2.5
 scipy>=1.14
 
 # ===========================================


### PR DESCRIPTION
## Root cause

Weekly Verification installs the Python 3.12 NumPy wheel while Mypy intentionally checks the library against its minimum Python 3.11 target. NumPy 2.5.2 introduced Python 3.12-only `type` syntax in that wheel's stubs, so Mypy stopped in third-party code before project tests.

## Fix

- constrain the dev and root scientific dependency surfaces to NumPy 2.4.x while Python 3.11 remains supported
- preserve the audited lock at NumPy 2.4.6
- extend the toolchain-boundary regression test

## Verification

- `Python/tests/test_release_environment.py`: 13 passed
- Black and Ruff: pass
- local Mypy: 179 source files, zero issues
- canonical quick gate: 10/10
- CI failure evidence: Weekly run 31334551557 installed NumPy 2.5.2; all other completed Weekly lanes remained green