### PR TITLE
docs(maintenance): close post-release session

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-10 — v0.23.0 Alpha released; public artifact UAT green
+**Updated:** 2026-08-10 — v0.23.0 Alpha released; post-release maintenance closed
 
 ---
 
@@ -126,29 +126,28 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| LIB-IS456-V1 | Finish the bounded [IS 456 product milestone](planning/is456-library-first-master-plan.md) without expanding to multi-code or excluded structural systems | Main Agent + owner | ✅ C0-C4 software/evidence closeout complete; release and engineering-use holds remain |
+| DEPS-MAINT-001 | Triage the nine remaining Dependabot PRs in bounded Python and React compatibility batches | Main Agent | ⏸ NEXT SESSION |
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-IS456-C1 | Create reviewable scoped checkpoints, preserve automation commit `f812eb3f`, and synchronize `origin/main` without history rewriting | Main Agent | 1 packet | P0 | ✅ DONE `d4eb9e9d` |
-| LIB-IS456-C2 | Run final source/live product UAT for supported Python, FastAPI, React batch/report, footing/slab, and export paths | Main Agent | 1 packet | P0 | ✅ DONE |
-| LIB-IS456-C3 | Freeze exact local wheel/sdist evidence and clean-install/CLI UAT for the frozen candidate | Main Agent | 1 packet | P0 | ✅ DONE `9be6eb35` |
-| LIB-IS456-C4 | Assemble the final bounded-scope evidence packet and freeze limitations/review boundaries | Main Agent + owner | 1 packet | P0 | ✅ DONE on PR #696 |
-| LIB-IS456-FINAL-REVIEW | Review only after C4 and owner scope freeze; no engineering-usability claim before it | qualified structural engineer | final gate | P0 | ⏸ READY FOR QUALIFIED REVIEW |
+| DEPS-MAINT-PY | Rebase and evaluate Python PRs #679 and #686-#688; keep lock/install surfaces consistent | Main Agent | 1 packet | P1 | ⏸ QUEUED |
+| DEPS-MAINT-REACT | Rebase and evaluate React group PR #680 against individual majors #681-#684; retain one coherent upgrade path | Main Agent | 1 packet | P1 | ⏸ QUEUED |
+| LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL STABLE GATE |
 
 ## Backlog
 
-The version roadmap and historical backlog remain below. Planned development
-may continue under LIB-PRO-001, but publication and every engineering-usability
-claim remain prohibited until the final frozen-scope review and separate owner
-release decision.
+The version roadmap and historical backlog remain below. The v0.23.0 Alpha is
+published. No new product milestone is active. Stable-release and
+engineering-use approval remain held for the cumulative qualified review.
 
 ## Recently Done
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| LIB-IS456-V1 | Completed C0-C4, bounded evidence, exact artifacts, public Alpha UAT, and v0.23.0 publication | Main Agent + owner | ✅ DONE |
+| MAINT-009 | Integrated automation and Actions updates, repaired Weekly Verification compatibility, and cleared obsolete GitHub/session state | Main Agent | ✅ DONE |
 | MAINT-001 | Preserve the inherited worktree, recover the Mac baseline, and close PR #676 required checks | Main Agent | ✅ DONE |
 | MAINT-006 | Add enforceable low-token defaults, context rules, analytics-calibrated model routing, and automation | Main Agent | ✅ DONE |
 | MAINT-007 | Re-audit and modernize onboarding, agent/tool discovery, usage telemetry, and PR browser behavior | Main Agent | ✅ DONE |

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-09
+last_updated: 2026-08-10
 doc_type: guide
 complexity: intermediate
 tags: []
@@ -17,7 +17,7 @@ tags: []
 **Status:** Approved
 **Importance:** Critical
 **Created:** 2026-03-25
-**Last Updated:** 2026-08-09
+**Last Updated:** 2026-08-10
 
 ---
 
@@ -339,3 +339,6 @@ tags: []
 | 2026-08-10 | LIB-IS456-REL-1 | Repaired the release validator state machine so exact-wheel, owner-authorized candidates carry truthful dated metadata while ordinary unpublished candidates still fail closed | — |
 | 2026-08-10 | LIB-IS456-REL-2 | Repaired the publish workflow's runner-local interpreter assumption, merged PRs #696/#697 through green gates, and completed exact TestPyPI rehearsal | 3f880d5b |
 | 2026-08-10 | LIB-IS456-REL-3 | Published v0.23.0 Alpha from tag `v0.23.0`, verified production hashes/SBOM/inventories against PyPI and GitHub assets, and passed exact public-package UAT | 3f880d5b |
+| 2026-08-10 | MAINT-009-A | Merged automation and Actions runtime updates through PRs #695 and #692; removed proven merged/stale branches and PR #548 | 0d01fa1f, fe9383fc |
+| 2026-08-10 | MAINT-009-B | Fixed Weekly Verification's Python 3.11 typing boundary through explicit Mypy and NumPy constraints; exact current-main run passed | 610b404b, 22bc8a45 |
+| 2026-08-10 | MAINT-009-C | Closed 129 obsolete nightly-failure issues, cleared generated repository artifacts, and prepared the dependency-maintenance handoff | — |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,85 +4,78 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-10
-- Focus: v0.23.0 Alpha release complete; later roadmap work remains inactive
+- Focus: post-v0.23.0 maintenance closed; dependency compatibility is next
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.0` at `3f880d5b`
-**Plan:** [is456-library-first-master-plan.md](is456-library-first-master-plan.md)
+**Maintenance baseline:** `22bc8a45`
+**Task board:** [TASKS.md](../TASKS.md)
 
 ## Required Reading
 
+- [Current task board](../TASKS.md)
 - [IS 456 library-first master plan](is456-library-first-master-plan.md)
 - [Release evidence crosswalk](../verification/is456-library-first-evidence.md)
-- [Current task board](../TASKS.md)
 
-| Release state | Version | Decision |
+| State | Target | Decision |
 |---|---|---|
-| **Current** | v0.23.0 | Alpha development preview released; exact public UAT green |
-| **Next** | v0.24.0 | Inactive until separately activated by the owner |
+| **Current** | v0.23.0 Alpha | Released; public artifact UAT and current-main Weekly Verification are green |
+| **Next** | DEPS-MAINT-001 | Triage the nine fresh dependency PRs; do not activate v0.24 product work |
 
-## Outcome
+## Closed outcome
 
-C0-C4 and the owner-authorized v0.23.0 Alpha release are complete. PR #696
-merged the bounded product/evidence closeout at `71e74a7e`. PR #697 fixed the
-publish runner's interpreter contract and merged at `3f880d5b`.
+- Merged automation recovery PR #695 and GitHub Actions runtime PR #692.
+- Repaired the real Weekly Verification typing failure through PR #699 and the
+  final NumPy `<2.5` compatibility constraint in PR #700.
+- Exact current-main Weekly Verification run `31334828353` passed wheel/CLI,
+  locked audits, Docker health, Python, FastAPI, repository drift, and React.
+- Closed stale PR #548 and all 129 historical `Nightly QA failed` issues after
+  the current-main workflow passed; GitHub now has zero open issues.
+- Removed verified merged release/automation branches, their linked worktree,
+  and the superseded orphan `task/TASK-DOCSYNC` branch. Remote non-Dependabot
+  branches are now only `main` and `gh-pages`.
+- Moved 22 generated release/build artifacts (5.6 MB) out of the repository to
+  recoverable staging at `/private/tmp/structural-lib-maint-20260810.sLuHRf`.
+- Project health, audit readiness, and efficiency baselines were 100/100,
+  19/19, and PASS before this handoff.
 
-The release is available on PyPI and as a GitHub prerelease. It remains a
-case-qualified development preview, not a whole-standard or professional-
-approval claim. Qualified structural-engineering review is cumulative and is
-required only before stable or engineering-use approval, not per development
-packet or Alpha release.
+## Retained release boundary
 
-## Release identity
-
-- Tag/source: `v0.23.0` / `3f880d5bbc338baefc4aec8ed472cafe840a5c99`
-- TestPyPI run: `31332187566`, green before tag creation.
-- Production run: `31332420554`, green for build, UAT, PyPI, and GitHub Release.
-- Wheel: 478,903 bytes, 181 files, SHA-256
-  `cd56a5301160fc7d62154e9d6e567ba8bf9bb8608827c9454b63161276c5408a`.
-- Sdist: 395,422 bytes, 206 files, SHA-256
-  `fe03a86d6c518a5f293c874e825930bb79de984cb53bebaf63a7610c3f042a73`.
-- Manifest SHA-256:
-  `efadd1e6b0b1e8c3c7e242a057ea83a3bbef19059462a5ccd5ccde5ac2ba9ab5`.
-- CycloneDX 1.6 SBOM SHA-256:
-  `8c76f919df65e913d0d507d0ac824bb2c077fbb530a53732bc65bed68f482686`.
-- Both content allowlist and protected-content gates passed.
-- Exact public PyPI UAT: 5,406 passed, 51 skipped, 6 deselected; installed
-  `job`, `critical`, `report`, and CLI-help workflows passed.
-
-## Bounded product evidence retained
-
-- Supported beam, rectangular-column, concentric isolated-footing, one-way
-  slab, and bounded two-way slab paths are recorded in the evidence crosswalk.
-- Unsafe beam shear remains FAIL across Python, SSE, React, apply behavior,
-  and export output.
-- Public package contents exclude protected standards and non-product
-  research/migration/code-family namespaces.
-- Runtime, exact-artifact, status-truth, allowlist, protected-content, OIDC,
-  and post-publication verification gates remain mandatory.
+The v0.23.0 Alpha remains a case-qualified development preview, not a
+whole-standard or professional-approval claim. Retain the accumulated source,
+benchmark, unit, unsafe-case, limitation, and exact-artifact evidence for one
+cumulative qualified structural-engineering review before any stable or
+engineering-use approval.
 
 ## Next action
 
-No new product lane is active. The owner must separately choose the next
-milestone. Retain the accumulated source, benchmark, unit, unsafe-case,
-limitation, and artifact evidence for one final qualified review before any
-stable or engineering-use approval.
+Run one dependency-maintenance parent task and keep ecosystems separate:
+
+1. Rebase and evaluate Python PRs #679 and #686-#688. Start with install/lock
+   consistency; do not merge #679 while Ruff pins disagree across surfaces.
+2. Evaluate React group PR #680 against individual major PRs #681-#684 and
+   retain one coherent upgrade route. #680 and #684 currently fail React CI.
+3. Use focused validation while iterating, then one quick gate and one full
+   final gate. Keep v0.24 and other product-roadmap work inactive.
+
+## GitHub state
+
+- Open issues: 0.
+- Open PRs: nine Dependabot PRs (#679-#684 and #686-#688).
+- Green but still compatibility-sensitive: #679, #681-#683, and #688.
+- Currently failing their relevant lane: #680, #684, #686, and #687.
 
 ## Terminal issues recorded
 
-- `check_links.py --modified` is unsupported; the maintained full link check
-  passed with zero broken links.
-- Index generation rewrote unrelated generated caches; only those cache diffs
-  were surgically reversed.
-- A referenced `check_release_candidate.py` entrypoint does not exist; the
-  maintained `./run.sh release candidate-check` command passed.
-- One cleanup assumed `Python/build` existed; the missing directory produced a
-  harmless diagnostic and the fresh build completed. Future cleanup must test
-  each explicit generated path before moving it.
-- The first TestPyPI run failed before upload because tests hard-coded the
-  repository `.venv`; PR #697 uses the active interpreter and the rerun passed.
-- One artifact download retry found the file already present after the first
-  request completed; explicit hash and manifest inspection succeeded.
-- The first evidence commits used descriptive release-row labels; the session
-  contract requires literal `Current` and `Next`, which were restored before
-  retrying.
+- Finder Trash staging was denied by macOS privacy controls and
+  `/usr/bin/realpath` is absent. `.venv/bin/python` path resolution plus an
+  explicit `/private/tmp` recoverable staging directory worked.
+- The first exact Weekly dispatch was cancelled when `main` changed during the
+  Actions update. The next run exposed Mypy/NumPy stub incompatibility.
+- PR #699 correctly constrained Mypy but did not constrain the unpinned NumPy
+  install surface. CI logs proved NumPy 2.5.2 was the remaining root cause; PR
+  #700 fixed that boundary, and the exact current-main rerun passed.
+- A zsh unmatched-glob lookup for `Python/requirements*.txt` was replaced by
+  an `rg --files` lookup.
+- Newly merged squash commits required an explicit fetch before local tree-ID
+  comparison. Branch cleanup was performed only after equal trees were proven.


### PR DESCRIPTION
## Summary
- close the v0.23.0 post-release maintenance session
- record the green current-main Weekly Verification and GitHub cleanup
- hand off the nine dependency PRs as the next bounded session

## Verification
- `./run.sh check --quick` (10/10)
- `./run.sh efficiency check`
- `scripts/check_links.py` (0 broken links)
- commit hooks, including session-doc consistency