### PR TITLE
fix(deps): guard Python 3.11 compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # The maintained runtime is Python 3.11. Revisit these ceilings only with a
+    # coordinated runtime/Pydantic upgrade and clean-environment evidence.
+    ignore:
+      - dependency-name: "numpy"
+        versions: [">=2.5"]
+      - dependency-name: "scipy"
+        versions: [">=1.18"]
+      - dependency-name: "pydantic-core"
+        versions: [">2.46.4"]
 
   # Keep the distributable Python package dependencies up to date.
   - package-ecosystem: "pip"
@@ -77,6 +86,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "numpy"
+        versions: [">=2.5"]
 
   # Keep the React application dependencies up to date.
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- prevent Dependabot from regenerating NumPy 2.5+ and SciPy 1.18+ proposals while the maintained runtime is Python 3.11
- keep pydantic-core aligned with the exact version required by pydantic 2.13.4
- apply the NumPy ceiling to both root and distributable-package pip update scopes

## Root cause
PR #711 repeated the already-rejected updates. Its FastAPI lane cannot install because NumPy 2.5.1 and SciPy 1.18 require Python 3.12+, while the project and CI intentionally run Python 3.11. Its pydantic-core 2.48.0 lock also conflicts with pydantic 2.13.4, which requires core 2.46.4.

## Validation
- parsed the YAML and asserted the ignore rules by ecosystem/directory
- ./run.sh check --quick: 10/10 passed
- ./run.sh check: 30/30 passed
- pre-commit: passed

The ceilings should be revisited only as part of a coordinated Python/Pydantic runtime upgrade.