### PR TITLE
fix(health): resolve Python in linked worktrees

### DIFF
--- a/Python/tests/test_agent_governance_automation.py
+++ b/Python/tests/test_agent_governance_automation.py
@@ -31,6 +31,7 @@ cli_smoke = importlib.import_module("test_cli_smoke")
 evolve = importlib.import_module("evolve")
 external_cli = importlib.import_module("external_cli_test")
 find_automation = importlib.import_module("find_automation")
+project_health = importlib.import_module("project_health")
 tool_permissions = importlib.import_module("tool_permissions")
 tool_registry = importlib.import_module("tool_registry")
 
@@ -61,6 +62,7 @@ def test_control_paths_use_python_runtime_launcher():
 
     assert check_all.VENV_PYTHON == launcher
     assert cli_smoke.VENV == launcher
+    assert str(project_health.PYTHON_RUNTIME) == launcher
     assert 'VENV="$SCRIPTS/python_runtime.sh"' in run_sh
     assert all(".venv/bin/python" not in line for line in entry_lines)
 

--- a/scripts/project_health.py
+++ b/scripts/project_health.py
@@ -40,7 +40,7 @@ SKILLS_DIR = REPO_ROOT / ".github" / "skills"
 PROMPTS_DIR = REPO_ROOT / ".github" / "prompts"
 FEEDBACK_DIR = REPO_ROOT / "logs" / "feedback"
 EVOLUTION_DIR = REPO_ROOT / "logs" / "evolution"
-VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+PYTHON_RUNTIME = SCRIPTS_DIR / "python_runtime.sh"
 
 # Category weights for health score
 WEIGHTS = {
@@ -103,7 +103,7 @@ def _run_check_script(
     script_name: str, args: list[str] | None = None
 ) -> tuple[int, str]:
     """Run a check script and return (exit_code, output)."""
-    cmd = [str(VENV_PYTHON), str(SCRIPTS_DIR / script_name)]
+    cmd = [str(PYTHON_RUNTIME), str(SCRIPTS_DIR / script_name)]
     if args:
         cmd.extend(args)
     try:
@@ -539,15 +539,20 @@ def scan_infra(fix: bool = False) -> CategoryResult:
             )
         )
 
-    # Check 2: Python venv active and has key deps
+    # Check 2: Project Python runtime resolves and has key deps
     result.checks_run += 1
-    if VENV_PYTHON.exists():
+    if PYTHON_RUNTIME.exists():
         code, output = (
             subprocess.run(
-                [str(VENV_PYTHON), "-c", "import pydantic, pandas, numpy; print('ok')"],
+                [
+                    str(PYTHON_RUNTIME),
+                    "-c",
+                    "import pydantic, pandas, numpy; print('ok')",
+                ],
                 capture_output=True,
                 text=True,
                 timeout=15,
+                cwd=str(REPO_ROOT),
             ).returncode,
             "",
         )
@@ -566,7 +571,7 @@ def scan_infra(fix: bool = False) -> CategoryResult:
             Issue(
                 category="infra",
                 severity="error",
-                message="Python venv not found at .venv/",
+                message="Project Python runtime launcher not found",
             )
         )
 


### PR DESCRIPTION
## Summary
- route project-health subprocesses through the canonical worktree-aware Python launcher
- validate runtime dependencies through the same launcher
- assert the scanner remains on that control path

## Verification
- focused governance tests (40 passed)
- Black and Ruff
- `./run.sh health` from a linked worktree without a local `.venv` (100/100)
- `./run.sh check --quick` (10/10)
- commit hooks