### PR TITLE
feat(ui): establish Session 1 workbench foundations

### DIFF
--- a/Python/tests/unit/test_geometry_space_contract.py
+++ b/Python/tests/unit/test_geometry_space_contract.py
@@ -1,0 +1,72 @@
+"""GeometrySpaceV1 golden contract fixture checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+FIXTURE = Path(__file__).parents[3] / "tests" / "fixtures" / "geometry-space-v1.json"
+
+
+def _renderer(point: dict[str, float]) -> tuple[float, float, float]:
+    return (point["x"], point["z"], -point["y"])
+
+
+def _local_beam_renderer(point: dict[str, float]) -> tuple[float, float, float]:
+    return (point["x"] * 0.001, point["z"] * 0.001, point["y"] * 0.001)
+
+
+def test_geometry_space_v1_fixture_preserves_identity_and_global_source_metres() -> (
+    None
+):
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    transport = fixture["global"]
+
+    assert transport["schemaVersion"] == "GeometrySpaceV1"
+    assert transport["frame"] == "GlobalSourceSpaceV1"
+    assert transport["units"] == "m"
+    assert transport["axes"] == "x=east,y=north,z=up"
+    assert [member["memberId"] for member in transport["members"]] == [
+        member["sourceId"] for member in transport["members"]
+    ]
+    assert len({member["memberId"] for member in transport["members"]}) == len(
+        transport["members"]
+    )
+    assert all(member["inputHash"] for member in transport["members"])
+    assert all(member["projectRevision"] == 3 for member in transport["members"])
+    assert all(member["memberRevision"] == 7 for member in transport["members"])
+    assert transport["members"][0]["end"]["x"] == 6
+
+
+def test_geometry_space_v1_fixture_transform_bounds_and_detail_placement() -> None:
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    transport = fixture["global"]
+    points = [
+        point
+        for member in transport["members"]
+        for point in (member["start"], member["end"])
+    ]
+
+    bounds = {
+        "minX": min(point["x"] for point in points),
+        "maxX": max(point["x"] for point in points),
+        "minY": min(point["y"] for point in points),
+        "maxY": max(point["y"] for point in points),
+        "minZ": min(point["z"] for point in points),
+        "maxZ": max(point["z"] for point in points),
+    }
+    assert bounds == transport["bounds"]
+    assert _renderer(transport["members"][1]["end"]) == tuple(
+        transport["rendererCoordinates"]["ETABS-Frame-201"]["end"]
+    )
+
+    detail = fixture["detail"]
+    assert detail["frame"] == "LocalBeamSpaceV1"
+    assert detail["route"] == "/api/v1/geometry/beam/full"
+    assert detail["origin"] == "left-support,center-width,soffit"
+    assert _local_beam_renderer(detail["rebar"]["end"]) == pytest.approx(
+        (6.0, 0.056, -0.096)
+    )
+    assert detail["stirrup"]["positionX"] == 150

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-10 — UIX-001 Session 1 Wave 0 locked; Wave 1 foundations active
+**Updated:** 2026-08-10 — UIX-001 Session 1 Wave 1 foundation checkpoint in progress
 
 ---
 
@@ -126,7 +126,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| UIX-001 | Build one compact 3D-first structural workbench and a schema-driven no-code foundation | Main Agent | 🚧 [SESSION 1 WAVE 1 — P2/P3 FOUNDATIONS](planning/ui-experience-foundation-master-plan.md) |
+| UIX-001 | Build one compact 3D-first structural workbench and a schema-driven no-code foundation | Main Agent | 🚧 [SESSION 1 WAVE 1 — FOUNDATION CHECKPOINT](planning/ui-experience-foundation-master-plan.md) |
 
 ## Up Next
 
@@ -138,7 +138,7 @@
 
 The version roadmap and historical backlog remain below. The v0.23.0 Alpha is
 published. UIX-001 is owner-accepted; its Wave 0 evidence/route/state/3D lock is
-accepted and Session 1 Wave 1 foundations are active. Stable-release and
+accepted and Session 1 Wave 1 foundations are in progress. Stable-release and
 engineering-use approval remain held for the cumulative qualified review.
 
 ## Recently Done

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-10 — UIX-001 Session 1 Wave 1 foundation checkpoint in progress
+**Updated:** 2026-08-10 — UIX-001 P2/P3 accepted; P4 quick-design migration ready
 
 ---
 
@@ -10,7 +10,7 @@
 - **WIP = 2** (max 2 active tasks at once)
 - **Done = tests pass + docs updated + scanner passes**
 - **Archive rule:** Move completed items to [tasks-history.md](_archive/tasks-history.md) after 20+ items
-- **No new Streamlit work** — all new features go to React. Bug fixes only for Streamlit-only features.
+- **Streamlit is retired** — React is the only active UI. Do not restore its runtime, dependencies, hooks, or feature work; legacy files are reference-only until removal.
 
 ---
 
@@ -94,21 +94,21 @@
 | **v0.25** | ACI 318-19 Beam | 📋 PLANNED | ACI beam flexure + shear, PCA Notes ±0.1% benchmarks |
 | **v1.0** | Production Multi-Code | 📋 PLANNED | IS 456 complete, ACI 318 beam+column, EC2 beam, API stability guarantee |
 
-### Migration Status (React vs Streamlit)
+### React migration status
 
-| Feature | Streamlit | React | API Ready | Priority |
-|---------|-----------|-------|-----------|----------|
-| Single beam design | ✅ | ✅ | ✅ | Done |
-| CSV import (40+ cols) | ✅ | ✅ | ✅ | Done |
-| 3D visualization | ✅ | ✅ R3F | ✅ | Done |
-| Export (BBS/DXF/Report) | ✅ | ✅ | ✅ | Done |
-| Dashboard insights | ✅ | ✅ | ✅ | Done |
-| Rebar suggestions | ✅ | ✅ | ✅ | Done |
-| **Batch design UI** | ✅ | ✅ | ✅ streaming.py | Done |
-| **Compliance checker** | ✅ | ✅ DesignView panel | ✅ insights.py | Done |
-| **Cost optimizer** | ✅ | ✅ DesignView rebar | ✅ optimization.py | Done |
-| **AI Assistant** | ✅ | -- | Partial | ⏸ Deferred |
-| Learning center | ✅ | -- | -- | 🟢 Low |
+| Feature | React | API Ready | Priority |
+|---------|-------|-----------|----------|
+| Single beam design | ✅ | ✅ | Done |
+| CSV import (40+ cols) | ✅ | ✅ | Done |
+| 3D visualization | ✅ R3F | ✅ | Done |
+| Export (BBS/DXF/Report) | ✅ | ✅ | Done |
+| Dashboard insights | ✅ | ✅ | Done |
+| Rebar suggestions | ✅ | ✅ | Done |
+| **Batch design UI** | ✅ | ✅ streaming.py | Done |
+| **Compliance checker** | ✅ DesignView panel | ✅ insights.py | Done |
+| **Cost optimizer** | ✅ DesignView rebar | ✅ optimization.py | Done |
+| **AI Assistant** | -- | Partial | ⏸ Deferred |
+| Learning center | -- | -- | 🟢 Low |
 
 ### v0.21 Remaining Items (Library Expansion)
 
@@ -126,7 +126,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| UIX-001 | Build one compact 3D-first structural workbench and a schema-driven no-code foundation | Main Agent | 🚧 [SESSION 1 WAVE 1 — FOUNDATION CHECKPOINT](planning/ui-experience-foundation-master-plan.md) |
+| UIX-001 | Build one compact 3D-first structural workbench and a schema-driven no-code foundation | Main Agent | 🚧 [SESSION 1 P4 — QUICK-DESIGN MIGRATION](planning/ui-experience-foundation-master-plan.md) |
 
 ## Up Next
 
@@ -138,7 +138,7 @@
 
 The version roadmap and historical backlog remain below. The v0.23.0 Alpha is
 published. UIX-001 is owner-accepted; its Wave 0 evidence/route/state/3D lock is
-accepted and Session 1 Wave 1 foundations are in progress. Stable-release and
+accepted, P2/P3 foundations are accepted, and P4 is ready. Stable-release and
 engineering-use approval remain held for the cumulative qualified review.
 
 ## Recently Done

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-10 — UIX-001 accepted; Session 1 Wave 0 active
+**Updated:** 2026-08-10 — UIX-001 Session 1 Wave 0 locked; Wave 1 foundations active
 
 ---
 
@@ -126,7 +126,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| UIX-001 | Build one compact 3D-first structural workbench and a schema-driven no-code foundation | Main Agent | 🚧 [SESSION 1 WAVE 0 — READ-ONLY CONTRACT LOCK](planning/ui-experience-foundation-master-plan.md) |
+| UIX-001 | Build one compact 3D-first structural workbench and a schema-driven no-code foundation | Main Agent | 🚧 [SESSION 1 WAVE 1 — P2/P3 FOUNDATIONS](planning/ui-experience-foundation-master-plan.md) |
 
 ## Up Next
 
@@ -137,9 +137,9 @@
 ## Backlog
 
 The version roadmap and historical backlog remain below. The v0.23.0 Alpha is
-published. UIX-001 is owner-accepted and Session 1 Wave 0 is active; implementation
-edits remain gated until its read-only contract lock is accepted. Stable-release
-and engineering-use approval remain held for the cumulative qualified review.
+published. UIX-001 is owner-accepted; its Wave 0 evidence/route/state/3D lock is
+accepted and Session 1 Wave 1 foundations are active. Stable-release and
+engineering-use approval remain held for the cumulative qualified review.
 
 ## Recently Done
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -30,7 +30,7 @@
       "last_updated": "2026-08-10",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "58758573f161"
+      "content_hash": "5869b0078fe2"
     },
     {
       "name": "WORKLOG.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "5c22306c15184684"
+  "content_hash": "d5c304628b3b90b6"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -30,7 +30,7 @@
       "last_updated": "2026-08-10",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "63f106b85012"
+      "content_hash": "ea8fd8bba361"
     },
     {
       "name": "WORKLOG.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "cce5adbb7d2a20df"
+  "content_hash": "88ed11ce229c2909"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -30,7 +30,7 @@
       "last_updated": "2026-08-10",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "ea8fd8bba361"
+      "content_hash": "58758573f161"
     },
     {
       "name": "WORKLOG.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "88ed11ce229c2909"
+  "content_hash": "5c22306c15184684"
 }

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -31,8 +31,8 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
-| `next-session-brief.md` | 2026-08-10 | 📋 UIX-001 owner-review handoff |
-| `ui-experience-foundation-master-plan.md` | 2026-08-10 | 🚧 Owner accepted; Session 1 Wave 0 active; edits contract-gated |
+| `next-session-brief.md` | 2026-08-10 | 🚧 UIX-001 Session 1 Wave 1 handoff |
+| `ui-experience-foundation-master-plan.md` | 2026-08-10 | 🚧 Wave 0 lock accepted; Session 1 P2/P3 foundations active |
 | `compact-modernization-plan.md` | 2026-08-09 | 📋 Ready after PR #676 |
 | `is456-library-first-master-plan.md` | 2026-08-10 | ✅ C0-C4 and v0.23.0 Alpha release complete |
 | `professional-library-remediation-plan.md` | 2026-08-10 | ✅ Software remediation evidence ledger; final professional review deferred |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -12,7 +12,7 @@
       "last_updated": "2026-08-10",
       "title": "Planning",
       "description": "Internal planning documents and research notes. | Document | Purpose |",
-      "content_hash": "4c7a2cbce979"
+      "content_hash": "22d91bbd6af5"
     },
     {
       "name": "adoption-trust-surface-plan.md",
@@ -91,11 +91,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 89,
+      "size_lines": 96,
       "last_updated": "2026-08-10",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-10",
-      "content_hash": "60fd73c75e1a"
+      "content_hash": "533dd8bd30d2"
     },
     {
       "name": "pre-release-checklist.md",
@@ -126,12 +126,12 @@
     {
       "name": "ui-experience-foundation-master-plan.md",
       "type": "documentation",
-      "size_lines": 1961,
+      "size_lines": 2284,
       "last_updated": "2026-08-10",
       "description": "The product will move from a collection of equally weighted pages to one compact, professional structural workbench.",
-      "content_hash": "e6040a34c9dd"
+      "content_hash": "a2d3cf170555"
     }
   ],
   "subfolders": [],
-  "content_hash": "9045d2563f2081a9"
+  "content_hash": "4e1504d051cad2bd"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -91,11 +91,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 96,
+      "size_lines": 105,
       "last_updated": "2026-08-10",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-10",
-      "content_hash": "533dd8bd30d2"
+      "content_hash": "dbb90f1667b7"
     },
     {
       "name": "pre-release-checklist.md",
@@ -126,12 +126,12 @@
     {
       "name": "ui-experience-foundation-master-plan.md",
       "type": "documentation",
-      "size_lines": 2284,
+      "size_lines": 2312,
       "last_updated": "2026-08-10",
       "description": "The product will move from a collection of equally weighted pages to one compact, professional structural workbench.",
-      "content_hash": "a2d3cf170555"
+      "content_hash": "542b67d4a860"
     }
   ],
   "subfolders": [],
-  "content_hash": "4e1504d051cad2bd"
+  "content_hash": "3be64815d283d8b3"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -91,11 +91,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 105,
+      "size_lines": 107,
       "last_updated": "2026-08-10",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-10",
-      "content_hash": "dbb90f1667b7"
+      "content_hash": "4378f6d1abdc"
     },
     {
       "name": "pre-release-checklist.md",
@@ -126,12 +126,12 @@
     {
       "name": "ui-experience-foundation-master-plan.md",
       "type": "documentation",
-      "size_lines": 2312,
+      "size_lines": 2333,
       "last_updated": "2026-08-10",
       "description": "The product will move from a collection of equally weighted pages to one compact, professional structural workbench.",
-      "content_hash": "542b67d4a860"
+      "content_hash": "1fc1e3709971"
     }
   ],
   "subfolders": [],
-  "content_hash": "3be64815d283d8b3"
+  "content_hash": "bbcf6b0346b2c0c4"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -18,8 +18,8 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-10 | 89 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-10 | 96 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Installed metadata version: 0.23.0 - **Release source:** tag | 66 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |
-| [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 1961 |
+| [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2284 |

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -18,8 +18,8 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-10 | 105 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-10 | 107 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Installed metadata version: 0.23.0 - **Release source:** tag | 66 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |
-| [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2312 |
+| [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2333 |

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -18,8 +18,8 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-10 | 96 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-10 | 105 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Installed metadata version: 0.23.0 - **Release source:** tag | 66 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |
-| [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2284 |
+| [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2312 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,7 +4,7 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-10
-- Focus: UIX-001 Session 1 Wave 1 P2/P3 foundations active
+- Focus: UIX-001 Session 1 Wave 1 foundation checkpoint in progress
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.0` Alpha
@@ -16,8 +16,8 @@
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | UIX-001 Session 1 Wave 1 | Implement P2 shell/primitives and P3 revisioned workspace/persistence boundaries |
-| **Next** | UIX-001 P4 handoff | Start quick migration only after parent acceptance of P2/P3 contracts |
+| **Current** | UIX-001 Session 1 Wave 1 | Validate and integrate the P2/P3 foundation contracts and accepted 3D fixture |
+| **Next** | UIX-001 P4 handoff | Start quick migration only after P2/P3 live integration and parent acceptance |
 | **Held** | Stable/engineering use | Requires cumulative qualified structural-engineering review |
 
 ## Required Reading
@@ -45,21 +45,25 @@
   maintained runtime.
 - No GitHub Pages deployment or release action was performed.
 
-## Session 1 Wave 1
+## Session 1 Wave 1 checkpoint
 
-Wave 0 is accepted in master-plan section 22. It froze the route map, three-width
+Wave 0 is accepted in master-plan section 22. Wave 1 now has typed navigation,
+presentation-only workbench primitives, WorkspaceSnapshotV1 identity and
+IndexedDB boundaries, latest-request cancellation, AbortSignal-aware REST calls,
+and the two-frame GeometrySpaceV1 golden fixture. The Wave 0 checkpoint froze the
+route map, three-width
 wireframes, quantitative simplification targets, IndexedDB project persistence,
 revision-bound result/export lifecycle, one AbortSignal-aware React transport
 facade, GeometrySpaceV1, essential 3D layers, and the browser/scene baselines.
 
-1. **Parent:** own typed routes/navigation, WorkspaceSnapshotV1, result/request
-   identity, persistence/migrations, status/export truth, and shared integration.
-2. **Frontend flow:** implement only the approved visual tokens, repeated
-   primitives, and shell presentation against parent-owned contracts.
-3. **3D foundation:** implement GeometrySpaceV1 contract/golden fixture and return
-   the decomposition map; no P8 layers yet.
-4. **Checkpoint:** accept P2/P3, stale/out-of-order negatives, reload/recovery,
-   narrow-shell reachability, and the 3D fixture before the P4 follow-up.
+1. **Parent:** finish schema migration/recovery, autosave/conflict integration,
+   and truthful lifecycle/export selectors against the existing contracts.
+2. **Frontend flow:** integrate the shell and typed navigation without exposing a
+   second route hierarchy; prove critical actions remain reachable at 390 px.
+3. **3D foundation:** the two-frame fixture is implemented and focused tests pass;
+   P7 decomposition and P8 layers remain out of this checkpoint.
+4. **Checkpoint:** accept reload/recovery, narrow-shell reachability, and live
+   request/result settlement before the P4 follow-up.
 
 ## Open dependency holds
 
@@ -91,5 +95,10 @@ facade, GeometrySpaceV1, essential 3D layers, and the browser/scene baselines.
   separate worktrees and must never switch this checkout.
 - The optional agent-browser CLI was unavailable, so the maintained in-app
   Chromium browser was used for the live three-width baseline.
+- The in-app browser does not support `networkidle`; `domcontentloaded` plus an
+  explicit meaningful-element wait produced the repeatable live timings.
+- The first 3D source inspection used the obsolete `services/geometry_3d.py`
+  assumption; targeted file discovery found the maintained module at
+  `Python/structural_lib/visualization/geometry_3d.py`.
 - The archived `scripts/generate_folder_index.py` path was replaced by the
   maintained targeted `scripts/generate_enhanced_index.py` command.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,20 +4,20 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-10
-- Focus: UIX-001 Session 1 Wave 0 active; implementation remains contract-gated
+- Focus: UIX-001 Session 1 Wave 1 P2/P3 foundations active
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.0` Alpha
 
-**Branch:** `codex/ui-experience-foundation`
+**Branch:** codex/ui-workbench-session-1
 
-**Base:** `origin/main` at `fa0ee995`
+**Base:** origin/main at 32b9f33b
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | UIX-001 Session 1 Wave 0 | Run the parent baseline and two read-only audits, then freeze shared contracts |
-| **Next** | UIX-001 Session 1 Waves 1-2 | Begin implementation only after the Wave 0 contract lock passes |
+| **Current** | UIX-001 Session 1 Wave 1 | Implement P2 shell/primitives and P3 revisioned workspace/persistence boundaries |
+| **Next** | UIX-001 P4 handoff | Start quick migration only after parent acceptance of P2/P3 contracts |
 | **Held** | Stable/engineering use | Requires cumulative qualified structural-engineering review |
 
 ## Required Reading
@@ -45,20 +45,21 @@
   maintained runtime.
 - No GitHub Pages deployment or release action was performed.
 
-## Session 1 Wave 0
+## Session 1 Wave 1
 
-1. **Parent:** capture the live landing, sample, quick-design, import/project,
-   result, and export journeys; classify exposed/dormant features; confirm the
-   route/IA target; produce three-width wireframes and measurable baselines.
-2. **Application-truth audit:** reconcile React clients/hooks/stores with current
-   FastAPI/OpenAPI shapes; map revisions, latest-request-wins behavior, storage,
-   status truth, and export truth. Evidence only; no edits.
-3. **3D/browser audit:** freeze source/canonical/renderer axes, units, member IDs,
-   and schema versions; capture browser, bundle, scene, fallback, and performance
-   evidence. Evidence only; no edits.
-4. **Checkpoint:** freeze the route model, workspace/result revision contract,
-   API-client approach, storage decision inputs, authoritative 3D contract,
-   essential layer list, owned paths, and P0/P1 acceptance ledger before Wave 1.
+Wave 0 is accepted in master-plan section 22. It froze the route map, three-width
+wireframes, quantitative simplification targets, IndexedDB project persistence,
+revision-bound result/export lifecycle, one AbortSignal-aware React transport
+facade, GeometrySpaceV1, essential 3D layers, and the browser/scene baselines.
+
+1. **Parent:** own typed routes/navigation, WorkspaceSnapshotV1, result/request
+   identity, persistence/migrations, status/export truth, and shared integration.
+2. **Frontend flow:** implement only the approved visual tokens, repeated
+   primitives, and shell presentation against parent-owned contracts.
+3. **3D foundation:** implement GeometrySpaceV1 contract/golden fixture and return
+   the decomposition map; no P8 layers yet.
+4. **Checkpoint:** accept P2/P3, stale/out-of-order negatives, reload/recovery,
+   narrow-shell reachability, and the 3D fixture before the P4 follow-up.
 
 ## Open dependency holds
 
@@ -84,5 +85,11 @@
 - Updating the old UIX branch from current `main` produced documentation-only
   conflicts in `TASKS.md`, the planning indexes, and this briefing. Resolution
   retained the accepted UIX plan and current merged dependency/adoption evidence.
+- During Wave 0 another task merged the planning branch and switched the shared
+  root checkout. Work resumed only after PR #718 reached main and the dedicated
+  codex/ui-workbench-session-1 branch was created. Parallel tasks must use
+  separate worktrees and must never switch this checkout.
+- The optional agent-browser CLI was unavailable, so the maintained in-app
+  Chromium browser was used for the live three-width baseline.
 - The archived `scripts/generate_folder_index.py` path was replaced by the
   maintained targeted `scripts/generate_enhanced_index.py` command.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,7 +4,7 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-10
-- Focus: UIX-001 Session 1 Wave 1 foundation checkpoint in progress
+- Focus: UIX-001 Session 1 P2/P3 accepted; P4 quick-design migration ready
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.0` Alpha
@@ -16,8 +16,8 @@
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | UIX-001 Session 1 Wave 1 | Validate and integrate the P2/P3 foundation contracts and accepted 3D fixture |
-| **Next** | UIX-001 P4 handoff | Start quick migration only after P2/P3 live integration and parent acceptance |
+| **Current** | UIX-001 P4 | Migrate quick design onto the accepted workbench and latest-request-wins contracts |
+| **Next** | UIX-001 P5/P6 | Connect project intake, design, results, and export to durable revision truth |
 | **Held** | Stable/engineering use | Requires cumulative qualified structural-engineering review |
 
 ## Required Reading
@@ -47,23 +47,25 @@
 
 ## Session 1 Wave 1 checkpoint
 
-Wave 0 is accepted in master-plan section 22. Wave 1 now has typed navigation,
-presentation-only workbench primitives, WorkspaceSnapshotV1 identity and
-IndexedDB boundaries, latest-request cancellation, AbortSignal-aware REST calls,
-and the two-frame GeometrySpaceV1 golden fixture. The Wave 0 checkpoint froze the
-route map, three-width
-wireframes, quantitative simplification targets, IndexedDB project persistence,
-revision-bound result/export lifecycle, one AbortSignal-aware React transport
-facade, GeometrySpaceV1, essential 3D layers, and the browser/scene baselines.
+Wave 0 and the P2/P3 foundation checkpoint are accepted in master-plan section
+22. P2 provides the live two-destination shell, typed four-stage project
+navigation, restrained landing route, responsive reachability, and lazy heavy
+visualization delivery. P3 provides WorkspaceSnapshotV1, exact revision-bound
+evidence, fail-closed migration, atomic IndexedDB persistence and recovery,
+undo/revert invalidation, autosave, and multi-tab conflict detection. The
+AbortSignal-aware REST facade and two-frame GeometrySpaceV1 fixture are also in
+place.
 
-1. **Parent:** finish schema migration/recovery, autosave/conflict integration,
-   and truthful lifecycle/export selectors against the existing contracts.
-2. **Frontend flow:** integrate the shell and typed navigation without exposing a
-   second route hierarchy; prove critical actions remain reachable at 390 px.
-3. **3D foundation:** the two-frame fixture is implemented and focused tests pass;
-   P7 decomposition and P8 layers remain out of this checkpoint.
-4. **Checkpoint:** accept reload/recovery, narrow-shell reachability, and live
-   request/result settlement before the P4 follow-up.
+1. **P4:** connect quick design to the accepted latest-request coordinator and
+   workspace lifecycle; cancelled, delayed, and edit-stale responses must not
+   become current or exportable.
+2. **P5/P6:** remain out of the P4 packet. Imported-project resume and complete
+   project result/export parity are not yet accepted.
+3. **P7:** the frame fixture is ready; viewport decomposition remains separate.
+4. **Checkpoint evidence:** 197 React tests, lint, production build, and the
+   canonical quick gate pass. Chromium UAT passed at 1440, 1024, and 390 px and
+   proved real IndexedDB save/reload/delete plus BroadcastChannel conflict
+   notification without leaving synthetic data.
 
 ## Open dependency holds
 

--- a/docs/planning/ui-experience-foundation-master-plan.md
+++ b/docs/planning/ui-experience-foundation-master-plan.md
@@ -20,8 +20,7 @@ current_wave: 1
 
 **Type:** Master Plan
 **Audience:** Product owner, frontend, backend, API, structural-library, 3D, reviewer, and tester roles
-**Status:** Active — Session 1 Wave 0 accepted; Wave 1 foundation checkpoint is
-in progress, with live shell/persistence integration still pending
+**Status:** Active — Session 1 P0-P3 accepted; P4 quick-design migration ready
 **Importance:** Critical
 **Created:** 2026-08-10
 **Last Updated:** 2026-08-10
@@ -1882,16 +1881,16 @@ these tables only after the parent reviews evidence.
 
 | Macro session | Scope | State | Required exit |
 |---|---|---|---|
-| Session 1 | P0-P8 compact workbench and essential 3D | Wave 1 foundation checkpoint in progress | Session 1 exit gate in section 12.2 |
+| Session 1 | P0-P8 compact workbench and essential 3D | P2/P3 accepted; P4 ready | Session 1 exit gate in section 12.2 |
 | Session 2 | P9-P15 capability platform and cutover | Blocked on Session 1 | Session 2 exit gate in section 12.3 |
 
 | Session | Packet | State | Evidence/commit | Notes |
 |---|---|---|---|---|
 | 1 | P0 | Accepted | Section 22 | Live baseline, usefulness, browser, API/state, and 3D lock |
 | 1 | P1 | Accepted | Section 22 | Route map, targets, and three-width wireframes frozen |
-| 1 | P2 | In progress | Current branch | Typed navigation and presentation primitives implemented; live route/shell integration pending |
-| 1 | P3 | In progress | Current branch | Revision identity, store, persistence, sync, and request foundations implemented; live autosave/recovery integration pending |
-| 1 | P4 | Blocked on P2/P3 handoff | — | Quick-design migration |
+| 1 | P2 | Accepted | `d336803c` | Live shell and typed navigation; three-width reachability and lazy-delivery browser gates pass |
+| 1 | P3 | Accepted | `c270b6c1`, `0ccda406` | Durable revisioned state, recovery, autosave, and multi-tab conflict integration pass |
+| 1 | P4 | Ready | P2/P3 handoff | Quick-design migration is the next bounded packet |
 | 1 | P5 | Not started | — | Project intake/review |
 | 1 | P6 | Not started | — | Project design/results/export |
 | 1 | P7 | Ready | Current branch | Two-frame GeometrySpaceV1 fixture implemented; viewport decomposition not started |
@@ -2243,13 +2242,35 @@ Wave 1 starts with these confirmed blockers:
 9. `useGeometryAdvanced`, `useCSVTextImport`, serviceability UI fields, and SSE
    batch semantics are not live-contract ready.
 
-Wave 1 has implemented the P2/P3 contract foundations and the GeometrySpaceV1
-golden fixture. P4 remains blocked until live shell, autosave/recovery, request,
-status, and export integration proves those boundaries. P7 is ready for a later
-bounded decomposition packet; P8 remains blocked on P6 revision truth and P7.
-Wave 2 remains blocked on the P4 checkpoint and the later P5/P6 project-result
-handoff. No parallel worker owns App.tsx, shared contracts, stores, API client,
-public viewport contract, or this ledger without a fresh disjoint packet.
+### 22.10 Accepted P2/P3 foundation evidence
+
+The parent accepted P2 at `d336803c` and P3 at `c270b6c1` plus `0ccda406` after
+independent diff review and integration. The other active UI task first shared
+the root checkout; the parent stopped overlapping writes, assigned its P3 work to
+an isolated worktree/branch, reviewed its bounded commit, and then cherry-picked
+it. Future parallel UI work must retain disjoint worktrees and path ownership.
+
+- P2 exposes only Workbench and Projects globally, preserves the four typed
+  project stages, keeps critical actions reachable at 1440, 1024, and 390 px,
+  and removes eager Three/R3F, AG Grid, and Framer assets from the production
+  landing request path.
+- P3 persists WorkspaceSnapshotV1 atomically in IndexedDB, fails closed on an
+  unknown schema, recovers the last known good revision, invalidates evidence on
+  edits and undo/revert, autosaves dirty revisions, and blocks a higher external
+  revision through BroadcastChannel conflict state.
+- Focused and full React verification passed 197 tests plus lint and production
+  build; `./run.sh check --quick` passed all 10 checks.
+- Live Chromium UAT used real IndexedDB and BroadcastChannel behavior to prove
+  save, reload/load, conflict notification, and deletion. The synthetic proof
+  project was removed after validation.
+
+P4 is now ready against these accepted contracts. P5/P6 remain unstarted: the
+existing imported-project adapter has not yet proved full project resume or
+revision-matched project results/exports. P7 is ready for a separate bounded
+decomposition packet; P8 remains blocked on P6 revision truth and P7. Wave 2
+remains blocked on the P4 checkpoint and the later P5/P6 project-result handoff.
+No parallel worker owns App.tsx, shared contracts, stores, API client, public
+viewport contract, or this ledger without a fresh disjoint packet.
 
 ## 23. Immediate kickoff checklist
 

--- a/docs/planning/ui-experience-foundation-master-plan.md
+++ b/docs/planning/ui-experience-foundation-master-plan.md
@@ -20,8 +20,8 @@ current_wave: 1
 
 **Type:** Master Plan
 **Audience:** Product owner, frontend, backend, API, structural-library, 3D, reviewer, and tester roles
-**Status:** Active — owner accepted; Session 1 Wave 0 contract lock accepted;
-Wave 1 foundations are active
+**Status:** Active — Session 1 Wave 0 accepted; Wave 1 foundation checkpoint is
+in progress, with live shell/persistence integration still pending
 **Importance:** Critical
 **Created:** 2026-08-10
 **Last Updated:** 2026-08-10
@@ -1882,20 +1882,20 @@ these tables only after the parent reviews evidence.
 
 | Macro session | Scope | State | Required exit |
 |---|---|---|---|
-| Session 1 | P0-P8 compact workbench and essential 3D | Wave 1 active after Wave 0 lock | Session 1 exit gate in section 12.2 |
+| Session 1 | P0-P8 compact workbench and essential 3D | Wave 1 foundation checkpoint in progress | Session 1 exit gate in section 12.2 |
 | Session 2 | P9-P15 capability platform and cutover | Blocked on Session 1 | Session 2 exit gate in section 12.3 |
 
 | Session | Packet | State | Evidence/commit | Notes |
 |---|---|---|---|---|
 | 1 | P0 | Accepted | Section 22 | Live baseline, usefulness, browser, API/state, and 3D lock |
 | 1 | P1 | Accepted | Section 22 | Route map, targets, and three-width wireframes frozen |
-| 1 | P2 | Active | — | Visual foundation and shell |
-| 1 | P3 | Active | — | Workspace state/persistence |
+| 1 | P2 | In progress | Current branch | Typed navigation and presentation primitives implemented; live route/shell integration pending |
+| 1 | P3 | In progress | Current branch | Revision identity, store, persistence, sync, and request foundations implemented; live autosave/recovery integration pending |
 | 1 | P4 | Blocked on P2/P3 handoff | — | Quick-design migration |
 | 1 | P5 | Not started | — | Project intake/review |
 | 1 | P6 | Not started | — | Project design/results/export |
-| 1 | P7 | Not started | — | Viewport decomposition |
-| 1 | P8 | Not started | — | Essential 3D expansion/performance |
+| 1 | P7 | Ready | Current branch | Two-frame GeometrySpaceV1 fixture implemented; viewport decomposition not started |
+| 1 | P8 | Blocked on P6/P7 | — | Essential 3D layers require revision-matched result truth |
 | 2 | P9 | Not started | — | Workflow catalogue |
 | 2 | P10 | Not started | — | Catalogue API |
 | 2 | P11 | Not started | — | React schema vertical slice |
@@ -1917,38 +1917,44 @@ are already fixed.
 |---|---|
 | Session 1 base | origin/main and the current branch started at 32b9f33b after PR #718 |
 | Runtime | Python 3.11; Node 24.19.0; npm 11.17.0; Vite 7.3.6 |
-| Primary live browser | In-app Chromium 151 on macOS, DPR 1, reduced motion off |
-| P0 viewports | 1440 x 1000, 1024 x 768, and 390 x 844 |
-| API route/method audit | 23 React call sites across 9 files matched 63 OpenAPI paths; this does not prove response shapes |
-| Focused application checks | 17 Terra-routing/policy tests passed; existing API route/method check passed |
-| Focused 3D checks | Python building/detail geometry suites passed; useBeamGeometry had 4 passing React tests |
-| Production build | 2,778 modules transformed in 3.56 seconds; build passed |
-| Maintained sample | 153 members across 6 stories; sample API payload was 36,634 bytes before results and saved-state metadata |
+| Primary live browser | Codex in-app Chromium 151 on macOS, DPR 1; no error/warning entries, with two informational WebGL context-loss notices during repeated route changes |
+| P0 viewports | 1440 x 900, 1024 x 768, and 390 x 844 |
+| API/client audit | Complete-shape inspection of exposed and dormant React clients/hooks against FastAPI models and OpenAPI; route/method coincidence was not treated as shape proof |
+| Focused application evidence | Read-only source audit plus live quick, sample, editor, member-selection, empty-deep-link, and recovery journeys |
+| Focused 3D checks | 12 Python geometry/sample tests and 4 useBeamGeometry React tests passed |
+| Production build | 2,778 modules transformed in 5.14 seconds; TypeScript and Vite build passed |
+| Maintained sample | 153 members across 6 stories; API payload 36,634 bytes; proposed minimal WorkspaceSnapshotV1 payload 36,319 bytes before results/history |
+| Batch transport/control | Direct 153-member batch returned HTTP 200, 153/153 PASS, and 27,285 bytes in 10.6 ms; the live editor still displayed Designing after more than 34 seconds |
 
 Production gzip baselines from the P0 build are:
 
-- application index JavaScript 36.31 kB and shared CSS 12.77 kB;
+- application index JavaScript 36.30 kB and shared CSS 13.12 kB;
 - DesignView 11.52 kB;
 - BuildingEditorPage JavaScript 9.44 kB and route CSS 32.16 kB;
 - Three.js 185.67 kB and React Three Fiber/Drei 136.86 kB;
 - AG Grid 224.11 kB.
 
-The large Three.js and AG Grid chunks remain lazy route dependencies. P2 must not
-pull them into the landing shell. P7/P8 compare the final route delivery against
-this baseline; no percentage improvement is claimed before profiling.
+The production landing route currently loads the application index, HomePage,
+Framer Motion, React Three Fiber/Drei, and Three.js: about 1,394.8 kB raw and
+404.2 kB gzip of JavaScript, plus the shared CSS. AG Grid remains route-lazy, but
+the decorative landing canvas makes the 3D runtime eager. P2 must remove that
+landing cost or defer it behind an intentional workbench action. P7/P8 compare
+final route delivery against this baseline; no percentage improvement is claimed
+before profiling.
 
 ### 22.2 Live task-flow and simplicity baseline
 
 | Surface | Current live evidence | Main-process decision |
 |---|---|---|
-| Landing to quick result | Start Designing reached an already calculated PASS result in one intentional action | Preserve a one- or two-action quick path, but bind the result to current inputs |
+| Landing to quick result | Start Designing reached a visible PASS in one intentional action and 3.052 seconds in the warm local journey | Preserve a one- or two-action quick path, but bind the result to current inputs |
 | Quick design desktop | 16 buttons, 11 form controls, 7 links, one Canvas, inputs/result/3D/alternatives/export simultaneously visible | Recompose into Input, Review, and Export states with one emphasized action per state |
-| Quick design at 1024 | No document overflow was reported, but the beam was visibly clipped and lower results competed with a fixed dock | Use collapsible input rail and contextual result tray |
 | Quick design at 390 | The document reported no horizontal scroll while the right workspace was visibly outside the viewport; the fixed shell prevented recovery | Narrow review is a blocking P2/P4 requirement; dense editing may remain desktop-first |
 | Import entry | 14 buttons, 4 controls, 7 links, and three overlapping progress/navigation presentations | Keep single/dual/sample intake, but show one stage model and one next action |
-| Sample to editor | Sample Building then Open Building Editor loaded 153 members in two actions from import | Preserve; landing to sample review target is at most three intentional actions |
+| Sample to editor | `/import?sample=true` reached the 153-member preview in 406 ms; Open Building Editor produced a visible Canvas in 1.766 seconds | Preserve; landing to sample review target is at most three intentional actions |
 | Project editor | 15 buttons, 16 controls, 7 links, one Canvas, 153-row grid, materials, export, stage bar, toolbar, and dock in one fixed viewport | Make 3D/grid/inspector contextual regions inside one workbench |
-| Sample batch completion | On a stable rerun the batch endpoint returned HTTP 200, while after 8 seconds the header and all visible rows still said Designing | Confirm root cause in P3/P6; do not accept project result or export parity before it visibly settles |
+| Project editor at 1024 | Canvas, grid, and actions remained present with no document overflow, but the grid exposed only a clipped subset of columns | Keep review usable; dense editing remains desktop-first |
+| Project editor at 390 | No document overflow was reported, but the toolbar and critical actions were clipped by an overflow-hidden fixed workspace | P2 must keep save/recovery/status/next action reachable; do not promise dense grid editing |
+| Sample batch completion | The batch API settled 153/153 PASS in 10.6 ms, while the live header and visible rows remained Designing for more than 34 seconds | Treat as a frontend state-settlement blocker in P3/P6; project result and export parity are unaccepted |
 | Reload/resume | Reloading the populated editor retained the URL but produced No beams loaded; only a small Hub summary is persisted | Full project resume is absent and P3-blocking |
 | Empty deep links | editor, batch, dashboard, and design/results remain on their URLs and provide a recovery CTA | Retain recoverability, then replace with typed stage guards and canonical redirects |
 | Current navigation | TopBar and floating dock each expose the same five destinations; project pages add another four-step bar and import adds a second three-step signal | One typed global group plus one contextual project stage group |
@@ -1983,6 +1989,7 @@ The quantitative simplification targets are:
 | Beam detail page | Compatibility/deep-link candidate | Keep behind a shareable current-result identity or redirect |
 | useAutoDesign duplicate hook | Internal/dormant | Do not expose; consolidate behind the P4 request coordinator |
 | SSE useBatchDesign | Dormant/hold | Cannot truthfully represent HOLD, stale, unsupported, or not evaluated |
+| useCSVTextImport | Dormant/hold | Sends a JSON body while the endpoint declares query input; reconcile or retire before exposure |
 | Serviceability request/response fields | Dormant/hold | React contract is incomplete; no Session 1 UI exposure |
 | useGeometryAdvanced | Dormant/hold | Request and response shapes do not match the current API |
 | geometry/beam/3d | Legacy/hold | Do not use for the workbench; detailed beam uses geometry/beam/full |
@@ -2164,22 +2171,34 @@ not retained.
 
 ### 22.8 Frozen 3D contract and essential layers
 
-GeometrySpaceV1 has one renderer-bound unit and axis contract:
+GeometrySpaceV1 freezes two explicit coordinate frames rather than pretending
+the current building and local-detail paths share one universal transform:
 
-- canonical source points remain metres as x plan/east, y plan/north, z elevation/up;
-- transport points are millimetres and declare schemaVersion, units, axes,
-  memberId, sourceId, label, story, frameType, section, and relevant revisions;
-- the renderer boundary applies R(mm) = (0.001 x, 0.001 z, -0.001 y) exactly once;
-- local detail origin is left support, center width, and soffit;
-- geometry/beam/full is the sole detailed beam contract for P7;
-- building transport must preserve label/section and fail closed rather than
+- `GlobalSourceSpaceV1` uses metres with x = plan east, y = plan north, and
+  z = elevation/up. Its only renderer boundary is
+  `G(x, y, z) = (x, z, -y)` in Three.js world metres.
+- `LocalBeamSpaceV1` uses millimetres with x = left support to right support,
+  y = section width from center, and z = soffit upward. Its only local renderer
+  boundary is `L(x, y, z) = (0.001x, 0.001z, 0.001y)`; placement then uses the
+  selected member's global origin and basis. A global negative-y mapping must
+  never be applied again to local detail coordinates.
+- every transport declares `schemaVersion`, frame, units, axes, `memberId`,
+  stable `sourceId`, display label, story, frame type, section, project/member/
+  input revisions, and geometry input hash;
+- `memberId` is the imported source `UniqueName`, not the current derived
+  `Label_Story`. Grid row, selection, result, geometry, inspector, and overlay
+  keys use that same identity; production payloads have no generated fallback;
+- `geometry/beam/full` is the sole detailed beam contract for P7 and must receive
+  the selected `memberId` instead of falling back to `B1/GF`;
+- building transport must preserve identity/section and fail closed rather than
   silently skip malformed members before it becomes authoritative.
 
 The golden fixture contains two canonical source members, their normalized
-millimetre payload, exact renderer coordinates, and one known detailed beam with
-outline, rebar, and stirrup positions. Assertions cover ID preservation, one
-metre-to-millimetre conversion, transform, bounds/center, selection, member count,
-detail placement, schema rejection, and visible fallback.
+global and local payloads, exact renderer coordinates, and one known detailed
+beam with outline, rebar, and stirrup positions. Assertions cover stable source
+ID preservation, exactly one conversion per boundary, both transforms,
+bounds/center, selection, member count, detail placement, revision/hash matching,
+unknown-schema rejection, and visible fallback.
 
 P8 must ship only selection synchronization, floor/frame filtering,
 fit-to-selection, deterministic camera, non-WebGL access, and a truthful status
@@ -2188,40 +2207,49 @@ revision-matched join. Loads, building dimensions, new cross-section inspection,
 before/after comparison, decorative effects, and unprofiled instancing are
 deferred.
 
-The scene baselines are the maintained 153-member sample and a render-only
-612-member fixture made by four deterministic copies of that sample, each with a
-stable prefixed ID and a fixed 20 m source-space x offset. It never feeds
-engineering calculations. P8 records load-to-usable time, frame interaction,
-resource counts available from the renderer, route/project switching, context
-loss/recovery, and memory trend before accepting optimizations.
+The scene baselines are the maintained 153-member sample and a synthetic,
+render-only 1,530-member fixture made by ten deterministic copies of that sample.
+Each copy has `perf:<tile>:<source-id>` identity and a fixed source-metre offset;
+it never feeds engineering calculations. P8 records load-to-usable time, frame
+interaction, draw/resource counts available from the renderer, five project
+switches, context loss/recovery, and memory trend before accepting optimizations.
 
 ### 22.9 Browser gate and known blockers
 
-Chromium is the maintained primary gate at all three P0 widths. Current Safari on
-macOS receives desktop and 390 px review/recovery smoke coverage at the Session 1
-exit. Firefox/WebKit automation and broader browser support are held, not claimed,
-until evidence exists. The in-app browser remains the smallest repeatable live
-mechanism; no broad browser framework is added in Wave 1.
+Chromium 151 is the maintained primary gate at all three P0 widths. Current
+Safari on macOS receives 1440 x 900, 1024 x 768, and 390 px review/recovery smoke
+coverage at the Session 1 exit. Firefox support is held, not claimed, until the
+same deterministic sample replay exists. The in-app browser remains the smallest
+repeatable Chromium mechanism; Safari uses a bounded manual/Web Inspector pass,
+and no broad browser framework is added in Wave 1. WebGL loss currently has only
+code-path evidence, so live fallback evidence remains an exit-gate requirement.
 
 Wave 1 starts with these confirmed blockers:
 
-1. quick requests do not have effective transport cancellation or latest-result-
-   wins identity;
-2. current input edits can coexist with retained quick/project results and exports;
-3. the stable sample run can remain visually Designing after HTTP 200;
-4. full project reload/resume is absent;
-5. status records cannot represent every non-exportable lifecycle explicitly;
-6. the 390 px quick workspace clips critical content without a recovery scroll;
-7. building 3D uses a second scale/axis path and its API may silently omit invalid
-   members;
-8. useGeometryAdvanced, serviceability UI fields, and SSE batch semantics are not
-   live-contract ready.
+1. REST quick hooks create abort controllers but do not pass their signals to
+   `designBeam`; older responses and finalizers can replace newer state;
+2. WebSocket, SSE, and project batch results carry no request/project/member/input
+   revision identity, so delayed output cannot be rejected correctly;
+3. current input edits can coexist with retained quick/project results and exports;
+4. the stable sample run can remain visually Designing after its HTTP 200 response;
+5. full project reload/resume is absent and status records cannot represent every
+   non-exportable lifecycle explicitly;
+6. the 390 px quick and project workspaces clip critical content without a
+   recovery path;
+7. imported source `UniqueName` is dropped, selected detail requests can default
+   to `B1/GF`, and current building/local geometry use two undocumented frames;
+8. the landing route eagerly loads Framer Motion, React Three Fiber/Drei, and
+   Three.js for a decorative canvas;
+9. `useGeometryAdvanced`, `useCSVTextImport`, serviceability UI fields, and SSE
+   batch semantics are not live-contract ready.
 
-Wave 1 may now implement P2/P3 foundations. P4 remains blocked until the parent
-publishes the navigation, workspace, request, status, and export boundaries.
+Wave 1 has implemented the P2/P3 contract foundations and the GeometrySpaceV1
+golden fixture. P4 remains blocked until live shell, autosave/recovery, request,
+status, and export integration proves those boundaries. P7 is ready for a later
+bounded decomposition packet; P8 remains blocked on P6 revision truth and P7.
 Wave 2 remains blocked on the P4 checkpoint and the later P5/P6 project-result
 handoff. No parallel worker owns App.tsx, shared contracts, stores, API client,
-public viewport contract, or this ledger.
+public viewport contract, or this ledger without a fresh disjoint packet.
 
 ## 23. Immediate kickoff checklist
 

--- a/docs/planning/ui-experience-foundation-master-plan.md
+++ b/docs/planning/ui-experience-foundation-master-plan.md
@@ -6,8 +6,8 @@ owner: Main Agent and repository owner
 created: 2026-08-10
 last_updated: 2026-08-10
 doc_type: spec
-baseline_commit: fa0ee99548b82242f8c75056c76c097400a11350
-branch: codex/ui-experience-foundation
+baseline_commit: 32b9f33b204f5175efdf0d3e8d4d99e3634cf46c
+branch: codex/ui-workbench-session-1
 implementation_started: true
 second_audit_integrated: true
 execution_sessions: 2
@@ -15,13 +15,13 @@ max_concurrent_subagents: 2
 subagent_model: gpt-5.6-terra
 owner_accepted: 2026-08-10
 current_session: 1
-current_wave: 0
+current_wave: 1
 ---
 
 **Type:** Master Plan
 **Audience:** Product owner, frontend, backend, API, structural-library, 3D, reviewer, and tester roles
-**Status:** Active — owner accepted; Session 1 Wave 0 started; implementation
-edits remain gated on the Wave 0 contract lock
+**Status:** Active — owner accepted; Session 1 Wave 0 contract lock accepted;
+Wave 1 foundations are active
 **Importance:** Critical
 **Created:** 2026-08-10
 **Last Updated:** 2026-08-10
@@ -61,10 +61,11 @@ acceptance. The program does not change IS 456 formulas merely to serve the UI.
 ## 2. Plan authority and relationship to existing work
 
 The repository owner accepted this document on 2026-08-10. It is the execution
-authority for UIX-001. By explicit owner decision, the current branch owns
-planning plus Session 1; Session 2 uses a fresh branch after the Session 1
-verified green merge. Execution remains exactly two outcome-gated sessions under
-sections 12 and 16.1.
+authority for UIX-001. Planning and Terra routing merged to `main` through PR
+#718. The fresh branch `codex/ui-workbench-session-1` owns Session 1; Session 2
+uses another fresh branch after the Session 1 verified green merge. Execution
+remains exactly two implementation sessions under sections 12 and 16.1; the
+already-merged planning branch does not count as an implementation session.
 
 It supersedes the execution status in
 `docs/planning/react-ux-improvement-plan.md`, while preserving that document as
@@ -153,10 +154,11 @@ approval.
 
 ## 4. Verified current baseline
 
-The original UI observations were captured at `67b85302`. Session 1 now starts
-from `fa0ee995`, which includes ADOPT-001, the Python/React compatibility packets,
-the merge-policy update, and the Dependabot Python 3.11 guard. P0 must refresh
-every quantitative or contract-sensitive row before the Wave 0 checkpoint.
+The original UI observations were captured at `67b85302`. Session 1 starts from
+`32b9f33b`, which includes ADOPT-001, the Python/React compatibility packets, the
+merge-policy update, the Dependabot Python 3.11 guard, and the accepted UIX plan.
+Section 22 refreshes the quantitative and contract-sensitive baseline at that
+checkpoint.
 
 | Area | Verified baseline at `67b85302` | Program treatment |
 |---|---|---|
@@ -783,9 +785,10 @@ design, import, 3D review, project design, issue resolution, current-revision
 results, resume, and truthful export. Essential 3D inspection is integrated and
 the previous routes remain available for rollback until the exit gate passes.
 
-**Entry:** this plan is accepted and committed on the current UI branch before
-Wave 0 evidence changes. The branch started from the current origin/main baseline;
-dependency upgrades remain out and external-worktree locks in section 16.2 apply.
+**Entry:** this plan and Terra routing were accepted and merged through PR #718.
+Session 1 started on `codex/ui-workbench-session-1` from `origin/main` at
+`32b9f33b`. Dependency upgrades remain out and external-worktree locks in section
+16.2 apply.
 
 **Wave 0 — parallel read-only contract lock**
 
@@ -1678,15 +1681,14 @@ Rollback is packet-scoped:
 
 ### 16.1 Two execution branches and wave commits
 
-The owner explicitly accepted using the current
-`codex/ui-experience-foundation` branch for Session 1. Commit the accepted
-planning and Terra-routing changes before recording Wave 0 evidence. A planning
-merge is not required before this read-only wave.
+The accepted planning branch `codex/ui-experience-foundation` merged through PR
+#718 at `32b9f33b`. The fresh implementation branch
+`codex/ui-workbench-session-1` was then created from that exact `origin/main`
+head. The planning branch is history, not one of the two implementation sessions.
 
-1. **Session 1 branch:** continue on `codex/ui-experience-foundation`. Use
-   separate conventional commits for accepted plan/routing, Wave 0 evidence,
-   Wave 1 foundations, Wave 2 product flow, and integrated evidence where changes
-   are logically separable.
+1. **Session 1 branch:** continue on `codex/ui-workbench-session-1`. Use separate
+   conventional commits for Wave 0 evidence, Wave 1 foundations, Wave 2 product
+   flow, and integrated evidence where changes are logically separable.
 2. **Session 2 branch:** only after the Session 1 exit gate and verified green merge,
    create `codex/ui-platform-session-2` from updated main. Use separate commits
    for catalogue/API/renderer, bounded workflow/manifest, cutover, and evidence.
@@ -1705,10 +1707,12 @@ repository controls.
 
 ### 16.2 Parallel worktree isolation
 
-Parallel branches are safe only because each is checked out in a separate Git
+Parallel branches are safe only when each is checked out in a separate Git
 worktree. A branch is never checked out, staged, committed, merged, rebased, or
-cleaned from another branch's worktree. Before every implementation wave, the
-parent rechecks worktree status and changed-path overlap.
+cleaned from another branch's worktree. No parallel task may switch the root
+checkout away from `codex/ui-workbench-session-1`; it must create or reuse a
+separate worktree. Before every implementation wave, the parent rechecks current
+branch identity, worktree status, process/port ownership, and changed-path overlap.
 
 The former merge-policy, Python-dependency, and React-dependency locks were
 resolved on `main` before the Wave 0 baseline. `codex/social-preview` owns only
@@ -1878,16 +1882,16 @@ these tables only after the parent reviews evidence.
 
 | Macro session | Scope | State | Required exit |
 |---|---|---|---|
-| Session 1 | P0-P8 compact workbench and essential 3D | Not started | Session 1 exit gate in section 12.2 |
+| Session 1 | P0-P8 compact workbench and essential 3D | Wave 1 active after Wave 0 lock | Session 1 exit gate in section 12.2 |
 | Session 2 | P9-P15 capability platform and cutover | Blocked on Session 1 | Session 2 exit gate in section 12.3 |
 
 | Session | Packet | State | Evidence/commit | Notes |
 |---|---|---|---|---|
-| 1 | P0 | Not started | — | Baseline and usefulness lock |
-| 1 | P1 | Not started | — | Information architecture |
-| 1 | P2 | Not started | — | Visual foundation and shell |
-| 1 | P3 | Not started | — | Workspace state/persistence |
-| 1 | P4 | Not started | — | Quick-design migration |
+| 1 | P0 | Accepted | Section 22 | Live baseline, usefulness, browser, API/state, and 3D lock |
+| 1 | P1 | Accepted | Section 22 | Route map, targets, and three-width wireframes frozen |
+| 1 | P2 | Active | — | Visual foundation and shell |
+| 1 | P3 | Active | — | Workspace state/persistence |
+| 1 | P4 | Blocked on P2/P3 handoff | — | Quick-design migration |
 | 1 | P5 | Not started | — | Project intake/review |
 | 1 | P6 | Not started | — | Project design/results/export |
 | 1 | P7 | Not started | — | Viewport decomposition |
@@ -1900,7 +1904,326 @@ these tables only after the parent reviews evidence.
 | 2 | P14 | Not started | — | Route cutover/retirement |
 | 2 | P15 | Not started | — | Integrated closeout |
 
-## 22. Immediate kickoff checklist
+## 22. Session 1 Wave 0 evidence and contract lock
+
+This section is the accepted P0/P1 handoff for Wave 1. It consolidates the
+parent live-browser baseline and the two read-only Terra audits. It freezes
+product and transport boundaries; it does not claim that the confirmed defects
+are already fixed.
+
+### 22.1 Evidence basis
+
+| Evidence | Result |
+|---|---|
+| Session 1 base | origin/main and the current branch started at 32b9f33b after PR #718 |
+| Runtime | Python 3.11; Node 24.19.0; npm 11.17.0; Vite 7.3.6 |
+| Primary live browser | In-app Chromium 151 on macOS, DPR 1, reduced motion off |
+| P0 viewports | 1440 x 1000, 1024 x 768, and 390 x 844 |
+| API route/method audit | 23 React call sites across 9 files matched 63 OpenAPI paths; this does not prove response shapes |
+| Focused application checks | 17 Terra-routing/policy tests passed; existing API route/method check passed |
+| Focused 3D checks | Python building/detail geometry suites passed; useBeamGeometry had 4 passing React tests |
+| Production build | 2,778 modules transformed in 3.56 seconds; build passed |
+| Maintained sample | 153 members across 6 stories; sample API payload was 36,634 bytes before results and saved-state metadata |
+
+Production gzip baselines from the P0 build are:
+
+- application index JavaScript 36.31 kB and shared CSS 12.77 kB;
+- DesignView 11.52 kB;
+- BuildingEditorPage JavaScript 9.44 kB and route CSS 32.16 kB;
+- Three.js 185.67 kB and React Three Fiber/Drei 136.86 kB;
+- AG Grid 224.11 kB.
+
+The large Three.js and AG Grid chunks remain lazy route dependencies. P2 must not
+pull them into the landing shell. P7/P8 compare the final route delivery against
+this baseline; no percentage improvement is claimed before profiling.
+
+### 22.2 Live task-flow and simplicity baseline
+
+| Surface | Current live evidence | Main-process decision |
+|---|---|---|
+| Landing to quick result | Start Designing reached an already calculated PASS result in one intentional action | Preserve a one- or two-action quick path, but bind the result to current inputs |
+| Quick design desktop | 16 buttons, 11 form controls, 7 links, one Canvas, inputs/result/3D/alternatives/export simultaneously visible | Recompose into Input, Review, and Export states with one emphasized action per state |
+| Quick design at 1024 | No document overflow was reported, but the beam was visibly clipped and lower results competed with a fixed dock | Use collapsible input rail and contextual result tray |
+| Quick design at 390 | The document reported no horizontal scroll while the right workspace was visibly outside the viewport; the fixed shell prevented recovery | Narrow review is a blocking P2/P4 requirement; dense editing may remain desktop-first |
+| Import entry | 14 buttons, 4 controls, 7 links, and three overlapping progress/navigation presentations | Keep single/dual/sample intake, but show one stage model and one next action |
+| Sample to editor | Sample Building then Open Building Editor loaded 153 members in two actions from import | Preserve; landing to sample review target is at most three intentional actions |
+| Project editor | 15 buttons, 16 controls, 7 links, one Canvas, 153-row grid, materials, export, stage bar, toolbar, and dock in one fixed viewport | Make 3D/grid/inspector contextual regions inside one workbench |
+| Sample batch completion | On a stable rerun the batch endpoint returned HTTP 200, while after 8 seconds the header and all visible rows still said Designing | Confirm root cause in P3/P6; do not accept project result or export parity before it visibly settles |
+| Reload/resume | Reloading the populated editor retained the URL but produced No beams loaded; only a small Hub summary is persisted | Full project resume is absent and P3-blocking |
+| Empty deep links | editor, batch, dashboard, and design/results remain on their URLs and provide a recovery CTA | Retain recoverability, then replace with typed stage guards and canonical redirects |
+| Current navigation | TopBar and floating dock each expose the same five destinations; project pages add another four-step bar and import adds a second three-step signal | One typed global group plus one contextual project stage group |
+
+The quantitative simplification targets are:
+
+1. reduce five duplicated persistent destinations and ten duplicate entries to
+   at most two primary global destinations in Session 1: Workbench and Projects;
+2. render Import, Review, Design, and Results exactly once as project context;
+3. show at most one emphasized primary action in each workbench state;
+4. keep landing to quick useful result at two actions or fewer and landing to
+   sample project review at three actions or fewer;
+5. make selected failed/held member inspection a direct issue-queue or 3D/grid
+   selection, not a route hunt;
+6. make 390 px review, recovery, status, and next action fully reachable with no
+   clipped critical content; dense grid editing remains desktop-first;
+7. restore the last accepted project snapshot after reload and never display a
+   retained result as current after inputs change.
+
+### 22.3 Feature usefulness decisions
+
+| Capability/surface | Classification | Wave decision |
+|---|---|---|
+| Landing orientation, quick entry, sample entry, real resume | Exposed; merge | One restrained landing/workbench entry |
+| Quick beam design, checks, selected 3D detail, alternatives, export | Exposed; migrate | Preserve within the quick workbench after freshness repair |
+| Single CSV, dual CSV, sample import, material overrides | Exposed; migrate | One project intake stage |
+| Building 3D, grid, floor selection, selected member | Exposed; migrate | Core review/design workbench |
+| Batch progress, issue resolution, project results, BOQ/export | Exposed; migrate | Contextual Design and Results stages |
+| Load calculator and torsion | Exposed only in quick input | Progressive disclosure; no separate destination |
+| TopBar, FloatingDock, workflow breadcrumb arrays | Superseded duplication | Replace with one typed navigation source after parity |
+| Settings | Secondary exposed action | Retain only settings with an immediate visible effect |
+| Beam detail page | Compatibility/deep-link candidate | Keep behind a shareable current-result identity or redirect |
+| useAutoDesign duplicate hook | Internal/dormant | Do not expose; consolidate behind the P4 request coordinator |
+| SSE useBatchDesign | Dormant/hold | Cannot truthfully represent HOLD, stale, unsupported, or not evaluated |
+| Serviceability request/response fields | Dormant/hold | React contract is incomplete; no Session 1 UI exposure |
+| useGeometryAdvanced | Dormant/hold | Request and response shapes do not match the current API |
+| geometry/beam/3d | Legacy/hold | Do not use for the workbench; detailed beam uses geometry/beam/full |
+| Cross-section endpoint | Contextual existing utility | No new layer until member/revision identity is proven |
+| ModeSelectPage | Superseded/retire after redirects | No independent destination |
+| ModernAppLayout | Superseded/retire or mine | Must not become a competing shell |
+| Decorative effects, loads layer, comparison layer | Deferred | No Session 1 scope without authoritative data and performance evidence |
+
+No implementation worker may turn a dormant item into a visible feature without a
+new live contract and usefulness review.
+
+### 22.4 Frozen route and navigation contract
+
+| Current route | Session 1 canonical destination | Compatibility behavior |
+|---|---|---|
+| / | / | Keep as restrained landing |
+| /start | /workbench | Redirect and preserve history/back behavior |
+| /design | /workbench/quick | Delegate first, redirect after parity |
+| /design/results | /workbench/quick with current result panel | Empty or stale result goes to quick input with an explicit message |
+| /import | /workbench/projects/new | Delegate first, redirect after parity |
+| /editor | /workbench/projects/:projectId/review | Missing project uses typed recovery, not an unlabelled empty editor |
+| /batch | /workbench/projects/:projectId/design | Guard on imported project and current revision |
+| /dashboard | /workbench/projects/:projectId/results | Guard on a settled run; never infer completion |
+
+The stage order is Import -> Review -> Design -> Results. Export is an action in
+Results, not a global destination. A selected member, floor, open inspector, and
+result/run identity are addressable route or workspace state. Desktop and narrow
+navigation consume the same typed configuration. Browser back/forward and refresh
+must restore or fail closed through the same guards.
+
+### 22.5 Accepted three-width wireframes
+
+Landing and workbench entry:
+
+~~~text
+1440 / 1024
++---------------------------------------------------------------+
+| StructLib                         Projects          Settings   |
++---------------------------------------------------------------+
+| Structural workbench                                         |
+| [Continue last project]  [New project]  [Quick beam]          |
+| Recent project: name, saved time, stage, truthful status      |
+| Supported scope and evidence statement                        |
++---------------------------------------------------------------+
+
+390
++----------------------------------+
+| StructLib              Settings  |
++----------------------------------+
+| Continue last project            |
+| [Continue]                       |
+| [New project] [Quick beam]       |
+| Supported scope / recovery note  |
++----------------------------------+
+~~~
+
+Quick workbench:
+
+~~~text
+1440
++---------------------------------------------------------------+
+| Quick beam | save/current state | support/evidence | Export   |
++--------------------+-----------------------------+------------+
+| Input groups       | 3D / section               | Result     |
+| dimensions         | selected detail             | status     |
+| materials          |                             | governing  |
+| forces             |                             | checks     |
+| [Design]           |                             | next action|
++--------------------+-----------------------------+------------+
+| Alternatives or export tray opens only on request              |
++---------------------------------------------------------------+
+
+1024
++---------------------------------------------------------------+
+| Quick beam | state | primary action                             |
++--------------------+------------------------------------------+
+| Collapsible input  | 3D / result                              |
++--------------------+------------------------------------------+
+| Contextual result/check tray                                  |
++---------------------------------------------------------------+
+
+390
++----------------------------------+
+| Quick beam | state              |
+| Input summary [Edit]            |
+| [Design / Recalculate]          |
+| Result status + governing check |
+| Selected 3D or table fallback   |
+| Checks [Open]  Export [Open]    |
++----------------------------------+
+~~~
+
+Project workbench:
+
+~~~text
+1440
++----------------------------------------------------------------+
+| Project | Import Review Design Results | saved | primary action |
++--------+-------------------------------------------+-------------+
+| Stage  | 3D / main canvas                          | Inspector   |
+| rail   | selection, floor, truthful status layer   | member      |
+|        |                                            | checks      |
++--------+-------------------------------------------+-------------+
+| Issue queue / grid / run progress / results / export tray       |
++----------------------------------------------------------------+
+
+1024
++---------------------------------------------------------------+
+| Project | stage | saved | primary action                      |
++---------------------------------------------------------------+
+| 3D / main review                                               |
++-------------------------------+-------------------------------+
+| Issue/grid summary            | Selected-member inspector     |
++-------------------------------+-------------------------------+
+
+390 review/recovery
++----------------------------------+
+| Project | Review | saved state   |
+| Floor/filter [Open]              |
+| 3D summary or list fallback      |
+| Selected member + status         |
+| Governing issue / next action    |
+| [Open checks] [Continue]         |
++----------------------------------+
+~~~
+
+The narrow layout does not promise dense 153-row editing. It does promise project
+identity, save/recovery state, selection, status, critical issue review, and the
+next safe action.
+
+### 22.6 Workspace, result, and latest-request-wins contract
+
+P3 owns WorkspaceSnapshotV1 with:
+
+- schema version, project ID, project name, selected stage/member/floor;
+- stable source/member IDs, normalized explicit-unit inputs, project revision,
+  member revision, and input revision;
+- dirty/save state, current snapshot metadata, last-known-good metadata, and
+  migration origin;
+- explicit member lifecycle: current, stale, pending, error, unsupported, or
+  not_evaluated.
+
+Every result, geometry, alternative, metric, and export record carries:
+
+- input hash, input/member/project revision, request/run ID;
+- calculation identity and library version;
+- evidence and supported-case status;
+- its explicit lifecycle and settled decision state.
+
+An engineering input edit atomically makes all dependent records non-current
+before a new request starts. A response or finalizer applies only when request ID,
+input hash, and all relevant revisions still equal the active workspace. Older
+responses may be retained only as labelled history. Every exposed fetch accepts
+AbortSignal; abort is an optimization, while identity equality is the correctness
+gate.
+
+Export requires a current revision plus supported PASS evidence. Pending, stale,
+error, unsupported, not_evaluated, HOLD, and FAIL all fail closed. The server
+receives result identity and rejects mismatches; presentation fields alone never
+establish exportability.
+
+### 22.7 API-client and persistence decisions
+
+FastAPI Pydantic/OpenAPI remains transport authority. Session 1 keeps one React
+transport facade and adds only the exact quick, sample/import, batch, geometry,
+and export contracts needed by the maintained journeys. Each migrated method
+accepts AbortSignal and crosses a runtime-normalizing boundary with focused
+request/response fixtures. The stale standalone generated TypeScript client and
+dormant hooks are not treated as current truth. P10 may later replace the narrow
+facade with a fully generated client after generator parity is proven.
+
+Full project persistence uses native IndexedDB. The 36,634-byte raw sample is not
+the upper bound because results, geometry references, revision history, and
+last-known-good metadata must also be stored atomically. localStorage is limited
+to small UI preferences and a last-project pointer. P3 uses one versioned project
+record transaction, migration functions, a last-known-good record, portable
+export/import, and BroadcastChannel conflict notices. Raw uploaded file bytes are
+not retained.
+
+### 22.8 Frozen 3D contract and essential layers
+
+GeometrySpaceV1 has one renderer-bound unit and axis contract:
+
+- canonical source points remain metres as x plan/east, y plan/north, z elevation/up;
+- transport points are millimetres and declare schemaVersion, units, axes,
+  memberId, sourceId, label, story, frameType, section, and relevant revisions;
+- the renderer boundary applies R(mm) = (0.001 x, 0.001 z, -0.001 y) exactly once;
+- local detail origin is left support, center width, and soffit;
+- geometry/beam/full is the sole detailed beam contract for P7;
+- building transport must preserve label/section and fail closed rather than
+  silently skip malformed members before it becomes authoritative.
+
+The golden fixture contains two canonical source members, their normalized
+millimetre payload, exact renderer coordinates, and one known detailed beam with
+outline, rebar, and stirrup positions. Assertions cover ID preservation, one
+metre-to-millimetre conversion, transform, bounds/center, selection, member count,
+detail placement, schema rejection, and visible fallback.
+
+P8 must ship only selection synchronization, floor/frame filtering,
+fit-to-selection, deterministic camera, non-WebGL access, and a truthful status
+overlay after P6 revision binding. Utilization is conditional on a proven
+revision-matched join. Loads, building dimensions, new cross-section inspection,
+before/after comparison, decorative effects, and unprofiled instancing are
+deferred.
+
+The scene baselines are the maintained 153-member sample and a render-only
+612-member fixture made by four deterministic copies of that sample, each with a
+stable prefixed ID and a fixed 20 m source-space x offset. It never feeds
+engineering calculations. P8 records load-to-usable time, frame interaction,
+resource counts available from the renderer, route/project switching, context
+loss/recovery, and memory trend before accepting optimizations.
+
+### 22.9 Browser gate and known blockers
+
+Chromium is the maintained primary gate at all three P0 widths. Current Safari on
+macOS receives desktop and 390 px review/recovery smoke coverage at the Session 1
+exit. Firefox/WebKit automation and broader browser support are held, not claimed,
+until evidence exists. The in-app browser remains the smallest repeatable live
+mechanism; no broad browser framework is added in Wave 1.
+
+Wave 1 starts with these confirmed blockers:
+
+1. quick requests do not have effective transport cancellation or latest-result-
+   wins identity;
+2. current input edits can coexist with retained quick/project results and exports;
+3. the stable sample run can remain visually Designing after HTTP 200;
+4. full project reload/resume is absent;
+5. status records cannot represent every non-exportable lifecycle explicitly;
+6. the 390 px quick workspace clips critical content without a recovery scroll;
+7. building 3D uses a second scale/axis path and its API may silently omit invalid
+   members;
+8. useGeometryAdvanced, serviceability UI fields, and SSE batch semantics are not
+   live-contract ready.
+
+Wave 1 may now implement P2/P3 foundations. P4 remains blocked until the parent
+publishes the navigation, workspace, request, status, and export boundaries.
+Wave 2 remains blocked on the P4 checkpoint and the later P5/P6 project-result
+handoff. No parallel worker owns App.tsx, shared contracts, stores, API client,
+public viewport contract, or this ledger.
+
+## 23. Immediate kickoff checklist
 
 Implementation must not start until the owner accepts this plan or supplies edits.
 After acceptance:
@@ -1922,7 +2245,7 @@ After acceptance:
 10. do not release, delete branches, or make professional-use claims without the
     required owner approval.
 
-## 23. Final acceptance checklist
+## 24. Final acceptance checklist
 
 - [ ] Session 1 P0-P8 exit gate passed before Session 2 began.
 - [ ] Exactly two implementation sessions/branches were used; wave commits retain

--- a/docs/reference/3d-json-contract.md
+++ b/docs/reference/3d-json-contract.md
@@ -12,6 +12,29 @@ related_tasks: "TASK-3D-02, TASK-3D-03"
 
 # 3D JSON Contract — Beam Geometry Data Format
 
+## GeometrySpaceV1 workbench boundary
+
+For the P7 workbench migration, `GeometrySpaceV1` is the renderer-bound contract.
+It supersedes any ambiguous use of the legacy examples below at the boundary:
+
+- global source points are metres: `x=east`, `y=north`, `z=up`;
+- `GlobalSourceSpaceV1` transport remains in source metres with `schemaVersion`,
+  `frame`, `units`, `axes`, stable `memberId`/`sourceId`, `label`, `story`,
+  `frameType`, `section`, `inputHash`,
+  `projectRevision`, `memberRevision`, source revision, and geometry revision;
+- the global renderer boundary maps those source-metre points as `(x, z, -y)`;
+- `LocalBeamSpaceV1` remains a separate millimetre frame, origin left support /
+  centre width / soffit, with its own renderer mapping
+  `(0.001*x, 0.001*z, 0.001*y)` before global member placement;
+- `/api/v1/geometry/beam/full` is the sole detailed-beam P7 route;
+- malformed or duplicate members fail closed with a visible fallback marker. No
+  fallback IDs, inferred section data, or second scaling step are permitted.
+
+The checked golden fixture is `tests/fixtures/geometry-space-v1.json`. It fixes
+global source transport, both renderer transforms, bounds/centre, and one
+local-detail placement so P7 can decompose `Viewport3D` without changing
+coordinate behavior.
+
 > **Version:** 1.0.0
 > **Purpose:** Defines the JSON schema for exchanging 3D beam geometry between Python (structural_lib) and JavaScript/TypeScript (Three.js viewer).
 

--- a/react_app/src/App.tsx
+++ b/react_app/src/App.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import { Boxes, PanelsTopLeft } from 'lucide-react';
 import { activeGlobalDestination, GLOBAL_DESTINATIONS } from './app/navigation';
+import { WorkspacePersistenceBridge } from './workspace/WorkspacePersistenceBridge';
 import { TopBar } from './components/layout/TopBar';
 import { FloatingDock } from './components/ui/FloatingDock';
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
@@ -78,6 +79,7 @@ function App() {
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
+          <WorkspacePersistenceBridge />
           <div className="h-screen w-screen bg-zinc-950 flex flex-col">
             <a
               href="#main-content"

--- a/react_app/src/App.tsx
+++ b/react_app/src/App.tsx
@@ -7,15 +7,17 @@
 import { lazy, Suspense } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
+import { Boxes, PanelsTopLeft } from 'lucide-react';
+import { activeGlobalDestination, GLOBAL_DESTINATIONS } from './app/navigation';
 import { TopBar } from './components/layout/TopBar';
 import { FloatingDock } from './components/ui/FloatingDock';
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
 import { ToastContainer } from './components/ui/Toast';
-import { useImportedBeamsStore } from './store/importedBeamsStore';
 
 // Lazy-load route components for code splitting
 const HomePage = lazy(() => import('./components/pages/HomePage').then(m => ({ default: m.HomePage })));
 const HubPage = lazy(() => import('./components/pages/HubPage').then(m => ({ default: m.HubPage })));
+const WorkbenchHomePage = lazy(() => import('./components/pages/WorkbenchHomePage').then(m => ({ default: m.WorkbenchHomePage })));
 const DesignView = lazy(() => import('./components/design/DesignView').then(m => ({ default: m.DesignView })));
 const ImportView = lazy(() => import('./components/import/ImportView').then(m => ({ default: m.ImportView })));
 const BuildingEditorPage = lazy(() => import('./components/pages/BuildingEditorPage').then(m => ({ default: m.BuildingEditorPage })));
@@ -49,79 +51,26 @@ const queryClient = new QueryClient({
 function AppDock() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { beams } = useImportedBeamsStore();
 
   if (location.pathname === '/') return null;
 
-  const beamCount = beams.length;
+  const activeId = activeGlobalDestination(location.pathname);
+  const icons = {
+    workbench: <PanelsTopLeft className="h-5 w-5" aria-hidden="true" />,
+    projects: <Boxes className="h-5 w-5" aria-hidden="true" />,
+  };
+  const items = GLOBAL_DESTINATIONS.map((destination) => ({
+    ...destination,
+    active: activeId === destination.id,
+    onClick: () => navigate(destination.path),
+    icon: icons[destination.id],
+  }));
 
-  const items = [
-    {
-      id: 'design',
-      label: 'Design',
-      active: location.pathname === '/design' || location.pathname.startsWith('/design'),
-      onClick: () => navigate('/design'),
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
-            d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
-            d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
-        </svg>
-      ),
-    },
-    {
-      id: 'import',
-      label: 'Import',
-      active: location.pathname === '/import',
-      onClick: () => navigate('/import'),
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
-            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-        </svg>
-      ),
-    },
-    {
-      id: 'editor',
-      label: 'Editor',
-      active: location.pathname === '/editor',
-      badge: beamCount > 0 ? beamCount : undefined,
-      onClick: () => navigate('/editor'),
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
-            d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-        </svg>
-      ),
-    },
-    {
-      id: 'batch',
-      label: 'Batch',
-      active: location.pathname === '/batch',
-      onClick: () => navigate('/batch'),
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
-            d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-      ),
-    },
-    {
-      id: 'dashboard',
-      label: 'Dashboard',
-      active: location.pathname === '/dashboard',
-      onClick: () => navigate('/dashboard'),
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
-            d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-      ),
-    },
-  ];
-
-  return <FloatingDock items={items} position="bottom" />;
+  return (
+    <div className="md:hidden">
+      <FloatingDock items={items} position="bottom" />
+    </div>
+  );
 }
 
 function App() {
@@ -142,6 +91,10 @@ function App() {
                 <Routes>
                   <Route path="/" element={<HomePage />} />
                   <Route path="/start" element={<HubPage />} />
+                  <Route path="/workbench" element={<WorkbenchHomePage />} />
+                  <Route path="/workbench/quick" element={<DesignView />} />
+                  <Route path="/workbench/projects" element={<WorkbenchHomePage initialView="projects" />} />
+                  <Route path="/workbench/projects/new" element={<ImportView />} />
                   <Route path="/design" element={<DesignView />} />
                   <Route path="/design/results" element={<BeamDetailPage />} />
                   <Route path="/import" element={<ImportView />} />

--- a/react_app/src/api/__tests__/endpoints.test.ts
+++ b/react_app/src/api/__tests__/endpoints.test.ts
@@ -635,6 +635,29 @@ describe('API Response Contract — unwrap enforcement', () => {
     expect((result as any).data).toBeUndefined();
   });
 
+  it('designBeam() forwards AbortSignal through the transport boundary', async () => {
+    const innerData = {
+      success: true,
+      message: 'OK',
+      flexure: { ast_required: 850 },
+      ast_total: 850,
+      asc_total: 0,
+      utilization_ratio: 0.87,
+    };
+    const fetchSpy = mockFetch({ success: true, data: innerData });
+    const controller = new AbortController();
+
+    await designBeam(
+      { width: 300, depth: 500, moment: 150, fck: 25, fy: 500 },
+      { signal: controller.signal },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${API}/api/v1/design/beam`,
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
   it('loadSampleData() unwraps response envelope', async () => {
     const innerData = {
       success: true,

--- a/react_app/src/api/client.ts
+++ b/react_app/src/api/client.ts
@@ -132,6 +132,10 @@ export interface Geometry3DResponse {
 
 import { API_BASE_URL } from '../config';
 
+export interface RequestOptions {
+  signal?: AbortSignal;
+}
+
 /**
  * Unwrap FastAPI's standard response envelope.
  * All /api/v1/* endpoints return: {"success": true, "data": <actual payload>}
@@ -166,13 +170,20 @@ export async function checkHealth(): Promise<HealthResponse> {
 /**
  * Design a reinforced concrete beam.
  */
+export function designBeam(params: BeamDesignRequest): Promise<BeamDesignResponse>;
+export function designBeam(
+  params: BeamDesignRequest,
+  options: RequestOptions,
+): Promise<BeamDesignResponse>;
 export async function designBeam(
-  params: BeamDesignRequest
+  params: BeamDesignRequest,
+  options?: RequestOptions,
 ): Promise<BeamDesignResponse> {
   const response = await fetch(`${API_BASE_URL}/api/v1/design/beam`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(params),
+    ...(options?.signal ? { signal: options.signal } : {}),
   });
 
   if (!response.ok) {
@@ -187,12 +198,14 @@ export async function designBeam(
  * Generate 3D beam geometry for visualization.
  */
 export async function generateBeamGeometry(
-  request: Geometry3DRequest
+  request: Geometry3DRequest,
+  options?: RequestOptions,
 ): Promise<Geometry3DResponse> {
   const response = await fetch(`${API_BASE_URL}/api/v1/geometry/beam/3d`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(request),
+    ...(options?.signal ? { signal: options.signal } : {}),
   });
 
   if (!response.ok) {

--- a/react_app/src/app/__tests__/navigation.test.ts
+++ b/react_app/src/app/__tests__/navigation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GLOBAL_DESTINATIONS,
+  LEGACY_ROUTE_DECISIONS,
+  PROJECT_STAGES,
+  projectStagePath,
+  resolveLegacyDestination,
+  stageIsReachable,
+} from '../navigation';
+
+describe('workbench navigation contract', () => {
+  it('keeps one compact global destination source', () => {
+    expect(GLOBAL_DESTINATIONS.map((destination) => destination.id)).toEqual([
+      'workbench',
+      'projects',
+    ]);
+    expect(new Set(GLOBAL_DESTINATIONS.map((destination) => destination.path)).size).toBe(2);
+  });
+
+  it('keeps project stages ordered with explicit prerequisites', () => {
+    expect(PROJECT_STAGES.map((stage) => stage.id)).toEqual([
+      'import',
+      'review',
+      'design',
+      'results',
+    ]);
+    expect(stageIsReachable('import', new Set())).toBe(true);
+    expect(stageIsReachable('review', new Set())).toBe(false);
+    expect(stageIsReachable('review', new Set(['import']))).toBe(true);
+    expect(stageIsReachable('results', new Set(['import', 'review']))).toBe(false);
+    expect(stageIsReachable('results', new Set(['design']))).toBe(false);
+    expect(stageIsReachable('results', new Set(['import', 'review', 'design']))).toBe(true);
+  });
+
+  it('builds encoded project paths and fails closed without identity', () => {
+    expect(projectStagePath('project 01', 'review')).toBe(
+      '/workbench/projects/project%2001/review',
+    );
+    expect(() => projectStagePath('  ', 'review')).toThrow(/project ID is required/i);
+  });
+
+  it('maps every legacy route and recovers when a project is missing', () => {
+    expect(LEGACY_ROUTE_DECISIONS).toHaveLength(7);
+    expect(resolveLegacyDestination('/design')).toBe('/workbench/quick');
+    expect(resolveLegacyDestination('/editor')).toBe(
+      '/workbench?recovery=project-required',
+    );
+    expect(resolveLegacyDestination('/editor', 'sample')).toBe(
+      '/workbench/projects/sample/review',
+    );
+    expect(resolveLegacyDestination('/unknown')).toBeNull();
+  });
+});

--- a/react_app/src/app/__tests__/navigation.test.ts
+++ b/react_app/src/app/__tests__/navigation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  activeGlobalDestination,
   GLOBAL_DESTINATIONS,
   LEGACY_ROUTE_DECISIONS,
   PROJECT_STAGES,
@@ -49,5 +50,13 @@ describe('workbench navigation contract', () => {
       '/workbench/projects/sample/review',
     );
     expect(resolveLegacyDestination('/unknown')).toBeNull();
+  });
+
+  it('maps canonical and compatibility paths to one global destination', () => {
+    expect(activeGlobalDestination('/workbench/quick')).toBe('workbench');
+    expect(activeGlobalDestination('/design/results')).toBe('workbench');
+    expect(activeGlobalDestination('/workbench/projects/new')).toBe('projects');
+    expect(activeGlobalDestination('/editor')).toBe('projects');
+    expect(activeGlobalDestination('/')).toBeNull();
   });
 });

--- a/react_app/src/app/index.json
+++ b/react_app/src/app/index.json
@@ -1,0 +1,30 @@
+{
+  "folder": "react_app/src/app",
+  "type": "react-source",
+  "description": "",
+  "last_updated": "2026-08-10",
+  "file_count": 1,
+  "files": [
+    {
+      "name": "navigation.ts",
+      "type": "typescript",
+      "size_lines": 109,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "ProjectStage",
+        "GlobalDestination",
+        "ProjectStageDefinition",
+        "LegacyRouteDecision",
+        "GLOBAL_DESTINATIONS",
+        "PROJECT_STAGES",
+        "LEGACY_ROUTE_DECISIONS",
+        "projectStagePath",
+        "stageIsReachable",
+        "resolveLegacyDestination"
+      ],
+      "content_hash": "bbe97bc3e1b0"
+    }
+  ],
+  "subfolders": [],
+  "content_hash": "ad9f29d8bbba1110"
+}

--- a/react_app/src/app/index.md
+++ b/react_app/src/app/index.md
@@ -1,0 +1,11 @@
+# App
+
+**Type:** React Source
+**Last Updated:** 2026-08-10
+**Files:** 1
+
+## Typescript Files
+
+| File | Exports | Lines |
+|------|---------|-------|
+| [navigation.ts](navigation.ts) | ProjectStage, GlobalDestination, ProjectStageDefinition, LegacyRouteDecision, GLOBAL_DESTINATIONS (+5) | 109 |

--- a/react_app/src/app/navigation.ts
+++ b/react_app/src/app/navigation.ts
@@ -1,0 +1,108 @@
+export type ProjectStage = 'import' | 'review' | 'design' | 'results';
+
+export interface GlobalDestination {
+  id: 'workbench' | 'projects';
+  label: string;
+  path: string;
+}
+
+export interface ProjectStageDefinition {
+  id: ProjectStage;
+  label: string;
+  order: number;
+  requires: ProjectStage | null;
+}
+
+export interface LegacyRouteDecision {
+  legacyPath: string;
+  destination: string;
+  requiresProject: boolean;
+  requiresSettledRun: boolean;
+}
+
+export const GLOBAL_DESTINATIONS: readonly GlobalDestination[] = [
+  { id: 'workbench', label: 'Workbench', path: '/workbench' },
+  { id: 'projects', label: 'Projects', path: '/workbench/projects' },
+] as const;
+
+export const PROJECT_STAGES: readonly ProjectStageDefinition[] = [
+  { id: 'import', label: 'Import', order: 0, requires: null },
+  { id: 'review', label: 'Review', order: 1, requires: 'import' },
+  { id: 'design', label: 'Design', order: 2, requires: 'review' },
+  { id: 'results', label: 'Results', order: 3, requires: 'design' },
+] as const;
+
+export const LEGACY_ROUTE_DECISIONS: readonly LegacyRouteDecision[] = [
+  {
+    legacyPath: '/start',
+    destination: '/workbench',
+    requiresProject: false,
+    requiresSettledRun: false,
+  },
+  {
+    legacyPath: '/design',
+    destination: '/workbench/quick',
+    requiresProject: false,
+    requiresSettledRun: false,
+  },
+  {
+    legacyPath: '/design/results',
+    destination: '/workbench/quick',
+    requiresProject: false,
+    requiresSettledRun: true,
+  },
+  {
+    legacyPath: '/import',
+    destination: '/workbench/projects/new',
+    requiresProject: false,
+    requiresSettledRun: false,
+  },
+  {
+    legacyPath: '/editor',
+    destination: '/workbench/projects/:projectId/review',
+    requiresProject: true,
+    requiresSettledRun: false,
+  },
+  {
+    legacyPath: '/batch',
+    destination: '/workbench/projects/:projectId/design',
+    requiresProject: true,
+    requiresSettledRun: false,
+  },
+  {
+    legacyPath: '/dashboard',
+    destination: '/workbench/projects/:projectId/results',
+    requiresProject: true,
+    requiresSettledRun: true,
+  },
+] as const;
+
+export function projectStagePath(projectId: string, stage: ProjectStage): string {
+  const normalizedId = projectId.trim();
+  if (!normalizedId) {
+    throw new Error('A project ID is required to build a project-stage route.');
+  }
+  return `/workbench/projects/${encodeURIComponent(normalizedId)}/${stage}`;
+}
+
+export function stageIsReachable(
+  stage: ProjectStage,
+  completedStages: ReadonlySet<ProjectStage>,
+): boolean {
+  const definition = PROJECT_STAGES.find((candidate) => candidate.id === stage);
+  if (!definition) return false;
+  return PROJECT_STAGES
+    .filter((candidate) => candidate.order < definition.order)
+    .every((candidate) => completedStages.has(candidate.id));
+}
+
+export function resolveLegacyDestination(
+  legacyPath: string,
+  projectId?: string | null,
+): string | null {
+  const decision = LEGACY_ROUTE_DECISIONS.find((candidate) => candidate.legacyPath === legacyPath);
+  if (!decision) return null;
+  if (!decision.requiresProject) return decision.destination;
+  if (!projectId?.trim()) return '/workbench?recovery=project-required';
+  return decision.destination.replace(':projectId', encodeURIComponent(projectId.trim()));
+}

--- a/react_app/src/app/navigation.ts
+++ b/react_app/src/app/navigation.ts
@@ -20,6 +20,8 @@ export interface LegacyRouteDecision {
   requiresSettledRun: boolean;
 }
 
+export type GlobalDestinationId = GlobalDestination['id'];
+
 export const GLOBAL_DESTINATIONS: readonly GlobalDestination[] = [
   { id: 'workbench', label: 'Workbench', path: '/workbench' },
   { id: 'projects', label: 'Projects', path: '/workbench/projects' },
@@ -105,4 +107,22 @@ export function resolveLegacyDestination(
   if (!decision.requiresProject) return decision.destination;
   if (!projectId?.trim()) return '/workbench?recovery=project-required';
   return decision.destination.replace(':projectId', encodeURIComponent(projectId.trim()));
+}
+
+export function activeGlobalDestination(pathname: string): GlobalDestinationId | null {
+  if (
+    pathname.startsWith('/workbench/projects')
+    || ['/import', '/editor', '/batch', '/dashboard'].includes(pathname)
+  ) {
+    return 'projects';
+  }
+  if (
+    pathname === '/workbench'
+    || pathname.startsWith('/workbench/quick')
+    || pathname === '/start'
+    || pathname.startsWith('/design')
+  ) {
+    return 'workbench';
+  }
+  return null;
 }

--- a/react_app/src/components/__tests__/HomePage.test.tsx
+++ b/react_app/src/components/__tests__/HomePage.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HomePage } from '../pages/HomePage';
+
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
+describe('HomePage', () => {
+  beforeEach(() => navigate.mockClear());
+
+  it('offers one primary workbench action and two focused entries', () => {
+    render(<HomePage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open workbench/i }));
+    expect(navigate).toHaveBeenCalledWith('/workbench');
+    expect(screen.getByRole('button', { name: /quick beam/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /new project/i })).toBeVisible();
+  });
+});

--- a/react_app/src/components/__tests__/TopBar.test.tsx
+++ b/react_app/src/components/__tests__/TopBar.test.tsx
@@ -31,11 +31,9 @@ describe('TopBar', () => {
 
   it('renders navigation links', () => {
     render(React.createElement(TopBar));
-    expect(screen.getByText('Design')).toBeInTheDocument();
-    expect(screen.getByText('Import')).toBeInTheDocument();
-    expect(screen.getByText('Batch')).toBeInTheDocument();
-    expect(screen.getByText('Editor')).toBeInTheDocument();
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Workbench')).toBeInTheDocument();
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
   });
 
   it('renders home link pointing to /', () => {

--- a/react_app/src/components/__tests__/WorkbenchHomePage.test.tsx
+++ b/react_app/src/components/__tests__/WorkbenchHomePage.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkbenchHomePage } from '../pages/WorkbenchHomePage';
+
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
+describe('WorkbenchHomePage', () => {
+  beforeEach(() => navigate.mockClear());
+
+  it('keeps one project action and one quick-design entry reachable', () => {
+    render(<WorkbenchHomePage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open quick beam/i }));
+    expect(navigate).toHaveBeenCalledWith('/workbench/quick');
+
+    fireEvent.click(screen.getByRole('button', { name: /^new project/i }));
+    expect(navigate).toHaveBeenCalledWith('/workbench/projects/new');
+  });
+});

--- a/react_app/src/components/__tests__/WorkflowBreadcrumb.test.tsx
+++ b/react_app/src/components/__tests__/WorkflowBreadcrumb.test.tsx
@@ -12,26 +12,6 @@ vi.mock('react-router-dom', () => ({
   useLocation: () => mockUseLocation(),
 }));
 
-// Mock framer-motion — render motion.div as plain div
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: React.forwardRef(({ children, ...props }: any, ref: any) =>
-      React.createElement('div', { ...props, ref }, children)),
-    span: React.forwardRef(({ children, ...props }: any, ref: any) =>
-      React.createElement('span', { ...props, ref }, children)),
-  },
-}));
-
-// Mock lucide-react Check icon
-vi.mock('lucide-react', () => ({
-  Check: (props: any) => React.createElement('svg', { 'data-testid': 'check-icon', ...props }),
-}));
-
-// Mock cn utility
-vi.mock('../../lib/utils', () => ({
-  cn: (...args: any[]) => args.filter(Boolean).join(' '),
-}));
-
 // Mock importedBeamsStore
 const mockBeams: any[] = [];
 vi.mock('../../store/importedBeamsStore', () => ({
@@ -47,19 +27,16 @@ describe('WorkflowBreadcrumb', () => {
   it('renders all 4 workflow steps', () => {
     render(React.createElement(WorkflowBreadcrumb));
     expect(screen.getByText('Import')).toBeInTheDocument();
-    expect(screen.getByText('Editor')).toBeInTheDocument();
-    expect(screen.getByText('Batch Design')).toBeInTheDocument();
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByText('Design')).toBeInTheDocument();
+    expect(screen.getByText('Results')).toBeInTheDocument();
   });
 
   it('highlights the current step', () => {
     mockUseLocation.mockReturnValue({ pathname: '/editor' });
     render(React.createElement(WorkflowBreadcrumb));
 
-    // The editor step button should have aria-current="step"
-    const buttons = screen.getAllByRole('button');
-    const editorButton = buttons[1]; // Index 1 = Editor
-    expect(editorButton).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByRole('button', { name: /review/i })).toHaveAttribute('aria-current', 'step');
   });
 
   it('shows checkmark on completed steps', async () => {
@@ -70,8 +47,7 @@ describe('WorkflowBreadcrumb', () => {
     render(React.createElement(WorkflowBreadcrumb));
 
     // Import step is complete (beams.length > 0 and we're past it)
-    const checkIcons = screen.getAllByTestId('check-icon');
-    expect(checkIcons.length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /import/i })).not.toBeDisabled();
   });
 
   it('navigates when a completed step is clicked', () => {
@@ -81,9 +57,7 @@ describe('WorkflowBreadcrumb', () => {
 
     render(React.createElement(WorkflowBreadcrumb));
 
-    const buttons = screen.getAllByRole('button');
-    // Click the Import button (index 0) — it's a completed/past step
-    fireEvent.click(buttons[0]);
+    fireEvent.click(screen.getByRole('button', { name: /import/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/import');
   });
 
@@ -92,9 +66,9 @@ describe('WorkflowBreadcrumb', () => {
 
     render(React.createElement(WorkflowBreadcrumb));
 
-    const buttons = screen.getAllByRole('button');
-    // Dashboard button (index 3) — future step, should be disabled
-    fireEvent.click(buttons[3]);
+    const results = screen.getByRole('button', { name: /results/i });
+    expect(results).toBeDisabled();
+    fireEvent.click(results);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/react_app/src/components/index.json
+++ b/react_app/src/components/index.json
@@ -2,7 +2,7 @@
   "folder": "react_app/src/components",
   "type": "react-source",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 2,
   "files": [
     {
@@ -67,7 +67,12 @@
     {
       "name": "viewport",
       "path": "viewport/",
-      "file_count": 6
+      "file_count": 8
+    },
+    {
+      "name": "workbench",
+      "path": "workbench/",
+      "file_count": 8
     }
   ],
   "content_hash": "3265f2879e94f70b"

--- a/react_app/src/components/index.json
+++ b/react_app/src/components/index.json
@@ -57,7 +57,7 @@
     {
       "name": "pages",
       "path": "pages/",
-      "file_count": 7
+      "file_count": 8
     },
     {
       "name": "ui",

--- a/react_app/src/components/index.md
+++ b/react_app/src/components/index.md
@@ -1,7 +1,7 @@
 # Components
 
 **Type:** React Source
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 2
 
 ## React Component Files
@@ -25,4 +25,5 @@
 | [layout/](layout/) | 3 |  |
 | [pages/](pages/) | 7 |  |
 | [ui/](ui/) | 10 |  |
-| [viewport/](viewport/) | 6 |  |
+| [viewport/](viewport/) | 8 |  |
+| [workbench/](workbench/) | 8 |  |

--- a/react_app/src/components/index.md
+++ b/react_app/src/components/index.md
@@ -23,7 +23,7 @@
 | [design/](design/) | 11 |  |
 | [import/](import/) | 6 |  |
 | [layout/](layout/) | 3 |  |
-| [pages/](pages/) | 7 |  |
+| [pages/](pages/) | 8 |  |
 | [ui/](ui/) | 10 |  |
 | [viewport/](viewport/) | 8 |  |
 | [workbench/](workbench/) | 8 |  |

--- a/react_app/src/components/layout/SettingsPanel.tsx
+++ b/react_app/src/components/layout/SettingsPanel.tsx
@@ -2,7 +2,6 @@
  * SettingsPanel - Slide-over settings panel with theme, API, and version info.
  */
 import { X } from "lucide-react";
-import { motion, AnimatePresence } from "framer-motion";
 import { useEffect } from "react";
 
 interface SettingsPanelProps {
@@ -22,26 +21,19 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
     return () => window.removeEventListener("keydown", handleEscape);
   }, [isOpen, onClose]);
 
+  if (!isOpen) return null;
+
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <>
+    <>
           {/* Backdrop */}
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
+          <div
             onClick={onClose}
             className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50"
             aria-hidden="true"
           />
 
           {/* Slide-over panel */}
-          <motion.div
-            initial={{ x: "100%" }}
-            animate={{ x: 0 }}
-            exit={{ x: "100%" }}
-            transition={{ type: "spring", damping: 30, stiffness: 300 }}
+          <div
             className="fixed top-0 right-0 bottom-0 w-full max-w-md bg-zinc-900 border-l border-white/10 z-50 flex flex-col"
             role="dialog"
             aria-modal="true"
@@ -115,9 +107,7 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                 structural_engineering_lib © {new Date().getFullYear()}
               </p>
             </div>
-          </motion.div>
-        </>
-      )}
-    </AnimatePresence>
+          </div>
+    </>
   );
 }

--- a/react_app/src/components/layout/TopBar.tsx
+++ b/react_app/src/components/layout/TopBar.tsx
@@ -4,9 +4,7 @@
 import { useState } from "react";
 import { useLocation, Link } from "react-router-dom";
 import { Settings, ChevronRight } from "lucide-react";
-import { motion } from "framer-motion";
-import { useImportedBeamsStore } from "../../store/importedBeamsStore";
-import { useDesignStore } from "../../store/designStore";
+import { activeGlobalDestination, GLOBAL_DESTINATIONS } from "../../app/navigation";
 import { SettingsPanel } from "./SettingsPanel";
 
 const routeLabels: Record<string, string> = {
@@ -19,26 +17,17 @@ const routeLabels: Record<string, string> = {
   "/dashboard": "Dashboard",
   "/batch": "Batch Design",
   "/settings": "Settings",
+  "/workbench": "Workbench",
+  "/workbench/quick": "Quick Beam",
+  "/workbench/projects": "Projects",
+  "/workbench/projects/new": "New Project",
 };
-
-const navLinks = [
-  { path: "/design", label: "Design" },
-  { path: "/import", label: "Import" },
-  { path: "/batch", label: "Batch" },
-  { path: "/editor", label: "Editor" },
-  { path: "/dashboard", label: "Dashboard" },
-];
 
 export function TopBar() {
   const location = useLocation();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
-  // Get context for badges
-  const beams = useImportedBeamsStore((state) => state.beams);
-  const designResult = useDesignStore((state) => state.result);
-
-  const beamCount = beams.length;
-  const hasDesignResults = designResult !== null;
+  const activeDestination = activeGlobalDestination(location.pathname);
 
   // Don't show on home page
   if (location.pathname === "/") return null;
@@ -51,9 +40,7 @@ export function TopBar() {
   });
 
   return (
-    <motion.header
-      initial={{ opacity: 0, y: -10 }}
-      animate={{ opacity: 1, y: 0 }}
+    <header
       className="fixed top-0 left-0 right-0 z-40 h-14 flex items-center justify-between px-6 bg-zinc-950/80 backdrop-blur-xl border-b border-white/5"
     >
       {/* Left: Logo + Nav links */}
@@ -75,42 +62,19 @@ export function TopBar() {
 
         {/* Nav links */}
         <nav aria-label="Main navigation" className="hidden md:flex items-center gap-1">
-          {navLinks.map(link => {
-            const isActive = location.pathname === link.path ||
-              (link.path === "/design" && location.pathname.startsWith("/design"));
-
-            // Determine badge content
-            let badge: React.ReactNode = null;
-            if (link.path === "/editor" && beamCount > 0) {
-              badge = (
-                <span
-                  className="ml-1.5 px-1.5 py-0.5 text-[10px] font-semibold rounded bg-zinc-700 text-white tabular-nums"
-                  aria-label={`${beamCount} beams imported`}
-                >
-                  {beamCount}
-                </span>
-              );
-            } else if (link.path === "/dashboard" && hasDesignResults) {
-              badge = (
-                <span
-                  className="ml-1.5 w-1.5 h-1.5 rounded-full bg-green-400"
-                  aria-label="Design results available"
-                />
-              );
-            }
-
+          {GLOBAL_DESTINATIONS.map((destination) => {
+            const isActive = activeDestination === destination.id;
             return (
               <Link
-                key={link.path}
-                to={link.path}
+                key={destination.id}
+                to={destination.path}
                 className={`px-2.5 py-1.5 rounded-md text-xs font-medium transition-colors flex items-center ${
                   isActive
                     ? "bg-white/10 text-white"
                     : "text-zinc-400 hover:text-zinc-200 hover:bg-white/5"
                 }`}
               >
-                {link.label}
-                {badge}
+                {destination.label}
               </Link>
             );
           })}
@@ -147,6 +111,6 @@ export function TopBar() {
 
       {/* Settings Panel */}
       <SettingsPanel isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
-    </motion.header>
+    </header>
   );
 }

--- a/react_app/src/components/pages/HomePage.tsx
+++ b/react_app/src/components/pages/HomePage.tsx
@@ -1,447 +1,93 @@
-/**
- * HomePage - Minimal landing page with full-screen 3D beam construction animation
- */
-import { useNavigate } from "react-router-dom";
-import { motion } from "framer-motion";
-import { ArrowRight } from "lucide-react";
-import { Canvas, useFrame } from "@react-three/fiber";
-import { OrbitControls, Float } from "@react-three/drei";
-import { Suspense, useMemo, useRef, useEffect } from "react";
-import * as THREE from "three";
-import { useReducedMotion } from "../../hooks/useReducedMotion";
+/** Restrained landing page for the structural workbench. */
+import { ArrowRight, Boxes, PanelsTopLeft, ShieldCheck } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 
-/** Animated beam construction (12s build + continuous rotation) */
-function AnimatedBeamConstruction() {
-  const prefersReducedMotion = useReducedMotion();
-  const elapsed = useRef(0);
-  const groupRef = useRef<THREE.Group>(null);
-  const constructionComplete = useRef(false);
-
-  // Beam dimensions
-  const beamLength = 4.0;
-  const beamDepth = 0.5;
-  const beamWidth = 0.3;
-  const cover = 0.025;
-  const rebarDia = 0.016;
-
-  // Refs for animated objects
-  const formworkRef = useRef<THREE.LineSegments>(null);
-  const concreteRef = useRef<THREE.Mesh>(null);
-  const bottomRebarsRef = useRef<THREE.Group>(null);
-  const topRebarsRef = useRef<THREE.Group>(null);
-  const stirrupsRef = useRef<THREE.Group>(null);
-  const loadsRef = useRef<THREE.Group>(null);
-
-  // Geometries - imperatively created, need manual disposal
-  const { formworkGeometry, formworkBaseGeometry } = useMemo(() => {
-    const baseGeo = new THREE.BoxGeometry(beamLength, beamDepth, beamWidth);
-    const edgesGeo = new THREE.EdgesGeometry(baseGeo);
-    return { formworkGeometry: edgesGeo, formworkBaseGeometry: baseGeo };
-  }, []);
-
-  const concreteGeometry = useMemo(() => {
-    return new THREE.BoxGeometry(beamLength, beamDepth, beamWidth);
-  }, []);
-
-  const stirrupGeometry = useMemo(() => {
-    const w = beamWidth - 2 * cover;
-    const h = beamDepth - 2 * cover;
-    const points = [
-      new THREE.Vector3(-w / 2, -h / 2, 0),
-      new THREE.Vector3(w / 2, -h / 2, 0),
-      new THREE.Vector3(w / 2, h / 2, 0),
-      new THREE.Vector3(-w / 2, h / 2, 0),
-      new THREE.Vector3(-w / 2, -h / 2, 0),
-    ];
-    const geometry = new THREE.BufferGeometry().setFromPoints(points);
-    return geometry;
-  }, []);
-
-  // Pre-create stirrup geometries
-  const stirrupGeometries = useMemo(() => {
-    const count = 8;
-    return Array.from({ length: count }, () => stirrupGeometry.clone());
-  }, [stirrupGeometry]);
-
-  // Dispose Three.js geometries on unmount to prevent GPU memory leaks
-  useEffect(() => {
-    return () => {
-      formworkGeometry.dispose();
-      formworkBaseGeometry.dispose(); // Dispose the BoxGeometry used to create EdgesGeometry
-      concreteGeometry.dispose();
-      stirrupGeometry.dispose();
-      stirrupGeometries.forEach((geo) => geo.dispose());
-    };
-  }, [formworkGeometry, formworkBaseGeometry, concreteGeometry, stirrupGeometry, stirrupGeometries]);
-
-  // Bottom rebars: 4 bars
-  const bottomRebarPositions = useMemo(() => {
-    const y = -beamDepth / 2 + cover + rebarDia / 2;
-    const spacing = (beamWidth - 2 * cover - rebarDia) / 3;
-    return [
-      [-beamWidth / 2 + cover + rebarDia / 2, y],
-      [-beamWidth / 2 + cover + rebarDia / 2 + spacing, y],
-      [-beamWidth / 2 + cover + rebarDia / 2 + 2 * spacing, y],
-      [beamWidth / 2 - cover - rebarDia / 2, y],
-    ];
-  }, []);
-
-  // Top rebars: 2 bars
-  const topRebarPositions = useMemo(() => {
-    const y = beamDepth / 2 - cover - rebarDia / 2;
-    const spacing = beamWidth - 2 * cover - rebarDia;
-    return [
-      [-spacing / 2, y],
-      [spacing / 2, y],
-    ];
-  }, []);
-
-  // Stirrup positions: 8 stirrups
-  const stirrupPositions = useMemo(() => {
-    const count = 8;
-    const spacing = beamLength / (count + 1);
-    return Array.from({ length: count }, (_, i) => -beamLength / 2 + spacing * (i + 1));
-  }, []);
-
-  useFrame((_, delta) => {
-    // Skip animations if user prefers reduced motion
-    if (prefersReducedMotion) {
-      // Show final state - all elements visible, construction complete
-      if (formworkRef.current) {
-        formworkRef.current.scale.setScalar(1);
-        (formworkRef.current.material as THREE.LineBasicMaterial).opacity = 0.3;
-      }
-      if (concreteRef.current) {
-        (concreteRef.current.material as THREE.MeshPhysicalMaterial).opacity = 0.45;
-      }
-      if (bottomRebarsRef.current) {
-        bottomRebarsRef.current.children.forEach((rebar) => {
-          rebar.position.x = 0;
-          ((rebar as THREE.Mesh).material as THREE.MeshStandardMaterial).opacity = 0.85;
-        });
-      }
-      if (topRebarsRef.current) {
-        topRebarsRef.current.children.forEach((rebar) => {
-          rebar.position.x = 0;
-          ((rebar as THREE.Mesh).material as THREE.MeshStandardMaterial).opacity = 0.85;
-        });
-      }
-      if (stirrupsRef.current) {
-        stirrupsRef.current.children.forEach((stirrup) => {
-          stirrup.scale.set(1, 1, 1);
-          ((stirrup as THREE.LineSegments).material as THREE.LineBasicMaterial).opacity = 0.75;
-        });
-      }
-      if (loadsRef.current) {
-        loadsRef.current.children.forEach((load) => {
-          load.scale.setScalar(1);
-          load.children.forEach((child) => {
-            ((child as THREE.Mesh).material as THREE.MeshStandardMaterial).opacity = 0.85;
-          });
-        });
-      }
-      return;
-    }
-
-    elapsed.current += delta;
-    const t = elapsed.current;
-
-    // Construction phases (0-12s), then continuous rotation
-    const constructionDuration = 12;
-
-    if (t <= constructionDuration) {
-      // Phase 1 (0-2s): Formwork appears
-      if (formworkRef.current) {
-        const scale = Math.min(1, t / 2);
-        const easedScale = scale < 1 ? 1 - Math.cos((scale * Math.PI) / 2) : 1;
-        formworkRef.current.scale.setScalar(easedScale);
-        (formworkRef.current.material as THREE.LineBasicMaterial).opacity = easedScale * 0.7;
-      }
-
-      // Phase 2 (2-4s): Bottom rebars slide in
-      if (bottomRebarsRef.current && t >= 2) {
-        const rebarPhase = Math.max(0, t - 2) / 2.0;
-
-        bottomRebarsRef.current.children.forEach((rebar, i) => {
-          const stagger = i * 0.15;
-          const progress = Math.min(1, Math.max(0, rebarPhase - stagger / 2.0) * (2.0 / (2.0 - stagger)));
-          const easedProgress = progress < 1 ? 1 - Math.cos((progress * Math.PI) / 2) : 1;
-          rebar.position.x = THREE.MathUtils.lerp(-beamLength, 0, easedProgress);
-          ((rebar as THREE.Mesh).material as THREE.MeshStandardMaterial).opacity = easedProgress * 0.85;
-        });
-      }
-
-      // Phase 3 (4-6s): Top rebars slide in
-      if (topRebarsRef.current && t >= 4) {
-        const topRebarPhase = Math.max(0, t - 4) / 2.0;
-
-        topRebarsRef.current.children.forEach((rebar, i) => {
-          const stagger = i * 0.15;
-          const progress = Math.min(1, Math.max(0, topRebarPhase - stagger / 2.0) * (2.0 / (2.0 - stagger)));
-          const easedProgress = progress < 1 ? 1 - Math.cos((progress * Math.PI) / 2) : 1;
-          rebar.position.x = THREE.MathUtils.lerp(beamLength, 0, easedProgress);
-          ((rebar as THREE.Mesh).material as THREE.MeshStandardMaterial).opacity = easedProgress * 0.85;
-        });
-      }
-
-      // Phase 4 (6-8.5s): Stirrups materialize
-      if (stirrupsRef.current && t >= 6) {
-        const stirrupPhase = Math.max(0, t - 6) / 2.5;
-        stirrupsRef.current.children.forEach((stirrup, i) => {
-          const stagger = i * 0.12;
-          const progress = Math.min(1, Math.max(0, stirrupPhase - stagger / 2.5) * (2.5 / (2.5 - stagger)));
-          const easedProgress = progress < 1 ? 1 - Math.cos((progress * Math.PI) / 2) : 1;
-          const scale = THREE.MathUtils.lerp(0.8, 1, easedProgress);
-          stirrup.scale.set(scale, scale, scale);
-          ((stirrup as THREE.LineSegments).material as THREE.LineBasicMaterial).opacity = easedProgress * 0.75;
-        });
-      }
-
-      // Phase 5 (8.5-10.5s): Concrete fills
-      if (concreteRef.current && formworkRef.current && t >= 8.5) {
-        const concretePhase = Math.max(0, t - 8.5) / 2.0;
-        const easedPhase = concretePhase < 1 ? 1 - Math.cos((concretePhase * Math.PI) / 2) : 1;
-        (concreteRef.current.material as THREE.MeshPhysicalMaterial).opacity = easedPhase * 0.45;
-        (formworkRef.current.material as THREE.LineBasicMaterial).opacity = THREE.MathUtils.lerp(0.7, 0.3, easedPhase);
-      }
-
-      // Phase 6 (10.5-12s): Load arrows + deflection
-      if (loadsRef.current && t >= 10.5) {
-        const loadPhase = Math.max(0, t - 10.5) / 1.5;
-        const easedPhase = loadPhase < 1 ? 1 - Math.cos((loadPhase * Math.PI) / 2) : 1;
-
-        loadsRef.current.children.forEach((load) => {
-          load.scale.setScalar(easedPhase);
-          load.children.forEach((child) => {
-            ((child as THREE.Mesh).material as THREE.MeshStandardMaterial).opacity = easedPhase * 0.85;
-          });
-        });
-
-        // Subtle deflection
-        const deflection = -0.02 * easedPhase * Math.sin(Math.PI / 2);
-        if (concreteRef.current) concreteRef.current.position.y = deflection;
-        if (bottomRebarsRef.current) bottomRebarsRef.current.position.y = deflection;
-        if (topRebarsRef.current) topRebarsRef.current.position.y = deflection;
-        if (stirrupsRef.current) stirrupsRef.current.position.y = deflection;
-      }
-    } else {
-      // Construction complete - continuous slow rotation (15s per 360°)
-      if (!constructionComplete.current) {
-        constructionComplete.current = true;
-      }
-
-      // Continuous rotation on Y axis (~15 seconds per full rotation)
-      if (groupRef.current) {
-        const rotationSpeed = (Math.PI * 2) / 15; // Full 360° in 15 seconds
-        const rotationTime = t - constructionDuration;
-        groupRef.current.rotation.y = rotationTime * rotationSpeed;
-      }
-    }
-  });
-
-  return (
-    <Float speed={1.5} rotationIntensity={0.2} floatIntensity={0.4}>
-      <group ref={groupRef} rotation={[0.3, 0.5, 0.1]}>
-        {/* Formwork */}
-        <lineSegments ref={formworkRef} geometry={formworkGeometry}>
-          <lineBasicMaterial color="#6366f1" transparent opacity={0} />
-        </lineSegments>
-
-        {/* Concrete */}
-        <mesh ref={concreteRef} geometry={concreteGeometry}>
-          <meshPhysicalMaterial
-            color="#a8a29e"
-            transparent
-            opacity={0}
-            metalness={0.1}
-            roughness={0.7}
-            transmission={0.2}
-          />
-        </mesh>
-
-        {/* Bottom rebars */}
-        <group ref={bottomRebarsRef}>
-          {bottomRebarPositions.map(([z, y], i) => (
-            <mesh key={`bottom-${i}`} position={[-beamLength, y, z]} rotation={[0, 0, Math.PI / 2]}>
-              <cylinderGeometry args={[rebarDia / 2, rebarDia / 2, beamLength, 8]} />
-              <meshStandardMaterial
-                color="#a78bfa"
-                transparent
-                opacity={0}
-                metalness={0.7}
-                roughness={0.3}
-                emissive="#a78bfa"
-                emissiveIntensity={0.1}
-              />
-            </mesh>
-          ))}
-        </group>
-
-        {/* Top rebars */}
-        <group ref={topRebarsRef}>
-          {topRebarPositions.map(([z, y], i) => (
-            <mesh key={`top-${i}`} position={[beamLength, y, z]} rotation={[0, 0, Math.PI / 2]}>
-              <cylinderGeometry args={[rebarDia / 2, rebarDia / 2, beamLength, 8]} />
-              <meshStandardMaterial
-                color="#a78bfa"
-                transparent
-                opacity={0}
-                metalness={0.7}
-                roughness={0.3}
-                emissive="#a78bfa"
-                emissiveIntensity={0.1}
-              />
-            </mesh>
-          ))}
-        </group>
-
-        {/* Stirrups */}
-        <group ref={stirrupsRef}>
-          {stirrupPositions.map((x, i) => (
-            <lineSegments key={`stirrup-${i}`} position={[x, 0, 0]} rotation={[0, Math.PI / 2, 0]} geometry={stirrupGeometries[i]}>
-              <lineBasicMaterial color="#2dd4bf" transparent opacity={0} linewidth={2} />
-            </lineSegments>
-          ))}
-        </group>
-
-        {/* Load arrows */}
-        <group ref={loadsRef}>
-          {[-beamLength / 4, 0, beamLength / 4].map((x, i) => (
-            <group key={`load-${i}`} position={[x, beamDepth / 2 + 0.15, 0]}>
-              <mesh rotation={[Math.PI, 0, 0]}>
-                <coneGeometry args={[0.04, 0.12, 8]} />
-                <meshStandardMaterial color="#f43f5e" transparent opacity={0} />
-              </mesh>
-              <mesh position={[0, 0.1, 0]}>
-                <cylinderGeometry args={[0.015, 0.015, 0.08, 8]} />
-                <meshStandardMaterial color="#f43f5e" transparent opacity={0} />
-              </mesh>
-            </group>
-          ))}
-        </group>
-      </group>
-    </Float>
-  );
-}
+const secondaryActions = [
+  {
+    label: 'Quick beam',
+    description: 'Run one focused IS 456 beam design.',
+    path: '/workbench/quick',
+    icon: PanelsTopLeft,
+  },
+  {
+    label: 'New project',
+    description: 'Import and review a building project.',
+    path: '/workbench/projects/new',
+    icon: Boxes,
+  },
+] as const;
 
 export function HomePage() {
   const navigate = useNavigate();
-  const prefersReducedMotion = useReducedMotion();
 
   return (
-    <div className="relative w-screen h-screen bg-zinc-950 overflow-hidden">
-      {/* Full-screen 3D Beam Background */}
-      <div className="absolute inset-0" aria-hidden="true">
-        <Canvas camera={{ position: [0, 0, 5], fov: 45 }}>
-          <Suspense fallback={null}>
-            <ambientLight intensity={0.4} />
-            <directionalLight position={[5, 5, 5]} intensity={0.5} />
-            <pointLight position={[-5, -5, -5]} intensity={0.3} color="#a78bfa" />
-            <AnimatedBeamConstruction />
-            <OrbitControls enableZoom={false} enablePan={false} autoRotate={!prefersReducedMotion} autoRotateSpeed={0.3} />
-          </Suspense>
-        </Canvas>
-      </div>
+    <main className="min-h-dvh overflow-y-auto bg-zinc-950 text-zinc-100">
+      <div className="mx-auto flex min-h-dvh w-full max-w-6xl flex-col px-5 py-6 sm:px-8 lg:px-12">
+        <header className="flex items-center justify-between border-b border-white/10 pb-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-600 text-sm font-bold text-white">
+              SL
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-white">StructLib</p>
+              <p className="text-xs text-zinc-500">IS 456 structural workbench</p>
+            </div>
+          </div>
+          <span className="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-xs font-medium text-amber-200">
+            Alpha
+          </span>
+        </header>
 
-      {/* Subtle gradient orbs */}
-      <div className="absolute inset-0 pointer-events-none">
-        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-blue-600/10 rounded-full blur-[120px]" />
-        <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-purple-600/10 rounded-full blur-[120px]" />
-      </div>
+        <section className="grid flex-1 items-center gap-10 py-12 lg:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)]">
+          <div className="max-w-2xl">
+            <p className="mb-4 text-sm font-medium text-blue-300">Design, review, resolve, export</p>
+            <h1 className="text-balance text-4xl font-semibold tracking-tight text-white sm:text-5xl lg:text-6xl">
+              Reinforced-concrete design in one clear workflow.
+            </h1>
+            <p className="mt-6 max-w-xl text-base leading-7 text-zinc-400 sm:text-lg">
+              Move from focused beam checks to imported-project review without
+              learning a collection of disconnected screens.
+            </p>
 
-      {/* Minimal Overlay - Center positioned */}
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: prefersReducedMotion ? 0 : 0.8, delay: prefersReducedMotion ? 0 : 0.3 }}
-          className="flex flex-col items-center text-center px-6 py-8 rounded-2xl max-w-xl pointer-events-auto"
-          style={{
-            background: "rgba(0, 0, 0, 0.25)",
-            backdropFilter: "blur(12px)",
-            border: "1px solid rgba(255, 255, 255, 0.05)",
-          }}
-        >
-          {/* Small Logo */}
-          <motion.div
-            initial={{ scale: 0, rotate: -180 }}
-            animate={{ scale: 1, rotate: 0 }}
-            transition={prefersReducedMotion ? { duration: 0 } : { type: "spring", stiffness: 200, damping: 20, delay: 0.5 }}
-            className="w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center mb-6"
-          >
-            <svg
-              className="w-6 h-6 text-white"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+            <button
+              type="button"
+              onClick={() => navigate('/workbench')}
+              className="mt-8 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-950/40 transition-colors hover:bg-blue-500 sm:w-auto"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-            </svg>
-          </motion.div>
+              Open workbench
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
 
-          {/* Clean Title */}
-          <motion.h1
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: prefersReducedMotion ? 0 : 0.6, delay: prefersReducedMotion ? 0 : 0.7 }}
-            className="text-4xl font-bold text-white tracking-tight mb-3"
-          >
-            StructLib
-          </motion.h1>
+          <div className="space-y-3" aria-label="Workbench entry points">
+            {secondaryActions.map(({ label, description, path, icon: Icon }) => (
+              <button
+                key={path}
+                type="button"
+                onClick={() => navigate(path)}
+                className="group flex w-full items-center gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-left transition-colors hover:border-white/20 hover:bg-white/[0.06]"
+              >
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/[0.06] text-zinc-300 group-hover:text-white">
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-white">{label}</span>
+                  <span className="mt-0.5 block text-xs leading-5 text-zinc-500">{description}</span>
+                </span>
+                <ArrowRight className="h-4 w-4 text-zinc-600 group-hover:text-zinc-300" aria-hidden="true" />
+              </button>
+            ))}
 
-          {/* Subtle Tagline */}
-          <motion.p
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: prefersReducedMotion ? 0 : 0.6, delay: prefersReducedMotion ? 0 : 0.9 }}
-            className="text-sm text-white/60 mb-8"
-          >
-            IS 456:2000 Beam Design — Precision. Visualization. Export.
-          </motion.p>
-
-          {/* Action Buttons */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: prefersReducedMotion ? 0 : 0.5, delay: prefersReducedMotion ? 0 : 1.1 }}
-            className="flex items-center gap-4"
-          >
-            {/* Primary CTA */}
-            <motion.button
-              whileHover={prefersReducedMotion ? {} : { scale: 1.05 }}
-              whileTap={prefersReducedMotion ? {} : { scale: 0.97 }}
-              onClick={() => navigate("/design")}
-              className="group relative px-8 py-3 text-white font-semibold rounded-xl shadow-lg shadow-blue-500/20 hover:shadow-blue-500/40 transition-shadow flex items-center gap-2 overflow-hidden"
-            >
-              <div
-                className="absolute inset-0 bg-gradient-to-r from-blue-500 via-purple-600 to-blue-500 bg-[length:200%_100%]"
-                style={{ animation: prefersReducedMotion ? 'none' : 'shimmer 3s linear infinite' }}
-              />
-              <span className="relative z-10 flex items-center gap-2">
-                Start Designing
-                <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-              </span>
-            </motion.button>
-
-            {/* Secondary CTA - Ghost Button */}
-            <motion.button
-              whileHover={prefersReducedMotion ? {} : { scale: 1.05, borderColor: "rgba(255, 255, 255, 0.25)" }}
-              whileTap={prefersReducedMotion ? {} : { scale: 0.98 }}
-              onClick={() => navigate("/import")}
-              className="px-8 py-3 text-white font-semibold rounded-xl border-2 border-white/15 hover:bg-white/5 transition-all"
-            >
-              Explore
-            </motion.button>
-          </motion.div>
-        </motion.div>
+            <div className="flex gap-3 rounded-2xl border border-emerald-400/20 bg-emerald-400/[0.06] p-4">
+              <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-300" aria-hidden="true" />
+              <p className="text-xs leading-5 text-emerald-100/80">
+                Results identify supported cases and evidence status. Professional
+                engineering review remains required for project use.
+              </p>
+            </div>
+          </div>
+        </section>
       </div>
-
-      <style>{`
-        @keyframes shimmer {
-          0% { background-position: 200% 0; }
-          100% { background-position: -200% 0; }
-        }
-      `}</style>
-    </div>
+    </main>
   );
 }

--- a/react_app/src/components/pages/WorkbenchHomePage.tsx
+++ b/react_app/src/components/pages/WorkbenchHomePage.tsx
@@ -1,0 +1,98 @@
+import { ArrowRight, Boxes, Calculator, ShieldCheck } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { WorkbenchHeader } from '../workbench/WorkbenchHeader';
+import { WorkbenchPanel } from '../workbench/WorkbenchPanel';
+import { WorkbenchShell } from '../workbench/WorkbenchShell';
+
+export interface WorkbenchHomePageProps {
+  initialView?: 'workbench' | 'projects';
+}
+
+export function WorkbenchHomePage({
+  initialView = 'workbench',
+}: WorkbenchHomePageProps) {
+  const navigate = useNavigate();
+  const title = initialView === 'projects' ? 'Projects' : 'Structural workbench';
+
+  return (
+    <WorkbenchShell
+      className="pt-14"
+      header={(
+        <WorkbenchHeader
+          title={title}
+          projectName="IS 456 reinforced-concrete design"
+          primaryAction={(
+            <button
+              type="button"
+              onClick={() => navigate('/workbench/projects/new')}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+              New project
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
+        />
+      )}
+    >
+      <div className="mx-auto grid max-w-5xl gap-4 p-4 pb-24 sm:p-6 md:grid-cols-2 md:pb-8">
+        <WorkbenchPanel
+          title="Quick beam"
+          description="One focused calculation without creating a project."
+        >
+          <div className="flex items-start gap-3">
+            <span className="rounded-xl bg-blue-500/10 p-2.5 text-blue-300">
+              <Calculator className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm leading-6 text-zinc-400">
+                Enter beam inputs, inspect checks and 3D detail, then export only
+                when the result is current and supported.
+              </p>
+              <button
+                type="button"
+                onClick={() => navigate('/workbench/quick')}
+                className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-blue-300 hover:text-blue-200"
+              >
+                Open quick beam
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        </WorkbenchPanel>
+
+        <WorkbenchPanel
+          title="Project workflow"
+          description="Import, review, design and resolve in context."
+        >
+          <div className="flex items-start gap-3">
+            <span className="rounded-xl bg-violet-500/10 p-2.5 text-violet-300">
+              <Boxes className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm leading-6 text-zinc-400">
+                Start with CSV, ETABS/SAFE, or the maintained sample. Full project
+                resume appears here only after a durable snapshot exists.
+              </p>
+              <button
+                type="button"
+                onClick={() => navigate('/workbench/projects/new')}
+                className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-violet-300 hover:text-violet-200"
+              >
+                Start project
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        </WorkbenchPanel>
+
+        <div className="flex gap-3 rounded-xl border border-emerald-400/20 bg-emerald-400/[0.05] p-4 md:col-span-2">
+          <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-300" aria-hidden="true" />
+          <p className="text-xs leading-5 text-emerald-100/80">
+            Supported scope and evidence status remain visible throughout the
+            workflow. Software results do not replace qualified engineering review.
+          </p>
+        </div>
+      </div>
+    </WorkbenchShell>
+  );
+}

--- a/react_app/src/components/ui/FloatingDock.tsx
+++ b/react_app/src/components/ui/FloatingDock.tsx
@@ -1,6 +1,5 @@
-import { cn } from "../../lib/utils";
-import { useState, type ReactNode } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import type { ReactNode } from 'react';
+import { cn } from '../../lib/utils';
 
 interface DockItem {
   id: string;
@@ -14,138 +13,60 @@ interface DockItem {
 interface FloatingDockProps {
   items: DockItem[];
   className?: string;
-  position?: "bottom" | "left" | "right";
+  position?: 'bottom' | 'left' | 'right';
 }
 
-/**
- * FloatingDock - macOS-style animated dock navigation.
- * Features:
- * - Hover magnification effect
- * - Smooth spring animations
- * - Badge support for notifications
- * - Active state indicators
- */
+const POSITION_CLASS = {
+  bottom: 'bottom-6 left-1/2 -translate-x-1/2 flex-row',
+  left: 'left-6 top-1/2 -translate-y-1/2 flex-col',
+  right: 'right-6 top-1/2 -translate-y-1/2 flex-col',
+} as const;
+
+/** Compact mobile navigation; destinations come from the typed app configuration. */
 export function FloatingDock({
   items,
   className,
-  position = "bottom",
+  position = 'bottom',
 }: FloatingDockProps) {
-  const [hoveredId, setHoveredId] = useState<string | null>(null);
-
-  const positionClasses = {
-    bottom: "bottom-6 left-1/2 -translate-x-1/2 flex-row",
-    left: "left-6 top-1/2 -translate-y-1/2 flex-col",
-    right: "right-6 top-1/2 -translate-y-1/2 flex-col",
-  };
-
   return (
     <nav aria-label="Quick navigation">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4, ease: "easeOut" }}
+      <div
         className={cn(
-          "fixed z-50 flex items-center gap-2 p-2",
-          "bg-zinc-900/80 backdrop-blur-2xl",
-          "border border-white/10 rounded-2xl",
-          "shadow-2xl shadow-black/50",
-          positionClasses[position],
-          className
+          'fixed z-50 flex items-center gap-2 rounded-2xl border border-white/10 bg-zinc-900/90 p-2 shadow-2xl shadow-black/50 backdrop-blur-2xl',
+          POSITION_CLASS[position],
+          className,
         )}
       >
-        {items.map((item, index) => (
-        <DockIcon
-          key={item.id}
-          item={item}
-          isHovered={hoveredId === item.id}
-          isNeighborHovered={
-            items.some((i, idx) =>
-              i.id === hoveredId && Math.abs(idx - index) === 1
-            )
-          }
-          onHover={() => setHoveredId(item.id)}
-          onLeave={() => setHoveredId(null)}
-        />
-      ))}
-      </motion.div>
-    </nav>
-  );
-}
-
-interface DockIconProps {
-  item: DockItem;
-  isHovered: boolean;
-  isNeighborHovered: boolean;
-  onHover: () => void;
-  onLeave: () => void;
-}
-
-function DockIcon({
-  item,
-  isHovered,
-  isNeighborHovered,
-  onHover,
-  onLeave,
-}: DockIconProps) {
-  // Calculate scale based on hover state (macOS-style magnification)
-  const scale = isHovered ? 1.4 : isNeighborHovered ? 1.15 : 1;
-
-  return (
-    <motion.button
-      aria-label={item.label}
-      onClick={item.onClick}
-      onMouseEnter={onHover}
-      onMouseLeave={onLeave}
-      animate={{ scale }}
-      transition={{
-        type: "spring",
-        stiffness: 400,
-        damping: 25,
-      }}
-      className={cn(
-        "relative flex items-center justify-center",
-        "w-12 h-12 rounded-xl",
-        "transition-colors duration-200",
-        item.active
-          ? "bg-white/15 text-white"
-          : "bg-white/5 text-white/70 hover:bg-white/10 hover:text-white"
-      )}
-    >
-      {/* Icon */}
-      <div className="w-6 h-6">{item.icon}</div>
-
-      {/* Badge */}
-      {item.badge && (
-        <span className="absolute -top-1 -right-1 flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-bold text-white bg-red-500 rounded-full">
-          {item.badge}
-        </span>
-      )}
-
-      {/* Active indicator */}
-      {item.active && (
-        <motion.div
-          layoutId="dock-active"
-          className="absolute -bottom-1 w-1 h-1 rounded-full bg-white"
-        />
-      )}
-
-      {/* Tooltip */}
-      <AnimatePresence>
-        {isHovered && (
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 5 }}
-            transition={{ duration: 0.15 }}
-            className="absolute -top-10 left-1/2 -translate-x-1/2 whitespace-nowrap px-2 py-1 text-xs font-medium text-white bg-zinc-800 rounded-lg border border-white/10"
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            aria-label={item.label}
+            aria-current={item.active ? 'page' : undefined}
+            onClick={item.onClick}
+            className={cn(
+              'group relative flex h-12 w-12 items-center justify-center rounded-xl transition-colors',
+              item.active
+                ? 'bg-white/15 text-white'
+                : 'bg-white/5 text-white/70 hover:bg-white/10 hover:text-white',
+            )}
           >
-            {item.label}
-            {/* Arrow */}
-            <div className="absolute left-1/2 -bottom-1 -translate-x-1/2 w-2 h-2 bg-zinc-800 border-r border-b border-white/10 rotate-45" />
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </motion.button>
+            <span className="h-6 w-6">{item.icon}</span>
+            {item.badge ? (
+              <span className="absolute -top-1 -right-1 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+                {item.badge}
+              </span>
+            ) : null}
+            {item.active ? (
+              <span className="absolute -bottom-1 h-1 w-1 rounded-full bg-white" />
+            ) : null}
+            <span className="pointer-events-none absolute -top-10 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-lg border border-white/10 bg-zinc-800 px-2 py-1 text-xs font-medium text-white opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+              {item.label}
+            </span>
+          </button>
+        ))}
+      </div>
+    </nav>
   );
 }
 

--- a/react_app/src/components/ui/WorkflowBreadcrumb.tsx
+++ b/react_app/src/components/ui/WorkflowBreadcrumb.tsx
@@ -1,148 +1,64 @@
-/**
- * WorkflowBreadcrumb - Horizontal step indicator for batch workflow
- *
- * Shows the 4-step batch workflow journey: Import → Editor → Batch Design → Dashboard
- * Highlights current step, shows completed steps with checkmarks.
- * Completed steps are clickable for navigation.
- */
-import { useNavigate, useLocation } from 'react-router-dom';
-import { Check } from 'lucide-react';
-import { motion } from 'framer-motion';
+/** Compatibility adapter from legacy project routes to the typed stage model. */
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  PROJECT_STAGES,
+  stageIsReachable,
+  type ProjectStage,
+} from '../../app/navigation';
 import { useImportedBeamsStore } from '../../store/importedBeamsStore';
-import { cn } from '../../lib/utils';
+import {
+  StageNavigation,
+  type WorkbenchStage,
+} from '../workbench/StageNavigation';
 
-interface Step {
-  id: string;
-  label: string;
-  route: string;
+const LEGACY_STAGE_ROUTES: Record<ProjectStage, string> = {
+  import: '/import',
+  review: '/editor',
+  design: '/batch',
+  results: '/dashboard',
+};
+
+function stageForPath(pathname: string): ProjectStage | null {
+  const legacy = Object.entries(LEGACY_STAGE_ROUTES).find(([, path]) => path === pathname);
+  if (legacy) return legacy[0] as ProjectStage;
+  const canonical = PROJECT_STAGES.find((stage) => pathname.endsWith(`/${stage.id}`));
+  return canonical?.id ?? null;
 }
-
-const WORKFLOW_STEPS: Step[] = [
-  { id: 'import', label: 'Import', route: '/import' },
-  { id: 'editor', label: 'Editor', route: '/editor' },
-  { id: 'batch', label: 'Batch Design', route: '/batch' },
-  { id: 'dashboard', label: 'Dashboard', route: '/dashboard' },
-];
 
 export function WorkflowBreadcrumb() {
   const navigate = useNavigate();
   const location = useLocation();
   const { beams } = useImportedBeamsStore();
+  const currentStage = stageForPath(location.pathname);
+  const currentOrder = PROJECT_STAGES.find((stage) => stage.id === currentStage)?.order ?? -1;
+  const completed = new Set<ProjectStage>();
 
-  // Determine current step index from route
-  const currentStepIndex = WORKFLOW_STEPS.findIndex(
-    (step) => step.route === location.pathname
-  );
+  if (beams.length > 0) completed.add('import');
+  if (currentOrder > 1) completed.add('review');
+  if (beams.some((beam) => beam.ast_required !== undefined)) completed.add('design');
 
-  // Step completion logic
-  const isStepComplete = (stepIndex: number): boolean => {
-    if (stepIndex === 0) {
-      // Import: complete when beams.length > 0
-      return beams.length > 0;
-    }
-    if (stepIndex === 1) {
-      // Editor: complete when on editor or later (batch/dashboard)
-      return currentStepIndex >= 1;
-    }
-    if (stepIndex === 2) {
-      // Batch Design: complete when any beam has results
-      return beams.some((b) => b.ast_required !== undefined);
-    }
-    if (stepIndex === 3) {
-      // Dashboard: final step, complete when reached
-      return currentStepIndex >= 3;
-    }
-    return false;
-  };
+  const stages: WorkbenchStage[] = PROJECT_STAGES.map((stage) => {
+    const isCurrent = stage.id === currentStage;
+    const isComplete = completed.has(stage.id) && !isCurrent;
+    const isAvailable = stageIsReachable(stage.id, completed);
+    const state = isCurrent
+      ? 'current'
+      : isComplete
+        ? 'complete'
+        : isAvailable
+          ? 'available'
+          : 'locked';
 
-  const handleStepClick = (stepIndex: number, route: string) => {
-    // Only allow navigation to completed steps or current step
-    if (stepIndex <= currentStepIndex || isStepComplete(stepIndex)) {
-      navigate(route);
-    }
-  };
+    return {
+      id: stage.id,
+      label: stage.label,
+      state,
+      description: state === 'locked' ? `Complete ${stage.requires ?? 'the prior stage'} first` : undefined,
+      onSelect: state === 'locked'
+        ? undefined
+        : () => navigate(LEGACY_STAGE_ROUTES[stage.id]),
+    };
+  });
 
-  return (
-    <div className="w-full px-6 py-4 bg-zinc-900/50 border-b border-zinc-800">
-      <div className="max-w-4xl mx-auto">
-        <div className="flex items-center justify-between relative">
-          {/* Background connecting line */}
-          <div className="absolute top-4 left-0 right-0 h-px bg-zinc-700 -z-10" />
-
-          {WORKFLOW_STEPS.map((step, index) => {
-            const isCurrent = index === currentStepIndex;
-            const isComplete = isStepComplete(index);
-            const isClickable = index <= currentStepIndex || isComplete;
-            const isPast = index < currentStepIndex;
-
-            return (
-              <motion.div
-                key={step.id}
-                className="flex flex-col items-center gap-2 flex-1 relative"
-                initial={{ opacity: 0, y: -10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-              >
-                {/* Step circle */}
-                <button
-                  onClick={() => handleStepClick(index, step.route)}
-                  disabled={!isClickable}
-                  className={cn(
-                    'relative w-8 h-8 rounded-full flex items-center justify-center',
-                    'transition-all duration-200 ring-4 ring-zinc-900/50',
-                    isCurrent && 'bg-blue-500 text-white scale-110',
-                    !isCurrent && isComplete && 'bg-green-600 text-white',
-                    !isCurrent && !isComplete && 'bg-zinc-700 text-zinc-400',
-                    isClickable && 'cursor-pointer hover:scale-105',
-                    !isClickable && 'cursor-not-allowed opacity-50'
-                  )}
-                  aria-current={isCurrent ? 'step' : undefined}
-                  aria-label={`${step.label}${isCurrent ? ' (current)' : ''}${isComplete ? ' (complete)' : ''}`}
-                >
-                  {isComplete && !isCurrent ? (
-                    <Check className="w-4 h-4" strokeWidth={3} />
-                  ) : (
-                    <span className="text-sm font-semibold">{index + 1}</span>
-                  )}
-
-                  {/* Pulse animation for current step */}
-                  {isCurrent && (
-                    <motion.span
-                      className="absolute inset-0 rounded-full bg-blue-500"
-                      initial={{ scale: 1, opacity: 0.5 }}
-                      animate={{ scale: 1.3, opacity: 0 }}
-                      transition={{ repeat: Infinity, duration: 1.5 }}
-                    />
-                  )}
-                </button>
-
-                {/* Step label */}
-                <span
-                  className={cn(
-                    'text-xs font-medium text-center whitespace-nowrap transition-colors',
-                    isCurrent && 'text-blue-400',
-                    !isCurrent && isComplete && 'text-green-400',
-                    !isCurrent && !isComplete && 'text-zinc-500'
-                  )}
-                >
-                  {step.label}
-                </span>
-
-                {/* Progress line between steps */}
-                {index < WORKFLOW_STEPS.length - 1 && (
-                  <div
-                    className={cn(
-                      'absolute top-4 left-1/2 w-full h-px transition-colors duration-300',
-                      isPast ? 'bg-green-500' : 'bg-zinc-700'
-                    )}
-                    style={{ transform: 'translateY(-50%)' }}
-                  />
-                )}
-              </motion.div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
+  return <StageNavigation stages={stages} ariaLabel="Project stages" />;
 }

--- a/react_app/src/components/viewport/__tests__/geometrySpace.test.ts
+++ b/react_app/src/components/viewport/__tests__/geometrySpace.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GEOMETRY_SPACE_FALLBACK,
+  boundsForMembers,
+  centerForBounds,
+  globalSourcePointToRendererM,
+  localBeamPointToRendererM,
+  validateGeometrySpaceV1,
+} from '../geometrySpace';
+
+// Mirrors tests/fixtures/geometry-space-v1.json without adding Node types to
+// the browser TypeScript project. The Python contract test reads that file.
+const fixture = {
+  global: {
+    schemaVersion: 'GeometrySpaceV1',
+    frame: 'GlobalSourceSpaceV1',
+    units: 'm',
+    axes: 'x=east,y=north,z=up',
+    members: [
+      {
+        memberId: 'ETABS-Frame-101', sourceId: 'ETABS-Frame-101', label: 'B1', story: 'GF', frameType: 'beam',
+        section: { widthMm: 300, depthMm: 500 }, inputHash: 'input-b1',
+        projectRevision: 3, memberRevision: 7, sourceRevision: 7, geometryRevision: 7,
+        start: { x: 0, y: 0, z: 0 }, end: { x: 6, y: 0, z: 0 },
+      },
+      {
+        memberId: 'ETABS-Frame-201', sourceId: 'ETABS-Frame-201', label: 'C1', story: 'GF', frameType: 'column',
+        section: { widthMm: 450, depthMm: 450 }, inputHash: 'input-c1',
+        projectRevision: 3, memberRevision: 7, sourceRevision: 7, geometryRevision: 7,
+        start: { x: 6, y: 0, z: 0 }, end: { x: 6, y: 0, z: 3 },
+      },
+    ],
+    bounds: { minX: 0, maxX: 6, minY: 0, maxY: 0, minZ: 0, maxZ: 3 },
+    center: { x: 3, y: 0, z: 1.5 },
+  },
+  detail: {
+    route: '/api/v1/geometry/beam/full', origin: 'left-support,center-width,soffit',
+    rebar: { end: { x: 6000, y: -96, z: 56 } }, stirrup: { positionX: 150 },
+  },
+} as const;
+
+describe('GeometrySpaceV1', () => {
+  it('preserves source IDs as stable member IDs in global source metres', () => {
+    const validated = validateGeometrySpaceV1(fixture.global);
+    expect(validated).toMatchObject({ ok: true });
+    expect(fixture.global.members.map((member) => member.memberId)).toEqual(fixture.global.members.map((member) => member.sourceId));
+    expect(fixture.global.members[0]).toMatchObject({
+      inputHash: 'input-b1',
+      projectRevision: 3,
+      memberRevision: 7,
+    });
+  });
+
+  it('maps global source metres to renderer metres exactly once', () => {
+    expect(globalSourcePointToRendererM(fixture.global.members[1].end)).toEqual([6, 3, 0]);
+    expect(globalSourcePointToRendererM({ x: 1, y: 2, z: 3 })).toEqual([1, 3, -2]);
+  });
+
+  it('derives fixture bounds and centre without dropping members', () => {
+    const bounds = boundsForMembers(fixture.global.members);
+    expect(bounds).toEqual(fixture.global.bounds);
+    expect(centerForBounds(bounds)).toEqual(fixture.global.center);
+    expect(new Set(fixture.global.members.map((member) => member.memberId)).size).toBe(2);
+  });
+
+  it('rejects incompatible schemas with a visible fallback marker', () => {
+    const invalid = validateGeometrySpaceV1({ ...fixture.global, schemaVersion: 'GeometrySpaceV0' });
+    expect(invalid).toEqual(expect.objectContaining({ ok: false, fallbackMarker: GEOMETRY_SPACE_FALLBACK }));
+  });
+
+  it('keeps known local-detail placement in millimetres', () => {
+    expect(fixture.detail.route).toBe('/api/v1/geometry/beam/full');
+    expect(fixture.detail.origin).toBe('left-support,center-width,soffit');
+    expect(localBeamPointToRendererM(fixture.detail.rebar.end)).toEqual([6, 0.056, -0.096]);
+    expect(fixture.detail.stirrup.positionX).toBe(150);
+  });
+});

--- a/react_app/src/components/viewport/geometrySpace.ts
+++ b/react_app/src/components/viewport/geometrySpace.ts
@@ -1,0 +1,127 @@
+/**
+ * GeometrySpaceV1 owns the two renderer boundaries frozen for P7.
+ *
+ * Global structural coordinates use x=east, y=north, z=up. Local beam-detail
+ * coordinates use x=span, y=section width, z=height above soffit. Callers must
+ * not pre-scale or pre-swap either frame.
+ */
+
+export const GEOMETRY_SPACE_V1 = 'GeometrySpaceV1' as const;
+export const GLOBAL_SOURCE_SPACE_V1 = 'GlobalSourceSpaceV1' as const;
+export const LOCAL_BEAM_SPACE_V1 = 'LocalBeamSpaceV1' as const;
+export const GEOMETRY_SPACE_FALLBACK = 'geometry-space-v1-invalid' as const;
+
+export type GlobalSourcePointM = Readonly<{ x: number; y: number; z: number }>;
+export type LocalBeamPointMm = Readonly<{ x: number; y: number; z: number }>;
+export type RendererPointM = readonly [number, number, number];
+
+export interface GeometryMemberV1 {
+  memberId: string;
+  sourceId: string;
+  label: string;
+  story: string;
+  frameType: 'beam' | 'column' | 'brace';
+  section: { widthMm: number; depthMm: number };
+  inputHash: string;
+  projectRevision: number;
+  memberRevision: number;
+  sourceRevision: number;
+  geometryRevision: number;
+  start: GlobalSourcePointM;
+  end: GlobalSourcePointM;
+}
+
+export interface GeometrySpaceV1 {
+  schemaVersion: typeof GEOMETRY_SPACE_V1;
+  frame: typeof GLOBAL_SOURCE_SPACE_V1;
+  units: 'm';
+  axes: 'x=east,y=north,z=up';
+  members: readonly GeometryMemberV1[];
+}
+
+export type GeometrySpaceValidation =
+  | { ok: true; value: GeometrySpaceV1 }
+  | { ok: false; fallbackMarker: typeof GEOMETRY_SPACE_FALLBACK; reason: string };
+
+/** Map source-metre global geometry into Three.js world metres exactly once. */
+export function globalSourcePointToRendererM(point: GlobalSourcePointM): RendererPointM {
+  const rendererZ = -point.y;
+  return [point.x, point.z, rendererZ === 0 ? 0 : rendererZ];
+}
+
+/** Map local beam-detail mm without applying the global north-axis inversion. */
+export function localBeamPointToRendererM(point: LocalBeamPointMm): RendererPointM {
+  const rendererZ = point.y * 0.001;
+  return [point.x * 0.001, point.z * 0.001, rendererZ === 0 ? 0 : rendererZ];
+}
+
+export function boundsForMembers(members: readonly GeometryMemberV1[]) {
+  const points = members.flatMap((member) => [member.start, member.end]);
+  if (points.length === 0) throw new Error('GeometrySpaceV1 requires one or more members.');
+
+  return {
+    minX: Math.min(...points.map((point) => point.x)),
+    maxX: Math.max(...points.map((point) => point.x)),
+    minY: Math.min(...points.map((point) => point.y)),
+    maxY: Math.max(...points.map((point) => point.y)),
+    minZ: Math.min(...points.map((point) => point.z)),
+    maxZ: Math.max(...points.map((point) => point.z)),
+  };
+}
+
+export function centerForBounds(bounds: ReturnType<typeof boundsForMembers>): GlobalSourcePointM {
+  return {
+    x: (bounds.minX + bounds.maxX) / 2,
+    y: (bounds.minY + bounds.maxY) / 2,
+    z: (bounds.minZ + bounds.maxZ) / 2,
+  };
+}
+
+export function validateGeometrySpaceV1(value: unknown): GeometrySpaceValidation {
+  if (!isRecord(value)
+    || value.schemaVersion !== GEOMETRY_SPACE_V1
+    || value.frame !== GLOBAL_SOURCE_SPACE_V1
+    || value.units !== 'm'
+    || value.axes !== 'x=east,y=north,z=up') {
+    return invalid('Unsupported GeometrySpaceV1 schema, frame, units, or axes.');
+  }
+  if (!Array.isArray(value.members) || value.members.length === 0) return invalid('GeometrySpaceV1 requires members.');
+
+  const ids = new Set<string>();
+  for (const member of value.members) {
+    if (!isGeometryMember(member)) return invalid('GeometrySpaceV1 member is incomplete or invalid.');
+    if (ids.has(member.memberId)) return invalid('GeometrySpaceV1 contains duplicate memberId values.');
+    ids.add(member.memberId);
+  }
+  return { ok: true, value: value as unknown as GeometrySpaceV1 };
+}
+
+function invalid(reason: string): GeometrySpaceValidation {
+  return { ok: false, fallbackMarker: GEOMETRY_SPACE_FALLBACK, reason };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isPoint(value: unknown): value is GlobalSourcePointM {
+  return isRecord(value) && ['x', 'y', 'z'].every((key) => typeof value[key] === 'number' && Number.isFinite(value[key]));
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function isGeometryMember(value: unknown): value is GeometryMemberV1 {
+  if (!isRecord(value) || !isRecord(value.section)) return false;
+  return ['memberId', 'sourceId', 'label', 'story'].every((key) => typeof value[key] === 'string' && value[key].length > 0)
+    && (value.frameType === 'beam' || value.frameType === 'column' || value.frameType === 'brace')
+    && typeof value.section.widthMm === 'number' && value.section.widthMm > 0
+    && typeof value.section.depthMm === 'number' && value.section.depthMm > 0
+    && typeof value.inputHash === 'string' && value.inputHash.length > 0
+    && isPositiveInteger(value.projectRevision)
+    && isPositiveInteger(value.memberRevision)
+    && isPositiveInteger(value.sourceRevision)
+    && isPositiveInteger(value.geometryRevision)
+    && isPoint(value.start) && isPoint(value.end);
+}

--- a/react_app/src/components/viewport/index.json
+++ b/react_app/src/components/viewport/index.json
@@ -2,67 +2,85 @@
   "folder": "react_app/src/components/viewport",
   "type": "react-source",
   "description": "",
-  "last_updated": "2026-02-10",
-  "file_count": 6,
+  "last_updated": "2026-08-10",
+  "file_count": 5,
   "files": [
     {
       "name": "LandingView.tsx",
       "type": "react-component",
       "size_lines": 171,
-      "last_updated": "2026-01-26",
+      "last_updated": "2026-03-26",
       "exports": [
         "LandingView"
       ],
       "props_type": "LandingViewProps",
-      "description": "LandingView - Hero landing page with quick actions."
-    },
-    {
-      "name": "Viewport3D.css",
-      "type": "stylesheet",
-      "size_lines": 24,
-      "last_updated": "2026-01-25"
+      "description": "LandingView - Hero landing page with quick actions.",
+      "content_hash": "237b258682b5"
     },
     {
       "name": "Viewport3D.tsx",
       "type": "react-component",
-      "size_lines": 1038,
-      "last_updated": "2026-02-10",
+      "size_lines": 1025,
+      "last_updated": "2026-04-05",
       "exports": [
         "RebarPreviewGeometry",
         "Viewport3DMode",
         "Viewport3D"
       ],
       "props_type": "BeamMeshProps",
-      "description": "Viewport3D Component"
-    },
-    {
-      "name": "WorkspaceLayout.css",
-      "type": "stylesheet",
-      "size_lines": 29,
-      "last_updated": "2026-01-25"
+      "description": "Viewport3D Component",
+      "content_hash": "a5aab45d042a"
     },
     {
       "name": "WorkspaceLayout.tsx",
       "type": "react-component",
-      "size_lines": 84,
-      "last_updated": "2026-02-10",
+      "size_lines": 83,
+      "last_updated": "2026-03-26",
       "exports": [
         "WorkspaceLayout"
       ],
-      "description": "WorkspaceLayout Component"
+      "description": "WorkspaceLayout Component",
+      "content_hash": "3ac605129456"
+    },
+    {
+      "name": "geometrySpace.ts",
+      "type": "typescript",
+      "size_lines": 128,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "GEOMETRY_SPACE_V1",
+        "GLOBAL_SOURCE_SPACE_V1",
+        "LOCAL_BEAM_SPACE_V1",
+        "GEOMETRY_SPACE_FALLBACK",
+        "GlobalSourcePointM",
+        "LocalBeamPointMm",
+        "RendererPointM",
+        "GeometryMemberV1",
+        "GeometrySpaceV1",
+        "GeometrySpaceValidation",
+        "globalSourcePointToRendererM",
+        "localBeamPointToRendererM",
+        "boundsForMembers",
+        "centerForBounds",
+        "validateGeometrySpaceV1"
+      ],
+      "description": "GeometrySpaceV1 owns the two renderer boundaries frozen for P7.",
+      "content_hash": "d814be9e0b23"
     },
     {
       "name": "index.ts",
       "type": "typescript",
       "size_lines": 7,
-      "last_updated": "2026-02-10",
+      "last_updated": "2026-03-26",
       "exports": [
         "Viewport3D",
         "WorkspaceLayout",
         "LandingView"
       ],
-      "description": "Viewport feature group — 3D visualization components"
+      "description": "Viewport feature group — 3D visualization components",
+      "content_hash": "746199c4a785"
     }
   ],
-  "subfolders": []
+  "subfolders": [],
+  "content_hash": "6c130bc33b378281"
 }

--- a/react_app/src/components/viewport/index.md
+++ b/react_app/src/components/viewport/index.md
@@ -1,24 +1,20 @@
 # Viewport
 
 **Type:** React Source
-**Last Updated:** 2026-02-10
-**Files:** 6
+**Last Updated:** 2026-08-10
+**Files:** 5
 
 ## React Component Files
 
 | File | Exports | Lines |
 |------|---------|-------|
 | [LandingView.tsx](LandingView.tsx) | LandingView | 171 |
-| [Viewport3D.tsx](Viewport3D.tsx) | RebarPreviewGeometry, Viewport3DMode, Viewport3D | 1038 |
-| [WorkspaceLayout.tsx](WorkspaceLayout.tsx) | WorkspaceLayout | 84 |
-
-## Stylesheet Files
-
-- [Viewport3D.css](Viewport3D.css)
-- [WorkspaceLayout.css](WorkspaceLayout.css)
+| [Viewport3D.tsx](Viewport3D.tsx) | RebarPreviewGeometry, Viewport3DMode, Viewport3D | 1025 |
+| [WorkspaceLayout.tsx](WorkspaceLayout.tsx) | WorkspaceLayout | 83 |
 
 ## Typescript Files
 
 | File | Exports | Lines |
 |------|---------|-------|
+| [geometrySpace.ts](geometrySpace.ts) | GEOMETRY_SPACE_V1, GLOBAL_SOURCE_SPACE_V1, LOCAL_BEAM_SPACE_V1, GEOMETRY_SPACE_FALLBACK, GlobalSourcePointM (+10) | 128 |
 | [index.ts](index.ts) | Viewport3D, WorkspaceLayout, LandingView | 7 |

--- a/react_app/src/components/workbench/ResultLifecycleBadge.tsx
+++ b/react_app/src/components/workbench/ResultLifecycleBadge.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import { AlertTriangle, CheckCircle2, CircleDashed, Clock3, FileWarning, ShieldX } from 'lucide-react';
+import type { ResultLifecycle } from '../../workspace/types';
+
+export interface ResultLifecycleBadgeProps {
+  lifecycle: ResultLifecycle;
+  className?: string;
+}
+
+interface LifecyclePresentation {
+  label: string;
+  icon: ReactNode;
+  className: string;
+}
+
+const LIFECYCLE_PRESENTATION: Record<ResultLifecycle, LifecyclePresentation> = {
+  current: { label: 'Current result', icon: <CheckCircle2 aria-hidden="true" className="h-3.5 w-3.5" />, className: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' },
+  stale: { label: 'Stale result', icon: <Clock3 aria-hidden="true" className="h-3.5 w-3.5" />, className: 'border-amber-500/40 bg-amber-500/10 text-amber-200' },
+  pending: { label: 'Result pending', icon: <CircleDashed aria-hidden="true" className="h-3.5 w-3.5" />, className: 'border-blue-500/40 bg-blue-500/10 text-blue-200' },
+  error: { label: 'Result error', icon: <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5" />, className: 'border-rose-500/40 bg-rose-500/10 text-rose-200' },
+  unsupported: { label: 'Unsupported case', icon: <ShieldX aria-hidden="true" className="h-3.5 w-3.5" />, className: 'border-violet-500/40 bg-violet-500/10 text-violet-200' },
+  not_evaluated: { label: 'Not evaluated', icon: <FileWarning aria-hidden="true" className="h-3.5 w-3.5" />, className: 'border-zinc-500/50 bg-zinc-500/10 text-zinc-200' },
+};
+
+/** Presentation-only lifecycle marker. Callers supply the authoritative lifecycle. */
+export function ResultLifecycleBadge({ lifecycle, className = '' }: ResultLifecycleBadgeProps) {
+  const presentation = LIFECYCLE_PRESENTATION[lifecycle];
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${presentation.className} ${className}`} role="status">
+      {presentation.icon}
+      {presentation.label}
+    </span>
+  );
+}

--- a/react_app/src/components/workbench/StageNavigation.tsx
+++ b/react_app/src/components/workbench/StageNavigation.tsx
@@ -1,0 +1,53 @@
+export type WorkbenchStageState = 'complete' | 'current' | 'available' | 'locked';
+
+export interface WorkbenchStage {
+  id: string;
+  label: string;
+  state: WorkbenchStageState;
+  description?: string;
+  onSelect?: () => void;
+}
+
+export interface StageNavigationProps {
+  stages: readonly WorkbenchStage[];
+  ariaLabel?: string;
+}
+
+const STATE_CLASS: Record<WorkbenchStageState, string> = {
+  complete: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+  current: 'border-blue-400 bg-blue-500/15 text-blue-100',
+  available: 'border-white/15 bg-white/5 text-zinc-200 hover:bg-white/10',
+  locked: 'border-white/10 bg-zinc-900 text-zinc-500',
+};
+
+/** Renders supplied stages only; it deliberately has no route knowledge. */
+export function StageNavigation({ stages, ariaLabel = 'Workbench stages' }: StageNavigationProps) {
+  return (
+    <nav aria-label={ariaLabel} className="overflow-x-auto border-b border-white/10 bg-zinc-950 px-4 sm:px-6">
+      <ol className="mx-auto flex min-w-max max-w-screen-2xl gap-2 py-2">
+        {stages.map((stage, index) => {
+          const locked = stage.state === 'locked';
+          const current = stage.state === 'current';
+          return (
+            <li key={stage.id}>
+              <button
+                type="button"
+                disabled={locked || !stage.onSelect}
+                onClick={stage.onSelect}
+                aria-current={current ? 'step' : undefined}
+                aria-describedby={stage.description ? `${stage.id}-description` : undefined}
+                className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm font-medium transition-colors disabled:cursor-not-allowed ${STATE_CLASS[stage.state]}`}
+              >
+                <span aria-hidden="true" className="text-xs tabular-nums">{index + 1}</span>
+                <span>{stage.label}</span>
+              </button>
+              {stage.description ? (
+                <span id={`${stage.id}-description`} className="sr-only">{stage.description}</span>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/react_app/src/components/workbench/Workbench.test.tsx
+++ b/react_app/src/components/workbench/Workbench.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ResultLifecycleBadge } from './ResultLifecycleBadge';
+import { StageNavigation } from './StageNavigation';
+import { WorkbenchHeader } from './WorkbenchHeader';
+import { WorkbenchShell } from './WorkbenchShell';
+
+describe('workbench primitives', () => {
+  it('keeps the narrow inspector and tray in the semantic reading order', () => {
+    render(
+      <WorkbenchShell
+        header={<WorkbenchHeader title="Project review" primaryAction={<button>Run design</button>} />}
+        inspector={<p>Selected beam</p>}
+        tray={<p>Issue queue</p>}
+      >
+        <p>Main canvas</p>
+      </WorkbenchShell>,
+    );
+
+    expect(screen.getByRole('region', { name: 'Workbench content' })).toHaveTextContent('Main canvas');
+    expect(screen.getByRole('complementary', { name: 'Selected item inspector' })).toHaveTextContent('Selected beam');
+    expect(screen.getByRole('region', { name: 'Workbench results and actions' })).toHaveTextContent('Issue queue');
+    expect(screen.getByRole('button', { name: 'Run design' })).toBeVisible();
+  });
+
+  it('renders supplied stages without owning their destinations', async () => {
+    const user = userEvent.setup();
+    const selectReview = vi.fn();
+    render(
+      <StageNavigation
+        stages={[
+          { id: 'import', label: 'Import', state: 'complete', onSelect: vi.fn() },
+          { id: 'review', label: 'Review', state: 'current', onSelect: selectReview },
+          { id: 'design', label: 'Design', state: 'locked', description: 'Complete review first' },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /review/i }));
+    expect(selectReview).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: /design/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /review/i })).toHaveAttribute('aria-current', 'step');
+  });
+
+  it.each([
+    ['current', 'Current result'],
+    ['stale', 'Stale result'],
+    ['pending', 'Result pending'],
+    ['error', 'Result error'],
+    ['unsupported', 'Unsupported case'],
+    ['not_evaluated', 'Not evaluated'],
+  ] as const)('renders %s as icon-plus-text lifecycle status', (lifecycle, label) => {
+    render(<ResultLifecycleBadge lifecycle={lifecycle} />);
+    expect(screen.getByRole('status')).toHaveTextContent(label);
+    expect(screen.getByRole('status').querySelector('svg')).not.toBeNull();
+  });
+});

--- a/react_app/src/components/workbench/WorkbenchHeader.tsx
+++ b/react_app/src/components/workbench/WorkbenchHeader.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+import type { SaveState } from '../../workspace/types';
+
+export interface WorkbenchHeaderProps {
+  title: string;
+  projectName?: string;
+  saveState?: SaveState;
+  secondaryActions?: ReactNode;
+  primaryAction?: ReactNode;
+  children?: ReactNode;
+}
+
+const SAVE_STATE_LABEL: Record<SaveState, string> = {
+  clean: 'Saved',
+  saving: 'Saving',
+  dirty: 'Unsaved changes',
+  error: 'Save needs attention',
+};
+
+const SAVE_STATE_CLASS: Record<SaveState, string> = {
+  clean: 'text-emerald-300',
+  saving: 'text-blue-300',
+  dirty: 'text-amber-300',
+  error: 'text-rose-300',
+};
+
+/** A header with one intentional primary-action slot. */
+export function WorkbenchHeader({
+  title,
+  projectName,
+  saveState,
+  secondaryActions,
+  primaryAction,
+  children,
+}: WorkbenchHeaderProps) {
+  return (
+    <header className="border-b border-white/10 bg-zinc-950/95 px-4 py-3 sm:px-6">
+      <div className="mx-auto flex max-w-screen-2xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          {projectName ? <p className="truncate text-xs text-zinc-400">{projectName}</p> : null}
+          <h1 className="truncate text-lg font-semibold text-white">{title}</h1>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {saveState ? (
+            <span
+              className={`text-xs font-medium ${SAVE_STATE_CLASS[saveState]}`}
+              role="status"
+            >
+              {SAVE_STATE_LABEL[saveState]}
+            </span>
+          ) : null}
+          {children}
+          {secondaryActions ? <div className="flex items-center gap-2">{secondaryActions}</div> : null}
+          {primaryAction ? (
+            <div className="w-full [&>a]:w-full [&>button]:w-full sm:w-auto sm:[&>a]:w-auto sm:[&>button]:w-auto">
+              {primaryAction}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/react_app/src/components/workbench/WorkbenchPanel.tsx
+++ b/react_app/src/components/workbench/WorkbenchPanel.tsx
@@ -1,0 +1,31 @@
+import { useId, type ReactNode } from 'react';
+
+export interface WorkbenchPanelProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function WorkbenchPanel({
+  title,
+  description,
+  actions,
+  children,
+  className = '',
+}: WorkbenchPanelProps) {
+  const headingId = useId();
+  return (
+    <section className={`rounded-xl border border-white/10 bg-zinc-900/60 ${className}`} aria-labelledby={headingId}>
+      <div className="flex items-start justify-between gap-3 border-b border-white/10 px-4 py-3">
+        <div className="min-w-0">
+          <h2 id={headingId} className="text-sm font-semibold text-white">{title}</h2>
+          {description ? <p className="mt-1 text-xs text-zinc-400">{description}</p> : null}
+        </div>
+        {actions ? <div className="shrink-0">{actions}</div> : null}
+      </div>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}

--- a/react_app/src/components/workbench/WorkbenchShell.tsx
+++ b/react_app/src/components/workbench/WorkbenchShell.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+
+export interface WorkbenchShellProps {
+  header: ReactNode;
+  children: ReactNode;
+  inspector?: ReactNode;
+  tray?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Structural layout only. Route, selection, and status ownership stay with the
+ * consuming workbench flow.
+ */
+export function WorkbenchShell({
+  header,
+  children,
+  inspector,
+  tray,
+  className = '',
+}: WorkbenchShellProps) {
+  return (
+    <section className={`min-h-dvh bg-zinc-950 text-zinc-100 ${className}`}>
+      {header}
+      <div className="grid min-h-0 grid-cols-1 xl:grid-cols-[minmax(0,1fr)_22rem]">
+        <section className="min-w-0" aria-label="Workbench content">
+          {children}
+        </section>
+        {inspector ? (
+          <aside
+            aria-label="Selected item inspector"
+            className="min-w-0 border-t border-white/10 bg-zinc-900/50 xl:border-t-0 xl:border-l"
+          >
+            {inspector}
+          </aside>
+        ) : null}
+      </div>
+      {tray ? (
+        <section
+          aria-label="Workbench results and actions"
+          className="border-t border-white/10 bg-zinc-950/95"
+        >
+          {tray}
+        </section>
+      ) : null}
+    </section>
+  );
+}

--- a/react_app/src/components/workbench/WorkbenchShell.tsx
+++ b/react_app/src/components/workbench/WorkbenchShell.tsx
@@ -20,7 +20,7 @@ export function WorkbenchShell({
   className = '',
 }: WorkbenchShellProps) {
   return (
-    <section className={`min-h-dvh bg-zinc-950 text-zinc-100 ${className}`}>
+    <section className={`h-full min-h-0 overflow-y-auto bg-zinc-950 text-zinc-100 ${className}`}>
       {header}
       <div className="grid min-h-0 grid-cols-1 xl:grid-cols-[minmax(0,1fr)_22rem]">
         <section className="min-w-0" aria-label="Workbench content">

--- a/react_app/src/components/workbench/index.json
+++ b/react_app/src/components/workbench/index.json
@@ -73,9 +73,9 @@
       ],
       "props_type": "WorkbenchShellProps",
       "description": "Structural layout only. Route, selection, and status ownership stay with the",
-      "content_hash": "d9203e8f7283"
+      "content_hash": "4a923c7cb60e"
     }
   ],
   "subfolders": [],
-  "content_hash": "016ee9650732ce64"
+  "content_hash": "9cdfc147a5ce1b8a"
 }

--- a/react_app/src/components/workbench/index.json
+++ b/react_app/src/components/workbench/index.json
@@ -1,0 +1,81 @@
+{
+  "folder": "react_app/src/components/workbench",
+  "type": "react-source",
+  "description": "",
+  "last_updated": "2026-08-10",
+  "file_count": 6,
+  "files": [
+    {
+      "name": "ResultLifecycleBadge.tsx",
+      "type": "react-component",
+      "size_lines": 35,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "ResultLifecycleBadgeProps",
+        "ResultLifecycleBadge"
+      ],
+      "props_type": "ResultLifecycleBadgeProps",
+      "content_hash": "fec401abcda0"
+    },
+    {
+      "name": "StageNavigation.tsx",
+      "type": "react-component",
+      "size_lines": 54,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WorkbenchStageState",
+        "WorkbenchStage",
+        "StageNavigationProps",
+        "StageNavigation"
+      ],
+      "props_type": "StageNavigationProps",
+      "content_hash": "221e857476e3"
+    },
+    {
+      "name": "Workbench.test.tsx",
+      "type": "react-component",
+      "size_lines": 59,
+      "last_updated": "2026-08-10",
+      "content_hash": "2b4dec35b8dc"
+    },
+    {
+      "name": "WorkbenchHeader.tsx",
+      "type": "react-component",
+      "size_lines": 64,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WorkbenchHeaderProps",
+        "WorkbenchHeader"
+      ],
+      "props_type": "WorkbenchHeaderProps",
+      "content_hash": "d751b5a413ae"
+    },
+    {
+      "name": "WorkbenchPanel.tsx",
+      "type": "react-component",
+      "size_lines": 32,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WorkbenchPanelProps",
+        "WorkbenchPanel"
+      ],
+      "props_type": "WorkbenchPanelProps",
+      "content_hash": "380cf556d619"
+    },
+    {
+      "name": "WorkbenchShell.tsx",
+      "type": "react-component",
+      "size_lines": 49,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WorkbenchShellProps",
+        "WorkbenchShell"
+      ],
+      "props_type": "WorkbenchShellProps",
+      "description": "Structural layout only. Route, selection, and status ownership stay with the",
+      "content_hash": "d9203e8f7283"
+    }
+  ],
+  "subfolders": [],
+  "content_hash": "016ee9650732ce64"
+}

--- a/react_app/src/components/workbench/index.md
+++ b/react_app/src/components/workbench/index.md
@@ -1,0 +1,16 @@
+# Workbench
+
+**Type:** React Source
+**Last Updated:** 2026-08-10
+**Files:** 6
+
+## React Component Files
+
+| File | Exports | Lines |
+|------|---------|-------|
+| [ResultLifecycleBadge.tsx](ResultLifecycleBadge.tsx) | ResultLifecycleBadgeProps, ResultLifecycleBadge | 35 |
+| [StageNavigation.tsx](StageNavigation.tsx) | WorkbenchStageState, WorkbenchStage, StageNavigationProps, StageNavigation | 54 |
+| [Workbench.test.tsx](Workbench.test.tsx) |  | 59 |
+| [WorkbenchHeader.tsx](WorkbenchHeader.tsx) | WorkbenchHeaderProps, WorkbenchHeader | 64 |
+| [WorkbenchPanel.tsx](WorkbenchPanel.tsx) | WorkbenchPanelProps, WorkbenchPanel | 32 |
+| [WorkbenchShell.tsx](WorkbenchShell.tsx) | WorkbenchShellProps, WorkbenchShell | 49 |

--- a/react_app/src/index.json
+++ b/react_app/src/index.json
@@ -8,10 +8,10 @@
     {
       "name": "App.tsx",
       "type": "react-component",
-      "size_lines": 117,
+      "size_lines": 119,
       "last_updated": "2026-08-10",
       "description": "Structural Engineering App",
-      "content_hash": "52da26bffa41"
+      "content_hash": "5432b97c7c91"
     },
     {
       "name": "config.ts",
@@ -101,8 +101,8 @@
     {
       "name": "workspace",
       "path": "workspace/",
-      "file_count": 12
+      "file_count": 17
     }
   ],
-  "content_hash": "e06bd909110238eb"
+  "content_hash": "e62c89c582894afc"
 }

--- a/react_app/src/index.json
+++ b/react_app/src/index.json
@@ -2,7 +2,7 @@
   "folder": "react_app/src",
   "type": "react-source",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 5,
   "files": [
     {
@@ -54,6 +54,11 @@
       "file_count": 2
     },
     {
+      "name": "app",
+      "path": "app/",
+      "file_count": 4
+    },
+    {
       "name": "assets",
       "path": "assets/",
       "file_count": 1
@@ -61,12 +66,12 @@
     {
       "name": "components",
       "path": "components/",
-      "file_count": 56
+      "file_count": 66
     },
     {
       "name": "hooks",
       "path": "hooks/",
-      "file_count": 23
+      "file_count": 24
     },
     {
       "name": "lib",
@@ -91,7 +96,12 @@
     {
       "name": "utils",
       "path": "utils/",
-      "file_count": 5
+      "file_count": 10
+    },
+    {
+      "name": "workspace",
+      "path": "workspace/",
+      "file_count": 12
     }
   ],
   "content_hash": "85b284cebe12a7c7"

--- a/react_app/src/index.json
+++ b/react_app/src/index.json
@@ -8,10 +8,10 @@
     {
       "name": "App.tsx",
       "type": "react-component",
-      "size_lines": 164,
-      "last_updated": "2026-04-05",
+      "size_lines": 117,
+      "last_updated": "2026-08-10",
       "description": "Structural Engineering App",
-      "content_hash": "f04cc58ccc78"
+      "content_hash": "52da26bffa41"
     },
     {
       "name": "config.ts",
@@ -66,7 +66,7 @@
     {
       "name": "components",
       "path": "components/",
-      "file_count": 66
+      "file_count": 69
     },
     {
       "name": "hooks",
@@ -104,5 +104,5 @@
       "file_count": 12
     }
   ],
-  "content_hash": "85b284cebe12a7c7"
+  "content_hash": "e06bd909110238eb"
 }

--- a/react_app/src/index.md
+++ b/react_app/src/index.md
@@ -8,7 +8,7 @@
 
 | File | Exports | Lines |
 |------|---------|-------|
-| [App.tsx](App.tsx) |  | 117 |
+| [App.tsx](App.tsx) |  | 119 |
 | [main.tsx](main.tsx) |  | 11 |
 
 ## Stylesheet Files
@@ -36,4 +36,4 @@
 | [test/](test/) | 2 |  |
 | [types/](types/) | 4 |  |
 | [utils/](utils/) | 10 |  |
-| [workspace/](workspace/) | 12 |  |
+| [workspace/](workspace/) | 17 |  |

--- a/react_app/src/index.md
+++ b/react_app/src/index.md
@@ -8,7 +8,7 @@
 
 | File | Exports | Lines |
 |------|---------|-------|
-| [App.tsx](App.tsx) |  | 164 |
+| [App.tsx](App.tsx) |  | 117 |
 | [main.tsx](main.tsx) |  | 11 |
 
 ## Stylesheet Files
@@ -29,7 +29,7 @@
 | [api/](api/) | 2 |  |
 | [app/](app/) | 4 |  |
 | [assets/](assets/) | 1 |  |
-| [components/](components/) | 66 |  |
+| [components/](components/) | 69 |  |
 | [hooks/](hooks/) | 24 |  |
 | [lib/](lib/) | 1 |  |
 | [store/](store/) | 6 |  |

--- a/react_app/src/index.md
+++ b/react_app/src/index.md
@@ -1,7 +1,7 @@
 # Src
 
 **Type:** React Source
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 5
 
 ## React Component Files
@@ -27,11 +27,13 @@
 | Folder | Files | Description |
 |--------|-------|-------------|
 | [api/](api/) | 2 |  |
+| [app/](app/) | 4 |  |
 | [assets/](assets/) | 1 |  |
-| [components/](components/) | 56 |  |
-| [hooks/](hooks/) | 23 |  |
+| [components/](components/) | 66 |  |
+| [hooks/](hooks/) | 24 |  |
 | [lib/](lib/) | 1 |  |
 | [store/](store/) | 6 |  |
 | [test/](test/) | 2 |  |
 | [types/](types/) | 4 |  |
-| [utils/](utils/) | 5 |  |
+| [utils/](utils/) | 10 |  |
+| [workspace/](workspace/) | 12 |  |

--- a/react_app/src/workspace/WorkspacePersistenceBridge.tsx
+++ b/react_app/src/workspace/WorkspacePersistenceBridge.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from 'react';
+import { WorkspaceAutosaveCoordinator } from './autosave';
+import {
+  createIndexedDbWorkspacePersistence,
+  type WorkspacePersistence,
+} from './persistence';
+import {
+  createWorkspaceRevisionSync,
+  type WorkspaceRevisionSync,
+} from './sync';
+import type { WorkspaceSnapshotV1 } from './types';
+import { useWorkspaceStore } from './workspaceStore';
+
+interface WorkspaceRuntime {
+  autosave: WorkspaceAutosaveCoordinator;
+  persistence: WorkspacePersistence;
+}
+
+export interface WorkspacePersistenceBridgeProps {
+  autosaveDelayMs?: number;
+  createPersistence?: () => WorkspacePersistence;
+  createRevisionSync?: typeof createWorkspaceRevisionSync;
+}
+
+function currentSnapshotMatches(snapshot: WorkspaceSnapshotV1): boolean {
+  const current = useWorkspaceStore.getState().snapshot;
+  return Boolean(
+    current
+    && current.projectId === snapshot.projectId
+    && current.projectRevision === snapshot.projectRevision,
+  );
+}
+
+/** Connects the revisioned workspace store to durable local persistence. */
+export function WorkspacePersistenceBridge({
+  autosaveDelayMs = 500,
+  createPersistence = createIndexedDbWorkspacePersistence,
+  createRevisionSync = createWorkspaceRevisionSync,
+}: WorkspacePersistenceBridgeProps = {}) {
+  const snapshot = useWorkspaceStore((state) => state.snapshot);
+  const [runtime, setRuntime] = useState<WorkspaceRuntime | null>(null);
+  const syncRef = useRef<WorkspaceRevisionSync | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    let autosave: WorkspaceAutosaveCoordinator | null = null;
+    try {
+      const persistence = createPersistence();
+      autosave = new WorkspaceAutosaveCoordinator(
+        persistence,
+        autosaveDelayMs,
+        {
+          onStateChange(state, savedSnapshot) {
+            if (!currentSnapshotMatches(savedSnapshot)) return;
+            const store = useWorkspaceStore.getState();
+            if (state === 'saving') store.setSaveState('saving');
+            if (state === 'saved') {
+              store.markSaved(savedSnapshot.updatedAt);
+              syncRef.current?.announce(savedSnapshot);
+            }
+            if (state === 'error' || state === 'conflict') {
+              store.setSaveState('error');
+            }
+          },
+        },
+      );
+      if (active) setRuntime({ autosave, persistence });
+    } catch {
+      useWorkspaceStore.getState().setSaveState('error');
+    }
+
+    return () => {
+      active = false;
+      autosave?.dispose();
+      syncRef.current?.close();
+      syncRef.current = null;
+    };
+  }, [autosaveDelayMs, createPersistence]);
+
+  useEffect(() => {
+    syncRef.current?.close();
+    syncRef.current = null;
+    const current = useWorkspaceStore.getState().snapshot;
+    if (!runtime || !current || current.projectId !== snapshot?.projectId) return;
+
+    runtime.autosave.prime(
+      current.projectId,
+      current.savedAt === null ? null : current.projectRevision,
+    );
+    try {
+      syncRef.current = createRevisionSync(
+        crypto.randomUUID(),
+        (notice) => {
+          runtime.autosave.noteExternalRevision(notice);
+          const current = useWorkspaceStore.getState().snapshot;
+          if (current?.projectId === notice.projectId) {
+            useWorkspaceStore.getState().setSaveState('error');
+          }
+        },
+      );
+    } catch {
+      useWorkspaceStore.getState().setSaveState('error');
+    }
+
+    return () => {
+      syncRef.current?.close();
+      syncRef.current = null;
+    };
+  }, [createRevisionSync, runtime, snapshot?.projectId, snapshot?.savedAt]);
+
+  useEffect(() => {
+    if (
+      !runtime
+      || !snapshot
+      || !snapshot.dirty
+      || snapshot.saveState !== 'dirty'
+    ) {
+      return;
+    }
+    runtime.autosave.schedule(snapshot);
+  }, [runtime, snapshot]);
+
+  return null;
+}

--- a/react_app/src/workspace/__tests__/WorkspacePersistenceBridge.test.tsx
+++ b/react_app/src/workspace/__tests__/WorkspacePersistenceBridge.test.tsx
@@ -1,0 +1,55 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkspacePersistenceBridge } from '../WorkspacePersistenceBridge';
+import { createIndexedDbWorkspacePersistence } from '../persistence';
+import type { WorkspaceRevisionNotice } from '../sync';
+import { useWorkspaceStore } from '../workspaceStore';
+import { FakeIndexedDbFactory } from './fakeIndexedDb';
+
+describe('WorkspacePersistenceBridge', () => {
+  beforeEach(() => useWorkspaceStore.getState().reset());
+
+  it('persists a dirty project and reports a newer external revision', async () => {
+    const factory = new FakeIndexedDbFactory();
+    const persistence = createIndexedDbWorkspacePersistence(
+      factory as unknown as IDBFactory,
+    );
+    const announce = vi.fn();
+    const receiveExternalRevision = vi.fn<(notice: WorkspaceRevisionNotice) => void>();
+    useWorkspaceStore.getState().createProject(
+      'project-1',
+      'Project 1',
+      '2026-08-10T00:00:00.000Z',
+    );
+
+    render(
+      <WorkspacePersistenceBridge
+        autosaveDelayMs={0}
+        createPersistence={() => persistence}
+        createRevisionSync={(_sourceId, onExternal) => {
+          receiveExternalRevision.mockImplementation(onExternal);
+          return { announce, close: vi.fn() };
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(useWorkspaceStore.getState().snapshot?.saveState).toBe('clean');
+    });
+    await expect(persistence.load('project-1')).resolves.toMatchObject({
+      projectRevision: 1,
+      dirty: false,
+      saveState: 'clean',
+    });
+    expect(announce).toHaveBeenCalledOnce();
+
+    receiveExternalRevision({
+      type: 'workspace-revision',
+      sourceId: 'other-tab',
+      projectId: 'project-1',
+      projectRevision: 2,
+      updatedAt: '2026-08-10T00:01:00.000Z',
+    });
+    expect(useWorkspaceStore.getState().snapshot?.saveState).toBe('error');
+  });
+});

--- a/react_app/src/workspace/__tests__/autosave.test.ts
+++ b/react_app/src/workspace/__tests__/autosave.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FakeIndexedDbFactory } from './fakeIndexedDb';
+import { WorkspaceAutosaveCoordinator } from '../autosave';
+import {
+  createIndexedDbWorkspacePersistence,
+  WorkspaceConflictError,
+} from '../persistence';
+import { WORKSPACE_SCHEMA_VERSION, type WorkspaceSnapshotV1 } from '../types';
+
+function snapshot(projectRevision: number): WorkspaceSnapshotV1 {
+  return {
+    schemaVersion: WORKSPACE_SCHEMA_VERSION,
+    projectId: 'project-1',
+    projectName: 'Project 1',
+    projectRevision,
+    members: [],
+    selectedStage: 'review',
+    selectedMemberId: null,
+    selectedFloor: null,
+    dirty: true,
+    saveState: 'dirty',
+    createdAt: '2026-08-10T00:00:00.000Z',
+    updatedAt: `2026-08-10T00:0${projectRevision}:00.000Z`,
+    savedAt: null,
+    migrationOrigin: null,
+  };
+}
+
+describe('workspace autosave coordinator', () => {
+  it('coalesces queued snapshots and saves only the latest revision', async () => {
+    const factory = new FakeIndexedDbFactory();
+    const persistence = createIndexedDbWorkspacePersistence(factory as unknown as IDBFactory);
+    const onStateChange = vi.fn();
+    const coordinator = new WorkspaceAutosaveCoordinator(
+      persistence,
+      60_000,
+      { onStateChange },
+    );
+    coordinator.prime('project-1', null);
+    coordinator.schedule(snapshot(1));
+    coordinator.schedule(snapshot(2));
+
+    await coordinator.flush();
+
+    await expect(persistence.load('project-1')).resolves.toMatchObject({
+      projectRevision: 2,
+    });
+    expect(onStateChange.mock.calls.map(([state]) => state)).toEqual(['saving', 'saved']);
+    coordinator.dispose();
+  });
+
+  it('blocks autosave after a newer external revision notice', async () => {
+    const factory = new FakeIndexedDbFactory();
+    const persistence = createIndexedDbWorkspacePersistence(factory as unknown as IDBFactory);
+    await persistence.save(snapshot(1), { expectedProjectRevision: null });
+    const onStateChange = vi.fn();
+    const coordinator = new WorkspaceAutosaveCoordinator(
+      persistence,
+      60_000,
+      { onStateChange },
+    );
+    coordinator.prime('project-1', 1);
+    coordinator.noteExternalRevision({
+      type: 'workspace-revision',
+      sourceId: 'tab-2',
+      projectId: 'project-1',
+      projectRevision: 2,
+      updatedAt: '2026-08-10T00:02:00.000Z',
+    });
+    coordinator.schedule(snapshot(2));
+
+    await expect(coordinator.flush()).rejects.toBeInstanceOf(WorkspaceConflictError);
+    await expect(persistence.load('project-1')).resolves.toMatchObject({
+      projectRevision: 1,
+    });
+    expect(onStateChange.mock.calls.map(([state]) => state)).toEqual(['conflict']);
+    coordinator.dispose();
+  });
+});

--- a/react_app/src/workspace/__tests__/fakeIndexedDb.ts
+++ b/react_app/src/workspace/__tests__/fakeIndexedDb.ts
@@ -1,0 +1,214 @@
+type Listener = () => void;
+
+class FakeEventTarget {
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    const callback = typeof listener === 'function'
+      ? () => listener(new Event(type))
+      : () => listener.handleEvent(new Event(type));
+    const listeners = this.listeners.get(type) ?? new Set<Listener>();
+    listeners.add(callback);
+    this.listeners.set(type, listeners);
+  }
+
+  protected emit(type: string): void {
+    for (const listener of this.listeners.get(type) ?? []) listener();
+  }
+}
+
+class FakeRequest<T> extends FakeEventTarget {
+  result!: T;
+  error: DOMException | null = null;
+
+  succeed(result: T): void {
+    this.result = result;
+    this.emit('success');
+  }
+
+  fail(error: DOMException): void {
+    this.error = error;
+    this.emit('error');
+  }
+}
+
+class FakeTransaction extends FakeEventTarget {
+  error: DOMException | null = null;
+  private pending = 0;
+  private completionScheduled = false;
+  readonly store: FakeObjectStore;
+
+  constructor(
+    records: Map<string, unknown>,
+    shouldFailWrite: () => DOMException | null,
+  ) {
+    super();
+    this.store = new FakeObjectStore(this, records, shouldFailWrite);
+  }
+
+  objectStore(): IDBObjectStore {
+    return this.store as unknown as IDBObjectStore;
+  }
+
+  run<T>(operation: () => T): IDBRequest<T> {
+    this.pending += 1;
+    const request = new FakeRequest<T>();
+    queueMicrotask(() => {
+      try {
+        request.succeed(operation());
+      } catch (error) {
+        this.error = error instanceof DOMException
+          ? error
+          : new DOMException('IndexedDB operation failed.', 'UnknownError');
+        request.fail(this.error);
+        this.emit('error');
+        this.emit('abort');
+      } finally {
+        this.pending -= 1;
+        this.scheduleCompletion();
+      }
+    });
+    return request as unknown as IDBRequest<T>;
+  }
+
+  abort(): void {
+    this.error = new DOMException('Transaction aborted.', 'AbortError');
+    this.emit('abort');
+  }
+
+  private scheduleCompletion(): void {
+    if (this.completionScheduled || this.error) return;
+    this.completionScheduled = true;
+    setTimeout(() => {
+      this.completionScheduled = false;
+      if (this.pending === 0 && !this.error) this.emit('complete');
+    }, 0);
+  }
+}
+
+class FakeObjectStore {
+  private readonly transaction: FakeTransaction;
+  private readonly records: Map<string, unknown>;
+  private readonly shouldFailWrite: () => DOMException | null;
+
+  constructor(
+    transaction: FakeTransaction,
+    records: Map<string, unknown>,
+    shouldFailWrite: () => DOMException | null,
+  ) {
+    this.transaction = transaction;
+    this.records = records;
+    this.shouldFailWrite = shouldFailWrite;
+  }
+
+  get(key: IDBValidKey): IDBRequest<unknown> {
+    return this.transaction.run(() => this.records.get(String(key)));
+  }
+
+  getAll(): IDBRequest<unknown[]> {
+    return this.transaction.run(() => [...this.records.values()]);
+  }
+
+  put(value: unknown): IDBRequest<IDBValidKey> {
+    return this.transaction.run<IDBValidKey>(() => {
+      const failure = this.shouldFailWrite();
+      if (failure) throw failure;
+      const projectId = (value as { projectId?: unknown }).projectId;
+      if (typeof projectId !== 'string') {
+        throw new DOMException('Missing projectId key.', 'DataError');
+      }
+      this.records.set(projectId, structuredClone(value));
+      return projectId;
+    });
+  }
+
+  delete(key: IDBValidKey): IDBRequest<undefined> {
+    return this.transaction.run(() => {
+      const failure = this.shouldFailWrite();
+      if (failure) throw failure;
+      this.records.delete(String(key));
+      return undefined;
+    });
+  }
+
+  clear(): IDBRequest<undefined> {
+    return this.transaction.run(() => {
+      const failure = this.shouldFailWrite();
+      if (failure) throw failure;
+      this.records.clear();
+      return undefined;
+    });
+  }
+}
+
+class FakeDatabase {
+  private readonly records = new Map<string, unknown>();
+  private hasProjectStore = false;
+  private readonly shouldFailWrite: () => DOMException | null;
+
+  constructor(shouldFailWrite: () => DOMException | null) {
+    this.shouldFailWrite = shouldFailWrite;
+  }
+
+  readonly objectStoreNames = {
+    contains: (name: string) => name === 'projects' && this.hasProjectStore,
+  };
+
+  createObjectStore(name: string): IDBObjectStore {
+    if (name !== 'projects') throw new DOMException('Unknown store.', 'NotFoundError');
+    this.hasProjectStore = true;
+    return {} as IDBObjectStore;
+  }
+
+  transaction(name: string): IDBTransaction {
+    if (name !== 'projects' || !this.hasProjectStore) {
+      throw new DOMException('Unknown store.', 'NotFoundError');
+    }
+    return new FakeTransaction(this.records, this.shouldFailWrite) as unknown as IDBTransaction;
+  }
+
+  seed(projectId: string, value: unknown): void {
+    this.records.set(projectId, structuredClone(value));
+  }
+
+  read(projectId: string): unknown {
+    return structuredClone(this.records.get(projectId));
+  }
+}
+
+class FakeOpenRequest extends FakeRequest<IDBDatabase> {
+  emitForUpgrade(): void {
+    this.emit('upgradeneeded');
+  }
+}
+
+export class FakeIndexedDbFactory {
+  private failure: DOMException | null = null;
+  private readonly database = new FakeDatabase(() => {
+    const failure = this.failure;
+    this.failure = null;
+    return failure;
+  });
+
+  open(): IDBOpenDBRequest {
+    const request = new FakeOpenRequest();
+    queueMicrotask(() => {
+      request.result = this.database as unknown as IDBDatabase;
+      request.emitForUpgrade();
+      request.succeed(this.database as unknown as IDBDatabase);
+    });
+    return request as unknown as IDBOpenDBRequest;
+  }
+
+  failNextWrite(name: string = 'QuotaExceededError'): void {
+    this.failure = new DOMException('Synthetic storage failure.', name);
+  }
+
+  seed(projectId: string, value: unknown): void {
+    this.database.seed(projectId, value);
+  }
+
+  read(projectId: string): unknown {
+    return this.database.read(projectId);
+  }
+}

--- a/react_app/src/workspace/__tests__/persistence.test.ts
+++ b/react_app/src/workspace/__tests__/persistence.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseWorkspaceSnapshot,
+  serializeWorkspaceSnapshot,
+  WorkspacePersistenceError,
+} from '../persistence';
+import {
+  WORKSPACE_SCHEMA_VERSION,
+  type WorkspaceSnapshotV1,
+} from '../types';
+
+const snapshot: WorkspaceSnapshotV1 = {
+  schemaVersion: WORKSPACE_SCHEMA_VERSION,
+  projectId: 'project-1',
+  projectName: 'Project 1',
+  projectRevision: 1,
+  members: [],
+  selectedStage: 'import',
+  selectedMemberId: null,
+  selectedFloor: null,
+  dirty: false,
+  saveState: 'clean',
+  createdAt: '2026-08-10T00:00:00.000Z',
+  updatedAt: '2026-08-10T00:00:00.000Z',
+  savedAt: '2026-08-10T00:00:00.000Z',
+  migrationOrigin: null,
+};
+
+describe('portable workspace persistence contract', () => {
+  it('round-trips a valid versioned snapshot', () => {
+    expect(parseWorkspaceSnapshot(serializeWorkspaceSnapshot(snapshot))).toEqual(snapshot);
+  });
+
+  it('fails closed on unknown schemas and malformed members', () => {
+    expect(() => parseWorkspaceSnapshot(JSON.stringify({
+      ...snapshot,
+      schemaVersion: 2,
+    }))).toThrow(WorkspacePersistenceError);
+
+    expect(() => parseWorkspaceSnapshot(JSON.stringify({
+      ...snapshot,
+      members: [{ memberId: 'beam-1' }],
+    }))).toThrow(WorkspacePersistenceError);
+  });
+
+  it('reports invalid JSON without returning a partial project', () => {
+    expect(() => parseWorkspaceSnapshot('{not-json')).toThrow(
+      /not valid JSON/i,
+    );
+  });
+});

--- a/react_app/src/workspace/__tests__/persistence.test.ts
+++ b/react_app/src/workspace/__tests__/persistence.test.ts
@@ -1,51 +1,233 @@
 import { describe, expect, it } from 'vitest';
+import { FakeIndexedDbFactory } from './fakeIndexedDb';
 import {
+  createIndexedDbWorkspacePersistence,
+  migrateWorkspaceSnapshot,
   parseWorkspaceSnapshot,
   serializeWorkspaceSnapshot,
+  WorkspaceConflictError,
   WorkspacePersistenceError,
+  WorkspaceRecoveryRequiredError,
+  WorkspaceSchemaVersionError,
 } from '../persistence';
 import {
   WORKSPACE_SCHEMA_VERSION,
+  type EvidenceRecord,
+  type PersistedWorkspaceRecord,
   type WorkspaceSnapshotV1,
 } from '../types';
 
-const snapshot: WorkspaceSnapshotV1 = {
-  schemaVersion: WORKSPACE_SCHEMA_VERSION,
-  projectId: 'project-1',
-  projectName: 'Project 1',
-  projectRevision: 1,
-  members: [],
-  selectedStage: 'import',
-  selectedMemberId: null,
-  selectedFloor: null,
-  dirty: false,
-  saveState: 'clean',
-  createdAt: '2026-08-10T00:00:00.000Z',
-  updatedAt: '2026-08-10T00:00:00.000Z',
-  savedAt: '2026-08-10T00:00:00.000Z',
-  migrationOrigin: null,
-};
+function makeSnapshot(
+  projectRevision = 1,
+  overrides: Partial<WorkspaceSnapshotV1> = {},
+): WorkspaceSnapshotV1 {
+  return {
+    schemaVersion: WORKSPACE_SCHEMA_VERSION,
+    projectId: 'project-1',
+    projectName: 'Project 1',
+    projectRevision,
+    members: [],
+    selectedStage: 'import',
+    selectedMemberId: null,
+    selectedFloor: null,
+    dirty: true,
+    saveState: 'dirty',
+    createdAt: '2026-08-10T00:00:00.000Z',
+    updatedAt: `2026-08-10T00:0${projectRevision}:00.000Z`,
+    savedAt: null,
+    migrationOrigin: null,
+    ...overrides,
+  };
+}
+
+function persistenceWithFactory() {
+  const factory = new FakeIndexedDbFactory();
+  return {
+    factory,
+    persistence: createIndexedDbWorkspacePersistence(factory as unknown as IDBFactory),
+  };
+}
+
+function pendingResult(projectRevision: number): EvidenceRecord {
+  return {
+    projectId: 'project-1',
+    memberId: 'ETABS-101',
+    inputHash: 'hash-1',
+    inputRevision: 1,
+    memberRevision: 1,
+    projectRevision,
+    lifecycle: 'pending',
+    requestId: 'request-1',
+    runId: null,
+    calculationIdentity: null,
+    libraryVersion: null,
+    decision: null,
+    supportStatus: 'HELD',
+    data: null,
+    error: null,
+    createdAt: '2026-08-10T00:01:30.000Z',
+    settledAt: null,
+  };
+}
 
 describe('portable workspace persistence contract', () => {
-  it('round-trips a valid versioned snapshot', () => {
-    expect(parseWorkspaceSnapshot(serializeWorkspaceSnapshot(snapshot))).toEqual(snapshot);
+  it('passes through V1 and round-trips a valid versioned snapshot', () => {
+    const snapshot = makeSnapshot();
+    expect(migrateWorkspaceSnapshot(snapshot)).toBe(snapshot);
+    expect(parseWorkspaceSnapshot(serializeWorkspaceSnapshot(snapshot))).toEqual({
+      ...snapshot,
+      dirty: false,
+      saveState: 'clean',
+      savedAt: snapshot.updatedAt,
+    });
   });
 
   it('fails closed on unknown schemas and malformed members', () => {
     expect(() => parseWorkspaceSnapshot(JSON.stringify({
-      ...snapshot,
+      ...makeSnapshot(),
       schemaVersion: 2,
-    }))).toThrow(WorkspacePersistenceError);
+    }))).toThrow(WorkspaceSchemaVersionError);
 
     expect(() => parseWorkspaceSnapshot(JSON.stringify({
-      ...snapshot,
+      ...makeSnapshot(),
       members: [{ memberId: 'beam-1' }],
     }))).toThrow(WorkspacePersistenceError);
   });
 
   it('reports invalid JSON without returning a partial project', () => {
-    expect(() => parseWorkspaceSnapshot('{not-json')).toThrow(
-      /not valid JSON/i,
+    expect(() => parseWorkspaceSnapshot('{not-json')).toThrow(/not valid JSON/i);
+  });
+
+  it('rejects non-stale evidence bound to another project revision', () => {
+    const projectRevision = 2;
+    const record = { ...pendingResult(projectRevision), lifecycle: 'not_evaluated' as const };
+    const snapshot = makeSnapshot(projectRevision, {
+      members: [{
+        memberId: 'ETABS-101', sourceId: 'ETABS-101', label: 'B1', story: 'GF',
+        frameType: 'beam', inputHash: 'hash-1', inputRevision: 1, memberRevision: 1,
+        inputs: { widthMm: 300 }, result: { ...record, projectRevision: 1 },
+        geometry: null, alternatives: null, metrics: null,
+      }],
+    });
+
+    expect(() => migrateWorkspaceSnapshot(snapshot)).toThrow(WorkspacePersistenceError);
+  });
+});
+
+describe('IndexedDB workspace persistence', () => {
+  it('saves and loads through the transaction path', async () => {
+    const { persistence } = persistenceWithFactory();
+    await persistence.save(makeSnapshot(), {
+      expectedProjectRevision: null,
+      savedAt: '2026-08-10T00:02:00.000Z',
+    });
+
+    await expect(persistence.load('project-1')).resolves.toMatchObject({
+      projectRevision: 1,
+      dirty: false,
+      saveState: 'clean',
+      savedAt: '2026-08-10T00:02:00.000Z',
+    });
+  });
+
+  it('normalizes pending evidence so reload cannot resume it as active truth', async () => {
+    const { persistence } = persistenceWithFactory();
+    const projectRevision = 2;
+    const snapshot = makeSnapshot(projectRevision, {
+      members: [{
+        memberId: 'ETABS-101',
+        sourceId: 'ETABS-101',
+        label: 'B1',
+        story: 'GF',
+        frameType: 'beam',
+        inputHash: 'hash-1',
+        inputRevision: 1,
+        memberRevision: 1,
+        inputs: { widthMm: 300 },
+        result: pendingResult(projectRevision),
+        geometry: null,
+        alternatives: null,
+        metrics: null,
+      }],
+      selectedMemberId: 'ETABS-101',
+    });
+
+    await persistence.save(snapshot, { expectedProjectRevision: null });
+    const loaded = await persistence.load('project-1');
+
+    expect(loaded?.members[0].result).toMatchObject({
+      lifecycle: 'not_evaluated',
+      supportStatus: 'HELD',
+      data: null,
+      settledAt: null,
+    });
+    expect(snapshot.members[0].result?.lifecycle).toBe('pending');
+  });
+
+  it('retains last-known-good and requires explicit recovery from corrupt current data', async () => {
+    const { factory, persistence } = persistenceWithFactory();
+    await persistence.save(makeSnapshot(1), { expectedProjectRevision: null });
+    await persistence.save(makeSnapshot(2), { expectedProjectRevision: 1 });
+
+    const record = factory.read('project-1') as PersistedWorkspaceRecord;
+    factory.seed('project-1', {
+      ...record,
+      current: { ...record.current, schemaVersion: 99 },
+    });
+
+    await expect(persistence.load('project-1')).rejects.toBeInstanceOf(
+      WorkspaceRecoveryRequiredError,
     );
+    await expect(persistence.loadLastKnownGood('project-1')).resolves.toMatchObject({
+      projectRevision: 1,
+    });
+    await expect(persistence.recoverLastKnownGood('project-1')).resolves.toMatchObject({
+      projectRevision: 1,
+    });
+    await expect(persistence.load('project-1')).resolves.toMatchObject({
+      projectRevision: 1,
+    });
+  });
+
+  it('rejects revision conflicts without overwriting the newer record', async () => {
+    const { persistence } = persistenceWithFactory();
+    await persistence.save(makeSnapshot(1), { expectedProjectRevision: null });
+    await persistence.save(makeSnapshot(2), { expectedProjectRevision: 1 });
+
+    await expect(
+      persistence.save(makeSnapshot(3), { expectedProjectRevision: 1 }),
+    ).rejects.toBeInstanceOf(WorkspaceConflictError);
+    await expect(persistence.load('project-1')).resolves.toMatchObject({
+      projectRevision: 2,
+    });
+  });
+
+  it('surfaces quota failures and preserves the prior durable snapshot', async () => {
+    const { factory, persistence } = persistenceWithFactory();
+    await persistence.save(makeSnapshot(1), { expectedProjectRevision: null });
+    factory.failNextWrite();
+
+    await expect(
+      persistence.save(makeSnapshot(2), { expectedProjectRevision: 1 }),
+    ).rejects.toThrow(/previous last-known-good snapshot was retained/i);
+    await expect(persistence.load('project-1')).resolves.toMatchObject({
+      projectRevision: 1,
+    });
+  });
+
+  it('deletes one project and explicitly clears all projects', async () => {
+    const { persistence } = persistenceWithFactory();
+    await persistence.save(makeSnapshot(1), { expectedProjectRevision: null });
+    await persistence.save(makeSnapshot(1, {
+      projectId: 'project-2',
+      projectName: 'Project 2',
+    }), { expectedProjectRevision: null });
+
+    await expect(persistence.delete('project-1')).resolves.toBe(true);
+    await expect(persistence.delete('project-1')).resolves.toBe(false);
+    await expect(persistence.load('project-2')).resolves.not.toBeNull();
+
+    await persistence.clear();
+    await expect(persistence.list()).resolves.toEqual([]);
   });
 });

--- a/react_app/src/workspace/__tests__/requestCoordinator.test.ts
+++ b/react_app/src/workspace/__tests__/requestCoordinator.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { LatestRequestCoordinator } from '../requestCoordinator';
+import type { RevisionIdentity } from '../types';
+
+const identity: RevisionIdentity = {
+  projectId: 'project-1',
+  memberId: 'beam-1',
+  inputHash: 'hash-1',
+  inputRevision: 1,
+  memberRevision: 1,
+  projectRevision: 1,
+};
+
+describe('LatestRequestCoordinator', () => {
+  it('aborts the older request and rejects its response', () => {
+    const coordinator = new LatestRequestCoordinator();
+    const older = coordinator.begin('beam-1:design', 'request-1', identity);
+    const newer = coordinator.begin('beam-1:design', 'request-2', identity);
+
+    expect(older.signal.aborted).toBe(true);
+    expect(coordinator.isCurrent(older, identity)).toBe(false);
+    expect(coordinator.isCurrent(newer, identity)).toBe(true);
+  });
+
+  it('rejects a response when any active revision changed', () => {
+    const coordinator = new LatestRequestCoordinator();
+    const token = coordinator.begin('beam-1:design', 'request-1', identity);
+
+    expect(
+      coordinator.isCurrent(token, {
+        ...identity,
+        inputHash: 'hash-2',
+        inputRevision: 2,
+      }),
+    ).toBe(false);
+    expect(coordinator.settle(token, identity)).toBe(true);
+    expect(coordinator.settle(token, identity)).toBe(false);
+  });
+
+  it('cancels all active work', () => {
+    const coordinator = new LatestRequestCoordinator();
+    const first = coordinator.begin('beam-1:design', 'request-1', identity);
+    const second = coordinator.begin('beam-1:geometry', 'request-2', identity);
+
+    coordinator.cancelAll();
+
+    expect(first.signal.aborted).toBe(true);
+    expect(second.signal.aborted).toBe(true);
+    expect(coordinator.isCurrent(first, identity)).toBe(false);
+  });
+});

--- a/react_app/src/workspace/__tests__/sync.test.ts
+++ b/react_app/src/workspace/__tests__/sync.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWorkspaceRevisionSync, type WorkspaceRevisionNotice } from '../sync';
+import type { WorkspaceSnapshotV1 } from '../types';
+
+class FakeChannel {
+  listener: ((event: MessageEvent<WorkspaceRevisionNotice>) => void) | null = null;
+  posted: WorkspaceRevisionNotice[] = [];
+  closed = false;
+
+  postMessage(message: WorkspaceRevisionNotice): void {
+    this.posted.push(message);
+  }
+
+  addEventListener(
+    _type: 'message',
+    listener: (event: MessageEvent<WorkspaceRevisionNotice>) => void,
+  ): void {
+    this.listener = listener;
+  }
+
+  removeEventListener(): void {
+    this.listener = null;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+const snapshot = {
+  projectId: 'project-1',
+  projectRevision: 4,
+  updatedAt: '2026-08-10T00:00:00.000Z',
+} as WorkspaceSnapshotV1;
+
+describe('workspace revision sync', () => {
+  it('broadcasts only project revision metadata', () => {
+    const channel = new FakeChannel();
+    const sync = createWorkspaceRevisionSync('tab-1', vi.fn(), () => channel);
+
+    sync.announce(snapshot);
+
+    expect(channel.posted).toEqual([{
+      type: 'workspace-revision',
+      sourceId: 'tab-1',
+      projectId: 'project-1',
+      projectRevision: 4,
+      updatedAt: '2026-08-10T00:00:00.000Z',
+    }]);
+    expect(channel.posted[0]).not.toHaveProperty('members');
+  });
+
+  it('ignores its own notice and reports another tab revision', () => {
+    const channel = new FakeChannel();
+    const onExternal = vi.fn();
+    const sync = createWorkspaceRevisionSync('tab-1', onExternal, () => channel);
+    const notice: WorkspaceRevisionNotice = {
+      type: 'workspace-revision',
+      sourceId: 'tab-1',
+      projectId: 'project-1',
+      projectRevision: 5,
+      updatedAt: '2026-08-10T00:01:00.000Z',
+    };
+
+    channel.listener?.({ data: notice } as MessageEvent<WorkspaceRevisionNotice>);
+    expect(onExternal).not.toHaveBeenCalled();
+
+    channel.listener?.({
+      data: { ...notice, sourceId: 'tab-2' },
+    } as MessageEvent<WorkspaceRevisionNotice>);
+    expect(onExternal).toHaveBeenCalledOnce();
+
+    sync.close();
+    expect(channel.closed).toBe(true);
+  });
+});

--- a/react_app/src/workspace/__tests__/workspaceStore.test.ts
+++ b/react_app/src/workspace/__tests__/workspaceStore.test.ts
@@ -163,4 +163,73 @@ describe('workspace revision contract', () => {
       useWorkspaceStore.getState().snapshot!.members[1].result?.lifecycle,
     ).toBe('stale');
   });
+
+  it('undoes member inputs as a new revision and invalidates retained evidence', () => {
+    const pending = useWorkspaceStore.getState().beginMemberRequest(
+      'beam-1',
+      'result',
+      'request-before-edit',
+    )!;
+    expect(useWorkspaceStore.getState().applyMemberRecord(
+      'beam-1',
+      'result',
+      settledResult(pending),
+    )).toBe(true);
+
+    useWorkspaceStore.getState().updateMemberInputs(
+      'beam-1',
+      { widthMm: 350, depthMm: 500 },
+      'hash-2',
+      '2026-08-10T00:03:00.000Z',
+    );
+    expect(useWorkspaceStore.getState().undoMemberInputs(
+      'beam-1',
+      '2026-08-10T00:04:00.000Z',
+    )).toBe(true);
+
+    const snapshot = useWorkspaceStore.getState().snapshot!;
+    const member = snapshot.members[0];
+    expect(member.inputs).toEqual({ widthMm: 300, depthMm: 450 });
+    expect(member.inputHash).toBe('hash-1');
+    expect(member.inputRevision).toBe(3);
+    expect(member.memberRevision).toBe(3);
+    expect(snapshot.projectRevision).toBe(4);
+    expect(member.result?.lifecycle).toBe('stale');
+    expect(recordCanExport(member.result, memberIdentity(snapshot, member))).toBe(false);
+    expect(useWorkspaceStore.getState().undoMemberInputs('beam-1')).toBe(false);
+  });
+
+  it('reverts to explicit prior inputs without restoring prior currentness', () => {
+    useWorkspaceStore.getState().updateMemberInputs(
+      'beam-1',
+      { widthMm: 350, depthMm: 450 },
+      'hash-2',
+    );
+    const pending = useWorkspaceStore.getState().beginMemberRequest(
+      'beam-1',
+      'result',
+      'request-after-edit',
+    )!;
+    expect(useWorkspaceStore.getState().applyMemberRecord(
+      'beam-1',
+      'result',
+      settledResult(pending),
+    )).toBe(true);
+
+    expect(useWorkspaceStore.getState().revertMemberInputs(
+      'beam-1',
+      {
+        inputs: { widthMm: 325, depthMm: 475 },
+        inputHash: 'hash-reviewed',
+      },
+      '2026-08-10T00:05:00.000Z',
+    )).toBe(true);
+
+    const snapshot = useWorkspaceStore.getState().snapshot!;
+    const member = snapshot.members[0];
+    expect(member.inputs).toEqual({ widthMm: 325, depthMm: 475 });
+    expect(member.inputHash).toBe('hash-reviewed');
+    expect(member.result?.lifecycle).toBe('stale');
+    expect(recordCanExport(member.result, memberIdentity(snapshot, member))).toBe(false);
+  });
 });

--- a/react_app/src/workspace/__tests__/workspaceStore.test.ts
+++ b/react_app/src/workspace/__tests__/workspaceStore.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { memberIdentity, recordCanExport } from '../identity';
+import type { EvidenceRecord } from '../types';
+import { useWorkspaceStore } from '../workspaceStore';
+
+function resetWithMember(): void {
+  const store = useWorkspaceStore.getState();
+  store.reset();
+  store.createProject('project-1', 'Project 1', '2026-08-10T00:00:00.000Z');
+  useWorkspaceStore.getState().replaceMembers(
+    [
+      {
+        memberId: 'beam-1',
+        sourceId: 'B1',
+        label: 'B1',
+        story: '1',
+        inputHash: 'hash-1',
+        inputs: { widthMm: 300, depthMm: 450 },
+      },
+    ],
+    '2026-08-10T00:01:00.000Z',
+  );
+}
+
+function settledResult(pending: EvidenceRecord): EvidenceRecord {
+  return {
+    ...pending,
+    lifecycle: 'current',
+    decision: 'PASS',
+    supportStatus: 'SUPPORTED',
+    calculationIdentity: 'calc-1',
+    libraryVersion: '0.23.0',
+    data: { utilization: 0.8 },
+    settledAt: '2026-08-10T00:02:00.000Z',
+  };
+}
+
+describe('workspace revision contract', () => {
+  beforeEach(resetWithMember);
+
+  it('applies only the active request at the current full identity', () => {
+    const pending = useWorkspaceStore.getState().beginMemberRequest(
+      'beam-1',
+      'result',
+      'request-1',
+      '2026-08-10T00:01:30.000Z',
+    );
+    expect(pending).not.toBeNull();
+
+    const result = settledResult(pending!);
+    expect(
+      useWorkspaceStore.getState().applyMemberRecord(
+        'beam-1',
+        'result',
+        result,
+        '2026-08-10T00:02:00.000Z',
+      ),
+    ).toBe(true);
+
+    const snapshot = useWorkspaceStore.getState().snapshot!;
+    const member = snapshot.members[0];
+    expect(recordCanExport(member.result, memberIdentity(snapshot, member))).toBe(true);
+  });
+
+  it('invalidates every dependent record atomically after an input edit', () => {
+    for (const kind of ['result', 'geometry', 'alternatives', 'metrics'] as const) {
+      const pending = useWorkspaceStore.getState().beginMemberRequest(
+        'beam-1',
+        kind,
+        `request-${kind}`,
+      )!;
+      expect(
+        useWorkspaceStore.getState().applyMemberRecord(
+          'beam-1',
+          kind,
+          settledResult(pending),
+        ),
+      ).toBe(true);
+    }
+
+    useWorkspaceStore.getState().updateMemberInputs(
+      'beam-1',
+      { widthMm: 350, depthMm: 450 },
+      'hash-2',
+      '2026-08-10T00:03:00.000Z',
+    );
+
+    const snapshot = useWorkspaceStore.getState().snapshot!;
+    const member = snapshot.members[0];
+    expect(member.inputRevision).toBe(2);
+    expect(member.memberRevision).toBe(2);
+    expect(snapshot.projectRevision).toBe(3);
+    expect([
+      member.result?.lifecycle,
+      member.geometry?.lifecycle,
+      member.alternatives?.lifecycle,
+      member.metrics?.lifecycle,
+    ]).toEqual(['stale', 'stale', 'stale', 'stale']);
+    expect(recordCanExport(member.result, memberIdentity(snapshot, member))).toBe(false);
+  });
+
+  it('rejects a delayed result from the prior revision', () => {
+    const pending = useWorkspaceStore.getState().beginMemberRequest(
+      'beam-1',
+      'result',
+      'request-old',
+    )!;
+    const delayed = settledResult(pending);
+
+    useWorkspaceStore.getState().updateMemberInputs(
+      'beam-1',
+      { widthMm: 400, depthMm: 450 },
+      'hash-new',
+    );
+    useWorkspaceStore.getState().beginMemberRequest('beam-1', 'result', 'request-new');
+
+    expect(
+      useWorkspaceStore.getState().applyMemberRecord(
+        'beam-1',
+        'result',
+        delayed,
+      ),
+    ).toBe(false);
+    expect(
+      useWorkspaceStore.getState().snapshot!.members[0].result?.requestId,
+    ).toBe('request-new');
+  });
+
+  it('marks other member evidence stale when the project revision changes', () => {
+    useWorkspaceStore.getState().replaceMembers(
+      [
+        {
+          memberId: 'beam-1', sourceId: 'B1', label: 'B1', story: '1',
+          inputHash: 'hash-1', inputs: { widthMm: 300, depthMm: 450 },
+        },
+        {
+          memberId: 'beam-2', sourceId: 'B2', label: 'B2', story: '1',
+          inputHash: 'hash-2', inputs: { widthMm: 300, depthMm: 450 },
+        },
+      ],
+      '2026-08-10T00:02:00.000Z',
+    );
+    const pending = useWorkspaceStore.getState().beginMemberRequest(
+      'beam-2',
+      'result',
+      'request-beam-2',
+    )!;
+    expect(
+      useWorkspaceStore.getState().applyMemberRecord(
+        'beam-2',
+        'result',
+        settledResult(pending),
+      ),
+    ).toBe(true);
+
+    useWorkspaceStore.getState().updateMemberInputs(
+      'beam-1',
+      { widthMm: 350, depthMm: 450 },
+      'hash-1-next',
+    );
+
+    expect(
+      useWorkspaceStore.getState().snapshot!.members[1].result?.lifecycle,
+    ).toBe('stale');
+  });
+});

--- a/react_app/src/workspace/autosave.ts
+++ b/react_app/src/workspace/autosave.ts
@@ -1,0 +1,122 @@
+import {
+  WorkspaceConflictError,
+  type WorkspacePersistence,
+} from './persistence';
+import type { WorkspaceRevisionNotice } from './sync';
+import type { WorkspaceSnapshotV1 } from './types';
+
+export type WorkspaceAutosaveState = 'saving' | 'saved' | 'error' | 'conflict';
+
+export interface WorkspaceAutosaveCallbacks {
+  onStateChange?: (
+    state: WorkspaceAutosaveState,
+    snapshot: WorkspaceSnapshotV1,
+    error?: unknown,
+  ) => void;
+}
+
+/**
+ * Debounces durable saves while keeping the persisted revision explicit.
+ * Live integration must prime each project before scheduling its first save.
+ */
+export class WorkspaceAutosaveCoordinator {
+  private readonly persistence: WorkspacePersistence;
+  private readonly delayMs: number;
+  private readonly callbacks: WorkspaceAutosaveCallbacks;
+  private readonly persistedRevisions = new Map<string, number | null>();
+  private readonly externalRevisions = new Map<string, number>();
+  private queued: WorkspaceSnapshotV1 | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private activeFlush: Promise<void> | null = null;
+
+  constructor(
+    persistence: WorkspacePersistence,
+    delayMs = 500,
+    callbacks: WorkspaceAutosaveCallbacks = {},
+  ) {
+    this.persistence = persistence;
+    this.delayMs = delayMs;
+    this.callbacks = callbacks;
+  }
+
+  prime(projectId: string, persistedRevision: number | null): void {
+    if (!projectId.trim()) throw new Error('A project ID is required for autosave.');
+    if (persistedRevision !== null && (!Number.isInteger(persistedRevision) || persistedRevision < 1)) {
+      throw new Error('Persisted project revision must be a positive integer or null.');
+    }
+    this.persistedRevisions.set(projectId, persistedRevision);
+    this.externalRevisions.delete(projectId);
+  }
+
+  schedule(snapshot: WorkspaceSnapshotV1): void {
+    if (!this.persistedRevisions.has(snapshot.projectId)) {
+      throw new Error('Autosave must be primed with the persisted project revision.');
+    }
+    this.queued = structuredClone(snapshot);
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.flush().catch(() => undefined);
+    }, this.delayMs);
+  }
+
+  noteExternalRevision(notice: WorkspaceRevisionNotice): void {
+    if (!this.persistedRevisions.has(notice.projectId)) return;
+    const persistedRevision = this.persistedRevisions.get(notice.projectId) ?? 0;
+    if (notice.projectRevision > persistedRevision) {
+      this.externalRevisions.set(notice.projectId, notice.projectRevision);
+    }
+  }
+
+  flush(): Promise<void> {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.activeFlush) return this.activeFlush;
+    this.activeFlush = this.flushQueued().finally(() => {
+      this.activeFlush = null;
+    });
+    return this.activeFlush;
+  }
+
+  dispose(): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = null;
+    this.queued = null;
+  }
+
+  private async flushQueued(): Promise<void> {
+    while (this.queued) {
+      const snapshot = this.queued;
+      this.queued = null;
+      const expectedRevision = this.persistedRevisions.get(snapshot.projectId);
+      const externalRevision = this.externalRevisions.get(snapshot.projectId);
+      if (externalRevision !== undefined) {
+        const error = new WorkspaceConflictError(
+          snapshot.projectId,
+          expectedRevision,
+          externalRevision,
+        );
+        this.callbacks.onStateChange?.('conflict', snapshot, error);
+        throw error;
+      }
+
+      this.callbacks.onStateChange?.('saving', snapshot);
+      try {
+        await this.persistence.save(snapshot, {
+          expectedProjectRevision: expectedRevision,
+        });
+        this.persistedRevisions.set(snapshot.projectId, snapshot.projectRevision);
+        this.callbacks.onStateChange?.('saved', snapshot);
+      } catch (error) {
+        this.callbacks.onStateChange?.(
+          error instanceof WorkspaceConflictError ? 'conflict' : 'error',
+          snapshot,
+          error,
+        );
+        throw error;
+      }
+    }
+  }
+}

--- a/react_app/src/workspace/identity.ts
+++ b/react_app/src/workspace/identity.ts
@@ -1,0 +1,97 @@
+import type {
+  EvidenceRecord,
+  JsonValue,
+  RevisionIdentity,
+  WorkspaceMember,
+  WorkspaceSnapshotV1,
+} from './types';
+
+export function recordMatchesIdentity(
+  record: EvidenceRecord | null,
+  identity: RevisionIdentity,
+): boolean {
+  return Boolean(
+    record
+    && record.projectId === identity.projectId
+    && record.memberId === identity.memberId
+    && record.inputHash === identity.inputHash
+    && record.inputRevision === identity.inputRevision
+    && record.memberRevision === identity.memberRevision
+    && record.projectRevision === identity.projectRevision,
+  );
+}
+
+export function recordIsCurrent(
+  record: EvidenceRecord | null,
+  identity: RevisionIdentity,
+): boolean {
+  return record?.lifecycle === 'current' && recordMatchesIdentity(record, identity);
+}
+
+export function recordCanExport(
+  record: EvidenceRecord | null,
+  identity: RevisionIdentity,
+): boolean {
+  return Boolean(
+    recordIsCurrent(record, identity)
+    && record?.decision === 'PASS'
+    && record.supportStatus === 'SUPPORTED'
+    && record.data !== null
+    && record.calculationIdentity !== null
+    && record.libraryVersion !== null
+    && record.settledAt !== null,
+  );
+}
+
+export function memberIdentity(
+  snapshot: WorkspaceSnapshotV1,
+  member: WorkspaceMember,
+): RevisionIdentity {
+  return {
+    projectId: snapshot.projectId,
+    memberId: member.memberId,
+    inputHash: member.inputHash,
+    inputRevision: member.inputRevision,
+    memberRevision: member.memberRevision,
+    projectRevision: snapshot.projectRevision,
+  };
+}
+
+export function staleRecord(record: EvidenceRecord | null): EvidenceRecord | null {
+  if (!record || record.lifecycle === 'stale') return record;
+  return {
+    ...record,
+    lifecycle: 'stale',
+  };
+}
+
+export function invalidateMemberRecords(member: WorkspaceMember): WorkspaceMember {
+  return {
+    ...member,
+    result: staleRecord(member.result),
+    geometry: staleRecord(member.geometry),
+    alternatives: staleRecord(member.alternatives),
+    metrics: staleRecord(member.metrics),
+  };
+}
+
+export function pendingRecord<TData extends JsonValue>(
+  identity: RevisionIdentity,
+  requestId: string,
+  createdAt: string,
+): EvidenceRecord<TData> {
+  return {
+    ...identity,
+    lifecycle: 'pending',
+    requestId,
+    runId: null,
+    calculationIdentity: null,
+    libraryVersion: null,
+    decision: null,
+    supportStatus: 'HELD',
+    data: null,
+    error: null,
+    createdAt,
+    settledAt: null,
+  };
+}

--- a/react_app/src/workspace/index.json
+++ b/react_app/src/workspace/index.json
@@ -3,8 +3,33 @@
   "type": "react-source",
   "description": "",
   "last_updated": "2026-08-10",
-  "file_count": 6,
+  "file_count": 8,
   "files": [
+    {
+      "name": "WorkspacePersistenceBridge.tsx",
+      "type": "react-component",
+      "size_lines": 125,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WorkspacePersistenceBridgeProps",
+        "WorkspacePersistenceBridge"
+      ],
+      "props_type": "WorkspacePersistenceBridgeProps",
+      "content_hash": "dd1735c561e8"
+    },
+    {
+      "name": "autosave.ts",
+      "type": "typescript",
+      "size_lines": 123,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WorkspaceAutosaveState",
+        "WorkspaceAutosaveCallbacks",
+        "WorkspaceAutosaveCoordinator"
+      ],
+      "description": "Debounces durable saves while keeping the persisted revision explicit.",
+      "content_hash": "f3ecd55959d8"
+    },
     {
       "name": "identity.ts",
       "type": "typescript",
@@ -24,17 +49,22 @@
     {
       "name": "persistence.ts",
       "type": "typescript",
-      "size_lines": 213,
+      "size_lines": 437,
       "last_updated": "2026-08-10",
       "exports": [
+        "WorkspaceSaveOptions",
         "WorkspacePersistenceError",
         "WorkspaceRecoveryRequiredError",
+        "WorkspaceSchemaVersionError",
+        "WorkspaceConflictError",
         "WorkspacePersistence",
+        "migrateWorkspaceSnapshot",
+        "normalizeWorkspaceSnapshotForPersistence",
         "createIndexedDbWorkspacePersistence",
         "serializeWorkspaceSnapshot",
         "parseWorkspaceSnapshot"
       ],
-      "content_hash": "64b783432d76"
+      "content_hash": "f927fe01b915"
     },
     {
       "name": "requestCoordinator.ts",
@@ -62,7 +92,7 @@
     {
       "name": "types.ts",
       "type": "typescript",
-      "size_lines": 223,
+      "size_lines": 251,
       "last_updated": "2026-08-10",
       "exports": [
         "WORKSPACE_SCHEMA_VERSION",
@@ -81,21 +111,22 @@
         "WorkspaceProjectSummary",
         "isWorkspaceSnapshotV1"
       ],
-      "content_hash": "6ef8a74edc66"
+      "content_hash": "999a88673288"
     },
     {
       "name": "workspaceStore.ts",
       "type": "typescript",
-      "size_lines": 279,
+      "size_lines": 380,
       "last_updated": "2026-08-10",
       "exports": [
         "MemberRecordKind",
+        "MemberInputState",
         "NewWorkspaceMember",
         "useWorkspaceStore"
       ],
-      "content_hash": "2595462ef92b"
+      "content_hash": "c9d615e94c2a"
     }
   ],
   "subfolders": [],
-  "content_hash": "888e804123b0af40"
+  "content_hash": "ea82fbc12bdad40d"
 }

--- a/react_app/src/workspace/index.json
+++ b/react_app/src/workspace/index.json
@@ -1,0 +1,101 @@
+{
+  "folder": "react_app/src/workspace",
+  "type": "react-source",
+  "description": "",
+  "last_updated": "2026-08-10",
+  "file_count": 6,
+  "files": [
+    {
+      "name": "identity.ts",
+      "type": "typescript",
+      "size_lines": 98,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "recordMatchesIdentity",
+        "recordIsCurrent",
+        "recordCanExport",
+        "memberIdentity",
+        "staleRecord",
+        "invalidateMemberRecords",
+        "pendingRecord"
+      ],
+      "content_hash": "4d71f0086704"
+    },
+    {
+      "name": "persistence.ts",
+      "type": "typescript",
+      "size_lines": 213,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WorkspacePersistenceError",
+        "WorkspaceRecoveryRequiredError",
+        "WorkspacePersistence",
+        "createIndexedDbWorkspacePersistence",
+        "serializeWorkspaceSnapshot",
+        "parseWorkspaceSnapshot"
+      ],
+      "content_hash": "64b783432d76"
+    },
+    {
+      "name": "requestCoordinator.ts",
+      "type": "typescript",
+      "size_lines": 79,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "RequestToken",
+        "LatestRequestCoordinator"
+      ],
+      "content_hash": "e44582152d65"
+    },
+    {
+      "name": "sync.ts",
+      "type": "typescript",
+      "size_lines": 69,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WorkspaceRevisionNotice",
+        "WorkspaceRevisionSync",
+        "createWorkspaceRevisionSync"
+      ],
+      "content_hash": "2fe30e7919b1"
+    },
+    {
+      "name": "types.ts",
+      "type": "typescript",
+      "size_lines": 223,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "WORKSPACE_SCHEMA_VERSION",
+        "JsonPrimitive",
+        "JsonValue",
+        "ResultLifecycle",
+        "EvidenceDecision",
+        "SupportStatus",
+        "SaveState",
+        "RevisionIdentity",
+        "RecordError",
+        "EvidenceRecord",
+        "WorkspaceMember",
+        "WorkspaceSnapshotV1",
+        "PersistedWorkspaceRecord",
+        "WorkspaceProjectSummary",
+        "isWorkspaceSnapshotV1"
+      ],
+      "content_hash": "6ef8a74edc66"
+    },
+    {
+      "name": "workspaceStore.ts",
+      "type": "typescript",
+      "size_lines": 279,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "MemberRecordKind",
+        "NewWorkspaceMember",
+        "useWorkspaceStore"
+      ],
+      "content_hash": "2595462ef92b"
+    }
+  ],
+  "subfolders": [],
+  "content_hash": "888e804123b0af40"
+}

--- a/react_app/src/workspace/index.md
+++ b/react_app/src/workspace/index.md
@@ -1,0 +1,16 @@
+# Workspace
+
+**Type:** React Source
+**Last Updated:** 2026-08-10
+**Files:** 6
+
+## Typescript Files
+
+| File | Exports | Lines |
+|------|---------|-------|
+| [identity.ts](identity.ts) | recordMatchesIdentity, recordIsCurrent, recordCanExport, memberIdentity, staleRecord (+2) | 98 |
+| [persistence.ts](persistence.ts) | WorkspacePersistenceError, WorkspaceRecoveryRequiredError, WorkspacePersistence, createIndexedDbWorkspacePersistence, serializeWorkspaceSnapshot (+1) | 213 |
+| [requestCoordinator.ts](requestCoordinator.ts) | RequestToken, LatestRequestCoordinator | 79 |
+| [sync.ts](sync.ts) | WorkspaceRevisionNotice, WorkspaceRevisionSync, createWorkspaceRevisionSync | 69 |
+| [types.ts](types.ts) | WORKSPACE_SCHEMA_VERSION, JsonPrimitive, JsonValue, ResultLifecycle, EvidenceDecision (+10) | 223 |
+| [workspaceStore.ts](workspaceStore.ts) | MemberRecordKind, NewWorkspaceMember, useWorkspaceStore | 279 |

--- a/react_app/src/workspace/index.md
+++ b/react_app/src/workspace/index.md
@@ -2,15 +2,22 @@
 
 **Type:** React Source
 **Last Updated:** 2026-08-10
-**Files:** 6
+**Files:** 8
+
+## React Component Files
+
+| File | Exports | Lines |
+|------|---------|-------|
+| [WorkspacePersistenceBridge.tsx](WorkspacePersistenceBridge.tsx) | WorkspacePersistenceBridgeProps, WorkspacePersistenceBridge | 125 |
 
 ## Typescript Files
 
 | File | Exports | Lines |
 |------|---------|-------|
+| [autosave.ts](autosave.ts) | WorkspaceAutosaveState, WorkspaceAutosaveCallbacks, WorkspaceAutosaveCoordinator | 123 |
 | [identity.ts](identity.ts) | recordMatchesIdentity, recordIsCurrent, recordCanExport, memberIdentity, staleRecord (+2) | 98 |
-| [persistence.ts](persistence.ts) | WorkspacePersistenceError, WorkspaceRecoveryRequiredError, WorkspacePersistence, createIndexedDbWorkspacePersistence, serializeWorkspaceSnapshot (+1) | 213 |
+| [persistence.ts](persistence.ts) | WorkspaceSaveOptions, WorkspacePersistenceError, WorkspaceRecoveryRequiredError, WorkspaceSchemaVersionError, WorkspaceConflictError (+6) | 437 |
 | [requestCoordinator.ts](requestCoordinator.ts) | RequestToken, LatestRequestCoordinator | 79 |
 | [sync.ts](sync.ts) | WorkspaceRevisionNotice, WorkspaceRevisionSync, createWorkspaceRevisionSync | 69 |
-| [types.ts](types.ts) | WORKSPACE_SCHEMA_VERSION, JsonPrimitive, JsonValue, ResultLifecycle, EvidenceDecision (+10) | 223 |
-| [workspaceStore.ts](workspaceStore.ts) | MemberRecordKind, NewWorkspaceMember, useWorkspaceStore | 279 |
+| [types.ts](types.ts) | WORKSPACE_SCHEMA_VERSION, JsonPrimitive, JsonValue, ResultLifecycle, EvidenceDecision (+10) | 251 |
+| [workspaceStore.ts](workspaceStore.ts) | MemberRecordKind, MemberInputState, NewWorkspaceMember, useWorkspaceStore | 380 |

--- a/react_app/src/workspace/persistence.ts
+++ b/react_app/src/workspace/persistence.ts
@@ -1,4 +1,5 @@
 import {
+  WORKSPACE_SCHEMA_VERSION,
   isWorkspaceSnapshotV1,
   type PersistedWorkspaceRecord,
   type WorkspaceProjectSummary,
@@ -8,6 +9,11 @@ import {
 const DATABASE_NAME = 'structlib-workbench';
 const DATABASE_VERSION = 1;
 const PROJECT_STORE = 'projects';
+
+export interface WorkspaceSaveOptions {
+  expectedProjectRevision?: number | null;
+  savedAt?: string;
+}
 
 export class WorkspacePersistenceError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -28,11 +34,42 @@ export class WorkspaceRecoveryRequiredError extends WorkspacePersistenceError {
   }
 }
 
+export class WorkspaceSchemaVersionError extends WorkspacePersistenceError {
+  readonly schemaVersion: unknown;
+
+  constructor(schemaVersion: unknown) {
+    super(`Unsupported workspace schema version: ${String(schemaVersion)}.`);
+    this.name = 'WorkspaceSchemaVersionError';
+    this.schemaVersion = schemaVersion;
+  }
+}
+
+export class WorkspaceConflictError extends WorkspacePersistenceError {
+  readonly projectId: string;
+  readonly expectedProjectRevision: number | null | undefined;
+  readonly actualProjectRevision: number | null;
+
+  constructor(
+    projectId: string,
+    expectedProjectRevision: number | null | undefined,
+    actualProjectRevision: number | null,
+  ) {
+    super('Project save was rejected because a newer external revision exists.');
+    this.name = 'WorkspaceConflictError';
+    this.projectId = projectId;
+    this.expectedProjectRevision = expectedProjectRevision;
+    this.actualProjectRevision = actualProjectRevision;
+  }
+}
+
 export interface WorkspacePersistence {
-  save(snapshot: WorkspaceSnapshotV1): Promise<void>;
+  save(snapshot: WorkspaceSnapshotV1, options?: WorkspaceSaveOptions): Promise<void>;
   load(projectId: string): Promise<WorkspaceSnapshotV1 | null>;
   loadLastKnownGood(projectId: string): Promise<WorkspaceSnapshotV1 | null>;
+  recoverLastKnownGood(projectId: string): Promise<WorkspaceSnapshotV1>;
   list(): Promise<WorkspaceProjectSummary[]>;
+  delete(projectId: string): Promise<boolean>;
+  clear(): Promise<void>;
 }
 
 function requestResult<T>(request: IDBRequest<T>): Promise<T> {
@@ -62,6 +99,12 @@ function transactionComplete(transaction: IDBTransaction): Promise<void> {
   });
 }
 
+function trackedTransactionCompletion(transaction: IDBTransaction): Promise<void> {
+  const completed = transactionComplete(transaction);
+  void completed.catch(() => undefined);
+  return completed;
+}
+
 function openDatabase(factory: IDBFactory): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = factory.open(DATABASE_NAME, DATABASE_VERSION);
@@ -84,16 +127,124 @@ function openDatabase(factory: IDBFactory): Promise<IDBDatabase> {
   });
 }
 
-function requireValidSnapshot(
-  value: unknown,
-  label: string,
-): WorkspaceSnapshotV1 {
+function requireValidSnapshot(value: unknown, label: string): WorkspaceSnapshotV1 {
   if (!isWorkspaceSnapshotV1(value)) {
     throw new WorkspacePersistenceError(
       `${label} is missing, corrupt, or uses an unsupported schema version.`,
     );
   }
   return value;
+}
+
+function schemaVersionOf(value: unknown): unknown {
+  return value !== null && typeof value === 'object' && 'schemaVersion' in value
+    ? value.schemaVersion
+    : undefined;
+}
+
+/** Explicit migration boundary. V1 passes through; unknown versions fail closed. */
+export function migrateWorkspaceSnapshot(value: unknown): WorkspaceSnapshotV1 {
+  const schemaVersion = schemaVersionOf(value);
+  if (schemaVersion !== WORKSPACE_SCHEMA_VERSION) {
+    throw new WorkspaceSchemaVersionError(schemaVersion);
+  }
+  return requireValidSnapshot(value, 'Project snapshot');
+}
+
+function normalizePendingRecord(record: WorkspaceSnapshotV1['members'][number]['result']) {
+  if (record?.lifecycle !== 'pending') return record;
+  return {
+    ...record,
+    lifecycle: 'not_evaluated' as const,
+    runId: null,
+    calculationIdentity: null,
+    libraryVersion: null,
+    decision: null,
+    supportStatus: 'HELD' as const,
+    data: null,
+    error: null,
+    settledAt: null,
+  };
+}
+
+/** Convert transient in-memory state into truth that is safe to resume. */
+export function normalizeWorkspaceSnapshotForPersistence(
+  snapshot: WorkspaceSnapshotV1,
+  savedAt = snapshot.updatedAt,
+): WorkspaceSnapshotV1 {
+  const validSnapshot = migrateWorkspaceSnapshot(snapshot);
+  const normalized: WorkspaceSnapshotV1 = {
+    ...validSnapshot,
+    members: validSnapshot.members.map((member) => ({
+      ...member,
+      inputs: structuredClone(member.inputs),
+      result: normalizePendingRecord(member.result),
+      geometry: normalizePendingRecord(member.geometry),
+      alternatives: normalizePendingRecord(member.alternatives),
+      metrics: normalizePendingRecord(member.metrics),
+    })),
+    dirty: false,
+    saveState: 'clean',
+    savedAt,
+  };
+  return requireValidSnapshot(normalized, 'Normalized project snapshot');
+}
+
+function tryMigrateSnapshot(value: unknown): WorkspaceSnapshotV1 | null {
+  try {
+    return migrateWorkspaceSnapshot(value);
+  } catch {
+    return null;
+  }
+}
+
+function existingCurrentOrRecovery(
+  projectId: string,
+  record: PersistedWorkspaceRecord | undefined,
+): WorkspaceSnapshotV1 | null {
+  if (!record) return null;
+  const current = tryMigrateSnapshot(record.current);
+  if (current) return current;
+  if (tryMigrateSnapshot(record.lastKnownGood)) {
+    throw new WorkspaceRecoveryRequiredError(projectId);
+  }
+  throw new WorkspacePersistenceError(
+    'The saved project and its last-known-good snapshot are unreadable.',
+  );
+}
+
+function assertNoRevisionConflict(
+  incoming: WorkspaceSnapshotV1,
+  existing: WorkspaceSnapshotV1 | null,
+  options: WorkspaceSaveOptions,
+): void {
+  if ('expectedProjectRevision' in options) {
+    const actualRevision = existing?.projectRevision ?? null;
+    if (options.expectedProjectRevision !== actualRevision) {
+      throw new WorkspaceConflictError(
+        incoming.projectId,
+        options.expectedProjectRevision,
+        actualRevision,
+      );
+    }
+    return;
+  }
+  if (
+    existing
+    && (
+      existing.projectRevision > incoming.projectRevision
+      || (
+        existing.projectRevision === incoming.projectRevision
+        && existing.updatedAt > incoming.updatedAt
+      )
+    )
+  ) {
+    throw new WorkspaceConflictError(
+      incoming.projectId,
+      undefined,
+      existing.projectRevision,
+    );
+  }
 }
 
 export function createIndexedDbWorkspacePersistence(
@@ -113,25 +264,32 @@ export function createIndexedDbWorkspacePersistence(
   });
 
   return {
-    async save(snapshot) {
+    async save(snapshot, options = {}) {
       try {
-        const validSnapshot = requireValidSnapshot(snapshot, 'Project snapshot');
+        const validSnapshot = normalizeWorkspaceSnapshotForPersistence(
+          snapshot,
+          options.savedAt ?? snapshot.updatedAt,
+        );
         const database = await databasePromise;
         const transaction = database.transaction(PROJECT_STORE, 'readwrite');
+        const completed = trackedTransactionCompletion(transaction);
         const store = transaction.objectStore(PROJECT_STORE);
         const existing = await requestResult(
           store.get(validSnapshot.projectId) as IDBRequest<PersistedWorkspaceRecord | undefined>,
         );
+        const existingCurrent = existingCurrentOrRecovery(validSnapshot.projectId, existing);
+        assertNoRevisionConflict(validSnapshot, existingCurrent, options);
+        const priorGood = existingCurrent
+          ?? tryMigrateSnapshot(existing?.lastKnownGood)
+          ?? validSnapshot;
         const record: PersistedWorkspaceRecord = {
           projectId: validSnapshot.projectId,
           current: validSnapshot,
-          lastKnownGood: existing?.current && isWorkspaceSnapshotV1(existing.current)
-            ? existing.current
-            : validSnapshot,
+          lastKnownGood: priorGood,
           updatedAt: validSnapshot.updatedAt,
         };
-        store.put(record);
-        await transactionComplete(transaction);
+        await requestResult(store.put(record));
+        await completed;
       } catch (error) {
         if (error instanceof WorkspacePersistenceError) throw error;
         throw new WorkspacePersistenceError(
@@ -144,45 +302,78 @@ export function createIndexedDbWorkspacePersistence(
     async load(projectId) {
       const database = await databasePromise;
       const transaction = database.transaction(PROJECT_STORE, 'readonly');
+      const completed = trackedTransactionCompletion(transaction);
       const request = transaction.objectStore(PROJECT_STORE).get(projectId);
       const record = await requestResult(
         request as IDBRequest<PersistedWorkspaceRecord | undefined>,
       );
-      await transactionComplete(transaction);
+      await completed;
       if (!record) return null;
-      if (isWorkspaceSnapshotV1(record.current)) return record.current;
-      if (isWorkspaceSnapshotV1(record.lastKnownGood)) {
-        throw new WorkspaceRecoveryRequiredError(projectId);
-      }
-      throw new WorkspacePersistenceError(
-        'The saved project and its last-known-good snapshot are unreadable.',
-      );
+      return existingCurrentOrRecovery(projectId, record);
     },
 
     async loadLastKnownGood(projectId) {
       const database = await databasePromise;
       const transaction = database.transaction(PROJECT_STORE, 'readonly');
+      const completed = trackedTransactionCompletion(transaction);
       const request = transaction.objectStore(PROJECT_STORE).get(projectId);
       const record = await requestResult(
         request as IDBRequest<PersistedWorkspaceRecord | undefined>,
       );
-      await transactionComplete(transaction);
+      await completed;
       if (!record) return null;
-      return requireValidSnapshot(record.lastKnownGood, 'Last-known-good snapshot');
+      return migrateWorkspaceSnapshot(record.lastKnownGood);
+    },
+
+    async recoverLastKnownGood(projectId) {
+      try {
+        const database = await databasePromise;
+        const transaction = database.transaction(PROJECT_STORE, 'readwrite');
+        const completed = trackedTransactionCompletion(transaction);
+        const store = transaction.objectStore(PROJECT_STORE);
+        const record = await requestResult(
+          store.get(projectId) as IDBRequest<PersistedWorkspaceRecord | undefined>,
+        );
+        if (!record) {
+          throw new WorkspacePersistenceError('No saved project exists to recover.');
+        }
+        if (tryMigrateSnapshot(record.current)) {
+          throw new WorkspacePersistenceError(
+            'The current project is valid and does not require recovery.',
+          );
+        }
+        const recovered = normalizeWorkspaceSnapshotForPersistence(
+          migrateWorkspaceSnapshot(record.lastKnownGood),
+        );
+        const recoveredRecord: PersistedWorkspaceRecord = {
+          projectId,
+          current: recovered,
+          lastKnownGood: recovered,
+          updatedAt: recovered.updatedAt,
+        };
+        await requestResult(store.put(recoveredRecord));
+        await completed;
+        return recovered;
+      } catch (error) {
+        if (error instanceof WorkspacePersistenceError) throw error;
+        throw new WorkspacePersistenceError('Project recovery failed.', { cause: error });
+      }
     },
 
     async list() {
       const database = await databasePromise;
       const transaction = database.transaction(PROJECT_STORE, 'readonly');
+      const completed = trackedTransactionCompletion(transaction);
       const records = await requestResult(
         transaction.objectStore(PROJECT_STORE).getAll() as IDBRequest<
           PersistedWorkspaceRecord[]
         >,
       );
-      await transactionComplete(transaction);
+      await completed;
       return records
-        .filter((record) => isWorkspaceSnapshotV1(record.current))
-        .map(({ current }) => ({
+        .map((record) => tryMigrateSnapshot(record.current))
+        .filter((current): current is WorkspaceSnapshotV1 => current !== null)
+        .map((current) => ({
           projectId: current.projectId,
           projectName: current.projectName,
           selectedStage: current.selectedStage,
@@ -192,11 +383,44 @@ export function createIndexedDbWorkspacePersistence(
         }))
         .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
     },
+
+    async delete(projectId) {
+      try {
+        const database = await databasePromise;
+        const transaction = database.transaction(PROJECT_STORE, 'readwrite');
+        const completed = trackedTransactionCompletion(transaction);
+        const store = transaction.objectStore(PROJECT_STORE);
+        const existing = await requestResult(store.get(projectId));
+        if (existing === undefined) {
+          await completed;
+          return false;
+        }
+        await requestResult(store.delete(projectId));
+        await completed;
+        return true;
+      } catch (error) {
+        if (error instanceof WorkspacePersistenceError) throw error;
+        throw new WorkspacePersistenceError('Project delete failed.', { cause: error });
+      }
+    },
+
+    async clear() {
+      try {
+        const database = await databasePromise;
+        const transaction = database.transaction(PROJECT_STORE, 'readwrite');
+        const completed = trackedTransactionCompletion(transaction);
+        await requestResult(transaction.objectStore(PROJECT_STORE).clear());
+        await completed;
+      } catch (error) {
+        if (error instanceof WorkspacePersistenceError) throw error;
+        throw new WorkspacePersistenceError('Project storage clear failed.', { cause: error });
+      }
+    },
   };
 }
 
 export function serializeWorkspaceSnapshot(snapshot: WorkspaceSnapshotV1): string {
-  return JSON.stringify(requireValidSnapshot(snapshot, 'Project snapshot'));
+  return JSON.stringify(normalizeWorkspaceSnapshotForPersistence(snapshot));
 }
 
 export function parseWorkspaceSnapshot(serialized: string): WorkspaceSnapshotV1 {
@@ -208,5 +432,5 @@ export function parseWorkspaceSnapshot(serialized: string): WorkspaceSnapshotV1 
       cause: error,
     });
   }
-  return requireValidSnapshot(parsed, 'Project snapshot');
+  return normalizeWorkspaceSnapshotForPersistence(migrateWorkspaceSnapshot(parsed));
 }

--- a/react_app/src/workspace/persistence.ts
+++ b/react_app/src/workspace/persistence.ts
@@ -1,0 +1,212 @@
+import {
+  isWorkspaceSnapshotV1,
+  type PersistedWorkspaceRecord,
+  type WorkspaceProjectSummary,
+  type WorkspaceSnapshotV1,
+} from './types';
+
+const DATABASE_NAME = 'structlib-workbench';
+const DATABASE_VERSION = 1;
+const PROJECT_STORE = 'projects';
+
+export class WorkspacePersistenceError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'WorkspacePersistenceError';
+  }
+}
+
+export class WorkspaceRecoveryRequiredError extends WorkspacePersistenceError {
+  readonly projectId: string;
+
+  constructor(projectId: string) {
+    super(
+      'The latest saved project is unreadable. A last-known-good snapshot is available for explicit recovery.',
+    );
+    this.name = 'WorkspaceRecoveryRequiredError';
+    this.projectId = projectId;
+  }
+}
+
+export interface WorkspacePersistence {
+  save(snapshot: WorkspaceSnapshotV1): Promise<void>;
+  load(projectId: string): Promise<WorkspaceSnapshotV1 | null>;
+  loadLastKnownGood(projectId: string): Promise<WorkspaceSnapshotV1 | null>;
+  list(): Promise<WorkspaceProjectSummary[]>;
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.addEventListener('success', () => resolve(request.result), { once: true });
+    request.addEventListener(
+      'error',
+      () => reject(request.error ?? new Error('IndexedDB request failed.')),
+      { once: true },
+    );
+  });
+}
+
+function transactionComplete(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.addEventListener('complete', () => resolve(), { once: true });
+    transaction.addEventListener(
+      'abort',
+      () => reject(transaction.error ?? new Error('IndexedDB transaction aborted.')),
+      { once: true },
+    );
+    transaction.addEventListener(
+      'error',
+      () => reject(transaction.error ?? new Error('IndexedDB transaction failed.')),
+      { once: true },
+    );
+  });
+}
+
+function openDatabase(factory: IDBFactory): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = factory.open(DATABASE_NAME, DATABASE_VERSION);
+    request.addEventListener(
+      'upgradeneeded',
+      () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains(PROJECT_STORE)) {
+          database.createObjectStore(PROJECT_STORE, { keyPath: 'projectId' });
+        }
+      },
+      { once: true },
+    );
+    request.addEventListener('success', () => resolve(request.result), { once: true });
+    request.addEventListener(
+      'error',
+      () => reject(request.error ?? new Error('Unable to open project storage.')),
+      { once: true },
+    );
+  });
+}
+
+function requireValidSnapshot(
+  value: unknown,
+  label: string,
+): WorkspaceSnapshotV1 {
+  if (!isWorkspaceSnapshotV1(value)) {
+    throw new WorkspacePersistenceError(
+      `${label} is missing, corrupt, or uses an unsupported schema version.`,
+    );
+  }
+  return value;
+}
+
+export function createIndexedDbWorkspacePersistence(
+  suppliedFactory?: IDBFactory,
+): WorkspacePersistence {
+  const factory = suppliedFactory ?? globalThis.indexedDB;
+  if (!factory) {
+    throw new WorkspacePersistenceError(
+      'IndexedDB is unavailable. Export the project snapshot before leaving this page.',
+    );
+  }
+
+  const databasePromise = openDatabase(factory).catch((error: unknown) => {
+    throw new WorkspacePersistenceError('Unable to initialize project storage.', {
+      cause: error,
+    });
+  });
+
+  return {
+    async save(snapshot) {
+      try {
+        const validSnapshot = requireValidSnapshot(snapshot, 'Project snapshot');
+        const database = await databasePromise;
+        const transaction = database.transaction(PROJECT_STORE, 'readwrite');
+        const store = transaction.objectStore(PROJECT_STORE);
+        const existing = await requestResult(
+          store.get(validSnapshot.projectId) as IDBRequest<PersistedWorkspaceRecord | undefined>,
+        );
+        const record: PersistedWorkspaceRecord = {
+          projectId: validSnapshot.projectId,
+          current: validSnapshot,
+          lastKnownGood: existing?.current && isWorkspaceSnapshotV1(existing.current)
+            ? existing.current
+            : validSnapshot,
+          updatedAt: validSnapshot.updatedAt,
+        };
+        store.put(record);
+        await transactionComplete(transaction);
+      } catch (error) {
+        if (error instanceof WorkspacePersistenceError) throw error;
+        throw new WorkspacePersistenceError(
+          'Project save failed. The previous last-known-good snapshot was retained.',
+          { cause: error },
+        );
+      }
+    },
+
+    async load(projectId) {
+      const database = await databasePromise;
+      const transaction = database.transaction(PROJECT_STORE, 'readonly');
+      const request = transaction.objectStore(PROJECT_STORE).get(projectId);
+      const record = await requestResult(
+        request as IDBRequest<PersistedWorkspaceRecord | undefined>,
+      );
+      await transactionComplete(transaction);
+      if (!record) return null;
+      if (isWorkspaceSnapshotV1(record.current)) return record.current;
+      if (isWorkspaceSnapshotV1(record.lastKnownGood)) {
+        throw new WorkspaceRecoveryRequiredError(projectId);
+      }
+      throw new WorkspacePersistenceError(
+        'The saved project and its last-known-good snapshot are unreadable.',
+      );
+    },
+
+    async loadLastKnownGood(projectId) {
+      const database = await databasePromise;
+      const transaction = database.transaction(PROJECT_STORE, 'readonly');
+      const request = transaction.objectStore(PROJECT_STORE).get(projectId);
+      const record = await requestResult(
+        request as IDBRequest<PersistedWorkspaceRecord | undefined>,
+      );
+      await transactionComplete(transaction);
+      if (!record) return null;
+      return requireValidSnapshot(record.lastKnownGood, 'Last-known-good snapshot');
+    },
+
+    async list() {
+      const database = await databasePromise;
+      const transaction = database.transaction(PROJECT_STORE, 'readonly');
+      const records = await requestResult(
+        transaction.objectStore(PROJECT_STORE).getAll() as IDBRequest<
+          PersistedWorkspaceRecord[]
+        >,
+      );
+      await transactionComplete(transaction);
+      return records
+        .filter((record) => isWorkspaceSnapshotV1(record.current))
+        .map(({ current }) => ({
+          projectId: current.projectId,
+          projectName: current.projectName,
+          selectedStage: current.selectedStage,
+          projectRevision: current.projectRevision,
+          updatedAt: current.updatedAt,
+          saveState: current.saveState,
+        }))
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    },
+  };
+}
+
+export function serializeWorkspaceSnapshot(snapshot: WorkspaceSnapshotV1): string {
+  return JSON.stringify(requireValidSnapshot(snapshot, 'Project snapshot'));
+}
+
+export function parseWorkspaceSnapshot(serialized: string): WorkspaceSnapshotV1 {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch (error) {
+    throw new WorkspacePersistenceError('Project snapshot is not valid JSON.', {
+      cause: error,
+    });
+  }
+  return requireValidSnapshot(parsed, 'Project snapshot');
+}

--- a/react_app/src/workspace/requestCoordinator.ts
+++ b/react_app/src/workspace/requestCoordinator.ts
@@ -1,0 +1,78 @@
+import type { RevisionIdentity } from './types';
+
+export interface RequestToken {
+  key: string;
+  requestId: string;
+  identity: RevisionIdentity;
+  signal: AbortSignal;
+}
+
+interface ActiveRequest extends RequestToken {
+  controller: AbortController;
+}
+
+function sameIdentity(left: RevisionIdentity, right: RevisionIdentity): boolean {
+  return (
+    left.projectId === right.projectId
+    && left.memberId === right.memberId
+    && left.inputHash === right.inputHash
+    && left.inputRevision === right.inputRevision
+    && left.memberRevision === right.memberRevision
+    && left.projectRevision === right.projectRevision
+  );
+}
+
+export class LatestRequestCoordinator {
+  private readonly active = new Map<string, ActiveRequest>();
+
+  begin(key: string, requestId: string, identity: RevisionIdentity): RequestToken {
+    const normalizedKey = key.trim();
+    const normalizedRequestId = requestId.trim();
+    if (!normalizedKey || !normalizedRequestId) {
+      throw new Error('Request key and request ID are required.');
+    }
+
+    this.cancel(normalizedKey);
+    const controller = new AbortController();
+    const request: ActiveRequest = {
+      key: normalizedKey,
+      requestId: normalizedRequestId,
+      identity: { ...identity },
+      signal: controller.signal,
+      controller,
+    };
+    this.active.set(normalizedKey, request);
+    return request;
+  }
+
+  isCurrent(token: RequestToken, currentIdentity: RevisionIdentity): boolean {
+    const active = this.active.get(token.key);
+    return Boolean(
+      active
+      && !token.signal.aborted
+      && active.requestId === token.requestId
+      && sameIdentity(active.identity, token.identity)
+      && sameIdentity(token.identity, currentIdentity),
+    );
+  }
+
+  settle(token: RequestToken, currentIdentity: RevisionIdentity): boolean {
+    if (!this.isCurrent(token, currentIdentity)) return false;
+    this.active.delete(token.key);
+    return true;
+  }
+
+  cancel(key: string): void {
+    const active = this.active.get(key);
+    if (!active) return;
+    active.controller.abort();
+    this.active.delete(key);
+  }
+
+  cancelAll(): void {
+    for (const active of this.active.values()) {
+      active.controller.abort();
+    }
+    this.active.clear();
+  }
+}

--- a/react_app/src/workspace/sync.ts
+++ b/react_app/src/workspace/sync.ts
@@ -1,0 +1,68 @@
+import type { WorkspaceSnapshotV1 } from './types';
+
+const CHANNEL_NAME = 'structlib-workbench-projects';
+
+export interface WorkspaceRevisionNotice {
+  type: 'workspace-revision';
+  sourceId: string;
+  projectId: string;
+  projectRevision: number;
+  updatedAt: string;
+}
+
+interface RevisionChannel {
+  postMessage(message: WorkspaceRevisionNotice): void;
+  addEventListener(
+    type: 'message',
+    listener: (event: MessageEvent<WorkspaceRevisionNotice>) => void,
+  ): void;
+  removeEventListener(
+    type: 'message',
+    listener: (event: MessageEvent<WorkspaceRevisionNotice>) => void,
+  ): void;
+  close(): void;
+}
+
+export interface WorkspaceRevisionSync {
+  announce(snapshot: WorkspaceSnapshotV1): void;
+  close(): void;
+}
+
+export function createWorkspaceRevisionSync(
+  sourceId: string,
+  onExternalRevision: (notice: WorkspaceRevisionNotice) => void,
+  createChannel: (name: string) => RevisionChannel = (name) => new BroadcastChannel(name),
+): WorkspaceRevisionSync {
+  const normalizedSourceId = sourceId.trim();
+  if (!normalizedSourceId) throw new Error('A workspace sync source ID is required.');
+  const channel = createChannel(CHANNEL_NAME);
+  const listener = (event: MessageEvent<WorkspaceRevisionNotice>) => {
+    const notice = event.data;
+    if (
+      notice?.type !== 'workspace-revision'
+      || notice.sourceId === normalizedSourceId
+      || !notice.projectId
+      || !Number.isInteger(notice.projectRevision)
+    ) {
+      return;
+    }
+    onExternalRevision(notice);
+  };
+  channel.addEventListener('message', listener);
+
+  return {
+    announce(snapshot) {
+      channel.postMessage({
+        type: 'workspace-revision',
+        sourceId: normalizedSourceId,
+        projectId: snapshot.projectId,
+        projectRevision: snapshot.projectRevision,
+        updatedAt: snapshot.updatedAt,
+      });
+    },
+    close() {
+      channel.removeEventListener('message', listener);
+      channel.close();
+    },
+  };
+}

--- a/react_app/src/workspace/types.ts
+++ b/react_app/src/workspace/types.ts
@@ -187,12 +187,39 @@ function isWorkspaceMember(value: unknown): value is WorkspaceMember {
   );
 }
 
+function nonStaleRecordMatchesMember(
+  record: EvidenceRecord | null,
+  projectId: string,
+  projectRevision: number,
+  member: WorkspaceMember,
+): boolean {
+  if (!record || record.lifecycle === 'stale') return true;
+  return (
+    record.projectId === projectId
+    && record.projectRevision === projectRevision
+    && record.memberId === member.memberId
+    && record.inputHash === member.inputHash
+    && record.inputRevision === member.inputRevision
+    && record.memberRevision === member.memberRevision
+  );
+}
+
 export function isWorkspaceSnapshotV1(value: unknown): value is WorkspaceSnapshotV1 {
   if (!isRecord(value)) return false;
   const candidate = value as Partial<WorkspaceSnapshotV1>;
   const members = candidate.members;
   if (!Array.isArray(members) || !members.every(isWorkspaceMember)) return false;
   const memberIds = members.map((member) => member.memberId);
+  const projectId = candidate.projectId;
+  const projectRevision = candidate.projectRevision;
+  const hasConsistentNonStaleRecords = typeof projectId === 'string'
+    && isPositiveRevision(projectRevision)
+    && members.every((member) => (
+      nonStaleRecordMatchesMember(member.result, projectId, projectRevision, member)
+      && nonStaleRecordMatchesMember(member.geometry, projectId, projectRevision, member)
+      && nonStaleRecordMatchesMember(member.alternatives, projectId, projectRevision, member)
+      && nonStaleRecordMatchesMember(member.metrics, projectId, projectRevision, member)
+    ));
   return (
     candidate.schemaVersion === WORKSPACE_SCHEMA_VERSION
     && typeof candidate.projectId === 'string'
@@ -201,6 +228,7 @@ export function isWorkspaceSnapshotV1(value: unknown): value is WorkspaceSnapsho
     && candidate.projectName.length > 0
     && isPositiveRevision(candidate.projectRevision)
     && new Set(memberIds).size === memberIds.length
+    && hasConsistentNonStaleRecords
     && typeof candidate.selectedStage === 'string'
     && PROJECT_STAGES.has(candidate.selectedStage as ProjectStage)
     && (

--- a/react_app/src/workspace/types.ts
+++ b/react_app/src/workspace/types.ts
@@ -1,0 +1,222 @@
+import type { ProjectStage } from '../app/navigation';
+
+export const WORKSPACE_SCHEMA_VERSION = 1 as const;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type ResultLifecycle =
+  | 'current'
+  | 'stale'
+  | 'pending'
+  | 'error'
+  | 'unsupported'
+  | 'not_evaluated';
+
+export type EvidenceDecision = 'PASS' | 'FAIL' | 'HOLD';
+export type SupportStatus = 'SUPPORTED' | 'HELD';
+export type SaveState = 'clean' | 'dirty' | 'saving' | 'error';
+
+export interface RevisionIdentity {
+  projectId: string;
+  memberId: string;
+  inputHash: string;
+  inputRevision: number;
+  memberRevision: number;
+  projectRevision: number;
+}
+
+export interface RecordError {
+  code: string;
+  message: string;
+}
+
+export interface EvidenceRecord<TData extends JsonValue = JsonValue>
+  extends RevisionIdentity {
+  lifecycle: ResultLifecycle;
+  requestId: string;
+  runId: string | null;
+  calculationIdentity: string | null;
+  libraryVersion: string | null;
+  decision: EvidenceDecision | null;
+  supportStatus: SupportStatus;
+  data: TData | null;
+  error: RecordError | null;
+  createdAt: string;
+  settledAt: string | null;
+}
+
+export interface WorkspaceMember {
+  memberId: string;
+  sourceId: string;
+  label: string;
+  story: string | null;
+  frameType: string;
+  inputHash: string;
+  inputRevision: number;
+  memberRevision: number;
+  inputs: { [key: string]: JsonValue };
+  result: EvidenceRecord | null;
+  geometry: EvidenceRecord | null;
+  alternatives: EvidenceRecord | null;
+  metrics: EvidenceRecord | null;
+}
+
+export interface WorkspaceSnapshotV1 {
+  schemaVersion: typeof WORKSPACE_SCHEMA_VERSION;
+  projectId: string;
+  projectName: string;
+  projectRevision: number;
+  members: WorkspaceMember[];
+  selectedStage: ProjectStage;
+  selectedMemberId: string | null;
+  selectedFloor: string | null;
+  dirty: boolean;
+  saveState: SaveState;
+  createdAt: string;
+  updatedAt: string;
+  savedAt: string | null;
+  migrationOrigin: string | null;
+}
+
+export interface PersistedWorkspaceRecord {
+  projectId: string;
+  current: WorkspaceSnapshotV1;
+  lastKnownGood: WorkspaceSnapshotV1;
+  updatedAt: string;
+}
+
+export interface WorkspaceProjectSummary {
+  projectId: string;
+  projectName: string;
+  selectedStage: ProjectStage;
+  projectRevision: number;
+  updatedAt: string;
+  saveState: SaveState;
+}
+
+const PROJECT_STAGES = new Set<ProjectStage>(['import', 'review', 'design', 'results']);
+const SAVE_STATES = new Set<SaveState>(['clean', 'dirty', 'saving', 'error']);
+const LIFECYCLES = new Set<ResultLifecycle>([
+  'current',
+  'stale',
+  'pending',
+  'error',
+  'unsupported',
+  'not_evaluated',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'boolean'
+    || (typeof value === 'number' && Number.isFinite(value))
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  return isRecord(value) && Object.values(value).every(isJsonValue);
+}
+
+function isPositiveRevision(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) > 0;
+}
+
+function isEvidenceRecord(value: unknown): value is EvidenceRecord {
+  if (!isRecord(value)) return false;
+  const error = value.error;
+  return (
+    typeof value.projectId === 'string'
+    && value.projectId.length > 0
+    && typeof value.memberId === 'string'
+    && value.memberId.length > 0
+    && typeof value.inputHash === 'string'
+    && value.inputHash.length > 0
+    && isPositiveRevision(value.inputRevision)
+    && isPositiveRevision(value.memberRevision)
+    && isPositiveRevision(value.projectRevision)
+    && typeof value.lifecycle === 'string'
+    && LIFECYCLES.has(value.lifecycle as ResultLifecycle)
+    && typeof value.requestId === 'string'
+    && value.requestId.length > 0
+    && (value.runId === null || typeof value.runId === 'string')
+    && (value.calculationIdentity === null || typeof value.calculationIdentity === 'string')
+    && (value.libraryVersion === null || typeof value.libraryVersion === 'string')
+    && (value.decision === null || value.decision === 'PASS' || value.decision === 'FAIL' || value.decision === 'HOLD')
+    && (value.supportStatus === 'SUPPORTED' || value.supportStatus === 'HELD')
+    && (value.data === null || isJsonValue(value.data))
+    && (
+      error === null
+      || (
+        isRecord(error)
+        && typeof error.code === 'string'
+        && typeof error.message === 'string'
+      )
+    )
+    && typeof value.createdAt === 'string'
+    && (value.settledAt === null || typeof value.settledAt === 'string')
+  );
+}
+
+function isWorkspaceMember(value: unknown): value is WorkspaceMember {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.memberId === 'string'
+    && value.memberId.length > 0
+    && typeof value.sourceId === 'string'
+    && value.sourceId.length > 0
+    && typeof value.label === 'string'
+    && value.label.length > 0
+    && (value.story === null || typeof value.story === 'string')
+    && typeof value.frameType === 'string'
+    && value.frameType.length > 0
+    && typeof value.inputHash === 'string'
+    && value.inputHash.length > 0
+    && isPositiveRevision(value.inputRevision)
+    && isPositiveRevision(value.memberRevision)
+    && isJsonValue(value.inputs)
+    && isRecord(value.inputs)
+    && ['result', 'geometry', 'alternatives', 'metrics'].every((key) => (
+      value[key] === null || isEvidenceRecord(value[key])
+    ))
+  );
+}
+
+export function isWorkspaceSnapshotV1(value: unknown): value is WorkspaceSnapshotV1 {
+  if (!isRecord(value)) return false;
+  const candidate = value as Partial<WorkspaceSnapshotV1>;
+  const members = candidate.members;
+  if (!Array.isArray(members) || !members.every(isWorkspaceMember)) return false;
+  const memberIds = members.map((member) => member.memberId);
+  return (
+    candidate.schemaVersion === WORKSPACE_SCHEMA_VERSION
+    && typeof candidate.projectId === 'string'
+    && candidate.projectId.length > 0
+    && typeof candidate.projectName === 'string'
+    && candidate.projectName.length > 0
+    && isPositiveRevision(candidate.projectRevision)
+    && new Set(memberIds).size === memberIds.length
+    && typeof candidate.selectedStage === 'string'
+    && PROJECT_STAGES.has(candidate.selectedStage as ProjectStage)
+    && (
+      candidate.selectedMemberId === null
+      || (
+        typeof candidate.selectedMemberId === 'string'
+        && memberIds.includes(candidate.selectedMemberId)
+      )
+    )
+    && (candidate.selectedFloor === null || typeof candidate.selectedFloor === 'string')
+    && typeof candidate.dirty === 'boolean'
+    && typeof candidate.saveState === 'string'
+    && SAVE_STATES.has(candidate.saveState as SaveState)
+    && typeof candidate.createdAt === 'string'
+    && typeof candidate.updatedAt === 'string'
+    && (candidate.savedAt === null || typeof candidate.savedAt === 'string')
+    && (candidate.migrationOrigin === null || typeof candidate.migrationOrigin === 'string')
+  );
+}

--- a/react_app/src/workspace/workspaceStore.ts
+++ b/react_app/src/workspace/workspaceStore.ts
@@ -1,0 +1,278 @@
+import { create } from 'zustand';
+import type { ProjectStage } from '../app/navigation';
+import {
+  invalidateMemberRecords,
+  memberIdentity,
+  pendingRecord,
+  recordMatchesIdentity,
+} from './identity';
+import {
+  WORKSPACE_SCHEMA_VERSION,
+  type EvidenceRecord,
+  type JsonValue,
+  type WorkspaceMember,
+  type WorkspaceSnapshotV1,
+} from './types';
+
+export type MemberRecordKind = 'result' | 'geometry' | 'alternatives' | 'metrics';
+
+export interface NewWorkspaceMember {
+  memberId: string;
+  sourceId: string;
+  label: string;
+  story?: string | null;
+  frameType?: string;
+  inputHash: string;
+  inputs: { [key: string]: JsonValue };
+}
+
+interface WorkspaceState {
+  snapshot: WorkspaceSnapshotV1 | null;
+  createProject: (projectId: string, projectName: string, now?: string) => void;
+  loadSnapshot: (snapshot: WorkspaceSnapshotV1) => void;
+  replaceMembers: (members: NewWorkspaceMember[], now?: string) => void;
+  setStage: (stage: ProjectStage, now?: string) => void;
+  selectMember: (memberId: string | null) => void;
+  selectFloor: (floor: string | null) => void;
+  updateMemberInputs: (
+    memberId: string,
+    inputs: { [key: string]: JsonValue },
+    inputHash: string,
+    now?: string,
+  ) => void;
+  beginMemberRequest: (
+    memberId: string,
+    kind: MemberRecordKind,
+    requestId: string,
+    now?: string,
+  ) => EvidenceRecord | null;
+  applyMemberRecord: (
+    memberId: string,
+    kind: MemberRecordKind,
+    record: EvidenceRecord,
+    now?: string,
+  ) => boolean;
+  markSaved: (savedAt?: string) => void;
+  reset: () => void;
+}
+
+function timestamp(now?: string): string {
+  return now ?? new Date().toISOString();
+}
+
+function normalizeMember(member: NewWorkspaceMember): WorkspaceMember {
+  return {
+    memberId: member.memberId,
+    sourceId: member.sourceId,
+    label: member.label,
+    story: member.story ?? null,
+    frameType: member.frameType ?? 'beam',
+    inputHash: member.inputHash,
+    inputRevision: 1,
+    memberRevision: 1,
+    inputs: member.inputs,
+    result: null,
+    geometry: null,
+    alternatives: null,
+    metrics: null,
+  };
+}
+
+function normalizeMembers(members: NewWorkspaceMember[]): WorkspaceMember[] {
+  const normalized = members.map(normalizeMember);
+  const ids = normalized.map((member) => member.memberId.trim());
+  if (
+    ids.some((id) => !id)
+    || normalized.some((member) => !member.sourceId.trim() || !member.inputHash.trim())
+    || new Set(ids).size !== ids.length
+  ) {
+    throw new Error('Workspace members require unique IDs, source IDs, and input hashes.');
+  }
+  return normalized;
+}
+
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
+  snapshot: null,
+
+  createProject: (projectId, projectName, now) => {
+    const normalizedProjectId = projectId.trim();
+    const normalizedProjectName = projectName.trim();
+    if (!normalizedProjectId || !normalizedProjectName) {
+      throw new Error('Project ID and project name are required.');
+    }
+    const createdAt = timestamp(now);
+    set({
+      snapshot: {
+        schemaVersion: WORKSPACE_SCHEMA_VERSION,
+        projectId: normalizedProjectId,
+        projectName: normalizedProjectName,
+        projectRevision: 1,
+        members: [],
+        selectedStage: 'import',
+        selectedMemberId: null,
+        selectedFloor: null,
+        dirty: true,
+        saveState: 'dirty',
+        createdAt,
+        updatedAt: createdAt,
+        savedAt: null,
+        migrationOrigin: null,
+      },
+    });
+  },
+
+  loadSnapshot: (snapshot) => set({ snapshot }),
+
+  replaceMembers: (members, now) => {
+    const normalizedMembers = normalizeMembers(members);
+    set((state) => {
+      if (!state.snapshot) return state;
+      const updatedAt = timestamp(now);
+      return {
+        snapshot: {
+          ...state.snapshot,
+          members: normalizedMembers,
+          projectRevision: state.snapshot.projectRevision + 1,
+          selectedMemberId: null,
+          dirty: true,
+          saveState: 'dirty',
+          updatedAt,
+        },
+      };
+    });
+  },
+
+  setStage: (selectedStage, now) =>
+    set((state) => {
+      if (!state.snapshot || state.snapshot.selectedStage === selectedStage) return state;
+      return {
+        snapshot: {
+          ...state.snapshot,
+          selectedStage,
+          updatedAt: timestamp(now),
+        },
+      };
+    }),
+
+  selectMember: (selectedMemberId) =>
+    set((state) => {
+      if (!state.snapshot) return state;
+      const exists = selectedMemberId === null
+        || state.snapshot.members.some((member) => member.memberId === selectedMemberId);
+      return exists
+        ? { snapshot: { ...state.snapshot, selectedMemberId } }
+        : state;
+    }),
+
+  selectFloor: (selectedFloor) =>
+    set((state) => (
+      state.snapshot
+        ? { snapshot: { ...state.snapshot, selectedFloor } }
+        : state
+    )),
+
+  updateMemberInputs: (memberId, inputs, inputHash, now) => {
+    if (!inputHash.trim()) throw new Error('A normalized input hash is required.');
+    set((state) => {
+      if (!state.snapshot) return state;
+      const memberIndex = state.snapshot.members.findIndex(
+        (member) => member.memberId === memberId,
+      );
+      if (memberIndex < 0) return state;
+
+      const updatedAt = timestamp(now);
+      const existing = state.snapshot.members[memberIndex];
+      const members = state.snapshot.members.map((member, index) => (
+        index === memberIndex
+          ? invalidateMemberRecords({
+            ...existing,
+            inputs,
+            inputHash,
+            inputRevision: existing.inputRevision + 1,
+            memberRevision: existing.memberRevision + 1,
+          })
+          : invalidateMemberRecords(member)
+      ));
+      return {
+        snapshot: {
+          ...state.snapshot,
+          members,
+          projectRevision: state.snapshot.projectRevision + 1,
+          dirty: true,
+          saveState: 'dirty',
+          updatedAt,
+        },
+      };
+    });
+  },
+
+  beginMemberRequest: (memberId, kind, requestId, now) => {
+    if (!requestId.trim()) throw new Error('A request ID is required.');
+    const snapshot = get().snapshot;
+    const member = snapshot?.members.find((candidate) => candidate.memberId === memberId);
+    if (!snapshot || !member) return null;
+    const record = pendingRecord(memberIdentity(snapshot, member), requestId, timestamp(now));
+    set({
+      snapshot: {
+        ...snapshot,
+        members: snapshot.members.map((candidate) => (
+          candidate.memberId === memberId
+            ? { ...candidate, [kind]: record }
+            : candidate
+        )),
+      },
+    });
+    return record;
+  },
+
+  applyMemberRecord: (memberId, kind, record, now) => {
+    const snapshot = get().snapshot;
+    const member = snapshot?.members.find((candidate) => candidate.memberId === memberId);
+    if (!snapshot || !member) return false;
+    const activeRecord = member[kind];
+    const identity = memberIdentity(snapshot, member);
+    if (
+      !recordMatchesIdentity(record, identity)
+      || activeRecord?.requestId !== record.requestId
+      || activeRecord.lifecycle !== 'pending'
+      || record.lifecycle === 'pending'
+      || record.lifecycle === 'stale'
+      || record.settledAt === null
+    ) {
+      return false;
+    }
+
+    const members = snapshot.members.map((candidate) => (
+      candidate.memberId === memberId
+        ? { ...candidate, [kind]: record }
+        : candidate
+    ));
+    set({
+      snapshot: {
+        ...snapshot,
+        members,
+        dirty: true,
+        saveState: 'dirty',
+        updatedAt: timestamp(now),
+      },
+    });
+    return true;
+  },
+
+  markSaved: (savedAt) =>
+    set((state) => {
+      if (!state.snapshot) return state;
+      const saved = timestamp(savedAt);
+      return {
+        snapshot: {
+          ...state.snapshot,
+          dirty: false,
+          saveState: 'clean',
+          savedAt: saved,
+          updatedAt: saved,
+        },
+      };
+    }),
+
+  reset: () => set({ snapshot: null }),
+}));

--- a/react_app/src/workspace/workspaceStore.ts
+++ b/react_app/src/workspace/workspaceStore.ts
@@ -8,6 +8,7 @@ import {
 } from './identity';
 import {
   WORKSPACE_SCHEMA_VERSION,
+  isWorkspaceSnapshotV1,
   type EvidenceRecord,
   type JsonValue,
   type WorkspaceMember,
@@ -15,6 +16,13 @@ import {
 } from './types';
 
 export type MemberRecordKind = 'result' | 'geometry' | 'alternatives' | 'metrics';
+
+export interface MemberInputState {
+  inputHash: string;
+  inputs: { [key: string]: JsonValue };
+}
+
+const MAX_MEMBER_INPUT_HISTORY = 20;
 
 export interface NewWorkspaceMember {
   memberId: string;
@@ -28,6 +36,7 @@ export interface NewWorkspaceMember {
 
 interface WorkspaceState {
   snapshot: WorkspaceSnapshotV1 | null;
+  memberInputHistory: Record<string, MemberInputState[]>;
   createProject: (projectId: string, projectName: string, now?: string) => void;
   loadSnapshot: (snapshot: WorkspaceSnapshotV1) => void;
   replaceMembers: (members: NewWorkspaceMember[], now?: string) => void;
@@ -40,6 +49,12 @@ interface WorkspaceState {
     inputHash: string,
     now?: string,
   ) => void;
+  undoMemberInputs: (memberId: string, now?: string) => boolean;
+  revertMemberInputs: (
+    memberId: string,
+    prior: MemberInputState,
+    now?: string,
+  ) => boolean;
   beginMemberRequest: (
     memberId: string,
     kind: MemberRecordKind,
@@ -91,8 +106,51 @@ function normalizeMembers(members: NewWorkspaceMember[]): WorkspaceMember[] {
   return normalized;
 }
 
+function cloneInputs(inputs: { [key: string]: JsonValue }): { [key: string]: JsonValue } {
+  return structuredClone(inputs);
+}
+
+function changedSnapshotForMemberInputs(
+  snapshot: WorkspaceSnapshotV1,
+  memberId: string,
+  next: MemberInputState,
+  now?: string,
+): WorkspaceSnapshotV1 | null {
+  const memberIndex = snapshot.members.findIndex((member) => member.memberId === memberId);
+  if (memberIndex < 0 || !next.inputHash.trim()) return null;
+  const existing = snapshot.members[memberIndex];
+  if (existing.inputHash === next.inputHash) return null;
+  const members = snapshot.members.map((member, index) => (
+    index === memberIndex
+      ? invalidateMemberRecords({
+        ...existing,
+        inputs: cloneInputs(next.inputs),
+        inputHash: next.inputHash,
+        inputRevision: existing.inputRevision + 1,
+        memberRevision: existing.memberRevision + 1,
+      })
+      : invalidateMemberRecords(member)
+  ));
+  return {
+    ...snapshot,
+    members,
+    projectRevision: snapshot.projectRevision + 1,
+    dirty: true,
+    saveState: 'dirty',
+    updatedAt: timestamp(now),
+  };
+}
+
+function appendInputHistory(
+  history: MemberInputState[],
+  state: MemberInputState,
+): MemberInputState[] {
+  return [...history, state].slice(-MAX_MEMBER_INPUT_HISTORY);
+}
+
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   snapshot: null,
+  memberInputHistory: {},
 
   createProject: (projectId, projectName, now) => {
     const normalizedProjectId = projectId.trim();
@@ -118,10 +176,16 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         savedAt: null,
         migrationOrigin: null,
       },
+      memberInputHistory: {},
     });
   },
 
-  loadSnapshot: (snapshot) => set({ snapshot }),
+  loadSnapshot: (snapshot) => {
+    if (!isWorkspaceSnapshotV1(snapshot)) {
+      throw new Error('Cannot load an invalid workspace snapshot.');
+    }
+    set({ snapshot, memberInputHistory: {} });
+  },
 
   replaceMembers: (members, now) => {
     const normalizedMembers = normalizeMembers(members);
@@ -138,6 +202,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           saveState: 'dirty',
           updatedAt,
         },
+        memberInputHistory: {},
       };
     });
   },
@@ -175,35 +240,63 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     if (!inputHash.trim()) throw new Error('A normalized input hash is required.');
     set((state) => {
       if (!state.snapshot) return state;
-      const memberIndex = state.snapshot.members.findIndex(
-        (member) => member.memberId === memberId,
+      const existing = state.snapshot.members.find((member) => member.memberId === memberId);
+      if (!existing) return state;
+      const snapshot = changedSnapshotForMemberInputs(
+        state.snapshot,
+        memberId,
+        { inputs, inputHash },
+        now,
       );
-      if (memberIndex < 0) return state;
-
-      const updatedAt = timestamp(now);
-      const existing = state.snapshot.members[memberIndex];
-      const members = state.snapshot.members.map((member, index) => (
-        index === memberIndex
-          ? invalidateMemberRecords({
-            ...existing,
-            inputs,
-            inputHash,
-            inputRevision: existing.inputRevision + 1,
-            memberRevision: existing.memberRevision + 1,
-          })
-          : invalidateMemberRecords(member)
-      ));
+      if (!snapshot) return state;
       return {
-        snapshot: {
-          ...state.snapshot,
-          members,
-          projectRevision: state.snapshot.projectRevision + 1,
-          dirty: true,
-          saveState: 'dirty',
-          updatedAt,
+        snapshot,
+        memberInputHistory: {
+          ...state.memberInputHistory,
+          [memberId]: appendInputHistory(
+            state.memberInputHistory[memberId] ?? [],
+            { inputHash: existing.inputHash, inputs: cloneInputs(existing.inputs) },
+          ),
         },
       };
     });
+  },
+
+  undoMemberInputs: (memberId, now) => {
+    const state = get();
+    const history = state.memberInputHistory[memberId] ?? [];
+    const prior = history.at(-1);
+    if (!state.snapshot || !prior) return false;
+    const snapshot = changedSnapshotForMemberInputs(state.snapshot, memberId, prior, now);
+    if (!snapshot) return false;
+    set({
+      snapshot,
+      memberInputHistory: {
+        ...state.memberInputHistory,
+        [memberId]: history.slice(0, -1),
+      },
+    });
+    return true;
+  },
+
+  revertMemberInputs: (memberId, prior, now) => {
+    if (!prior.inputHash.trim()) throw new Error('A normalized input hash is required.');
+    const state = get();
+    const existing = state.snapshot?.members.find((member) => member.memberId === memberId);
+    if (!state.snapshot || !existing) return false;
+    const snapshot = changedSnapshotForMemberInputs(state.snapshot, memberId, prior, now);
+    if (!snapshot) return false;
+    set({
+      snapshot,
+      memberInputHistory: {
+        ...state.memberInputHistory,
+        [memberId]: appendInputHistory(
+          state.memberInputHistory[memberId] ?? [],
+          { inputHash: existing.inputHash, inputs: cloneInputs(existing.inputs) },
+        ),
+      },
+    });
+    return true;
   },
 
   beginMemberRequest: (memberId, kind, requestId, now) => {
@@ -274,5 +367,5 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       };
     }),
 
-  reset: () => set({ snapshot: null }),
+  reset: () => set({ snapshot: null, memberInputHistory: {} }),
 }));

--- a/react_app/src/workspace/workspaceStore.ts
+++ b/react_app/src/workspace/workspaceStore.ts
@@ -67,6 +67,7 @@ interface WorkspaceState {
     record: EvidenceRecord,
     now?: string,
   ) => boolean;
+  setSaveState: (saveState: WorkspaceSnapshotV1['saveState']) => void;
   markSaved: (savedAt?: string) => void;
   reset: () => void;
 }
@@ -351,6 +352,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     });
     return true;
   },
+
+  setSaveState: (saveState) =>
+    set((state) => (
+      state.snapshot
+        ? { snapshot: { ...state.snapshot, saveState } }
+        : state
+    )),
 
   markSaved: (savedAt) =>
     set((state) => {

--- a/react_app/vite.config.ts
+++ b/react_app/vite.config.ts
@@ -42,26 +42,16 @@ export default defineConfig({
     rollupOptions: {
       maxParallelFileOps: 2,
       output: {
-        manualChunks: {
-          // Split Three.js into separate chunk (~600KB gzipped)
-          three: ['three'],
-          // React Three Fiber ecosystem
-          'react-three': [
-            '@react-three/fiber',
-            '@react-three/drei',
-          ],
-          // React core
-          react: ['react', 'react-dom'],
-          // UI framework
-          dockview: ['dockview'],
-          // AG Grid — only needed by /editor and /import routes
-          'ag-grid': [
-            '@ag-grid-community/core',
-            '@ag-grid-community/react',
-            '@ag-grid-community/client-side-row-model',
-          ],
-          // Animation library
-          'framer-motion': ['framer-motion'],
+        onlyExplicitManualChunks: true,
+        manualChunks(id) {
+          const moduleId = id.replaceAll('\\', '/');
+          if (moduleId.includes('/node_modules/three/')) return 'three';
+          if (moduleId.includes('/node_modules/@react-three/')) return 'react-three';
+          if (moduleId.includes('/node_modules/framer-motion/')) return 'framer-motion';
+          if (moduleId.includes('/node_modules/zustand/')) return 'zustand';
+          if (moduleId.includes('/node_modules/dockview/')) return 'dockview';
+          if (moduleId.includes('/node_modules/@ag-grid-community/')) return 'ag-grid';
+          return undefined;
         },
       },
     },

--- a/tests/fixtures/geometry-space-v1.json
+++ b/tests/fixtures/geometry-space-v1.json
@@ -1,0 +1,57 @@
+{
+  "global": {
+    "schemaVersion": "GeometrySpaceV1",
+    "frame": "GlobalSourceSpaceV1",
+    "units": "m",
+    "axes": "x=east,y=north,z=up",
+    "members": [
+      {
+        "memberId": "ETABS-Frame-101",
+        "sourceId": "ETABS-Frame-101",
+        "label": "B1",
+        "story": "GF",
+        "frameType": "beam",
+        "section": { "widthMm": 300, "depthMm": 500 },
+        "inputHash": "input-b1",
+        "projectRevision": 3,
+        "memberRevision": 7,
+        "sourceRevision": 7,
+        "geometryRevision": 7,
+        "start": { "x": 0, "y": 0, "z": 0 },
+        "end": { "x": 6, "y": 0, "z": 0 }
+      },
+      {
+        "memberId": "ETABS-Frame-201",
+        "sourceId": "ETABS-Frame-201",
+        "label": "C1",
+        "story": "GF",
+        "frameType": "column",
+        "section": { "widthMm": 450, "depthMm": 450 },
+        "inputHash": "input-c1",
+        "projectRevision": 3,
+        "memberRevision": 7,
+        "sourceRevision": 7,
+        "geometryRevision": 7,
+        "start": { "x": 6, "y": 0, "z": 0 },
+        "end": { "x": 6, "y": 0, "z": 3 }
+      }
+    ],
+    "bounds": { "minX": 0, "maxX": 6, "minY": 0, "maxY": 0, "minZ": 0, "maxZ": 3 },
+    "center": { "x": 3, "y": 0, "z": 1.5 },
+    "rendererCoordinates": {
+      "ETABS-Frame-101": { "start": [0, 0, 0], "end": [6, 0, 0] },
+      "ETABS-Frame-201": { "start": [6, 0, 0], "end": [6, 3, 0] }
+    }
+  },
+  "detail": {
+    "route": "/api/v1/geometry/beam/full",
+    "schemaVersion": "1.0.0",
+    "frame": "LocalBeamSpaceV1",
+    "units": "mm",
+    "origin": "left-support,center-width,soffit",
+    "beamId": "ETABS-Frame-101",
+    "outline": [{ "x": 0, "y": -150, "z": 0 }, { "x": 6000, "y": 150, "z": 500 }],
+    "rebar": { "start": { "x": 0, "y": -96, "z": 56 }, "end": { "x": 6000, "y": -96, "z": 56 }, "diameterMm": 16 },
+    "stirrup": { "positionX": 150, "path": [{ "x": 150, "y": -106, "z": 44 }, { "x": 150, "y": 106, "z": 44 }] }
+  }
+}


### PR DESCRIPTION
## Summary

- lock the Session 1 route, workspace, revision, and geometry contracts
- replace the decorative landing with a restrained two-destination workbench shell
- add durable WorkspaceSnapshotV1 IndexedDB persistence, recovery, autosave, undo/revert invalidation, and multi-tab conflict handling
- add AbortSignal-aware design and geometry requests plus the two-frame GeometrySpaceV1 fixture
- retire Streamlit from active UI planning and advance UIX-001 to P4

## Verification

- 197 React tests passed
- React lint passed
- React production build passed
- ./run.sh check --quick passed 10/10
- ./run.sh check passed 30/30
- Chromium UAT passed at 1440x900, 1024x768, and 390x844
- real IndexedDB save/reload/delete and BroadcastChannel conflict behavior verified; synthetic record removed
- production landing requested no Three, R3F, AG Grid, or Framer assets

## Holds

- P4 quick-design migration and P5/P6 project result integration remain follow-up packets
- no GitHub Pages, release, tag, package publication, or professional-use claim is included