### PR TITLE
fix(agents): use versioned session handoff

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -336,26 +336,12 @@ When preparing a Codex Git/GitHub closeout:
 
 ## Structured Handoff (Session End)
 
-When a durable cross-session handoff is required, write `logs/handoff_latest.md` with this format:
-
-```markdown
-## Last Agent: [agent name]
-## Timestamp: YYYY-MM-DD HH:MM
-
-## What Was Done
-- [specific completed items]
-
-## What's Next
-- [most important next action — be specific: file, function, change]
-
-## Blockers
-- [anything that prevented completion]
-
-## Files Changed
-- [list with one-line description]
-```
-
-This file is read by `agent_brief.sh --handoff` for the next agent's context.
+When durable cross-session state changed, update
+`docs/planning/next-session-brief.md`. Preserve its Latest Handoff block,
+Required Reading section, literal `Current` and `Next` rows, completed outcome,
+next action, and any terminal issues. Update `docs/TASKS.md` only when task state
+changed. `agent_brief.sh --handoff` reads the versioned next-session brief;
+runtime files under `logs/` are not handoff sources of truth.
 
 ## Rules
 

--- a/scripts/agent_brief.sh
+++ b/scripts/agent_brief.sh
@@ -118,12 +118,12 @@ _handoff_context() {
     last_commit=$(git -C "$REPO_ROOT" --no-pager log -1 --format="%s" 2>/dev/null)
     echo "Last commit: $last_commit"
 
-    # Check for handoff file
-    local handoff="$REPO_ROOT/logs/handoff_latest.md"
-    if [[ -f "$handoff" ]]; then
+    if [[ -f "$BRIEF" ]]; then
         echo ""
-        echo -e "${B}Handoff from previous agent:${N}"
-        head -10 "$handoff"
+        echo -e "${B}Current versioned handoff:${N}"
+        head -20 "$BRIEF"
+    else
+        echo "No versioned handoff found at docs/planning/next-session-brief.md"
     fi
 }
 


### PR DESCRIPTION
## Summary
- remove the stale ignored `logs/handoff_latest.md` handoff contract
- make the orchestrator and `agent_brief.sh --handoff` use the versioned next-session brief
- restore agent-health validation to 100/100

## Verification
- `bash -n scripts/agent_brief.sh`
- `./scripts/agent_brief.sh --handoff`
- `./run.sh health --category agents` (100/100)
- `./run.sh check --quick` (10/10)
- commit hooks