### PR TITLE
chore(maintenance): refresh clean baseline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,7 +76,7 @@ Core CANNOT import from Services or UI.
 Agents keep duplicating code. Check what exists BEFORE writing new code:
 ```bash
 ls react_app/src/hooks/                                         # React hooks (CSV, geometry, export, insights)
-grep -r "@router" fastapi_app/routers/ | head -30               # FastAPI routes (15 routers)
+grep -r "@router" fastapi_app/routers/ | head -30               # FastAPI routes (17 routers)
 ./run.sh find --api <func>                                   # Public API exact signature (68 functions)
 .venv/bin/python scripts/discover_api_signatures.py <func>      # Exact param names
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Agents keep duplicating code. Check what exists BEFORE writing new code:
 
 ```bash
 ls react_app/src/hooks/                                         # React hooks (CSV, geometry, export, insights)
-grep -r "@router" fastapi_app/routers/ | head -30               # FastAPI endpoints (15 routers)
+grep -r "@router" fastapi_app/routers/ | head -30               # FastAPI endpoints (17 routers)
 ./run.sh find --api <func>                                   # Public API exact signature (68 functions)
 .venv/bin/python scripts/discover_api_signatures.py <func>      # Get exact param names (b_mm not width)
 ```

--- a/Python/examples/index.json
+++ b/Python/examples/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/examples",
   "type": "python-package",
   "description": "> **Purpose:** Example scripts demonstrating structural_lib usage",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 18,
   "files": [
     {
@@ -320,5 +320,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "79959aeb6dbaf1fc"
+  "content_hash": "5aa6f3bbb744153d"
 }

--- a/Python/examples/index.md
+++ b/Python/examples/index.md
@@ -3,7 +3,7 @@
 > **Purpose:** Example scripts demonstrating structural_lib usage
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 18
 
 ## Config Files

--- a/Python/structural_lib/codes/index.json
+++ b/Python/structural_lib/codes/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/codes",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 1,
   "files": [
     {
@@ -42,13 +42,13 @@
     {
       "name": "is456",
       "path": "is456/",
-      "file_count": 46,
+      "file_count": 55,
       "is_package": true
     }
   ],
-  "content_hash": "5731948e8601688f",
   "has_init": true,
   "public_api": [
     "is456"
-  ]
+  ],
+  "content_hash": "7990797f7098b83c"
 }

--- a/Python/structural_lib/codes/index.md
+++ b/Python/structural_lib/codes/index.md
@@ -1,7 +1,7 @@
 # Codes
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 1
 
 ## Public API
@@ -22,4 +22,4 @@
 | [common/](common/) 📦 | 1 |  |
 | [ec2/](ec2/) 📦 | 1 |  |
 | [is13920/](is13920/) 📦 | 4 |  |
-| [is456/](is456/) 📦 | 46 |  |
+| [is456/](is456/) 📦 | 55 |  |

--- a/Python/structural_lib/codes/is456/index.json
+++ b/Python/structural_lib/codes/is456/index.json
@@ -2,14 +2,14 @@
   "folder": "Python/structural_lib/codes/is456",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 14,
   "files": [
     {
       "name": "__init__.py",
       "type": "python",
       "size_lines": 148,
-      "last_updated": "2026-04-03",
+      "last_updated": "2026-08-09",
       "description": "IS 456:2000 - Indian Standard for Plain and Reinforced Concrete.",
       "classes": [
         {
@@ -26,12 +26,12 @@
           ]
         }
       ],
-      "content_hash": "248d2465c012"
+      "content_hash": "eab49c0651c4"
     },
     {
       "name": "clauses.json",
       "type": "config",
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-09",
       "top_level_keys": [
         "$schema",
         "metadata",
@@ -40,7 +40,7 @@
         "figures",
         "annexures"
       ],
-      "content_hash": "f974f3f59732"
+      "content_hash": "abee8e3dbffd"
     },
     {
       "name": "compliance.py",
@@ -316,8 +316,8 @@
     {
       "name": "traceability.py",
       "type": "python",
-      "size_lines": 354,
-      "last_updated": "2026-04-05",
+      "size_lines": 350,
+      "last_updated": "2026-08-09",
       "description": "IS 456 Traceability Module",
       "functions": [
         {
@@ -351,7 +351,7 @@
         },
         {
           "name": "search_clauses",
-          "description": "Search clauses by keyword in title, text, or keywords.",
+          "description": "Search distributable clause identity metadata by title or keywords.",
           "params": [
             "keyword"
           ]
@@ -375,7 +375,7 @@
       "constants": [
         "F"
       ],
-      "content_hash": "499eb980fe5f"
+      "content_hash": "036880ae4b70"
     }
   ],
   "subfolders": [
@@ -400,23 +400,29 @@
     {
       "name": "footing",
       "path": "footing/",
+      "file_count": 9,
+      "is_package": true
+    },
+    {
+      "name": "slab",
+      "path": "slab/",
       "file_count": 8,
       "is_package": true
     }
   ],
-  "content_hash": "d55ef1ae53680252",
   "has_init": true,
   "public_api": [
     "IS456Code",
     "beam",
     "column",
+    "footing",
+    "slab",
     "tables",
     "shear",
     "flexure",
     "detailing",
     "serviceability",
     "compliance",
-    "ductile",
     "slenderness",
     "torsion",
     "traceability",
@@ -425,5 +431,6 @@
     "get_clause_info",
     "list_clauses_by_category",
     "search_clauses"
-  ]
+  ],
+  "content_hash": "c43647f7ac0dc25a"
 }

--- a/Python/structural_lib/codes/is456/index.md
+++ b/Python/structural_lib/codes/is456/index.md
@@ -1,7 +1,7 @@
 # Is456
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 14
 
 ## Public API
@@ -9,13 +9,14 @@
 - `IS456Code`
 - `beam`
 - `column`
+- `footing`
+- `slab`
 - `tables`
 - `shear`
 - `flexure`
 - `detailing`
 - `serviceability`
 - `compliance`
-- `ductile`
 - `slenderness`
 - `torsion`
 - `traceability`
@@ -45,7 +46,7 @@
 | [slenderness.py](slenderness.py) | Slenderness Check Module — IS 456:2000 Beam Lateral Stabilit | 2 | 3 | 364 |
 | [tables.py](tables.py) | Module:       tables | 0 | 2 | 97 |
 | [torsion.py](torsion.py) | Backward compatibility shim — torsion module moved to beam/  | 0 | 0 | 29 |
-| [traceability.py](traceability.py) | IS 456 Traceability Module | 0 | 9 | 354 |
+| [traceability.py](traceability.py) | IS 456 Traceability Module | 0 | 9 | 350 |
 
 ## Subfolders
 
@@ -54,4 +55,5 @@
 | [beam/](beam/) 📦 | 6 |  |
 | [column/](column/) 📦 | 11 |  |
 | [common/](common/) 📦 | 5 |  |
-| [footing/](footing/) 📦 | 8 |  |
+| [footing/](footing/) 📦 | 9 |  |
+| [slab/](slab/) 📦 | 8 |  |

--- a/Python/structural_lib/core/index.json
+++ b/Python/structural_lib/core/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/core",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 18,
   "files": [
     {
@@ -80,8 +80,8 @@
     {
       "name": "data_types.py",
       "type": "python",
-      "size_lines": 1965,
-      "last_updated": "2026-04-07",
+      "size_lines": 1964,
+      "last_updated": "2026-08-09",
       "description": "Module:       types",
       "classes": [
         {
@@ -150,7 +150,7 @@
           "description": "Critical point on BMD/SFD diagram (max, min, zero crossing)."
         }
       ],
-      "content_hash": "b03d2d10ab27"
+      "content_hash": "d81a3b155344"
     },
     {
       "name": "deprecation.py",
@@ -1023,7 +1023,6 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "19848c548493a316",
   "has_init": true,
   "public_api": [
     "DesignCode",
@@ -1038,5 +1037,6 @@
     "TSection",
     "LSection",
     "CodeRegistry"
-  ]
+  ],
+  "content_hash": "243fe7627491a1b0"
 }

--- a/Python/structural_lib/core/index.md
+++ b/Python/structural_lib/core/index.md
@@ -1,7 +1,7 @@
 # Core
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 18
 
 ## Public API
@@ -26,7 +26,7 @@
 | [__init__.py](__init__.py) | Core module - Code-agnostic base classes and utilities. | 0 | 0 | 42 |
 | [base.py](base.py) | Abstract base classes for design code implementations. | 5 | 0 | 139 |
 | [constants.py](constants.py) | Module:       constants | 0 | 0 | 20 |
-| [data_types.py](data_types.py) | Module:       types | 15 | 0 | 1965 |
+| [data_types.py](data_types.py) | Module:       types | 15 | 0 | 1964 |
 | [deprecation.py](deprecation.py) | Module:       deprecation | 0 | 2 | 156 |
 | [error_messages.py](error_messages.py) | Module:       error_messages | 0 | 15 | 496 |
 | [errors.py](errors.py) | Module:       errors | 11 | 1 | 884 |

--- a/Python/structural_lib/index.json
+++ b/Python/structural_lib/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib",
   "type": "python-package",
   "description": "> **Purpose:** IS 456:2000 RC beam design calculations",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 51,
   "files": [
     {
@@ -17,19 +17,19 @@
     {
       "name": "__init__.py",
       "type": "python",
-      "size_lines": 372,
-      "last_updated": "2026-04-07",
+      "size_lines": 377,
+      "last_updated": "2026-08-10",
       "description": "Package:      structural_lib",
       "constants": [
         "_LAZY_MODULES"
       ],
-      "content_hash": "379e55fcbde3"
+      "content_hash": "8920b5929246"
     },
     {
       "name": "__main__.py",
       "type": "python",
-      "size_lines": 1533,
-      "last_updated": "2026-04-07",
+      "size_lines": 1573,
+      "last_updated": "2026-08-10",
       "description": "Unified CLI entrypoint for structural_lib.",
       "functions": [
         {
@@ -103,6 +103,13 @@
           ]
         },
         {
+          "name": "cmd_capabilities",
+          "description": "Print the canonical supported/held IS 456 capability contract.",
+          "params": [
+            "args"
+          ]
+        },
+        {
           "name": "main",
           "description": "Main entry point for the CLI.",
           "params": [
@@ -110,7 +117,7 @@
           ]
         }
       ],
-      "content_hash": "8470657ab1e2"
+      "content_hash": "36508a2dbd0a"
     },
     {
       "name": "adapters.py",
@@ -506,7 +513,7 @@
     {
       "name": "codes",
       "path": "codes/",
-      "file_count": 56,
+      "file_count": 65,
       "is_package": true
     },
     {
@@ -536,7 +543,7 @@
     {
       "name": "services",
       "path": "services/",
-      "file_count": 35,
+      "file_count": 40,
       "is_package": true
     },
     {
@@ -546,7 +553,6 @@
       "is_package": true
     }
   ],
-  "content_hash": "adad6aca83d16e81",
   "has_init": true,
   "public_api": [
     "__version__",
@@ -569,5 +575,6 @@
     "serialization",
     "serviceability",
     "shear"
-  ]
+  ],
+  "content_hash": "c8513106df68e4ae"
 }

--- a/Python/structural_lib/index.md
+++ b/Python/structural_lib/index.md
@@ -3,7 +3,7 @@
 > **Purpose:** IS 456:2000 RC beam design calculations
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 51
 
 ## Public API
@@ -39,8 +39,8 @@
 
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
-| [__init__.py](__init__.py) | Package:      structural_lib | 0 | 0 | 372 |
-| [__main__.py](__main__.py) | Unified CLI entrypoint for structural_lib. | 0 | 11 | 1533 |
+| [__init__.py](__init__.py) | Package:      structural_lib | 0 | 0 | 377 |
+| [__main__.py](__main__.py) | Unified CLI entrypoint for structural_lib. | 0 | 12 | 1573 |
 | [adapters.py](adapters.py) | Backward compatibility stub. | 0 | 0 | 17 |
 | [api.py](api.py) | Backward compatibility stub. | 0 | 0 | 14 |
 | [api_results.py](api_results.py) | Backward compatibility stub. | 0 | 0 | 18 |
@@ -94,10 +94,10 @@
 | Folder | Files | Description |
 |--------|-------|-------------|
 | [cli/](cli/) 📦 | 2 |  |
-| [codes/](codes/) 📦 | 56 |  |
+| [codes/](codes/) 📦 | 65 |  |
 | [core/](core/) 📦 | 20 |  |
 | [insights/](insights/) 📦 | 12 |  |
 | [reports/](reports/) 📦 | 7 |  |
 | [research/](research/) 📦 | 4 |  |
-| [services/](services/) 📦 | 35 |  |
+| [services/](services/) 📦 | 40 |  |
 | [visualization/](visualization/) 📦 | 4 |  |

--- a/Python/structural_lib/insights/index.json
+++ b/Python/structural_lib/insights/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/insights",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 10,
   "files": [
     {
@@ -109,7 +109,7 @@
       "name": "design_suggestions.py",
       "type": "python",
       "size_lines": 686,
-      "last_updated": "2026-03-28",
+      "last_updated": "2026-04-07",
       "description": "Design suggestion engine for beam design optimization.",
       "classes": [
         {
@@ -152,7 +152,7 @@
       "constants": [
         "_ENGINE_VERSION"
       ],
-      "content_hash": "856f2929389d"
+      "content_hash": "008d3ebcd44a"
     },
     {
       "name": "precheck.py",
@@ -204,7 +204,7 @@
       "name": "smart_designer.py",
       "type": "python",
       "size_lines": 636,
-      "last_updated": "2026-03-28",
+      "last_updated": "2026-04-07",
       "description": "Smart Designer — Unified intelligent design analysis dashboard.",
       "classes": [
         {
@@ -256,7 +256,7 @@
           ]
         }
       ],
-      "content_hash": "7228e2c532b6"
+      "content_hash": "2774f91c9cb0"
     },
     {
       "name": "types.py",
@@ -312,7 +312,6 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "162ba4bdc93c95d1",
   "has_init": true,
   "public_api": [
     "calculate_constructability_score",
@@ -335,5 +334,6 @@
     "ConstructabilityScore",
     "DashboardReport",
     "DesignAlternative"
-  ]
+  ],
+  "content_hash": "714d3bcbcd4b82a5"
 }

--- a/Python/structural_lib/insights/index.md
+++ b/Python/structural_lib/insights/index.md
@@ -1,7 +1,7 @@
 # Insights
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 10
 
 ## Public API

--- a/Python/structural_lib/reports/index.json
+++ b/Python/structural_lib/reports/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/reports",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 2,
   "files": [
     {
@@ -16,8 +16,8 @@
     {
       "name": "generator.py",
       "type": "python",
-      "size_lines": 348,
-      "last_updated": "2026-03-26",
+      "size_lines": 452,
+      "last_updated": "2026-08-10",
       "description": "Report Generator — Jinja2-based HTML report generation.",
       "classes": [
         {
@@ -53,9 +53,10 @@
         }
       ],
       "constants": [
+        "_SAFETY_SECTIONS",
         "TEMPLATES_DIR"
       ],
-      "content_hash": "9fffc50c9640"
+      "content_hash": "cad7a197fc81"
     }
   ],
   "subfolders": [
@@ -65,7 +66,6 @@
       "file_count": 3
     }
   ],
-  "content_hash": "b6884ca31920dc58",
   "has_init": true,
   "public_api": [
     "generate_html_report",
@@ -73,5 +73,6 @@
     "get_available_templates",
     "ReportContext",
     "JINJA2_AVAILABLE"
-  ]
+  ],
+  "content_hash": "5888faa39a8059c3"
 }

--- a/Python/structural_lib/reports/index.md
+++ b/Python/structural_lib/reports/index.md
@@ -1,7 +1,7 @@
 # Reports
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 2
 
 ## Public API
@@ -17,7 +17,7 @@
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | Reports Package — Professional Report Generation with Jinja2 | 0 | 0 | 47 |
-| [generator.py](generator.py) | Report Generator — Jinja2-based HTML report generation. | 1 | 3 | 348 |
+| [generator.py](generator.py) | Report Generator — Jinja2-based HTML report generation. | 1 | 3 | 452 |
 
 ## Subfolders
 

--- a/Python/structural_lib/visualization/index.json
+++ b/Python/structural_lib/visualization/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/visualization",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 2,
   "files": [
     {
@@ -17,7 +17,7 @@
       "name": "geometry_3d.py",
       "type": "python",
       "size_lines": 940,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-04-07",
       "description": "3D Geometry Module — Coordinate Computation for Visualization",
       "classes": [
         {
@@ -141,11 +141,10 @@
           ]
         }
       ],
-      "content_hash": "64e24763fb0f"
+      "content_hash": "fa3055d04cdf"
     }
   ],
   "subfolders": [],
-  "content_hash": "0a80080160dafaea",
   "has_init": true,
   "public_api": [
     "Point3D",
@@ -153,5 +152,6 @@
     "RebarPath",
     "StirrupLoop",
     "Beam3DGeometry"
-  ]
+  ],
+  "content_hash": "73b8ffaad45fe53a"
 }

--- a/Python/structural_lib/visualization/index.md
+++ b/Python/structural_lib/visualization/index.md
@@ -1,7 +1,7 @@
 # Visualization
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 2
 
 ## Public API

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2,8 +2,8 @@
   "folder": "Python/tests",
   "type": "python-package",
   "description": "This document describes the test taxonomy and structure for the structural_engineering_lib test suite.",
-  "last_updated": "2026-08-09",
-  "file_count": 53,
+  "last_updated": "2026-08-10",
+  "file_count": 58,
   "files": [
     {
       "name": "README.md",
@@ -64,8 +64,8 @@
     {
       "name": "test_agent_governance_automation.py",
       "type": "python",
-      "size_lines": 279,
-      "last_updated": "2026-08-09",
+      "size_lines": 428,
+      "last_updated": "2026-08-10",
       "description": "Regression tests for agent-governance automation controls.",
       "functions": [
         {
@@ -73,6 +73,9 @@
         },
         {
           "name": "test_control_paths_use_python_runtime_launcher"
+        },
+        {
+          "name": "test_watch_help_does_not_require_fswatch"
         },
         {
           "name": "test_current_session_ids_uses_injected_date_and_ignores_malformed_ids"
@@ -144,27 +147,28 @@
           "name": "test_tool_registry_does_not_infer_permission_from_git_text"
         },
         {
-          "name": "test_permission_metadata_audit_accepts_current_declarations"
+          "name": "test_remaining_automation_permissions_match_modes",
+          "params": [
+            "operation",
+            "mode",
+            "expected"
+          ]
         },
         {
-          "name": "test_permission_metadata_audit_rejects_modes_without_default",
-          "params": [
-            "tmp_path",
-            "monkeypatch"
-          ]
+          "name": "test_automation_discovery_metadata_is_single_source"
         }
       ],
       "constants": [
         "REPO_ROOT",
         "SCRIPTS_DIR"
       ],
-      "content_hash": "f32a67378f42"
+      "content_hash": "108dc1b66ce7"
     },
     {
       "name": "test_api_manifest_tools.py",
       "type": "python",
       "size_lines": 134,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "Regression tests for the single canonical public API manifest.",
       "functions": [
         {
@@ -501,7 +505,7 @@
       "name": "test_calculation_report.py",
       "type": "python",
       "size_lines": 745,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "Tests for the calculation_report module (TASK-277).",
       "classes": [
         {
@@ -1639,6 +1643,28 @@
       "content_hash": "6da4ea61aebb"
     },
     {
+      "name": "test_evidence.py",
+      "type": "python",
+      "size_lines": 108,
+      "last_updated": "2026-08-10",
+      "description": "Focused tests for the supported IS 456 beam evidence envelope.",
+      "functions": [
+        {
+          "name": "test_beam_evidence_hash_uses_normalized_consumed_inputs"
+        },
+        {
+          "name": "test_beam_evidence_hash_changes_for_relevant_input"
+        },
+        {
+          "name": "test_held_beam_evidence_does_not_present_a_pass_or_fail"
+        },
+        {
+          "name": "test_beam_report_exports_evidence_without_approval_claim"
+        }
+      ],
+      "content_hash": "ea52787db35d"
+    },
+    {
       "name": "test_exception_hierarchy.py",
       "type": "python",
       "size_lines": 278,
@@ -1695,7 +1721,7 @@
       "name": "test_footing.py",
       "type": "python",
       "size_lines": 1750,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "Tests for IS 456 footing design — TASK-650/651/652.",
       "classes": [
         {
@@ -1871,7 +1897,7 @@
       "name": "test_footing_load_transfer.py",
       "type": "python",
       "size_lines": 165,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "Focused independent arithmetic checks for IS 456 Cl. 34.4 load transfer.",
       "functions": [
         {
@@ -1901,6 +1927,26 @@
         }
       ],
       "content_hash": "ee88228af18c"
+    },
+    {
+      "name": "test_generated_clients.py",
+      "type": "python",
+      "size_lines": 71,
+      "last_updated": "2026-08-10",
+      "description": "Contract checks for the checked-in basic generated clients.",
+      "functions": [
+        {
+          "name": "test_python_client_unwraps_success_envelopes_and_uses_maintained_routes"
+        },
+        {
+          "name": "test_import_validator_resolves_checked_in_generated_client"
+        }
+      ],
+      "constants": [
+        "REPO_ROOT",
+        "CLIENT_ROOT"
+      ],
+      "content_hash": "5f72938f65a1"
     },
     {
       "name": "test_inputs.py",
@@ -1997,7 +2043,7 @@
       "name": "test_is456_common.py",
       "type": "python",
       "size_lines": 854,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "Tests for IS 456:2000 common modules - stress_blocks, reinforcement, validation.",
       "classes": [
         {
@@ -2198,8 +2244,8 @@
     {
       "name": "test_model_picker.py",
       "type": "python",
-      "size_lines": 92,
-      "last_updated": "2026-08-09",
+      "size_lines": 94,
+      "last_updated": "2026-08-10",
       "description": "Tests for the deterministic low-token model picker.",
       "functions": [
         {
@@ -2219,13 +2265,13 @@
           ]
         },
         {
-          "name": "test_mechanical_planning_doc_update_stays_on_luna"
+          "name": "test_mechanical_planning_doc_update_uses_terra_low"
         },
         {
           "name": "test_main_orchestrator_advises_terra_without_overriding_user_choice"
         },
         {
-          "name": "test_low_risk_override_prefers_luna"
+          "name": "test_low_risk_override_prefers_terra_low"
         },
         {
           "name": "test_model_policy_profiles_are_unique_and_complete"
@@ -2234,7 +2280,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "5263044f7410"
+      "content_hash": "b8d50bb1968e"
     },
     {
       "name": "test_multi_objective_optimizer.py",
@@ -2352,8 +2398,8 @@
     {
       "name": "test_packaging.py",
       "type": "python",
-      "size_lines": 418,
-      "last_updated": "2026-08-09",
+      "size_lines": 452,
+      "last_updated": "2026-08-10",
       "description": "Tests for package distribution correctness.",
       "classes": [
         {
@@ -2369,7 +2415,8 @@
           "name": "TestPackageScope",
           "description": "Verify no test/dev packages leak into the distribution.",
           "public_methods": [
-            "test_no_tests_in_top_level"
+            "test_no_tests_in_top_level",
+            "test_manifest_prunes_non_product_namespaces"
           ]
         },
         {
@@ -2435,11 +2482,12 @@
           "description": "Verify README code examples actually work.",
           "public_methods": [
             "test_readme_beam_design_snippet",
-            "test_readme_csv_adapter_snippet"
+            "test_readme_csv_adapter_snippet",
+            "test_api_levels_column_workflow_snippet"
           ]
         }
       ],
-      "content_hash": "87c54525f7fe"
+      "content_hash": "9dfa7df6929e"
     },
     {
       "name": "test_pipeline_state.py",
@@ -2540,10 +2588,14 @@
     {
       "name": "test_release_environment.py",
       "type": "python",
-      "size_lines": 189,
-      "last_updated": "2026-08-09",
+      "size_lines": 263,
+      "last_updated": "2026-08-10",
       "description": "Regression tests for local release preflight environment selection.",
       "functions": [
+        {
+          "name": "test_type_check_toolchain_requires_explicit_migration",
+          "description": "Do not let CI silently cross known Mypy/NumPy stub boundaries."
+        },
         {
           "name": "test_available_ram_uses_memory_pressure_percentage",
           "params": [
@@ -2587,6 +2639,20 @@
           ]
         },
         {
+          "name": "test_source_surface_versions_match_owner_authorized_release",
+          "params": [
+            "tmp_path",
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_release_ready_metadata_requires_recorded_owner_authorization",
+          "params": [
+            "tmp_path",
+            "monkeypatch"
+          ]
+        },
+        {
           "name": "test_source_surface_versions_fail_on_deliberate_mismatch",
           "params": [
             "tmp_path",
@@ -2609,13 +2675,13 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "6cde32e9477b"
+      "content_hash": "3df5715a4d03"
     },
     {
       "name": "test_release_scripts.py",
       "type": "python",
-      "size_lines": 404,
-      "last_updated": "2026-08-09",
+      "size_lines": 446,
+      "last_updated": "2026-08-10",
       "description": "Tests for release scripts (bump_version.py, release.py).",
       "classes": [
         {
@@ -2688,6 +2754,16 @@
           ]
         },
         {
+          "name": "TestPublishWorkflow",
+          "description": "The release workflow must preserve package maturity on GitHub.",
+          "public_methods": [
+            "test_development_status_controls_github_prerelease",
+            "test_future_publications_require_alpha_identifiers",
+            "test_alpha_ordering_preserves_legacy_release_history",
+            "test_docs_workflow_is_build_only_until_pages_is_configured"
+          ]
+        },
+        {
           "name": "TestReleasePreflight",
           "description": "Tests for the preflight subcommand.",
           "public_methods": [
@@ -2748,13 +2824,13 @@
         "RELEASE_SCRIPT",
         "VERSION_TRACKED_FILES"
       ],
-      "content_hash": "5ea6f3fef8c8"
+      "content_hash": "a1f6041c020d"
     },
     {
       "name": "test_report_edge_cases.py",
       "type": "python",
       "size_lines": 303,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "Edge case tests for report generation modules (TASK-520).",
       "classes": [
         {
@@ -2867,7 +2943,7 @@
       "name": "test_reports.py",
       "type": "python",
       "size_lines": 447,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "Tests for the reports module.",
       "classes": [
         {
@@ -3096,8 +3172,8 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 327,
-      "last_updated": "2026-08-09",
+      "size_lines": 462,
+      "last_updated": "2026-08-10",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
         {
@@ -3154,6 +3230,12 @@
           "name": "test_api_endpoint_extraction_stops_before_query_template"
         },
         {
+          "name": "test_api_call_method_extraction_stops_at_each_fetch",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
           "name": "test_api_route_shape_matches_dynamic_segments"
         },
         {
@@ -3176,14 +3258,21 @@
           "name": "test_generated_indexes_do_not_emit_trailing_space_hard_breaks"
         },
         {
-          "name": "test_session_end_preserves_current_same_day_handoff",
+          "name": "test_generated_json_indexes_end_with_newline",
           "params": [
             "tmp_path",
             "monkeypatch"
           ]
         },
         {
-          "name": "test_legacy_activity_log_uses_local_midnight_and_no_billing_estimate",
+          "name": "test_generated_index_hash_tracks_subfolder_projection",
+          "params": [
+            "tmp_path",
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_session_end_preserves_current_same_day_handoff",
           "params": [
             "tmp_path",
             "monkeypatch"
@@ -3193,7 +3282,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "5fd79d7492ad"
+      "content_hash": "90e3edeef907"
     },
     {
       "name": "test_session_store.py",
@@ -3495,8 +3584,8 @@
     {
       "name": "test_token_efficiency.py",
       "type": "python",
-      "size_lines": 82,
-      "last_updated": "2026-08-09",
+      "size_lines": 83,
+      "last_updated": "2026-08-10",
       "description": "Regression tests for repository-side token-efficiency controls.",
       "functions": [
         {
@@ -3518,7 +3607,39 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "42f9c69f73f7"
+      "content_hash": "78b907e92a49"
+    },
+    {
+      "name": "test_tool_manifest.py",
+      "type": "python",
+      "size_lines": 101,
+      "last_updated": "2026-08-10",
+      "description": "Focused gates for the catalogue-derived beam tool manifest.",
+      "functions": [
+        {
+          "name": "test_manifest_is_deterministic_and_catalogue_derived"
+        },
+        {
+          "name": "test_manifest_preserves_units_limitations_and_review_boundary"
+        },
+        {
+          "name": "test_manifest_schema_and_catalogue_validate_the_same_input"
+        },
+        {
+          "name": "test_unknown_capability_fails_closed"
+        },
+        {
+          "name": "test_committed_artifact_check_detects_byte_drift",
+          "params": [
+            "tmp_path"
+          ]
+        }
+      ],
+      "constants": [
+        "SAFE_INPUTS",
+        "REPO_ROOT"
+      ],
+      "content_hash": "a64b113ce718"
     },
     {
       "name": "test_visualization_edge_cases.py",
@@ -3799,6 +3920,69 @@
         }
       ],
       "content_hash": "96711c05fa04"
+    },
+    {
+      "name": "test_workflow_catalog.py",
+      "type": "python",
+      "size_lines": 87,
+      "last_updated": "2026-08-10",
+      "description": "Focused contract tests for the one-beam application workflow catalogue.",
+      "functions": [
+        {
+          "name": "test_catalog_is_deterministic_and_semantically_bound"
+        },
+        {
+          "name": "test_catalog_rejects_duplicate_and_unknown_registry_ids"
+        },
+        {
+          "name": "test_catalog_rejects_unknown_semantics_and_example_fields"
+        },
+        {
+          "name": "test_additive_fixture_migrates_and_breaking_version_fails"
+        }
+      ],
+      "content_hash": "9c4dcf16fa46"
+    },
+    {
+      "name": "test_workflow_runner.py",
+      "type": "python",
+      "size_lines": 189,
+      "last_updated": "2026-08-10",
+      "description": "Bounded-runner tests for the approved beam workflow only.",
+      "functions": [
+        {
+          "name": "test_template_is_deterministic_and_exactly_allowlisted"
+        },
+        {
+          "name": "test_tampered_definition_cannot_execute",
+          "params": [
+            "mutation",
+            "message"
+          ]
+        },
+        {
+          "name": "test_safe_run_stops_for_review_then_completes_with_acknowledgement"
+        },
+        {
+          "name": "test_unsafe_run_stops_before_export"
+        },
+        {
+          "name": "test_timeout_and_idempotency_are_deterministic"
+        },
+        {
+          "name": "test_active_run_can_be_cancelled_and_concurrency_stays_bounded",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_invalid_run_identity_and_oversized_input_fail_closed"
+        }
+      ],
+      "constants": [
+        "SAFE_INPUTS"
+      ],
+      "content_hash": "84c6cce1cff4"
     }
   ],
   "subfolders": [
@@ -3851,10 +4035,10 @@
     {
       "name": "unit",
       "path": "unit/",
-      "file_count": 33,
+      "file_count": 34,
       "is_package": true
     }
   ],
-  "content_hash": "01bc7417dcb67ae5",
-  "has_init": true
+  "has_init": true,
+  "content_hash": "26b08e5568daa17e"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -3,8 +3,8 @@
 This document describes the test taxonomy and structure for the structural_engineering_lib test suite.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-09
-**Files:** 53
+**Last Updated:** 2026-08-10
+**Files:** 58
 
 ## Documentation Files
 
@@ -18,7 +18,7 @@ This document describes the test taxonomy and structure for the structural_engin
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) |  | 0 | 0 | 1 |
 | [conftest.py](conftest.py) | Pytest configuration and Hypothesis profiles for the test su | 0 | 6 | 131 |
-| [test_agent_governance_automation.py](test_agent_governance_automation.py) | Regression tests for agent-governance automation controls. | 0 | 19 | 279 |
+| [test_agent_governance_automation.py](test_agent_governance_automation.py) | Regression tests for agent-governance automation controls. | 0 | 20 | 428 |
 | [test_api_manifest_tools.py](test_api_manifest_tools.py) | Regression tests for the single canonical public API manifes | 0 | 5 | 134 |
 | [test_api_results.py](test_api_results.py) | Tests for API result dataclasses. | 3 | 0 | 394 |
 | [test_api_stability.py](test_api_stability.py) | EA-9: Wheel API stability tests. | 6 | 0 | 233 |
@@ -39,34 +39,39 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_design_from_input.py](test_design_from_input.py) | Tests for design_from_input API function. | 1 | 0 | 142 |
 | [test_error_messages.py](test_error_messages.py) | Tests for error message templates. | 7 | 0 | 294 |
 | [test_etabs_import_integration.py](test_etabs_import_integration.py) | Integration tests for etabs_import Pydantic conversion funct | 4 | 4 | 330 |
+| [test_evidence.py](test_evidence.py) | Focused tests for the supported IS 456 beam evidence envelop | 0 | 4 | 108 |
 | [test_exception_hierarchy.py](test_exception_hierarchy.py) | Tests for exception hierarchy in errors module. | 4 | 0 | 278 |
 | [test_footing.py](test_footing.py) | Tests for IS 456 footing design — TASK-650/651/652. | 11 | 1 | 1750 |
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
+| [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
 | [test_is456_constants.py](test_is456_constants.py) | Tests for IS 456:2000 named design constants. | 1 | 0 | 163 |
-| [test_model_picker.py](test_model_picker.py) | Tests for the deterministic low-token model picker. | 0 | 7 | 92 |
+| [test_model_picker.py](test_model_picker.py) | Tests for the deterministic low-token model picker. | 0 | 7 | 94 |
 | [test_multi_objective_optimizer.py](test_multi_objective_optimizer.py) | Tests for the multi-objective optimizer module (NSGA-II). | 5 | 0 | 319 |
 | [test_numerics.py](test_numerics.py) | Tests for structural_lib.core.numerics - safe arithmetic uti | 4 | 0 | 136 |
-| [test_packaging.py](test_packaging.py) | Tests for package distribution correctness. | 9 | 0 | 418 |
+| [test_packaging.py](test_packaging.py) | Tests for package distribution correctness. | 9 | 0 | 452 |
 | [test_pipeline_state.py](test_pipeline_state.py) | Tests for scripts/pipeline_state.py — Pipeline step tracking | 7 | 0 | 353 |
 | [test_private_source_boundary.py](test_private_source_boundary.py) | Protected engineering-source material stays local and outsid | 0 | 2 | 40 |
-| [test_release_environment.py](test_release_environment.py) | Regression tests for local release preflight environment sel | 0 | 10 | 189 |
-| [test_release_scripts.py](test_release_scripts.py) | Tests for release scripts (bump_version.py, release.py). | 14 | 1 | 404 |
+| [test_release_environment.py](test_release_environment.py) | Regression tests for local release preflight environment sel | 0 | 13 | 263 |
+| [test_release_scripts.py](test_release_scripts.py) | Tests for release scripts (bump_version.py, release.py). | 15 | 1 | 446 |
 | [test_report_edge_cases.py](test_report_edge_cases.py) | Edge case tests for report generation modules (TASK-520). | 4 | 0 | 303 |
 | [test_report_svg.py](test_report_svg.py) | Tests for the SVG report generation module. | 4 | 0 | 141 |
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 908 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 18 | 327 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 462 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |
 | [test_timing_regression.py](test_timing_regression.py) | Regression tests for Windows-compatible timing. | 0 | 1 | 86 |
-| [test_token_efficiency.py](test_token_efficiency.py) | Regression tests for repository-side token-efficiency contro | 0 | 5 | 82 |
+| [test_token_efficiency.py](test_token_efficiency.py) | Regression tests for repository-side token-efficiency contro | 0 | 5 | 83 |
+| [test_tool_manifest.py](test_tool_manifest.py) | Focused gates for the catalogue-derived beam tool manifest. | 0 | 5 | 101 |
 | [test_visualization_edge_cases.py](test_visualization_edge_cases.py) | Edge case tests for 3D visualization / geometry module (TASK | 12 | 0 | 757 |
 | [test_visualization_geometry_3d.py](test_visualization_geometry_3d.py) | Tests for visualization.geometry_3d module. | 10 | 0 | 765 |
 | [test_visualization_integration.py](test_visualization_integration.py) | Integration tests for visualization.geometry_3d with detaili | 2 | 0 | 246 |
+| [test_workflow_catalog.py](test_workflow_catalog.py) | Focused contract tests for the one-beam application workflow | 0 | 4 | 87 |
+| [test_workflow_runner.py](test_workflow_runner.py) | Bounded-runner tests for the approved beam workflow only. | 0 | 7 | 189 |
 
 ## Subfolders
 
@@ -80,4 +85,4 @@ This document describes the test taxonomy and structure for the structural_engin
 | [performance/](performance/) 📦 | 3 |  |
 | [property/](property/) 📦 | 9 |  |
 | [regression/](regression/) 📦 | 11 |  |
-| [unit/](unit/) 📦 | 33 |  |
+| [unit/](unit/) 📦 | 34 |  |

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -190,7 +190,7 @@ def test_script_reference_validator_fails_missing_control_target(
 
 def test_api_endpoint_extraction_stops_before_query_template():
     expression = (
-        "`${API_BASE_URL}/api/v1/import/dual-csv" "${queryStr ? `?${queryStr}` : ''}`"
+        "`${API_BASE_URL}/api/v1/import/dual-csv${queryStr ? `?${queryStr}` : ''}`"
     )
     assert check_api._extract_endpoint(expression) == "/api/v1/import/dual-csv"
 
@@ -304,6 +304,25 @@ def test_generated_json_indexes_end_with_newline(
     generator.generate_json({"folder": "scripts"}, output)
 
     assert (output / "index.json").read_bytes().endswith(b"\n")
+
+
+def test_generated_index_hash_tracks_subfolder_projection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    generator = importlib.import_module("scripts.generate_enhanced_index")
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    (child / "first.py").write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setattr(generator, "PROJECT_ROOT", tmp_path)
+
+    initial = generator.scan_folder_enhanced(parent)
+    (child / "second.py").write_text("VALUE = 2\n", encoding="utf-8")
+    updated = generator.scan_folder_enhanced(parent)
+
+    assert initial["subfolders"][0]["file_count"] == 1
+    assert updated["subfolders"][0]["file_count"] == 2
+    assert initial["content_hash"] != updated["content_hash"]
 
 
 def test_session_end_preserves_current_same_day_handoff(

--- a/agents/index.json
+++ b/agents/index.json
@@ -2,14 +2,14 @@
   "folder": "agents",
   "type": "documentation",
   "description": "> **⚠️ NOTE:** The authoritative role system is in `.github/agents/` (16 Copilot agents with handoffs, skills, and pipeline enforcement). The role docs below are a **legacy reference** from an earlier",
-  "last_updated": "2026-08-07",
+  "last_updated": "2026-08-10",
   "file_count": 3,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 145,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "title": "Agent Prompt Cheat Sheet",
       "description": "> **⚠️ NOTE:** The authoritative role system is in .github/agents/ (16 Copilot agents with handoffs, skills, and pipeline enforcement). The role docs below are a **legacy reference** from an earlier f",
       "content_hash": "f17c7a90ff12"
@@ -17,24 +17,25 @@
     {
       "name": "agent_registry.json",
       "type": "config",
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-09",
       "top_level_keys": [
         "agents",
         "_meta"
       ],
-      "content_hash": "363ad7257e66"
+      "content_hash": "569ca107c4f9"
     },
     {
       "name": "model_policy.json",
       "type": "config",
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-10",
       "top_level_keys": [
         "_meta",
+        "unavailable_models",
         "defaults",
         "relative_token_rates",
         "profiles"
       ],
-      "content_hash": "04702a9182d8"
+      "content_hash": "ba77a5b94432"
     }
   ],
   "subfolders": [
@@ -50,5 +51,5 @@
       "description": "> **⚠️ LEGACY:** These role definitions are from an earlier agent framework. The authoritative agent definitions are now in `.github/agents/` (16 Copi"
     }
   ],
-  "content_hash": "a2cfc8784f128070"
+  "content_hash": "08b4edf5f365087f"
 }

--- a/agents/index.md
+++ b/agents/index.md
@@ -3,7 +3,7 @@
 > **⚠️ NOTE:** The authoritative role system is in `.github/agents/` (16 Copilot agents with handoffs, skills, and pipeline enforcement). The role docs below are a **legacy reference** from an earlier
 
 **Type:** Documentation
-**Last Updated:** 2026-08-07
+**Last Updated:** 2026-08-10
 **Files:** 3
 
 ## Config Files

--- a/agents/roles/index.json
+++ b/agents/roles/index.json
@@ -2,14 +2,14 @@
   "folder": "agents/roles",
   "type": "documentation",
   "description": "> **⚠️ LEGACY:** These role definitions are from an earlier agent framework. The authoritative agent definitions are now in `.github/agents/` (16 Copilot agents). These files are kept for reference on",
-  "last_updated": "2026-08-07",
+  "last_updated": "2026-08-10",
   "file_count": 13,
   "files": [
     {
       "name": "ARCHITECT.md",
       "type": "documentation",
       "size_lines": 89,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- Layered architecture and dependency direction - Stable public APIs and schema contracts",
       "content_hash": "67959d053b58"
     },
@@ -17,7 +17,7 @@
       "name": "CLIENT.md",
       "type": "documentation",
       "size_lines": 61,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- User Stories and Acceptance Criteria - Workflow validation (\"Does this make sense for an engineer?\")",
       "content_hash": "18cb78e71660"
     },
@@ -25,7 +25,7 @@
       "name": "DEV.md",
       "type": "documentation",
       "size_lines": 109,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- Clean architecture and proper layering - Library purity (no UI dependencies in core)",
       "content_hash": "7c6ca39a86a4"
     },
@@ -33,7 +33,7 @@
       "name": "DEVOPS.md",
       "type": "documentation",
       "size_lines": 150,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- Repo layout and file organization - VBA module export/import workflows",
       "content_hash": "b46c4dddd6ee"
     },
@@ -41,23 +41,23 @@
       "name": "DOCS.md",
       "type": "documentation",
       "size_lines": 41,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- Keep API/README/CHANGELOG/RELEASES/TASKS in sync with code and scope. - Write release notes and append-only ledger updates (respect immutability rules).",
       "content_hash": "4f360c10c6bc"
     },
     {
       "name": "GOVERNANCE.md",
       "type": "documentation",
-      "size_lines": 841,
-      "last_updated": "2026-08-07",
+      "size_lines": 840,
+      "last_updated": "2026-08-09",
       "description": "> \"Keep the project sustainable, clean, and governable. Channel Agent 6 & Agent 8's exceptional velocity into predictable long-term gains through strategic governance.\" AI agents amplify existing disc",
-      "content_hash": "faa64444039a"
+      "content_hash": "6372fe3b65ed"
     },
     {
       "name": "INTEGRATION.md",
       "type": "documentation",
       "size_lines": 58,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- BEAM_INPUT/BEAM_DESIGN schema definitions and versioning. - ETABS/STAAD/CSV mapping rules and validation at import.",
       "content_hash": "8a8cd18aeac4"
     },
@@ -65,7 +65,7 @@
       "name": "PM.md",
       "type": "documentation",
       "size_lines": 153,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- **Orchestration:** Assigning tasks to the right specialist agent (DEV, UI, CLIENT, etc.). - **Governance:** Enforcing version control rules and immutable history.",
       "content_hash": "bdcac6835b4c"
     },
@@ -73,7 +73,7 @@
       "name": "README.md",
       "type": "documentation",
       "size_lines": 25,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "title": "Agent Roles (LEGACY)",
       "description": "> **⚠️ LEGACY:** These role definitions are from an earlier agent framework. The authoritative agent definitions are now in .github/agents/ (16 Copilot agents). These files are kept for reference only",
       "content_hash": "6a8a5eccd732"
@@ -82,7 +82,7 @@
       "name": "RESEARCHER.md",
       "type": "documentation",
       "size_lines": 68,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- IS Codes (IS 456:2000, IS 13920:2016, SP 16, SP 34) - Algorithms and Numerical Methods (e.g., Bisection method for NA)",
       "content_hash": "c055bde6939f"
     },
@@ -90,7 +90,7 @@
       "name": "SUPPORT.md",
       "type": "documentation",
       "size_lines": 41,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- Maintain docs/reference/troubleshooting.md and docs/reference/known-pitfalls.md. - Capture repro steps, probes, and fixes for recurrent issues (e.g., Mac VBA overflow).",
       "content_hash": "f56386af5f36"
     },
@@ -98,7 +98,7 @@
       "name": "TESTER.md",
       "type": "documentation",
       "size_lines": 107,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- Numerical correctness against hand calculations - Edge case coverage (min/max values, boundary conditions)",
       "content_hash": "ba65800ce442"
     },
@@ -106,11 +106,11 @@
       "name": "UI.md",
       "type": "documentation",
       "size_lines": 61,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "- Worksheet layout and visual hierarchy - User interaction flow (Input -> Process -> Output)",
       "content_hash": "99a9f2535dd4"
     }
   ],
   "subfolders": [],
-  "content_hash": "05abac8a8dfb4284"
+  "content_hash": "b7b7bd68182cad84"
 }

--- a/agents/roles/index.md
+++ b/agents/roles/index.md
@@ -3,7 +3,7 @@
 > **⚠️ LEGACY:** These role definitions are from an earlier agent framework. The authoritative agent definitions are now in `.github/agents/` (16 Copilot agents). These files are kept for reference on
 
 **Type:** Documentation
-**Last Updated:** 2026-08-07
+**Last Updated:** 2026-08-10
 **Files:** 13
 
 ## Documentation Files
@@ -15,7 +15,7 @@
 | [DEV.md](DEV.md) |  | - Clean architecture and proper layering - Library purity (n | 109 |
 | [DEVOPS.md](DEVOPS.md) |  | - Repo layout and file organization - VBA module export/impo | 150 |
 | [DOCS.md](DOCS.md) |  | - Keep API/README/CHANGELOG/RELEASES/TASKS in sync with code | 41 |
-| [GOVERNANCE.md](GOVERNANCE.md) |  | > "Keep the project sustainable, clean, and governable. Chan | 841 |
+| [GOVERNANCE.md](GOVERNANCE.md) |  | > "Keep the project sustainable, clean, and governable. Chan | 840 |
 | [INTEGRATION.md](INTEGRATION.md) |  | - BEAM_INPUT/BEAM_DESIGN schema definitions and versioning.  | 58 |
 | [PM.md](PM.md) |  | - **Orchestration:** Assigning tasks to the right specialist | 153 |
 | [README.md](README.md) | Agent Roles (LEGACY) | > **⚠️ LEGACY:** These role definitions are from an earlier  | 25 |

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,82 @@
 
 ---
 
+## 2026-08-10 — Session: Fresh-Start Maintenance Closeout
+
+**Agent:** Codex
+**Branch:** `codex/maintenance-fresh-start`
+**Focus:** Synchronize merged main, retire disposable worktrees, repair generated truth, and leave a clean next-work baseline
+
+### Summary
+
+- Fast-forwarded local `main` from stale commit `44e85587` to merged UIX commit
+  `64e33627`, then created one bounded maintenance branch.
+- Removed five clean `/private/tmp/structlib-*` worktrees after verifying exact
+  directories, zero uncommitted files, no owning process, and retained branches.
+  The named Excel audit and social-preview worktrees remain untouched.
+- Confirmed no project server on ports 8000/5173, no stash, no stale remote branch
+  under the maintained 30-day policy, and no Git object-integrity failure.
+- Removed only generated root coverage/test/type/lint caches, React build output,
+  and Python bytecode. Preserved `.env`, `.venv`, fresh `node_modules`, logs,
+  benchmarks, Hypothesis state, P14 recovery backups, branches, and user worktrees.
+- Synchronized five public counts, regenerated all 32 canonical folder indexes,
+  and fixed index watermarking so future drift checks cover subfolder projections.
+
+### Issues encountered
+
+- The stale-branch helper rejected a guessed `--dry-run` flag and stopped the
+  first chained inspection before the later read-only probes ran.
+- Initial project health was 94/100: five public counts described the older
+  63-endpoint/15-router/75-public-function surface, and 25 index hashes were stale.
+- Regenerating all indexes changed some parent indexes that `--check` had called
+  current because their direct files were unchanged while subfolder counts moved.
+- The first focused formatter check requested normalization of the new index-hash
+  regression before the verification chain could continue.
+- A broad search guessed root and Python `Makefile` paths that do not exist.
+
+### Root causes and resolutions
+
+- `cleanup_stale_branches.py` is dry-run by default and exposes only `--delete`
+  for mutation. The maintained command was rerun without the invented flag and
+  reported no stale branch; no remote branch was deleted.
+- UIX added catalogue/workflow routers and public functions without refreshing
+  every generated count and folder index. `sync_numbers.py --fix` applied the
+  exact dry-run projection, and the enhanced-index generator refreshed the
+  canonical 32-folder set. Health now reports 100/100.
+- The index watermark was computed before subfolders were analyzed and covered
+  only direct file hashes, so parent projection drift could pass `--check`.
+  Watermarking now hashes the complete deterministic index payload except the
+  generation date. A focused regression proves a child-file-count change alters
+  the parent hash; two-pass generation/check reports all 32 current.
+- Ruff formatting, not a logic failure, blocked the first combined command. The
+  formatter output was retained and the focused 28-test/Ruff chain passed.
+- The repository has no Makefile maintenance entrypoint. Subsequent discovery
+  used `run.sh` and `scripts/automation-map.json`, which identified the canonical
+  cleanup script without adding another wrapper.
+
+### Verification
+
+- `./run.sh health` — 100/100 across docs, code, agents, infrastructure, and feedback.
+- `./run.sh efficiency check` — passed.
+- `scripts/generate_enhanced_index.py --all --check` — 32/32 current.
+- `scripts/sync_numbers.py` — 5,520 tests, 106 scripts, 26 hooks, 69 endpoints
+  across 17 routers, 78 public API functions, and 55 components; zero drift.
+- `pytest Python/tests/test_session_automation.py -q` — 28 passed.
+- Scoped Ruff check/format, Git diff check, Git object integrity, worktree prune
+  dry run, and the repository quick gate pass.
+- Final integrated `./run.sh check` — 30/30 passed.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: `cleanup_stale_branches.py --dry-run` is unsupported
+  because dry run is already the default -> rerunning without the flag returned
+  the intended read-only result.
+- ⚠️ TERMINAL ISSUE: Guessed `Makefile` and `Python/Makefile` search roots
+  do not exist -> `run.sh` plus the automation registry provided the maintained
+  commands.
+- ⚠️ TERMINAL ISSUE: The first Ruff format check stopped a chained command
+  -> the formatter normalized the focused test and the full chain passed on retry.
+
 ## 2026-08-10 — Session: UIX-001 Session 2 P9-P15
 
 **Agent:** Codex

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-10 — UIX-001 P0-P15 accepted; verified-green merge in progress
+**Updated:** 2026-08-10 — UIX-001 merged; fresh-start maintenance complete; no active implementation packet
 
 ---
 
@@ -147,7 +147,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
-| UIX-001 | Built one compact 3D-first structural workbench and schema-driven bounded workflow foundation | Main Agent | ✅ DONE — P0-P15 accepted; Pages/release/public runner remain held |
+| UIX-001 | Built one compact 3D-first structural workbench and schema-driven bounded workflow foundation | Main Agent | ✅ DONE — PR #721 merged; Pages/release/public runner remain held |
 | DEPS-MAINT-001 | Replaced incompatible Python and React dependency PRs with coherent Python 3.11/Node 24 packets and added recurrence guards | Main Agent | ✅ DONE — PRs #708, #709, and #712 merged |
 | ADOPT-001 | Completed executable public truth, capability discovery, typed API contracts, production auth fail-close, evidence identity, React/BOQ trust presentation, and truthful Alpha/docs policy | Main Agent | ✅ DONE — PR #707 merged; release holds retained |
 | LIB-IS456-V1 | Completed C0-C4, bounded evidence, exact artifacts, public Alpha UAT, and v0.23.0 publication | Main Agent + owner | ✅ DONE |

--- a/docs/agents/guides/index.json
+++ b/docs/agents/guides/index.json
@@ -2,7 +2,7 @@
   "folder": "docs/agents/guides",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-09",
+  "last_updated": "2026-08-10",
   "file_count": 14,
   "files": [
     {
@@ -97,7 +97,7 @@
       "name": "agent-bootstrap-complete-review.md",
       "type": "documentation",
       "size_lines": 125,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-10",
       "description": "docs/getting-started/agent-bootstrap.md is the 60-second onboarding entrypoint for any agent. This review enumerates every link in that file, explains why it exists, and notes the current startup flow",
       "content_hash": "616528f6eb9c"
     },
@@ -119,5 +119,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "a4adf151b4c2e30f"
+  "content_hash": "283b1abc787329d8"
 }

--- a/docs/agents/guides/index.md
+++ b/docs/agents/guides/index.md
@@ -1,7 +1,7 @@
 # Guides
 
 **Type:** Documentation
-**Last Updated:** 2026-08-09
+**Last Updated:** 2026-08-10
 **Files:** 14
 
 ## Documentation Files

--- a/docs/agents/index.json
+++ b/docs/agents/index.json
@@ -2,17 +2,17 @@
   "folder": "docs/agents",
   "type": "documentation",
   "description": "> **For AI Agents:** Use the semantic registry below to find the right docs quickly.",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 1,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 69,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-09",
       "title": "Agent Documentation Hub",
       "description": "> **For AI Agents:** Use the semantic registry below to find the right docs quickly. > **Start here** → Find your agent → Read Quick Start → Use Hub for details.",
-      "content_hash": "8850b345ac72"
+      "content_hash": "12e1efa548e6"
     }
   ],
   "subfolders": [
@@ -27,5 +27,5 @@
       "file_count": 3
     }
   ],
-  "content_hash": "6233faeeb00d62f4"
+  "content_hash": "aa1ce4629ae46950"
 }

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -3,7 +3,7 @@
 > **For AI Agents:** Use the semantic registry below to find the right docs quickly.
 
 **Type:** Documentation
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 1
 
 ## Documentation Files

--- a/docs/architecture/index.json
+++ b/docs/architecture/index.json
@@ -2,7 +2,7 @@
   "folder": "docs/architecture",
   "type": "mixed",
   "description": "Deep dives into project structure, design decisions, and system architecture.",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 13,
   "files": [
     {
@@ -90,11 +90,11 @@
     {
       "name": "unified-architecture-v1.md",
       "type": "documentation",
-      "size_lines": 1562,
-      "last_updated": "2026-04-07",
+      "size_lines": 1601,
+      "last_updated": "2026-08-10",
       "title": "Unified Architecture — structural_engineering_lib v1.0",
       "description": "> THE single source of truth for architecture decisions, quality gates, and safety guarantees. > Every agent, every session, every change must comply with this document.",
-      "content_hash": "23abffc6fe67"
+      "content_hash": "433875b6b964"
     },
     {
       "name": "visual-architecture.md",
@@ -112,5 +112,5 @@
       "file_count": 1
     }
   ],
-  "content_hash": "995eeb2875d2509d"
+  "content_hash": "2352788f2ebe5127"
 }

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -3,7 +3,7 @@
 Deep dives into project structure, design decisions, and system architecture.
 
 **Type:** Mixed
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 13
 
 ## Documentation Files
@@ -20,7 +20,7 @@ Deep dives into project structure, design decisions, and system architecture.
 | [mission-and-principles.md](mission-and-principles.md) |  | Structural engineering today, especially in everyday practic | 301 |
 | [project-overview.md](project-overview.md) |  | - mission-and-principles.md for the deeper "why" and product | 169 |
 | [self-evolving-system.md](self-evolving-system.md) |  | As the project evolves, **information entropy increases**: | | 197 |
-| [unified-architecture-v1.md](unified-architecture-v1.md) | Unified Architecture — structural_engine | > THE single source of truth for architecture decisions, qua | 1562 |
+| [unified-architecture-v1.md](unified-architecture-v1.md) | Unified Architecture — structural_engine | > THE single source of truth for architecture decisions, qua | 1601 |
 | [visual-architecture.md](visual-architecture.md) |  | Quick diagrams for layers, module groupings, and data flow.  | 155 |
 
 ## Subfolders

--- a/docs/contributing/index.json
+++ b/docs/contributing/index.json
@@ -2,7 +2,7 @@
   "folder": "docs/contributing",
   "type": "documentation",
   "description": "Guides for developers and maintainers of the structural engineering library.",
-  "last_updated": "2026-08-09",
+  "last_updated": "2026-08-10",
   "file_count": 24,
   "files": [
     {
@@ -66,9 +66,9 @@
       "name": "development-guide.md",
       "type": "documentation",
       "size_lines": 1522,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "1. Overview 2. Project Structure",
-      "content_hash": "46aa16e2389d"
+      "content_hash": "22ca5108a9df"
     },
     {
       "name": "doc-template.md",
@@ -200,5 +200,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "a1cc661b7e310854"
+  "content_hash": "37c6118169caacab"
 }

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -3,7 +3,7 @@
 Guides for developers and maintainers of the structural engineering library.
 
 **Type:** Documentation
-**Last Updated:** 2026-08-09
+**Last Updated:** 2026-08-10
 **Files:** 24
 
 ## Documentation Files

--- a/docs/getting-started/agent-bootstrap.md
+++ b/docs/getting-started/agent-bootstrap.md
@@ -134,7 +134,7 @@ Core CANNOT import from Services or UI. Services CANNOT import from UI. Units al
 
 ### FastAPI Endpoints (`fastapi_app/routers/`)
 
-63 endpoints across 15 routers (59 REST + 1 WebSocket):
+69 endpoints across 17 routers (59 REST + 1 WebSocket):
 
 | Router | Endpoint | Purpose |
 |--------|----------|---------|
@@ -203,7 +203,7 @@ Core CANNOT import from Services or UI. Services CANNOT import from UI. Units al
 
 | Module | Key Functions |
 |--------|---------------|
-| `services/api.py` | 75 public API functions; implementations split across `beam_api.py`, `column_api.py`, and `common_api.py` (16 private helpers) |
+| `services/api.py` | 78 public API functions; implementations split across `beam_api.py`, `column_api.py`, and `common_api.py` (16 private helpers) |
 | `api.py` | **Backward-compat stub only** — imports from `services/api.py` |
 | `services/adapters.py` | `GenericCSVAdapter`, `ETABSAdapter`, `SAFEAdapter` |
 | `visualization/geometry_3d.py` | `beam_to_3d_geometry()` — 3D rebar/stirrup positions |

--- a/docs/getting-started/index.json
+++ b/docs/getting-started/index.json
@@ -2,8 +2,8 @@
   "folder": "docs/getting-started",
   "type": "mixed",
   "description": "Quick onboarding guides for new users of the structural engineering library.",
-  "last_updated": "2026-08-09",
-  "file_count": 18,
+  "last_updated": "2026-08-10",
+  "file_count": 19,
   "files": [
     {
       "name": "NEW-DEVELOPER-ONBOARDING.md",
@@ -26,9 +26,9 @@
       "name": "agent-bootstrap.md",
       "type": "documentation",
       "size_lines": 738,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "description": "> **This is THE canonical bootstrap for all AI agents.** Entry points (CLAUDE.md, .github/copilot-instructions.md) link here. | # | Critical Warning | Why it matters |",
-      "content_hash": "d0512bfd5022"
+      "content_hash": "762fd878bac4"
     },
     {
       "name": "agent-essentials.md",
@@ -50,9 +50,9 @@
       "name": "beginners-guide.md",
       "type": "documentation",
       "size_lines": 159,
-      "last_updated": "2026-04-06",
+      "last_updated": "2026-08-10",
       "description": "This guide is written for engineers and students who are new to coding. Follow the steps exactly and you will get a working result. You have two ways to use this library:",
-      "content_hash": "760a790741e7"
+      "content_hash": "dd31442ade42"
     },
     {
       "name": "colab-workflow.md",
@@ -119,30 +119,38 @@
       "content_hash": "8c4943b0ed59"
     },
     {
+      "name": "product-tour.md",
+      "type": "documentation",
+      "size_lines": 99,
+      "last_updated": "2026-08-10",
+      "description": "See the supported workflow before installing anything. These screenshots are authentic captures from StructLib v0.23.0 running locally with the bundled",
+      "content_hash": "9ea3752a4fd5"
+    },
+    {
       "name": "python-quickstart.md",
       "type": "documentation",
       "size_lines": 201,
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-10",
       "description": "This guide shows how to install, run, and verify the Python library with simple, copy/paste steps. No prior packaging experience required. > **📚 New to this?** See beginners-guide.md for comprehensive",
-      "content_hash": "ec8e24016146"
+      "content_hash": "725fbcae959d"
     },
     {
       "name": "releases.md",
       "type": "documentation",
-      "size_lines": 1115,
-      "last_updated": "2026-08-09",
+      "size_lines": 1183,
+      "last_updated": "2026-08-10",
       "description": "This document serves as the **immutable source of truth** for project releases. Entries here represent \"locked\" versions that have been verified and approved.",
-      "content_hash": "1cf9fc5d2615"
+      "content_hash": "126e895bfbaa"
     },
     {
       "name": "user-guide.md",
       "type": "documentation",
       "size_lines": 223,
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-10",
       "description": "This guide walks you through a complete beam design workflow from start to finish. For detailed installation help, see Beginner's Guide. bash",
-      "content_hash": "74617c4fbb8b"
+      "content_hash": "94c8452d382e"
     }
   ],
   "subfolders": [],
-  "content_hash": "ac54ca14fffcf01d"
+  "content_hash": "cf9a2d1f5b6f41a2"
 }

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -3,8 +3,8 @@
 Quick onboarding guides for new users of the structural engineering library.
 
 **Type:** Mixed
-**Last Updated:** 2026-08-09
-**Files:** 18
+**Last Updated:** 2026-08-10
+**Files:** 19
 
 ## Documentation Files
 
@@ -24,6 +24,7 @@ Quick onboarding guides for new users of the structural engineering library.
 | [insights-guide.md](insights-guide.md) |  | > **Stability:** Experimental - API may change before v1.0 A | 546 |
 | [installation-notes.md](installation-notes.md) |  | All required packages have been installed successfully: - ** | 89 |
 | [mac-mini-setup.md](mac-mini-setup.md) |  | Complete instructions to clone and run the full stack on a f | 396 |
+| [product-tour.md](product-tour.md) |  | See the supported workflow before installing anything. These | 99 |
 | [python-quickstart.md](python-quickstart.md) |  | This guide shows how to install, run, and verify the Python  | 201 |
-| [releases.md](releases.md) |  | This document serves as the **immutable source of truth** fo | 1115 |
+| [releases.md](releases.md) |  | This document serves as the **immutable source of truth** fo | 1183 |
 | [user-guide.md](user-guide.md) |  | This guide walks you through a complete beam design workflow | 223 |

--- a/docs/guides/index.json
+++ b/docs/guides/index.json
@@ -2,7 +2,7 @@
   "folder": "docs/guides",
   "type": "documentation",
   "description": "End-user and developer guides for specific workflows.",
-  "last_updated": "2026-08-07",
+  "last_updated": "2026-08-10",
   "file_count": 9,
   "files": [
     {
@@ -17,10 +17,10 @@
     {
       "name": "ai-agent-coding-guide.md",
       "type": "documentation",
-      "size_lines": 1003,
-      "last_updated": "2026-03-30",
+      "size_lines": 1002,
+      "last_updated": "2026-08-09",
       "description": "This guide ensures consistent, high-quality code from all AI agents working on this project. Every AI agent MUST read and follow this guide before writing any code. 1. Library-first: All logic belongs",
-      "content_hash": "9d1718322a97"
+      "content_hash": "8fd9df9226d6"
     },
     {
       "name": "code-reuse-and-library-structure.md",
@@ -33,10 +33,10 @@
     {
       "name": "copilot-agents-usage-guide.md",
       "type": "documentation",
-      "size_lines": 603,
-      "last_updated": "2026-08-07",
+      "size_lines": 602,
+      "last_updated": "2026-08-09",
       "description": "You have **16 agents**, **14 skills**, and **16 prompt files** configured in VS Code Copilot. This guide shows you when and how to use each one. | What | How | Example |",
-      "content_hash": "2ef69b6c51a3"
+      "content_hash": "1e69c707bd80"
     },
     {
       "name": "fastapi-deployment-guide.md",
@@ -50,25 +50,25 @@
       "name": "maintenance-checklist.md",
       "type": "documentation",
       "size_lines": 190,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-09",
       "description": "| Frequency | Command | What It Does | Time | |-----------|---------|-------------|------|",
-      "content_hash": "5a38edb6c978"
+      "content_hash": "fd02d0b104d2"
     },
     {
       "name": "react-ui-user-flow.md",
       "type": "documentation",
-      "size_lines": 530,
-      "last_updated": "2026-03-30",
+      "size_lines": 533,
+      "last_updated": "2026-08-10",
       "description": "This document is the **single source of truth** for React app UX flows, consolidating research from: - 8-week-development-plan.md",
-      "content_hash": "43c11a5f7bc3"
+      "content_hash": "be2491ffd6ed"
     },
     {
       "name": "testing-and-cicd-strategy.md",
       "type": "documentation",
-      "size_lines": 281,
-      "last_updated": "2026-03-30",
+      "size_lines": 278,
+      "last_updated": "2026-08-09",
       "description": "This project has a **mature, production-grade** CI/CD setup. This document reflects what EXISTS and what's MISSING. ",
-      "content_hash": "3fe5c8a57eab"
+      "content_hash": "53ef9dea7864"
     },
     {
       "name": "week3-realtime-features-guide.md",
@@ -80,5 +80,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "d15482dabb2a96d1"
+  "content_hash": "90055d1eeb31fa48"
 }

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -3,7 +3,7 @@
 End-user and developer guides for specific workflows.
 
 **Type:** Documentation
-**Last Updated:** 2026-08-07
+**Last Updated:** 2026-08-10
 **Files:** 9
 
 ## Documentation Files
@@ -11,11 +11,11 @@ End-user and developer guides for specific workflows.
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | User Guides | End-user and developer guides for specific workflows. | Guid | 14 |
-| [ai-agent-coding-guide.md](ai-agent-coding-guide.md) |  | This guide ensures consistent, high-quality code from all AI | 1003 |
+| [ai-agent-coding-guide.md](ai-agent-coding-guide.md) |  | This guide ensures consistent, high-quality code from all AI | 1002 |
 | [code-reuse-and-library-structure.md](code-reuse-and-library-structure.md) |  | Every calculation, validation, and data transformation MUST  | 601 |
-| [copilot-agents-usage-guide.md](copilot-agents-usage-guide.md) |  | You have **16 agents**, **14 skills**, and **16 prompt files | 603 |
+| [copilot-agents-usage-guide.md](copilot-agents-usage-guide.md) |  | You have **16 agents**, **14 skills**, and **16 prompt files | 602 |
 | [fastapi-deployment-guide.md](fastapi-deployment-guide.md) |  | This guide covers deploying the structural_engineering_lib F | 414 |
 | [maintenance-checklist.md](maintenance-checklist.md) |  | | Frequency | Command | What It Does | Time | |-----------|- | 190 |
-| [react-ui-user-flow.md](react-ui-user-flow.md) |  | This document is the **single source of truth** for React ap | 530 |
-| [testing-and-cicd-strategy.md](testing-and-cicd-strategy.md) |  | This project has a **mature, production-grade** CI/CD setup. | 281 |
+| [react-ui-user-flow.md](react-ui-user-flow.md) |  | This document is the **single source of truth** for React ap | 533 |
+| [testing-and-cicd-strategy.md](testing-and-cicd-strategy.md) |  | This project has a **mature, production-grade** CI/CD setup. | 278 |
 | [week3-realtime-features-guide.md](week3-realtime-features-guide.md) |  | This document explains the real-time communication features  | 499 |

--- a/docs/index.json
+++ b/docs/index.json
@@ -8,29 +8,29 @@
     {
       "name": "README.md",
       "type": "documentation",
-      "size_lines": 252,
+      "size_lines": 253,
       "last_updated": "2026-08-10",
       "title": "Docs Index (Start Here)",
       "description": "Guides, references, evidence, and contributor material for the structural-lib-is456 Python package and the React/FastAPI workbench.",
-      "content_hash": "c3eecbcb1222"
+      "content_hash": "09e22d932251"
     },
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 545,
+      "size_lines": 948,
       "last_updated": "2026-08-10",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "b194a13e8173"
+      "content_hash": "b5a66d3814b6"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 666,
+      "size_lines": 669,
       "last_updated": "2026-08-10",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "5869b0078fe2"
+      "content_hash": "07e630125604"
     },
     {
       "name": "WORKLOG.md",
@@ -57,7 +57,7 @@
     {
       "name": "docs-index.json",
       "type": "config",
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-10",
       "top_level_keys": [
         "version",
         "generated",
@@ -192,7 +192,7 @@
     {
       "name": "reference",
       "path": "reference/",
-      "file_count": 1790
+      "file_count": 1792
     },
     {
       "name": "research",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 11,
+      "file_count": 12,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "d5c304628b3b90b6"
+  "content_hash": "d118b6845dc97f7a"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,9 @@ Guides, references, evidence, and contributor material for the
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 252 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 545 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 666 |
+| [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 948 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 669 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -45,7 +45,7 @@ Guides, references, evidence, and contributor material for the
 | [migration/](migration/) | 45 |  |
 | [planning/](planning/) | 17 |  |
 | [publications/](publications/) | 11 | This directory contains blog posts, technical articles, and academic papers docu |
-| [reference/](reference/) | 1790 |  |
+| [reference/](reference/) | 1792 |  |
 | [research/](research/) | 8 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 11 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 12 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -91,11 +91,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 78,
+      "size_lines": 95,
       "last_updated": "2026-08-10",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-10",
-      "content_hash": "dfa8593619d7"
+      "content_hash": "a70e069656d5"
     },
     {
       "name": "pre-release-checklist.md",
@@ -133,5 +133,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "6b0ed9bb9679c0a6"
+  "content_hash": "923de532575a35d7"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -18,7 +18,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-10 | 78 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-10 | 95 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Installed metadata version: 0.23.0 - **Release source:** tag | 66 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,19 +4,19 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-10
-- Focus: UIX-001 P0-P15 accepted; no implementation packet is active
+- Focus: Fresh-start maintenance complete; no implementation packet is active
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.0` Alpha
 
-**Branch:** `codex/ui-capability-platform`
+**Branch:** `main` after the maintenance closeout merge
 
-**Base:** Session 2 began from merged Session 1 commit `49d7780e`
+**Base:** UIX-001 merged at `64e33627`; maintenance branch started from that exact main
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | UIX-001 P0-P15 complete | Merge only after required checks are green |
+| **Current** | Repository ready | Main synchronized, health 100/100, generated truth current, root checkout clean |
 | **Next** | No active implementation packet | Await the owner-selected task; do not invent a third UIX cleanup session |
 | **Held** | Stable/engineering use | Requires cumulative qualified structural-engineering review |
 
@@ -26,6 +26,23 @@
 - [Session 2 acceptance](../verification/ui-experience-session-2-acceptance.md)
 - [Current task board](../TASKS.md)
 - [Release policy](../getting-started/releases.md)
+
+## Fresh-start maintenance closeout
+
+- Local `main` is synchronized to the merged UIX result.
+- Five clean disposable `/private/tmp` worktrees were removed while their branches
+  were retained; two named external worktrees were preserved for their owners.
+- No server is listening on the maintained frontend/backend ports, no stash was
+  present, and the stale-branch dry run found nothing eligible for deletion.
+- Five API/router counts and all 32 generated indexes are synchronized. Index
+  drift detection now includes child-folder projections rather than direct files
+  only.
+- Generated build/test/type/lint/coverage and bytecode caches were cleaned while
+  environments, dependencies, logs, benchmarks, recovery backups, and user state
+  were preserved.
+- Health is 100/100, token-efficiency passes, the quick gate is 10/10, the full
+  gate is 30/30, and the root checkout is the fresh baseline for the next
+  owner-selected packet.
 
 ## Accepted UIX outcome
 

--- a/docs/reference/index.json
+++ b/docs/reference/index.json
@@ -3,7 +3,7 @@
   "type": "mixed",
   "description": "",
   "last_updated": "2026-08-10",
-  "file_count": 28,
+  "file_count": 30,
   "files": [
     {
       "name": "3d-json-contract.md",
@@ -24,11 +24,11 @@
     {
       "name": "README.md",
       "type": "documentation",
-      "size_lines": 80,
-      "last_updated": "2026-03-29",
+      "size_lines": 81,
+      "last_updated": "2026-08-10",
       "title": "Reference Documentation",
       "description": "Comprehensive lookup documentation for APIs, formulas, contracts, and troubleshooting. | Need | Go To |",
-      "content_hash": "6ffc97220be6"
+      "content_hash": "c000c3e75584"
     },
     {
       "name": "agent-automation-pitfalls.md",
@@ -57,23 +57,23 @@
         "count",
         "symbols"
       ],
-      "content_hash": "b256f694202a"
+      "content_hash": "c3a45671fc2e"
     },
     {
       "name": "api-stability.md",
       "type": "documentation",
-      "size_lines": 639,
+      "size_lines": 647,
       "last_updated": "2026-08-10",
       "description": "> This document defines which parts of the library are safe to depend on and which may change. This library follows Semantic Versioning:",
-      "content_hash": "4b02ab138fca"
+      "content_hash": "23645463a577"
     },
     {
       "name": "api.md",
       "type": "documentation",
-      "size_lines": 3956,
+      "size_lines": 3962,
       "last_updated": "2026-08-10",
       "description": "geometry, loading, reinforcement, and evidence boundaries. The primary combined beam route covers rectangular flexure and shear (plus optional serviceability),",
-      "content_hash": "ba138dde89b7"
+      "content_hash": "b52421786c5d"
     },
     {
       "name": "automation-catalog.md",
@@ -92,9 +92,31 @@
       "content_hash": "f44f739cd52e"
     },
     {
+      "name": "beam-tool-manifest.json",
+      "type": "config",
+      "last_updated": "2026-08-10",
+      "top_level_keys": [
+        "activation",
+        "manifest_id",
+        "manifest_version",
+        "schema_version",
+        "source",
+        "tools"
+      ],
+      "content_hash": "b62abb9e4f86"
+    },
+    {
+      "name": "beam-tool-manifest.md",
+      "type": "documentation",
+      "size_lines": 32,
+      "last_updated": "2026-08-10",
+      "description": "The generated beam tool manifest describes the one approved is456.beam.design capability. It is a deterministic projection of the",
+      "content_hash": "744bdc879e86"
+    },
+    {
       "name": "clause-map.json",
       "type": "config",
-      "last_updated": "2026-04-04",
+      "last_updated": "2026-08-10",
       "top_level_keys": [
         "metadata",
         "mappings",
@@ -239,5 +261,5 @@
       "file_count": 1760
     }
   ],
-  "content_hash": "ebdcc17cd63e6c43"
+  "content_hash": "919f5dea1892a065"
 }

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,11 +2,12 @@
 
 **Type:** Mixed
 **Last Updated:** 2026-08-10
-**Files:** 28
+**Files:** 30
 
 ## Config Files
 
 - [api-manifest.json](api-manifest.json)
+- [beam-tool-manifest.json](beam-tool-manifest.json)
 - [clause-map.json](clause-map.json)
 
 ## Documentation Files
@@ -15,13 +16,14 @@
 |------|-------|-------------|-------|
 | [3d-json-contract.md](3d-json-contract.md) |  | For the P7 workbench migration, GeometrySpaceV1 is the rende | 481 |
 | [3d-visualization-performance.md](3d-visualization-performance.md) |  | This document provides performance benchmarks for the 3D bea | 172 |
-| [README.md](README.md) | Reference Documentation | Comprehensive lookup documentation for APIs, formulas, contr | 80 |
+| [README.md](README.md) | Reference Documentation | Comprehensive lookup documentation for APIs, formulas, contr | 81 |
 | [agent-automation-pitfalls.md](agent-automation-pitfalls.md) |  | <!-- lint-ignore-git --> > ⚠️ **Note:** This document includ | 634 |
 | [api-levels.md](api-levels.md) |  | structural_lib exposes three API levels. Pick the one that m | 117 |
-| [api-stability.md](api-stability.md) |  | > This document defines which parts of the library are safe  | 639 |
-| [api.md](api.md) |  | geometry, loading, reinforcement, and evidence boundaries. T | 3956 |
+| [api-stability.md](api-stability.md) |  | > This document defines which parts of the library are safe  | 647 |
+| [api.md](api.md) |  | geometry, loading, reinforcement, and evidence boundaries. T | 3962 |
 | [automation-catalog.md](automation-catalog.md) |  | The exhaustive machine-generated script inventory is scripts | 61 |
 | [bbs-dxf-contract.md](bbs-dxf-contract.md) |  | This document defines the stable contracts for Bar Bending S | 116 |
+| [beam-tool-manifest.md](beam-tool-manifest.md) |  | The generated beam tool manifest describes the one approved  | 32 |
 | [clause-map.md](clause-map.md) | IS 456 Clause-to-Function Mapping | Maps IS 456:2000 (and IS 13920:2016) clauses to their implem | 189 |
 | [deferred-integrations.md](deferred-integrations.md) |  | - Uses conservative default (0.7) in comparison scoring - Fu | 150 |
 | [deprecation-policy.md](deprecation-policy.md) |  | This document defines the deprecation policy for the structu | 368 |

--- a/fastapi_app/examples/index.json
+++ b/fastapi_app/examples/index.json
@@ -2,7 +2,7 @@
   "folder": "fastapi_app/examples",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 2,
   "files": [
     {
@@ -50,5 +50,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "527b9894b00a0b90"
+  "content_hash": "71bfea1d0f6546fa"
 }

--- a/fastapi_app/examples/index.md
+++ b/fastapi_app/examples/index.md
@@ -1,7 +1,7 @@
 # Examples
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 2
 
 ## Python Files

--- a/fastapi_app/index.json
+++ b/fastapi_app/index.json
@@ -2,8 +2,8 @@
   "folder": "fastapi_app",
   "type": "python-package",
   "description": "REST API + WebSocket bridge between the React frontend and the Python `structural_lib`.",
-  "last_updated": "2026-04-07",
-  "file_count": 7,
+  "last_updated": "2026-08-10",
+  "file_count": 8,
   "files": [
     {
       "name": "README.md",
@@ -18,15 +18,15 @@
       "name": "__init__.py",
       "type": "python",
       "size_lines": 11,
-      "last_updated": "2026-04-06",
+      "last_updated": "2026-08-10",
       "description": "FastAPI backend for structural_engineering_lib.",
-      "content_hash": "1510644cf71b"
+      "content_hash": "db91a1d0e32f"
     },
     {
       "name": "auth.py",
       "type": "python",
-      "size_lines": 376,
-      "last_updated": "2026-04-05",
+      "size_lines": 378,
+      "last_updated": "2026-08-10",
       "description": "Authentication and Authorization Module.",
       "classes": [
         {
@@ -108,33 +108,48 @@
         "RATE_LIMIT_REQUESTS",
         "RATE_LIMIT_WINDOW_SECONDS"
       ],
-      "content_hash": "b07b15bac038"
+      "content_hash": "6d5ec69e79c1"
     },
     {
       "name": "config.py",
       "type": "python",
-      "size_lines": 80,
-      "last_updated": "2026-04-06",
+      "size_lines": 124,
+      "last_updated": "2026-08-10",
       "description": "Application Configuration.",
       "classes": [
         {
           "name": "Settings",
-          "description": "Application settings loaded from environment variables."
+          "description": "Application settings loaded from environment variables.",
+          "public_methods": [
+            "validate_production_security"
+          ]
         }
       ],
       "functions": [
+        {
+          "name": "is_insecure_jwt_secret",
+          "description": "Return whether a JWT secret is empty, short, or a known placeholder.",
+          "params": [
+            "secret"
+          ]
+        },
         {
           "name": "get_settings",
           "description": "Get cached application settings."
         }
       ],
-      "content_hash": "eda8113d5e32"
+      "constants": [
+        "_PRODUCTION_ENVIRONMENTS",
+        "_INSECURE_JWT_SECRET_MARKERS",
+        "MINIMUM_JWT_SECRET_LENGTH"
+      ],
+      "content_hash": "b36dd973302e"
     },
     {
       "name": "error_utils.py",
       "type": "python",
-      "size_lines": 52,
-      "last_updated": "2026-04-06",
+      "size_lines": 74,
+      "last_updated": "2026-04-07",
       "description": "Error sanitization utilities for API responses.",
       "functions": [
         {
@@ -151,15 +166,23 @@
             "e",
             "context"
           ]
+        },
+        {
+          "name": "sanitize_error_string",
+          "description": "Sanitize a raw error string for API responses.",
+          "params": [
+            "msg",
+            "context"
+          ]
         }
       ],
-      "content_hash": "a17cd08e3bca"
+      "content_hash": "5b0b4fdf1daf"
     },
     {
       "name": "main.py",
       "type": "python",
-      "size_lines": 503,
-      "last_updated": "2026-04-06",
+      "size_lines": 566,
+      "last_updated": "2026-08-10",
       "description": "FastAPI Application Entry Point.",
       "classes": [
         {
@@ -185,6 +208,14 @@
         }
       ],
       "functions": [
+        {
+          "name": "request_validation_error_handler",
+          "description": "Map every Pydantic request failure to the maintained API envelope.",
+          "params": [
+            "request",
+            "exc"
+          ]
+        },
         {
           "name": "generic_exception_handler",
           "description": "Catch-all for unhandled exceptions. Logs full traceback server-side,",
@@ -212,12 +243,12 @@
         "API_TAGS_METADATA",
         "API_V1_PREFIX"
       ],
-      "content_hash": "635a8bdaa704"
+      "content_hash": "a9d046ae73f1"
     },
     {
       "name": "openapi_baseline.json",
       "type": "config",
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-10",
       "top_level_keys": [
         "components",
         "info",
@@ -225,7 +256,14 @@
         "paths",
         "tags"
       ],
-      "content_hash": "8c4dfa60d929"
+      "content_hash": "2c2dfb7056db"
+    },
+    {
+      "name": "ruff.toml",
+      "type": "config",
+      "last_updated": "2026-08-10",
+      "description": ".TOML configuration file",
+      "content_hash": "a86a2bd7f0e7"
     }
   ],
   "subfolders": [
@@ -237,23 +275,23 @@
     {
       "name": "models",
       "path": "models/",
-      "file_count": 12,
+      "file_count": 17,
       "is_package": true
     },
     {
       "name": "routers",
       "path": "routers/",
-      "file_count": 16,
+      "file_count": 20,
       "is_package": true
     },
     {
       "name": "tests",
       "path": "tests/",
-      "file_count": 25,
+      "file_count": 36,
       "description": "Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming.",
       "is_package": true
     }
   ],
-  "content_hash": "20c97c58500bcefb",
-  "has_init": true
+  "has_init": true,
+  "content_hash": "d5555b33783badf8"
 }

--- a/fastapi_app/index.md
+++ b/fastapi_app/index.md
@@ -3,12 +3,13 @@
 REST API + WebSocket bridge between the React frontend and the Python `structural_lib`.
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
-**Files:** 7
+**Last Updated:** 2026-08-10
+**Files:** 8
 
 ## Config Files
 
 - [openapi_baseline.json](openapi_baseline.json)
+- [ruff.toml](ruff.toml) — .TOML configuration file
 
 ## Documentation Files
 
@@ -21,16 +22,16 @@ REST API + WebSocket bridge between the React frontend and the Python `structura
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | FastAPI backend for structural_engineering_lib. | 0 | 0 | 11 |
-| [auth.py](auth.py) | Authentication and Authorization Module. | 3 | 7 | 376 |
-| [config.py](config.py) | Application Configuration. | 1 | 1 | 80 |
-| [error_utils.py](error_utils.py) | Error sanitization utilities for API responses. | 0 | 2 | 52 |
-| [main.py](main.py) | FastAPI Application Entry Point. | 3 | 4 | 503 |
+| [auth.py](auth.py) | Authentication and Authorization Module. | 3 | 7 | 378 |
+| [config.py](config.py) | Application Configuration. | 1 | 2 | 124 |
+| [error_utils.py](error_utils.py) | Error sanitization utilities for API responses. | 0 | 3 | 74 |
+| [main.py](main.py) | FastAPI Application Entry Point. | 3 | 5 | 566 |
 
 ## Subfolders
 
 | Folder | Files | Description |
 |--------|-------|-------------|
 | [examples/](examples/) | 4 |  |
-| [models/](models/) 📦 | 12 |  |
-| [routers/](routers/) 📦 | 16 |  |
-| [tests/](tests/) 📦 | 25 | Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin |
+| [models/](models/) 📦 | 17 |  |
+| [routers/](routers/) 📦 | 20 |  |
+| [tests/](tests/) 📦 | 36 | Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin |

--- a/fastapi_app/models/index.json
+++ b/fastapi_app/models/index.json
@@ -2,8 +2,8 @@
   "folder": "fastapi_app/models",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
-  "file_count": 10,
+  "last_updated": "2026-08-10",
+  "file_count": 15,
   "files": [
     {
       "name": "__init__.py",
@@ -16,8 +16,8 @@
     {
       "name": "analysis.py",
       "type": "python",
-      "size_lines": 254,
-      "last_updated": "2026-04-04",
+      "size_lines": 264,
+      "last_updated": "2026-04-07",
       "description": "Smart Analysis Pydantic Models.",
       "classes": [
         {
@@ -38,7 +38,10 @@
         },
         {
           "name": "SmartAnalysisRequest",
-          "description": "Request model for smart design analysis."
+          "description": "Request model for smart design analysis.",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
         },
         {
           "name": "Suggestion",
@@ -61,13 +64,13 @@
           "description": "Response model for smart analysis."
         }
       ],
-      "content_hash": "5cfa55411c2e"
+      "content_hash": "26dc50c893b8"
     },
     {
       "name": "beam.py",
       "type": "python",
-      "size_lines": 618,
-      "last_updated": "2026-04-05",
+      "size_lines": 679,
+      "last_updated": "2026-08-10",
       "description": "Beam Design and Detailing Pydantic Models.",
       "classes": [
         {
@@ -83,11 +86,21 @@
         },
         {
           "name": "BeamCheckRequest",
-          "description": "Request model for checking existing beam with provided reinforcement."
+          "description": "Request model for checking existing beam with provided reinforcement.",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
         },
         {
           "name": "BeamDetailingRequest",
-          "description": "Request model for beam reinforcement detailing."
+          "description": "Request model for beam reinforcement detailing.",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
+        },
+        {
+          "name": "EvidenceEnvelopeResponse",
+          "description": "Traceable identity metadata, not a professional approval certificate."
         },
         {
           "name": "FlexureResult",
@@ -131,21 +144,21 @@
           "public_methods": [
             "validate_depth_relationships"
           ]
-        },
-        {
-          "name": "TorsionDesignResponse",
-          "description": "Response model for torsion design."
         }
       ],
-      "content_hash": "b866ec0fd49a"
+      "content_hash": "15ef555cacf0"
     },
     {
       "name": "boq.py",
       "type": "python",
-      "size_lines": 77,
-      "last_updated": "2026-04-04",
+      "size_lines": 107,
+      "last_updated": "2026-08-10",
       "description": "Pydantic models for Project BOQ endpoint.",
       "classes": [
+        {
+          "name": "DatasetReference",
+          "description": "Optional source-dataset identity supplied by an import surface."
+        },
         {
           "name": "BeamMetadata",
           "description": "Per-beam metadata for BOQ aggregation."
@@ -153,6 +166,10 @@
         {
           "name": "ProjectBOQRequest",
           "description": "Request for project BOQ aggregation."
+        },
+        {
+          "name": "BOQEvidenceResponse",
+          "description": "Server-generated identity for one BOQ aggregation."
         },
         {
           "name": "SteelSummaryResponse",
@@ -171,13 +188,77 @@
           "description": "BOQ response with aggregated quantities and costs."
         }
       ],
-      "content_hash": "3d1a134375d0"
+      "content_hash": "cb7a0115d118"
+    },
+    {
+      "name": "capabilities.py",
+      "type": "python",
+      "size_lines": 79,
+      "last_updated": "2026-08-10",
+      "description": "Typed transport models for canonical IS 456 capability discovery.",
+      "classes": [
+        {
+          "name": "IS456FieldAliasModel",
+          "description": "One intentional compatibility spelling."
+        },
+        {
+          "name": "IS456FieldContractModel",
+          "description": "Units and domain of one canonical public quantity."
+        },
+        {
+          "name": "IS456StatusContractModel",
+          "description": "Meaning and limits of one public status field."
+        },
+        {
+          "name": "IS456WorkflowContractModel",
+          "description": "Semantic contract for a supported public workflow."
+        },
+        {
+          "name": "IS456AdapterContractModel",
+          "description": "Semantic contract for a supported transport boundary."
+        },
+        {
+          "name": "IS456SemanticContractModel",
+          "description": "Units, aliases, statuses, and limitations for supported routes."
+        },
+        {
+          "name": "IS456CapabilityModel",
+          "description": "One supported capability plus its held boundary."
+        },
+        {
+          "name": "IS456CapabilityDocumentModel",
+          "description": "Versioned capability discovery document shared by all public surfaces."
+        }
+      ],
+      "content_hash": "bb33ef5d0171"
+    },
+    {
+      "name": "catalog.py",
+      "type": "python",
+      "size_lines": 56,
+      "last_updated": "2026-08-10",
+      "description": "Typed transport models for the application workflow catalogue.",
+      "classes": [
+        {
+          "name": "CatalogFieldModel"
+        },
+        {
+          "name": "CatalogExampleModel"
+        },
+        {
+          "name": "WorkflowCapabilityModel"
+        },
+        {
+          "name": "WorkflowCatalogDocumentModel"
+        }
+      ],
+      "content_hash": "6279d6ba7bad"
     },
     {
       "name": "column.py",
       "type": "python",
-      "size_lines": 1005,
-      "last_updated": "2026-04-04",
+      "size_lines": 1174,
+      "last_updated": "2026-08-10",
       "description": "Column Design Pydantic Models.",
       "classes": [
         {
@@ -198,7 +279,10 @@
         },
         {
           "name": "ColumnAxialRequest",
-          "description": "Request model for short column axial capacity calculation."
+          "description": "Request model for short column axial capacity calculation.",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
         },
         {
           "name": "ColumnClassifyResponse",
@@ -214,7 +298,10 @@
         },
         {
           "name": "ColumnUniaxialRequest",
-          "description": "Request model for short column uniaxial bending design per IS 456 Cl 39.5."
+          "description": "Request model for short column uniaxial bending design per IS 456 Cl 39.5.",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
         },
         {
           "name": "ColumnUniaxialResponse",
@@ -222,7 +309,10 @@
         },
         {
           "name": "PMInteractionRequest",
-          "description": "Request model for P-M interaction curve generation."
+          "description": "Request model for P-M interaction curve generation.",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
         },
         {
           "name": "PMPoint",
@@ -234,20 +324,23 @@
         },
         {
           "name": "BiaxialCheckRequest",
-          "description": "Request model for biaxial bending check per IS 456 Cl 39.6 (Bresler load contour)."
+          "description": "Request model for biaxial bending check per IS 456 Cl 39.6 (Bresler load contour).",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
         },
         {
           "name": "BiaxialCheckResponse",
           "description": "Response model for biaxial bending check per IS 456 Cl 39.6."
         }
       ],
-      "content_hash": "e75eb4b2fec1"
+      "content_hash": "2b81a2987ad9"
     },
     {
       "name": "common.py",
       "type": "python",
-      "size_lines": 150,
-      "last_updated": "2026-03-26",
+      "size_lines": 137,
+      "last_updated": "2026-08-10",
       "description": "Common Pydantic Models.",
       "classes": [
         {
@@ -267,18 +360,11 @@
           "description": "Design code and assumptions."
         },
         {
-          "name": "APIResponse",
-          "description": "Standard API response wrapper."
-        },
-        {
           "name": "ErrorResponse",
           "description": "Error response model."
         }
       ],
-      "constants": [
-        "T"
-      ],
-      "content_hash": "840c108953f3"
+      "content_hash": "1a0e8f668f88"
     },
     {
       "name": "compliance.py",
@@ -356,8 +442,8 @@
     {
       "name": "geometry.py",
       "type": "python",
-      "size_lines": 394,
-      "last_updated": "2026-04-04",
+      "size_lines": 412,
+      "last_updated": "2026-08-09",
       "description": "3D Geometry Pydantic Models.",
       "classes": [
         {
@@ -382,7 +468,10 @@
         },
         {
           "name": "BeamGeometryRequest",
-          "description": "Request model for beam 3D geometry generation using library API."
+          "description": "Request model for beam 3D geometry generation using library API.",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
         },
         {
           "name": "BeamGeometryResponse",
@@ -402,7 +491,10 @@
         },
         {
           "name": "CrossSectionRequest",
-          "description": "Request model for 2D cross-section geometry."
+          "description": "Request model for 2D cross-section geometry.",
+          "public_methods": [
+            "validate_cross_fields"
+          ]
         },
         {
           "name": "CrossSectionResponse",
@@ -421,7 +513,103 @@
           "description": "Axis-aligned bounding box."
         }
       ],
-      "content_hash": "d9972f91b99f"
+      "content_hash": "74e7662984d5"
+    },
+    {
+      "name": "library_core.py",
+      "type": "python",
+      "size_lines": 178,
+      "last_updated": "2026-08-10",
+      "description": "Requests for the bounded footing and slab public-library workflows.",
+      "classes": [
+        {
+          "name": "FootingLoadTransferRequest",
+          "description": "Explicit inputs for the bounded concentric isolated-footing transfer check."
+        },
+        {
+          "name": "OneWaySlabDesignRequest",
+          "description": "Explicit inputs for the supported simply supported one-way slab strip."
+        },
+        {
+          "name": "FootingLoadTransferResponse",
+          "description": "Bounded isolated-footing bearing and dowel-transfer result."
+        },
+        {
+          "name": "SlabGeometryResponse",
+          "description": "Normalized one-way slab geometry used by the service."
+        },
+        {
+          "name": "OneWaySlabFlexureInputResponse",
+          "description": "Inputs retained with a one-way slab flexure result."
+        },
+        {
+          "name": "SlabGoverningCheckResponse",
+          "description": "One explicit flexure or detailing comparison."
+        },
+        {
+          "name": "OneWaySlabFlexureResponse",
+          "description": "Bounded one-way slab flexure result."
+        },
+        {
+          "name": "OneWaySlabDetailingInputResponse",
+          "description": "Inputs retained with a one-way slab detailing result."
+        },
+        {
+          "name": "OneWaySlabDetailingResponse",
+          "description": "Provided-bar checks and the serviceability review boundary."
+        },
+        {
+          "name": "OneWaySlabDesignResponse",
+          "description": "Complete bounded one-way slab flexure and detailing response."
+        }
+      ],
+      "content_hash": "fdfc89990b5d"
+    },
+    {
+      "name": "metadata.py",
+      "type": "python",
+      "size_lines": 97,
+      "last_updated": "2026-08-10",
+      "description": "Typed payload models for maintained static JSON metadata routes.",
+      "classes": [
+        {
+          "name": "APIInfoResponse",
+          "description": "Root API discovery payload."
+        },
+        {
+          "name": "DesignLimitsResponse",
+          "description": "Named IS 456 design-limit groups."
+        },
+        {
+          "name": "CostRatesResponse",
+          "description": "Default optimization rate groups and their context."
+        },
+        {
+          "name": "CodeClausesResponse",
+          "description": "IS 456/IS 13920 references grouped by check type."
+        },
+        {
+          "name": "MaterialAppearance",
+          "description": "Visualization material metadata."
+        },
+        {
+          "name": "MaterialAppearancesResponse",
+          "description": "Named visualization material appearances."
+        },
+        {
+          "name": "ImportFormatDescription",
+          "description": "One supported CSV input shape."
+        },
+        {
+          "name": "ImportFormatsResponse",
+          "description": "Supported CSV formats and auto-detection metadata."
+        },
+        {
+          "name": "DevelopmentLengthResponse",
+          "description": "One development-length calculation with explicit inputs and clause."
+        }
+      ],
+      "content_hash": "c85cead534dd"
     },
     {
       "name": "optimization.py",
@@ -472,13 +660,21 @@
     {
       "name": "response.py",
       "type": "python",
-      "size_lines": 45,
-      "last_updated": "2026-04-05",
+      "size_lines": 71,
+      "last_updated": "2026-08-10",
       "description": "Standardized API response wrappers.",
       "classes": [
         {
           "name": "APIResponse",
           "description": "Standardized response wrapper for all API endpoints."
+        },
+        {
+          "name": "RequestValidationErrorPayload",
+          "description": "Field-preserving Pydantic request validation error."
+        },
+        {
+          "name": "RequestValidationErrorResponse",
+          "description": "Documented 422 form of the maintained response envelope."
         }
       ],
       "functions": [
@@ -501,11 +697,53 @@
       "constants": [
         "T"
       ],
-      "content_hash": "6da6039abfee"
+      "content_hash": "303815ec1f8d"
+    },
+    {
+      "name": "workflows.py",
+      "type": "python",
+      "size_lines": 99,
+      "last_updated": "2026-08-10",
+      "description": "Typed models for the default-disabled bounded beam workflow transport.",
+      "classes": [
+        {
+          "name": "WorkflowStepDefinitionModel"
+        },
+        {
+          "name": "WorkflowBindingModel"
+        },
+        {
+          "name": "WorkflowLimitsModel"
+        },
+        {
+          "name": "WorkflowDefinitionModel"
+        },
+        {
+          "name": "WorkflowValidateRequest"
+        },
+        {
+          "name": "WorkflowRunRequest"
+        },
+        {
+          "name": "WorkflowValidationResponse"
+        },
+        {
+          "name": "WorkflowStepResultModel"
+        },
+        {
+          "name": "WorkflowAuditModel"
+        },
+        {
+          "name": "WorkflowRunResponse"
+        },
+        {
+          "name": "WorkflowCancellationResponse"
+        }
+      ],
+      "content_hash": "2dda37f6f900"
     }
   ],
   "subfolders": [],
-  "content_hash": "87f2b9f5c0d2c08c",
   "has_init": true,
   "public_api": [
     "BeamDesignRequest",
@@ -528,5 +766,6 @@
     "ErrorResponse",
     "DuctilityCheckRequest",
     "DuctilityCheckResponse"
-  ]
+  ],
+  "content_hash": "04cafbd7ed3c78a3"
 }

--- a/fastapi_app/models/index.md
+++ b/fastapi_app/models/index.md
@@ -1,8 +1,8 @@
 # Models
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
-**Files:** 10
+**Last Updated:** 2026-08-10
+**Files:** 15
 
 ## Public API
 
@@ -32,12 +32,17 @@
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | Pydantic Models Package. | 0 | 0 | 88 |
-| [analysis.py](analysis.py) | Smart Analysis Pydantic Models. | 10 | 0 | 254 |
-| [beam.py](beam.py) | Beam Design and Detailing Pydantic Models. | 15 | 0 | 618 |
-| [boq.py](boq.py) | Pydantic models for Project BOQ endpoint. | 6 | 0 | 77 |
-| [column.py](column.py) | Column Design Pydantic Models. | 15 | 0 | 1005 |
-| [common.py](common.py) | Common Pydantic Models. | 6 | 0 | 150 |
+| [analysis.py](analysis.py) | Smart Analysis Pydantic Models. | 10 | 0 | 264 |
+| [beam.py](beam.py) | Beam Design and Detailing Pydantic Models. | 15 | 0 | 679 |
+| [boq.py](boq.py) | Pydantic models for Project BOQ endpoint. | 8 | 0 | 107 |
+| [capabilities.py](capabilities.py) | Typed transport models for canonical IS 456 capability disco | 8 | 0 | 79 |
+| [catalog.py](catalog.py) | Typed transport models for the application workflow catalogu | 4 | 0 | 56 |
+| [column.py](column.py) | Column Design Pydantic Models. | 15 | 0 | 1174 |
+| [common.py](common.py) | Common Pydantic Models. | 5 | 0 | 137 |
 | [compliance.py](compliance.py) | IS 456 Compliance Check Pydantic Models. | 15 | 0 | 325 |
-| [geometry.py](geometry.py) | 3D Geometry Pydantic Models. | 15 | 0 | 394 |
+| [geometry.py](geometry.py) | 3D Geometry Pydantic Models. | 15 | 0 | 412 |
+| [library_core.py](library_core.py) | Requests for the bounded footing and slab public-library wor | 10 | 0 | 178 |
+| [metadata.py](metadata.py) | Typed payload models for maintained static JSON metadata rou | 9 | 0 | 97 |
 | [optimization.py](optimization.py) | Cost Optimization Pydantic Models. | 9 | 0 | 298 |
-| [response.py](response.py) | Standardized API response wrappers. | 1 | 2 | 45 |
+| [response.py](response.py) | Standardized API response wrappers. | 3 | 2 | 71 |
+| [workflows.py](workflows.py) | Typed models for the default-disabled bounded beam workflow  | 11 | 0 | 99 |

--- a/fastapi_app/routers/index.json
+++ b/fastapi_app/routers/index.json
@@ -2,22 +2,22 @@
   "folder": "fastapi_app/routers",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-04-07",
-  "file_count": 14,
+  "last_updated": "2026-08-10",
+  "file_count": 18,
   "files": [
     {
       "name": "__init__.py",
       "type": "python",
-      "size_lines": 36,
-      "last_updated": "2026-04-01",
+      "size_lines": 44,
+      "last_updated": "2026-08-10",
       "description": "FastAPI Routers Package.",
-      "content_hash": "da16792c49de"
+      "content_hash": "4235ead08b65"
     },
     {
       "name": "analysis.py",
       "type": "python",
-      "size_lines": 334,
-      "last_updated": "2026-04-05",
+      "size_lines": 338,
+      "last_updated": "2026-08-10",
       "description": "Smart Analysis Router.",
       "functions": [
         {
@@ -39,13 +39,45 @@
           "description": "Get IS 456:2000 code clause references."
         }
       ],
-      "content_hash": "c79a52368115"
+      "content_hash": "8e86dcd8585a"
+    },
+    {
+      "name": "capabilities.py",
+      "type": "python",
+      "size_lines": 23,
+      "last_updated": "2026-08-10",
+      "description": "Public discovery route for the canonical supported IS 456 contract.",
+      "functions": [
+        {
+          "name": "get_library_capabilities",
+          "description": "Return the same canonical document exposed by Python and the CLI."
+        }
+      ],
+      "content_hash": "69b361f5f967"
+    },
+    {
+      "name": "catalog.py",
+      "type": "python",
+      "size_lines": 51,
+      "last_updated": "2026-08-10",
+      "description": "Thin read-only transport for the canonical application workflow catalogue.",
+      "functions": [
+        {
+          "name": "get_workflow_catalog",
+          "description": "Return the library-owned catalogue without serializing Python callables.",
+          "params": [
+            "response",
+            "version"
+          ]
+        }
+      ],
+      "content_hash": "613fde4d7518"
     },
     {
       "name": "column.py",
       "type": "python",
-      "size_lines": 736,
-      "last_updated": "2026-04-06",
+      "size_lines": 750,
+      "last_updated": "2026-08-10",
       "description": "Column Design Router.",
       "functions": [
         {
@@ -140,13 +172,13 @@
           ]
         }
       ],
-      "content_hash": "9c761afc41ed"
+      "content_hash": "75c71eaa8352"
     },
     {
       "name": "design.py",
       "type": "python",
-      "size_lines": 882,
-      "last_updated": "2026-04-06",
+      "size_lines": 931,
+      "last_updated": "2026-08-10",
       "description": "Beam Design Router.",
       "functions": [
         {
@@ -217,13 +249,13 @@
           ]
         }
       ],
-      "content_hash": "24570368d5ff"
+      "content_hash": "94d8bfdc7b3d"
     },
     {
       "name": "detailing.py",
       "type": "python",
-      "size_lines": 402,
-      "last_updated": "2026-04-05",
+      "size_lines": 412,
+      "last_updated": "2026-08-10",
       "description": "Beam Detailing Router.",
       "functions": [
         {
@@ -255,13 +287,13 @@
           ]
         }
       ],
-      "content_hash": "07db19cffb61"
+      "content_hash": "ad4f898f9ee6"
     },
     {
       "name": "export.py",
       "type": "python",
-      "size_lines": 579,
-      "last_updated": "2026-04-06",
+      "size_lines": 661,
+      "last_updated": "2026-08-10",
       "description": "Export Router — BBS, DXF, and Report exports.",
       "classes": [
         {
@@ -318,13 +350,13 @@
           ]
         }
       ],
-      "content_hash": "4d16af60872e"
+      "content_hash": "bae2c6afe783"
     },
     {
       "name": "geometry.py",
       "type": "python",
-      "size_lines": 647,
-      "last_updated": "2026-04-05",
+      "size_lines": 653,
+      "last_updated": "2026-08-10",
       "description": "3D Geometry Router.",
       "functions": [
         {
@@ -360,7 +392,7 @@
           ]
         }
       ],
-      "content_hash": "99664043694f"
+      "content_hash": "c56bcb74da9e"
     },
     {
       "name": "health.py",
@@ -404,8 +436,8 @@
     {
       "name": "imports.py",
       "type": "python",
-      "size_lines": 930,
-      "last_updated": "2026-04-05",
+      "size_lines": 992,
+      "last_updated": "2026-08-10",
       "description": "CSV Import Router.",
       "classes": [
         {
@@ -419,6 +451,10 @@
         {
           "name": "BeamWith3D",
           "description": "Beam data with 3D positioning for visualization."
+        },
+        {
+          "name": "SampleDatasetEvidence",
+          "description": "Stable identity for the exact bundled source files."
         },
         {
           "name": "SampleDataResponse",
@@ -483,13 +519,13 @@
           "description": "Load sample building data from actual ETABS export CSV files."
         }
       ],
-      "content_hash": "2924c666ce78"
+      "content_hash": "f0e4e7889036"
     },
     {
       "name": "insights.py",
       "type": "python",
-      "size_lines": 507,
-      "last_updated": "2026-04-05",
+      "size_lines": 579,
+      "last_updated": "2026-08-10",
       "description": "Insights Router.",
       "classes": [
         {
@@ -571,13 +607,37 @@
           ]
         }
       ],
-      "content_hash": "5b167d8e29a4"
+      "content_hash": "c9c66c19afbf"
+    },
+    {
+      "name": "library_core.py",
+      "type": "python",
+      "size_lines": 74,
+      "last_updated": "2026-08-10",
+      "description": "Thin FastAPI consumers for the supported footing and slab library routes.",
+      "functions": [
+        {
+          "name": "check_footing_load_transfer",
+          "description": "Validate a request, call the public library service, and map its result.",
+          "params": [
+            "request"
+          ]
+        },
+        {
+          "name": "design_one_way_slab",
+          "description": "Validate a request, call the public slab service, and map its result.",
+          "params": [
+            "request"
+          ]
+        }
+      ],
+      "content_hash": "8dd0877b399b"
     },
     {
       "name": "optimization.py",
       "type": "python",
-      "size_lines": 327,
-      "last_updated": "2026-04-06",
+      "size_lines": 331,
+      "last_updated": "2026-08-10",
       "description": "Cost Optimization Router.",
       "functions": [
         {
@@ -599,13 +659,13 @@
           ]
         }
       ],
-      "content_hash": "606098b86400"
+      "content_hash": "54a33e797dd0"
     },
     {
       "name": "rebar.py",
       "type": "python",
-      "size_lines": 261,
-      "last_updated": "2026-04-05",
+      "size_lines": 269,
+      "last_updated": "2026-08-10",
       "description": "Rebar Validation and Application Router.",
       "classes": [
         {
@@ -653,15 +713,23 @@
           ]
         }
       ],
-      "content_hash": "80d763de4bf6"
+      "content_hash": "74775647e3ef"
     },
     {
       "name": "streaming.py",
       "type": "python",
-      "size_lines": 308,
-      "last_updated": "2026-04-04",
+      "size_lines": 351,
+      "last_updated": "2026-08-10",
       "description": "Server-Sent Events (SSE) Router for Batch Processing.",
       "classes": [
+        {
+          "name": "BatchJobProgress",
+          "description": "Completed and total item counts for one batch job."
+        },
+        {
+          "name": "BatchJobStatusResponse",
+          "description": "Typed polling response for one streamed batch job."
+        },
         {
           "name": "BatchJobManager",
           "description": "Manages batch job state for progress tracking.",
@@ -676,7 +744,16 @@
       "functions": [
         {
           "name": "stream_batch_design",
-          "description": "Stream batch beam design results.",
+          "description": "Stream a small legacy batch supplied through the query string.",
+          "params": [
+            "request",
+            "beams",
+            "_"
+          ]
+        },
+        {
+          "name": "stream_batch_design_post",
+          "description": "Stream a batch from a request body without request-target size limits.",
           "params": [
             "request",
             "beams",
@@ -692,13 +769,13 @@
           ]
         }
       ],
-      "content_hash": "4d0ea0c92e06"
+      "content_hash": "43cf71831126"
     },
     {
       "name": "websocket.py",
       "type": "python",
-      "size_lines": 355,
-      "last_updated": "2026-04-06",
+      "size_lines": 428,
+      "last_updated": "2026-08-10",
       "description": "WebSocket Router for Live Design Updates.",
       "classes": [
         {
@@ -747,24 +824,62 @@
           ]
         }
       ],
-      "content_hash": "3dc405e36039"
+      "content_hash": "bc24dda9664d"
+    },
+    {
+      "name": "workflows.py",
+      "type": "python",
+      "size_lines": 172,
+      "last_updated": "2026-08-10",
+      "description": "Default-disabled transport for the one allowlisted beam workflow.",
+      "functions": [
+        {
+          "name": "get_beam_workflow_template"
+        },
+        {
+          "name": "validate_beam_workflow",
+          "params": [
+            "request"
+          ]
+        },
+        {
+          "name": "run_beam_workflow",
+          "params": [
+            "request"
+          ]
+        },
+        {
+          "name": "cancel_beam_workflow",
+          "params": [
+            "run_id"
+          ]
+        }
+      ],
+      "constants": [
+        "_RUNNER"
+      ],
+      "content_hash": "e99d13ab2776"
     }
   ],
   "subfolders": [],
-  "content_hash": "ccd5b3718e63b847",
   "has_init": true,
   "public_api": [
     "analysis",
+    "catalog",
     "column",
     "design",
     "detailing",
+    "export",
     "geometry",
     "health",
     "imports",
     "insights",
+    "library_core",
     "optimization",
     "rebar",
     "streaming",
-    "websocket"
-  ]
+    "websocket",
+    "workflows"
+  ],
+  "content_hash": "c5c403f6b5e63ac9"
 }

--- a/fastapi_app/routers/index.md
+++ b/fastapi_app/routers/index.md
@@ -1,39 +1,47 @@
 # Routers
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
-**Files:** 14
+**Last Updated:** 2026-08-10
+**Files:** 18
 
 ## Public API
 
 - `analysis`
+- `catalog`
 - `column`
 - `design`
 - `detailing`
+- `export`
 - `geometry`
 - `health`
 - `imports`
 - `insights`
+- `library_core`
 - `optimization`
 - `rebar`
 - `streaming`
 - `websocket`
+- `workflows`
 
 ## Python Files
 
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
-| [__init__.py](__init__.py) | FastAPI Routers Package. | 0 | 0 | 36 |
-| [analysis.py](analysis.py) | Smart Analysis Router. | 0 | 3 | 334 |
-| [column.py](column.py) | Column Design Router. | 0 | 13 | 736 |
-| [design.py](design.py) | Beam Design Router. | 0 | 10 | 882 |
-| [detailing.py](detailing.py) | Beam Detailing Router. | 0 | 4 | 402 |
-| [export.py](export.py) | Export Router — BBS, DXF, and Report exports. | 4 | 5 | 579 |
-| [geometry.py](geometry.py) | 3D Geometry Router. | 0 | 5 | 647 |
+| [__init__.py](__init__.py) | FastAPI Routers Package. | 0 | 0 | 44 |
+| [analysis.py](analysis.py) | Smart Analysis Router. | 0 | 3 | 338 |
+| [capabilities.py](capabilities.py) | Public discovery route for the canonical supported IS 456 co | 0 | 1 | 23 |
+| [catalog.py](catalog.py) | Thin read-only transport for the canonical application workf | 0 | 1 | 51 |
+| [column.py](column.py) | Column Design Router. | 0 | 13 | 750 |
+| [design.py](design.py) | Beam Design Router. | 0 | 10 | 931 |
+| [detailing.py](detailing.py) | Beam Detailing Router. | 0 | 4 | 412 |
+| [export.py](export.py) | Export Router — BBS, DXF, and Report exports. | 4 | 5 | 661 |
+| [geometry.py](geometry.py) | 3D Geometry Router. | 0 | 5 | 653 |
 | [health.py](health.py) | Health Check Router. | 3 | 3 | 208 |
-| [imports.py](imports.py) | CSV Import Router. | 8 | 6 | 930 |
-| [insights.py](insights.py) | Insights Router. | 12 | 4 | 507 |
-| [optimization.py](optimization.py) | Cost Optimization Router. | 0 | 3 | 327 |
-| [rebar.py](rebar.py) | Rebar Validation and Application Router. | 7 | 2 | 261 |
-| [streaming.py](streaming.py) | Server-Sent Events (SSE) Router for Batch Processing. | 1 | 2 | 308 |
-| [websocket.py](websocket.py) | WebSocket Router for Live Design Updates. | 3 | 3 | 355 |
+| [imports.py](imports.py) | CSV Import Router. | 9 | 6 | 992 |
+| [insights.py](insights.py) | Insights Router. | 12 | 4 | 579 |
+| [library_core.py](library_core.py) | Thin FastAPI consumers for the supported footing and slab li | 0 | 2 | 74 |
+| [optimization.py](optimization.py) | Cost Optimization Router. | 0 | 3 | 331 |
+| [rebar.py](rebar.py) | Rebar Validation and Application Router. | 7 | 2 | 269 |
+| [streaming.py](streaming.py) | Server-Sent Events (SSE) Router for Batch Processing. | 3 | 3 | 351 |
+| [websocket.py](websocket.py) | WebSocket Router for Live Design Updates. | 3 | 3 | 428 |
+| [workflows.py](workflows.py) | Default-disabled transport for the one allowlisted beam work | 0 | 4 | 172 |

--- a/fastapi_app/tests/index.json
+++ b/fastapi_app/tests/index.json
@@ -2,8 +2,8 @@
   "folder": "fastapi_app/tests",
   "type": "python-package",
   "description": "Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming.",
-  "last_updated": "2026-04-07",
-  "file_count": 23,
+  "last_updated": "2026-08-10",
+  "file_count": 34,
   "files": [
     {
       "name": "README.md",
@@ -118,6 +118,72 @@
       "content_hash": "fea73f682b6c"
     },
     {
+      "name": "test_bundled_sample_evidence.py",
+      "type": "python",
+      "size_lines": 84,
+      "last_updated": "2026-08-10",
+      "description": "Reproducible software evidence for the bundled 153-beam acceptance sample.",
+      "functions": [
+        {
+          "name": "test_bundled_sample_boq_is_bound_to_dataset_and_calculation",
+          "params": [
+            "client"
+          ]
+        }
+      ],
+      "content_hash": "721ccbf51b86"
+    },
+    {
+      "name": "test_capabilities.py",
+      "type": "python",
+      "size_lines": 32,
+      "last_updated": "2026-08-10",
+      "description": "Cross-surface tests for canonical capability discovery.",
+      "functions": [
+        {
+          "name": "test_capability_route_matches_python_contract",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_capability_route_has_a_typed_openapi_success_schema",
+          "params": [
+            "client"
+          ]
+        }
+      ],
+      "content_hash": "bf3205115765"
+    },
+    {
+      "name": "test_catalog.py",
+      "type": "python",
+      "size_lines": 41,
+      "last_updated": "2026-08-10",
+      "description": "Cross-layer tests for the thin workflow catalogue transport.",
+      "functions": [
+        {
+          "name": "test_catalog_route_round_trips_library_document",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_catalog_route_supports_additive_alias_and_rejects_breaking_version",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_catalog_openapi_success_shape_is_typed",
+          "params": [
+            "client"
+          ]
+        }
+      ],
+      "content_hash": "a6ab14ba3460"
+    },
+    {
       "name": "test_column_additional_moment.py",
       "type": "python",
       "size_lines": 203,
@@ -147,8 +213,8 @@
     {
       "name": "test_column_biaxial.py",
       "type": "python",
-      "size_lines": 182,
-      "last_updated": "2026-04-05",
+      "size_lines": 179,
+      "last_updated": "2026-08-09",
       "description": "Tests for POST /api/v1/design/column/biaxial-check endpoint.",
       "classes": [
         {
@@ -176,7 +242,7 @@
           "description": "Edge cases: zero moments, slender column, optional params.",
           "public_methods": [
             "test_zero_moments",
-            "test_slender_column_warnings",
+            "test_slender_column_fails_closed",
             "test_with_l_unsupported",
             "test_without_l_unsupported"
           ]
@@ -199,7 +265,7 @@
         "ENDPOINT",
         "SAFE_PAYLOAD"
       ],
-      "content_hash": "8b7df6994047"
+      "content_hash": "1a0b915583dd"
     },
     {
       "name": "test_column_detailing.py",
@@ -366,6 +432,69 @@
       "content_hash": "a125fc65ff16"
     },
     {
+      "name": "test_config.py",
+      "type": "python",
+      "size_lines": 126,
+      "last_updated": "2026-08-10",
+      "description": "Tests for safe, environment-configurable FastAPI settings.",
+      "functions": [
+        {
+          "name": "test_server_host_is_private_by_default_and_environment_configurable",
+          "description": "Local startup stays private unless a deploy environment opts in.",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_development_defaults_remain_unauthenticated",
+          "description": "Local development and test startup retain the existing defaults.",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_production_requires_authentication",
+          "description": "Production-like profiles must not serve public endpoints.",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_production_app_import_refuses_disabled_authentication",
+          "description": "The ASGI application fails before serving with production auth disabled."
+        },
+        {
+          "name": "test_production_rejects_empty_or_placeholder_jwt_secret",
+          "description": "Production auth cannot be enabled with the supplied development secret.",
+          "params": [
+            "monkeypatch",
+            "secret"
+          ]
+        },
+        {
+          "name": "test_production_accepts_authentication_with_non_default_secret",
+          "description": "A configured production profile remains valid.",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_production_app_import_allows_valid_authentication_setup",
+          "description": "A configured production ASGI application can start."
+        },
+        {
+          "name": "test_development_app_import_keeps_current_local_startup_behavior",
+          "description": "The local profile still imports with development authentication defaults."
+        }
+      ],
+      "constants": [
+        "_REPOSITORY_ROOT",
+        "_VALID_PRODUCTION_SECRET",
+        "_DEFAULT_DEVELOPMENT_SECRET"
+      ],
+      "content_hash": "e3051f7b7005"
+    },
+    {
       "name": "test_design_compliance.py",
       "type": "python",
       "size_lines": 381,
@@ -460,8 +589,8 @@
     {
       "name": "test_endpoints.py",
       "type": "python",
-      "size_lines": 853,
-      "last_updated": "2026-04-05",
+      "size_lines": 1049,
+      "last_updated": "2026-08-10",
       "description": "Integration Tests for FastAPI Endpoints.",
       "classes": [
         {
@@ -479,13 +608,15 @@
           "description": "Tests for beam design endpoints.",
           "public_methods": [
             "test_design_beam_basic",
+            "test_doubly_reinforced_design_uses_compliance_utilization",
+            "test_design_and_report_share_beam_evidence_identity",
+            "test_unsafe_beam_evidence_is_explicitly_failed",
+            "test_report_evidence_ignores_client_safety_claims",
             "test_design_beam_validation_error",
             "test_design_beam_depth_ratio_validation",
             "test_check_beam",
             "test_get_design_limits",
-            "test_torsion_design_basic",
-            "test_torsion_design_unsafe_section",
-            "test_torsion_design_validation"
+            "test_torsion_design_basic"
           ]
         },
         {
@@ -581,7 +712,44 @@
           ]
         }
       ],
-      "content_hash": "956da8f224d4"
+      "content_hash": "3f514f5dff70"
+    },
+    {
+      "name": "test_error_sanitization.py",
+      "type": "python",
+      "size_lines": 118,
+      "last_updated": "2026-04-07",
+      "description": "Tests for error sanitization utilities (TASK-796).",
+      "classes": [
+        {
+          "name": "TestSanitizeErrorString",
+          "description": "Tests for sanitize_error_string().",
+          "public_methods": [
+            "test_normal_message_passes_through",
+            "test_strips_unix_file_path",
+            "test_strips_backslash_path",
+            "test_strips_traceback_keyword",
+            "test_context_appears_in_sanitized_output",
+            "test_empty_string_passes_through",
+            "test_message_with_only_slashes_in_units_stripped",
+            "test_reference_id_format"
+          ]
+        },
+        {
+          "name": "TestSanitizeError",
+          "description": "Tests for sanitize_error().",
+          "public_methods": [
+            "test_value_error_safe_message_preserved",
+            "test_value_error_with_path_stripped",
+            "test_type_error_safe_message_preserved",
+            "test_generic_exception_returns_internal_error",
+            "test_generic_exception_hides_original_message",
+            "test_value_error_with_backslash_stripped",
+            "test_value_error_with_traceback_stripped"
+          ]
+        }
+      ],
+      "content_hash": "a8d07c1ff654"
     },
     {
       "name": "test_export_bbs_dxf.py",
@@ -706,8 +874,8 @@
     {
       "name": "test_insights_dashboard.py",
       "type": "python",
-      "size_lines": 339,
-      "last_updated": "2026-04-05",
+      "size_lines": 387,
+      "last_updated": "2026-08-10",
       "description": "Tests for insights router endpoints.",
       "classes": [
         {
@@ -743,6 +911,7 @@
           "description": "Tests for POST /api/v1/insights/project-boq.",
           "public_methods": [
             "test_project_boq_basic",
+            "test_project_boq_identity_binds_dataset_and_normalized_inputs",
             "test_project_boq_custom_costs",
             "test_project_boq_empty_beams"
           ]
@@ -753,13 +922,13 @@
           "name": "client"
         }
       ],
-      "content_hash": "9b0f66e89dcd"
+      "content_hash": "97f6af18d787"
     },
     {
       "name": "test_integration.py",
       "type": "python",
-      "size_lines": 386,
-      "last_updated": "2026-04-05",
+      "size_lines": 390,
+      "last_updated": "2026-08-10",
       "description": "Integration tests for FastAPI structural design endpoints.",
       "classes": [
         {
@@ -828,13 +997,72 @@
           "description": "Create test client."
         }
       ],
-      "content_hash": "ed165009a24a"
+      "content_hash": "92f69b161cab"
+    },
+    {
+      "name": "test_library_core.py",
+      "type": "python",
+      "size_lines": 163,
+      "last_updated": "2026-08-10",
+      "description": "Request-to-public-library evidence for the new footing and slab consumers.",
+      "functions": [
+        {
+          "name": "test_footing_load_transfer_endpoint_calls_supported_public_workflow",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_footing_load_transfer_endpoint_rejects_non_integral_or_invalid_count",
+          "params": [
+            "client",
+            "dowel_count"
+          ]
+        },
+        {
+          "name": "test_footing_load_transfer_endpoint_accepts_four_integral_dowels",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_one_way_slab_endpoint_calls_supported_public_workflow",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_one_way_slab_endpoint_rejects_two_way_geometry",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_library_core_pydantic_422_uses_standard_envelope",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_existing_endpoint_pydantic_422_uses_same_envelope",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_openapi_documents_the_maintained_422_envelope",
+          "params": [
+            "client"
+          ]
+        }
+      ],
+      "content_hash": "0ae97d5ae880"
     },
     {
       "name": "test_load.py",
       "type": "python",
       "size_lines": 286,
-      "last_updated": "2026-04-06",
+      "last_updated": "2026-08-07",
       "description": "Load Tests for FastAPI Application.",
       "classes": [
         {
@@ -902,6 +1130,64 @@
       "content_hash": "2dc6ebdf8395"
     },
     {
+      "name": "test_maintenance_route_coverage.py",
+      "type": "python",
+      "size_lines": 150,
+      "last_updated": "2026-08-09",
+      "description": "Direct contract coverage for routes identified by the MAINT-004 parity audit.",
+      "functions": [
+        {
+          "name": "test_column_classify_route",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_column_eccentricity_route",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_column_axial_route",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_long_column_route",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_helical_check_route",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_column_ductile_detailing_route",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_rebar_validate_route",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_rebar_apply_route",
+          "params": [
+            "client"
+          ]
+        }
+      ],
+      "content_hash": "9729bb50d769"
+    },
+    {
       "name": "test_optimization_pareto.py",
       "type": "python",
       "size_lines": 158,
@@ -926,10 +1212,184 @@
       "content_hash": "bcfabea9e2ef"
     },
     {
+      "name": "test_plausibility_validators.py",
+      "type": "python",
+      "size_lines": 761,
+      "last_updated": "2026-08-09",
+      "description": "Tests for cross-field plausibility validators (TASK-729).",
+      "classes": [
+        {
+          "name": "TestBeamDesignRequestValidator",
+          "description": "Tests for BeamDesignRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_effective_depth_gte_depth",
+            "test_rejects_effective_depth_gt_depth",
+            "test_rejects_clear_cover_gte_depth",
+            "test_rejects_depth_width_ratio_gt_6",
+            "test_none_effective_depth_is_valid"
+          ]
+        },
+        {
+          "name": "TestBeamCheckRequestValidator",
+          "description": "Tests for BeamCheckRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_effective_depth_gte_depth",
+            "test_rejects_effective_depth_equal_depth",
+            "test_rejects_clear_cover_gte_depth",
+            "test_none_effective_depth_passes"
+          ]
+        },
+        {
+          "name": "TestBeamDetailingRequestValidator",
+          "description": "Tests for BeamDetailingRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_clear_cover_gte_depth"
+          ]
+        },
+        {
+          "name": "TestBeamGeometryRequestValidator",
+          "description": "Tests for BeamGeometryRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_cover_gte_depth",
+            "test_rejects_cover_gt_depth"
+          ]
+        },
+        {
+          "name": "TestCrossSectionRequestValidator",
+          "description": "Tests for CrossSectionRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_cover_gte_half_depth",
+            "test_cover_just_below_half_depth_passes"
+          ]
+        },
+        {
+          "name": "TestSmartAnalysisRequestValidator",
+          "description": "Tests for SmartAnalysisRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_depth_width_ratio_gt_6",
+            "test_depth_width_ratio_at_6_passes"
+          ]
+        },
+        {
+          "name": "TestColumnAxialRequestValidator",
+          "description": "Tests for ColumnAxialRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_asc_gte_ag",
+            "test_rejects_asc_gt_ag"
+          ]
+        },
+        {
+          "name": "TestColumnUniaxialRequestValidator",
+          "description": "Tests for ColumnUniaxialRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_d_prime_gte_half_D",
+            "test_rejects_d_prime_equal_half_D"
+          ]
+        },
+        {
+          "name": "TestBiaxialCheckRequestValidator",
+          "description": "Tests for BiaxialCheckRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_d_prime_gte_half_D"
+          ]
+        },
+        {
+          "name": "TestPMInteractionRequestValidator",
+          "description": "Tests for PMInteractionRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_d_prime_gte_half_D"
+          ]
+        },
+        {
+          "name": "TestAdditionalMomentRequestValidator",
+          "description": "Tests for AdditionalMomentRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_d_prime_gte_half_D",
+            "test_rejects_fck_below_15",
+            "test_rejects_fy_below_250"
+          ]
+        },
+        {
+          "name": "TestLongColumnRequestValidator",
+          "description": "Tests for LongColumnRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_d_prime_gte_half_D",
+            "test_rejects_fck_below_15",
+            "test_rejects_fy_below_250"
+          ]
+        },
+        {
+          "name": "TestColumnDesignRequestValidator",
+          "description": "Tests for ColumnDesignRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_d_prime_gte_half_D",
+            "test_rejects_fck_below_15",
+            "test_rejects_fy_below_250"
+          ]
+        },
+        {
+          "name": "TestHelicalCheckRequestValidator",
+          "description": "Tests for HelicalCheckRequest cross-field validators.",
+          "public_methods": [
+            "test_valid_inputs",
+            "test_rejects_d_core_gte_d",
+            "test_rejects_d_core_gt_d",
+            "test_rejects_fck_below_15",
+            "test_rejects_fy_below_250"
+          ]
+        }
+      ],
+      "content_hash": "3967e7381b9b"
+    },
+    {
+      "name": "test_public_documentation_contract.py",
+      "type": "python",
+      "size_lines": 70,
+      "last_updated": "2026-08-10",
+      "description": "Executable contracts for the public REST documentation.",
+      "functions": [
+        {
+          "name": "test_documented_beam_request_and_response_path",
+          "description": "The documented raw-HTTP beam quick start is copyable.",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_documented_health_version_matches_application",
+          "description": "The version shown in the public health reference is current.",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_public_guides_retain_the_maintained_contract_language",
+          "description": "Known stale field and response paths must not return to public guides."
+        }
+      ],
+      "constants": [
+        "REPO_ROOT"
+      ],
+      "content_hash": "c75296b85c55"
+    },
+    {
       "name": "test_security.py",
       "type": "python",
       "size_lines": 407,
-      "last_updated": "2026-04-04",
+      "last_updated": "2026-08-09",
       "description": "Security Tests for FastAPI Application.",
       "classes": [
         {
@@ -1016,8 +1476,8 @@
     {
       "name": "test_streaming.py",
       "type": "python",
-      "size_lines": 174,
-      "last_updated": "2026-04-04",
+      "size_lines": 276,
+      "last_updated": "2026-08-10",
       "description": "Tests for SSE Streaming Endpoint.",
       "classes": [
         {
@@ -1025,7 +1485,9 @@
           "description": "Test SSE batch design endpoint.",
           "public_methods": [
             "test_batch_design_single_beam",
+            "test_batch_design_stream_preserves_unsafe_shear_failure",
             "test_batch_design_multiple_beams",
+            "test_batch_design_post_accepts_maintained_sample_size",
             "test_batch_design_invalid_json",
             "test_batch_design_empty_array",
             "test_batch_design_progress_tracking"
@@ -1036,17 +1498,52 @@
           "description": "Test job status endpoint.",
           "public_methods": [
             "test_get_job_status_not_found",
+            "test_get_job_status_is_in_progress_until_every_item_completes",
             "test_get_job_status_after_batch"
           ]
         }
       ],
-      "content_hash": "04751b3c7bfc"
+      "content_hash": "36d80aeaa232"
+    },
+    {
+      "name": "test_typed_response_contracts.py",
+      "type": "python",
+      "size_lines": 72,
+      "last_updated": "2026-08-10",
+      "description": "OpenAPI and envelope contracts for the typed column and library-core routes.",
+      "functions": [
+        {
+          "name": "test_target_routes_expose_typed_success_contracts",
+          "description": "Every maintained JSON target route exposes its concrete payload schema.",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_typed_success_responses_preserve_existing_envelope_shape",
+          "description": "Response filtering must not add optional envelope fields to JSON 2xx output.",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_typed_import_format_metadata_does_not_add_null_fields",
+          "description": "Optional schema fields stay absent when the existing payload omits them.",
+          "params": [
+            "client"
+          ]
+        }
+      ],
+      "constants": [
+        "_SUCCESS_RESPONSE_SCHEMAS"
+      ],
+      "content_hash": "5d973d54a33b"
     },
     {
       "name": "test_websocket.py",
       "type": "python",
-      "size_lines": 166,
-      "last_updated": "2026-03-26",
+      "size_lines": 211,
+      "last_updated": "2026-08-10",
       "description": "Tests for WebSocket Live Design Endpoint.",
       "classes": [
         {
@@ -1055,6 +1552,7 @@
           "public_methods": [
             "test_websocket_connect_disconnect",
             "test_websocket_design_beam",
+            "test_websocket_and_rest_share_calculation_identity",
             "test_websocket_design_beam_latency",
             "test_websocket_unknown_message_type",
             "test_websocket_check_beam",
@@ -1063,10 +1561,54 @@
           ]
         }
       ],
-      "content_hash": "d735719cd182"
+      "content_hash": "6065b0583354"
+    },
+    {
+      "name": "test_workflows.py",
+      "type": "python",
+      "size_lines": 176,
+      "last_updated": "2026-08-10",
+      "description": "Transport gates for the explicitly activated bounded workflow runner.",
+      "functions": [
+        {
+          "name": "test_template_is_read_only_but_execution_is_disabled_by_default",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_enabled_transport_validates_runs_and_replays",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_enabled_transport_stops_tampered_and_timed_out_runs",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_enabled_transport_can_cancel_an_active_run",
+          "params": [
+            "client",
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_run_id_reuse_with_different_input_is_conflict",
+          "params": [
+            "client"
+          ]
+        }
+      ],
+      "constants": [
+        "SAFE_INPUTS"
+      ],
+      "content_hash": "e6bce7e98e96"
     }
   ],
   "subfolders": [],
-  "content_hash": "3529a084acfc5e34",
-  "has_init": true
+  "has_init": true,
+  "content_hash": "43c895ea39e6ec58"
 }

--- a/fastapi_app/tests/index.md
+++ b/fastapi_app/tests/index.md
@@ -3,8 +3,8 @@
 Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming.
 
 **Type:** Python Package
-**Last Updated:** 2026-04-07
-**Files:** 23
+**Last Updated:** 2026-08-10
+**Files:** 34
 
 ## Documentation Files
 
@@ -19,22 +19,33 @@ Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin
 | [__init__.py](__init__.py) | FastAPI Tests Package. | 0 | 0 | 6 |
 | [conftest.py](conftest.py) | Test Fixtures for FastAPI Tests. | 0 | 8 | 159 |
 | [test_auth.py](test_auth.py) | Tests for Authentication and Rate Limiting. | 3 | 2 | 243 |
+| [test_bundled_sample_evidence.py](test_bundled_sample_evidence.py) | Reproducible software evidence for the bundled 153-beam acce | 0 | 1 | 84 |
+| [test_capabilities.py](test_capabilities.py) | Cross-surface tests for canonical capability discovery. | 0 | 2 | 32 |
+| [test_catalog.py](test_catalog.py) | Cross-layer tests for the thin workflow catalogue transport. | 0 | 3 | 41 |
 | [test_column_additional_moment.py](test_column_additional_moment.py) | Tests for POST /api/v1/design/column/additional-moment endpo | 1 | 0 | 203 |
-| [test_column_biaxial.py](test_column_biaxial.py) | Tests for POST /api/v1/design/column/biaxial-check endpoint. | 4 | 0 | 182 |
+| [test_column_biaxial.py](test_column_biaxial.py) | Tests for POST /api/v1/design/column/biaxial-check endpoint. | 4 | 0 | 179 |
 | [test_column_detailing.py](test_column_detailing.py) | Tests for POST /api/v1/design/column/detailing endpoint. | 5 | 0 | 150 |
 | [test_column_effective_length.py](test_column_effective_length.py) | Tests for POST /api/v1/design/column/effective-length endpoi | 2 | 0 | 169 |
 | [test_column_pm_interaction.py](test_column_pm_interaction.py) | Tests for POST /api/v1/design/column/interaction-curve endpo | 2 | 0 | 106 |
 | [test_column_uniaxial.py](test_column_uniaxial.py) | Tests for POST /api/v1/design/column/uniaxial endpoint. | 3 | 0 | 142 |
+| [test_config.py](test_config.py) | Tests for safe, environment-configurable FastAPI settings. | 0 | 8 | 126 |
 | [test_design_compliance.py](test_design_compliance.py) | Tests for design router compliance endpoints. | 5 | 1 | 381 |
 | [test_detailing_anchorage.py](test_detailing_anchorage.py) | Tests for detailing router anchorage endpoint. | 1 | 1 | 98 |
-| [test_endpoints.py](test_endpoints.py) | Integration Tests for FastAPI Endpoints. | 11 | 0 | 853 |
+| [test_endpoints.py](test_endpoints.py) | Integration Tests for FastAPI Endpoints. | 11 | 0 | 1049 |
+| [test_error_sanitization.py](test_error_sanitization.py) | Tests for error sanitization utilities (TASK-796). | 2 | 0 | 118 |
 | [test_export_bbs_dxf.py](test_export_bbs_dxf.py) | Tests for export router endpoints. | 3 | 2 | 202 |
 | [test_geometry_full.py](test_geometry_full.py) | Tests for geometry router advanced endpoints. | 3 | 1 | 244 |
 | [test_imports_formats.py](test_imports_formats.py) | Tests for import router extended endpoints. | 2 | 1 | 82 |
-| [test_insights_dashboard.py](test_insights_dashboard.py) | Tests for insights router endpoints. | 4 | 1 | 339 |
-| [test_integration.py](test_integration.py) | Integration tests for FastAPI structural design endpoints. | 7 | 1 | 386 |
+| [test_insights_dashboard.py](test_insights_dashboard.py) | Tests for insights router endpoints. | 4 | 1 | 387 |
+| [test_integration.py](test_integration.py) | Integration tests for FastAPI structural design endpoints. | 7 | 1 | 390 |
+| [test_library_core.py](test_library_core.py) | Request-to-public-library evidence for the new footing and s | 0 | 8 | 163 |
 | [test_load.py](test_load.py) | Load Tests for FastAPI Application. | 6 | 2 | 286 |
+| [test_maintenance_route_coverage.py](test_maintenance_route_coverage.py) | Direct contract coverage for routes identified by the MAINT- | 0 | 8 | 150 |
 | [test_optimization_pareto.py](test_optimization_pareto.py) | Tests for Pareto multi-objective beam optimization endpoint. | 1 | 0 | 158 |
+| [test_plausibility_validators.py](test_plausibility_validators.py) | Tests for cross-field plausibility validators (TASK-729). | 14 | 0 | 761 |
+| [test_public_documentation_contract.py](test_public_documentation_contract.py) | Executable contracts for the public REST documentation. | 0 | 3 | 70 |
 | [test_security.py](test_security.py) | Security Tests for FastAPI Application. | 7 | 3 | 407 |
-| [test_streaming.py](test_streaming.py) | Tests for SSE Streaming Endpoint. | 2 | 0 | 174 |
-| [test_websocket.py](test_websocket.py) | Tests for WebSocket Live Design Endpoint. | 1 | 0 | 166 |
+| [test_streaming.py](test_streaming.py) | Tests for SSE Streaming Endpoint. | 2 | 0 | 276 |
+| [test_typed_response_contracts.py](test_typed_response_contracts.py) | OpenAPI and envelope contracts for the typed column and libr | 0 | 3 | 72 |
+| [test_websocket.py](test_websocket.py) | Tests for WebSocket Live Design Endpoint. | 1 | 0 | 211 |
+| [test_workflows.py](test_workflows.py) | Transport gates for the explicitly activated bounded workflo | 0 | 5 | 176 |

--- a/llms.txt
+++ b/llms.txt
@@ -27,7 +27,7 @@ V3 Stack
 - Python structural_lib core (Python/structural_lib/)
 - Docker deployment (docker-compose.yml)
 
-Key API Endpoints (FastAPI) — 63 endpoints across 15 routers
+Key API Endpoints (FastAPI) — 69 endpoints across 17 routers
 - GET /api/v1/library/capabilities - Canonical supported/held contract
 - POST /api/v1/design/beam - Beam design (Mu, Vu, Ast)
 - POST /api/v1/design/beam/check - Check existing design

--- a/react_app/src/components/index.json
+++ b/react_app/src/components/index.json
@@ -52,12 +52,12 @@
     {
       "name": "layout",
       "path": "layout/",
-      "file_count": 3
+      "file_count": 2
     },
     {
       "name": "pages",
       "path": "pages/",
-      "file_count": 8
+      "file_count": 4
     },
     {
       "name": "ui",
@@ -67,7 +67,7 @@
     {
       "name": "viewport",
       "path": "viewport/",
-      "file_count": 8
+      "file_count": 20
     },
     {
       "name": "workbench",
@@ -75,5 +75,5 @@
       "file_count": 8
     }
   ],
-  "content_hash": "3265f2879e94f70b"
+  "content_hash": "57e469d52a602a86"
 }

--- a/react_app/src/components/index.md
+++ b/react_app/src/components/index.md
@@ -22,8 +22,8 @@
 |--------|-------|-------------|
 | [design/](design/) | 11 |  |
 | [import/](import/) | 6 |  |
-| [layout/](layout/) | 3 |  |
-| [pages/](pages/) | 8 |  |
+| [layout/](layout/) | 2 |  |
+| [pages/](pages/) | 4 |  |
 | [ui/](ui/) | 10 |  |
-| [viewport/](viewport/) | 8 |  |
+| [viewport/](viewport/) | 20 |  |
 | [workbench/](workbench/) | 8 |  |

--- a/react_app/src/hooks/index.json
+++ b/react_app/src/hooks/index.json
@@ -2,7 +2,7 @@
   "folder": "react_app/src/hooks",
   "type": "react-source",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 16,
   "files": [
     {
@@ -33,19 +33,19 @@
     {
       "name": "useAutoDesign.ts",
       "type": "react-hook",
-      "size_lines": 69,
-      "last_updated": "2026-03-26",
+      "size_lines": 73,
+      "last_updated": "2026-08-10",
       "exports": [
         "useAutoDesign"
       ],
       "description": "useAutoDesign Hook",
-      "content_hash": "f9b4fa29b58c"
+      "content_hash": "6006b8641723"
     },
     {
       "name": "useBatchDesign.ts",
       "type": "react-hook",
-      "size_lines": 180,
-      "last_updated": "2026-04-05",
+      "size_lines": 557,
+      "last_updated": "2026-08-10",
       "exports": [
         "BatchProgress",
         "BatchResult",
@@ -53,14 +53,13 @@
         "BatchDesignState",
         "useBatchDesign"
       ],
-      "description": "useBatchDesign Hook",
-      "content_hash": "50a45ffdc661"
+      "content_hash": "3fc776a20e93"
     },
     {
       "name": "useBeamGeometry.ts",
       "type": "react-hook",
-      "size_lines": 162,
-      "last_updated": "2026-04-06",
+      "size_lines": 180,
+      "last_updated": "2026-08-10",
       "exports": [
         "Point3D",
         "RebarSegment",
@@ -68,16 +67,18 @@
         "StirrupLoop",
         "Beam3DGeometry",
         "BeamGeometryRequest",
+        "BEAM_GEOMETRY_SCHEMA_VERSION",
+        "BeamGeometryIdentity",
         "useBeamGeometry"
       ],
       "description": "useBeamGeometry Hook",
-      "content_hash": "c2d0c337e75b"
+      "content_hash": "cb922a18a712"
     },
     {
       "name": "useCSVImport.ts",
       "type": "react-hook",
-      "size_lines": 450,
-      "last_updated": "2026-04-06",
+      "size_lines": 456,
+      "last_updated": "2026-08-10",
       "exports": [
         "ImportedBeam",
         "BeamDesignPayload",
@@ -88,20 +89,21 @@
         "useSimpleBatchDesign"
       ],
       "description": "useCSVImport Hook",
-      "content_hash": "818b77c89936"
+      "content_hash": "39d8d4d4dfab"
     },
     {
       "name": "useDesignWebSocket.ts",
       "type": "react-hook",
-      "size_lines": 235,
-      "last_updated": "2026-04-04",
+      "size_lines": 249,
+      "last_updated": "2026-08-10",
       "exports": [
         "ConnectionStatus",
         "WebSocketState",
+        "normalizeWebSocketDesignResult",
         "useDesignWebSocket"
       ],
       "description": "useDesignWebSocket Hook",
-      "content_hash": "2d61149cab04"
+      "content_hash": "df7214e52ed8"
     },
     {
       "name": "useExport.ts",
@@ -143,8 +145,8 @@
     {
       "name": "useInsights.ts",
       "type": "react-hook",
-      "size_lines": 324,
-      "last_updated": "2026-04-06",
+      "size_lines": 346,
+      "last_updated": "2026-08-10",
       "exports": [
         "BeamResult",
         "StoryStats",
@@ -160,21 +162,22 @@
         "ProjectBOQConcreteEntry",
         "ProjectBOQStoryEntry",
         "ProjectBOQResponse",
-        "useProjectBOQ"
+        "ProjectBOQEvidence"
       ],
       "description": "useInsights Hook",
-      "content_hash": "cea3ad5b185f"
+      "content_hash": "3dc79f2036a4"
     },
     {
       "name": "useLiveDesign.ts",
       "type": "react-hook",
-      "size_lines": 264,
-      "last_updated": "2026-03-27",
+      "size_lines": 349,
+      "last_updated": "2026-08-10",
       "exports": [
+        "createQuickDesignIdentity",
         "useLiveDesign"
       ],
       "description": "useLiveDesign Hook",
-      "content_hash": "3d78d5f18487"
+      "content_hash": "6da01da9b033"
     },
     {
       "name": "useLoadAnalysis.ts",
@@ -248,5 +251,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "8a92a28c89451298"
+  "content_hash": "cf597cb1a564cf96"
 }

--- a/react_app/src/hooks/index.md
+++ b/react_app/src/hooks/index.md
@@ -1,22 +1,22 @@
 # Hooks
 
 **Type:** React Source
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 16
 
 ## React Hook Files
 
 | File | Exports | Lines |
 |------|---------|-------|
-| [useAutoDesign.ts](useAutoDesign.ts) | useAutoDesign | 69 |
-| [useBatchDesign.ts](useBatchDesign.ts) | BatchProgress, BatchResult, BatchStatus, BatchDesignState, useBatchDesign | 180 |
-| [useBeamGeometry.ts](useBeamGeometry.ts) | Point3D, RebarSegment, RebarPath, StirrupLoop, Beam3DGeometry (+2) | 162 |
-| [useCSVImport.ts](useCSVImport.ts) | ImportedBeam, BeamDesignPayload, DesignedBeam, useCSVFileImport, useCSVTextImport (+2) | 450 |
-| [useDesignWebSocket.ts](useDesignWebSocket.ts) | ConnectionStatus, WebSocketState, useDesignWebSocket | 235 |
+| [useAutoDesign.ts](useAutoDesign.ts) | useAutoDesign | 73 |
+| [useBatchDesign.ts](useBatchDesign.ts) | BatchProgress, BatchResult, BatchStatus, BatchDesignState, useBatchDesign | 557 |
+| [useBeamGeometry.ts](useBeamGeometry.ts) | Point3D, RebarSegment, RebarPath, StirrupLoop, Beam3DGeometry (+4) | 180 |
+| [useCSVImport.ts](useCSVImport.ts) | ImportedBeam, BeamDesignPayload, DesignedBeam, useCSVFileImport, useCSVTextImport (+2) | 456 |
+| [useDesignWebSocket.ts](useDesignWebSocket.ts) | ConnectionStatus, WebSocketState, normalizeWebSocketDesignResult, useDesignWebSocket | 249 |
 | [useExport.ts](useExport.ts) | ExportBeamParams, ExportReportParams, useExportBBS, useExportDXF, useExportReport (+3) | 190 |
 | [useGeometryAdvanced.ts](useGeometryAdvanced.ts) | Point3D, BuildingBeamInput, BuildingBeamResult, BuildingGeometryResponse, CrossSectionRequest (+4) | 172 |
-| [useInsights.ts](useInsights.ts) | BeamResult, StoryStats, DashboardData, CheckDetail, CodeChecksResult (+10) | 324 |
-| [useLiveDesign.ts](useLiveDesign.ts) | useLiveDesign | 264 |
+| [useInsights.ts](useInsights.ts) | BeamResult, StoryStats, DashboardData, CheckDetail, CodeChecksResult (+10) | 346 |
+| [useLiveDesign.ts](useLiveDesign.ts) | createQuickDesignIdentity, useLiveDesign | 349 |
 | [useLoadAnalysis.ts](useLoadAnalysis.ts) | useLoadAnalysis | 17 |
 | [useParetoDesign.ts](useParetoDesign.ts) | useParetoDesign | 18 |
 | [useRebarEditor.ts](useRebarEditor.ts) | BeamParams, RebarConfig, ValidationDetail, RebarValidateResponse, RebarApplyResponse (+2) | 159 |

--- a/react_app/src/index.json
+++ b/react_app/src/index.json
@@ -8,10 +8,10 @@
     {
       "name": "App.tsx",
       "type": "react-component",
-      "size_lines": 119,
+      "size_lines": 128,
       "last_updated": "2026-08-10",
       "description": "Structural Engineering App",
-      "content_hash": "5432b97c7c91"
+      "content_hash": "67f4330a7917"
     },
     {
       "name": "config.ts",
@@ -42,9 +42,9 @@
     {
       "name": "vite-env.d.ts",
       "type": "typescript",
-      "size_lines": 11,
-      "last_updated": "2026-03-26",
-      "content_hash": "8141849c8465"
+      "size_lines": 13,
+      "last_updated": "2026-08-10",
+      "content_hash": "d7a28b553c40"
     }
   ],
   "subfolders": [
@@ -56,7 +56,7 @@
     {
       "name": "app",
       "path": "app/",
-      "file_count": 4
+      "file_count": 6
     },
     {
       "name": "assets",
@@ -66,12 +66,17 @@
     {
       "name": "components",
       "path": "components/",
-      "file_count": 69
+      "file_count": 76
+    },
+    {
+      "name": "features",
+      "path": "features/",
+      "file_count": 17
     },
     {
       "name": "hooks",
       "path": "hooks/",
-      "file_count": 24
+      "file_count": 25
     },
     {
       "name": "lib",
@@ -101,8 +106,8 @@
     {
       "name": "workspace",
       "path": "workspace/",
-      "file_count": 17
+      "file_count": 20
     }
   ],
-  "content_hash": "e62c89c582894afc"
+  "content_hash": "d11345466e738ce7"
 }

--- a/react_app/src/index.md
+++ b/react_app/src/index.md
@@ -8,7 +8,7 @@
 
 | File | Exports | Lines |
 |------|---------|-------|
-| [App.tsx](App.tsx) |  | 119 |
+| [App.tsx](App.tsx) |  | 128 |
 | [main.tsx](main.tsx) |  | 11 |
 
 ## Stylesheet Files
@@ -20,20 +20,21 @@
 | File | Exports | Lines |
 |------|---------|-------|
 | [config.ts](config.ts) | API_BASE_URL, WS_BASE_URL | 17 |
-| [vite-env.d.ts](vite-env.d.ts) |  | 11 |
+| [vite-env.d.ts](vite-env.d.ts) |  | 13 |
 
 ## Subfolders
 
 | Folder | Files | Description |
 |--------|-------|-------------|
 | [api/](api/) | 2 |  |
-| [app/](app/) | 4 |  |
+| [app/](app/) | 6 |  |
 | [assets/](assets/) | 1 |  |
-| [components/](components/) | 69 |  |
-| [hooks/](hooks/) | 24 |  |
+| [components/](components/) | 76 |  |
+| [features/](features/) | 17 |  |
+| [hooks/](hooks/) | 25 |  |
 | [lib/](lib/) | 1 |  |
 | [store/](store/) | 6 |  |
 | [test/](test/) | 2 |  |
 | [types/](types/) | 4 |  |
 | [utils/](utils/) | 10 |  |
-| [workspace/](workspace/) | 17 |  |
+| [workspace/](workspace/) | 20 |  |

--- a/react_app/src/store/index.json
+++ b/react_app/src/store/index.json
@@ -2,34 +2,34 @@
   "folder": "react_app/src/store",
   "type": "react-source",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 2,
   "files": [
     {
       "name": "designStore.ts",
       "type": "typescript",
-      "size_lines": 88,
-      "last_updated": "2026-03-26",
+      "size_lines": 161,
+      "last_updated": "2026-08-10",
       "exports": [
         "DesignState",
         "useDesignStore"
       ],
       "description": "Design State Store using Zustand",
-      "content_hash": "89be3a44bd0c"
+      "content_hash": "c830fa8ffba2"
     },
     {
       "name": "importedBeamsStore.ts",
       "type": "typescript",
-      "size_lines": 54,
-      "last_updated": "2026-03-26",
+      "size_lines": 94,
+      "last_updated": "2026-08-10",
       "exports": [
         "ImportedBeamsState",
         "useImportedBeamsStore"
       ],
       "description": "Imported Beams Store",
-      "content_hash": "b1be98e68e79"
+      "content_hash": "c2acc14c5d84"
     }
   ],
   "subfolders": [],
-  "content_hash": "9b56a5606e23580f"
+  "content_hash": "f269bca1ca5e55ef"
 }

--- a/react_app/src/store/index.md
+++ b/react_app/src/store/index.md
@@ -1,12 +1,12 @@
 # Store
 
 **Type:** React Source
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 2
 
 ## Typescript Files
 
 | File | Exports | Lines |
 |------|---------|-------|
-| [designStore.ts](designStore.ts) | DesignState, useDesignStore | 88 |
-| [importedBeamsStore.ts](importedBeamsStore.ts) | ImportedBeamsState, useImportedBeamsStore | 54 |
+| [designStore.ts](designStore.ts) | DesignState, useDesignStore | 161 |
+| [importedBeamsStore.ts](importedBeamsStore.ts) | ImportedBeamsState, useImportedBeamsStore | 94 |

--- a/react_app/src/types/index.json
+++ b/react_app/src/types/index.json
@@ -2,14 +2,14 @@
   "folder": "react_app/src/types",
   "type": "react-source",
   "description": "",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-08-10",
   "file_count": 2,
   "files": [
     {
       "name": "csv.ts",
       "type": "typescript",
-      "size_lines": 86,
-      "last_updated": "2026-03-26",
+      "size_lines": 93,
+      "last_updated": "2026-08-10",
       "exports": [
         "Point3D",
         "BeamCSVRow",
@@ -17,7 +17,7 @@
         "parseBeamCSV"
       ],
       "description": "CSV Import Types",
-      "content_hash": "eea7c03999cd"
+      "content_hash": "fb1f936c56ee"
     },
     {
       "name": "index.ts",
@@ -29,5 +29,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "8f46988d4ba4a389"
+  "content_hash": "3104fa9ead9755f8"
 }

--- a/react_app/src/types/index.md
+++ b/react_app/src/types/index.md
@@ -1,12 +1,12 @@
 # Types
 
 **Type:** React Source
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-08-10
 **Files:** 2
 
 ## Typescript Files
 
 | File | Exports | Lines |
 |------|---------|-------|
-| [csv.ts](csv.ts) | Point3D, BeamCSVRow, ImportedBeamsState, parseBeamCSV | 86 |
+| [csv.ts](csv.ts) | Point3D, BeamCSVRow, ImportedBeamsState, parseBeamCSV | 93 |
 | [index.ts](index.ts) |  | 5 |

--- a/react_app/src/utils/index.json
+++ b/react_app/src/utils/index.json
@@ -2,19 +2,19 @@
   "folder": "react_app/src/utils",
   "type": "react-source",
   "description": "",
-  "last_updated": "2026-04-07",
-  "file_count": 3,
+  "last_updated": "2026-08-10",
+  "file_count": 5,
   "files": [
     {
       "name": "beamStatus.ts",
       "type": "typescript",
-      "size_lines": 23,
-      "last_updated": "2026-03-26",
+      "size_lines": 30,
+      "last_updated": "2026-08-09",
       "exports": [
         "BeamStatus",
         "deriveBeamStatus"
       ],
-      "content_hash": "36d89c5c378c"
+      "content_hash": "8b7f32dac125"
     },
     {
       "name": "materialOverrides.ts",
@@ -28,16 +28,41 @@
       "content_hash": "90bf1253c1c2"
     },
     {
+      "name": "quantities.ts",
+      "type": "typescript",
+      "size_lines": 8,
+      "last_updated": "2026-08-09",
+      "exports": [
+        "calculateSteelWeightKg"
+      ],
+      "content_hash": "d88235bbf216"
+    },
+    {
       "name": "sampleData.ts",
       "type": "typescript",
-      "size_lines": 21,
-      "last_updated": "2026-03-27",
+      "size_lines": 28,
+      "last_updated": "2026-08-10",
       "exports": [
         "mapSampleBeamsToRows"
       ],
-      "content_hash": "f7e40efa0281"
+      "content_hash": "c10f13a0b83f"
+    },
+    {
+      "name": "trustPresentation.ts",
+      "type": "typescript",
+      "size_lines": 51,
+      "last_updated": "2026-08-10",
+      "exports": [
+        "TrustStatus",
+        "TrustPresentation",
+        "getTrustPresentation",
+        "formatRatio",
+        "formatPercent",
+        "formatSignedRatio"
+      ],
+      "content_hash": "d0d352633ea1"
     }
   ],
   "subfolders": [],
-  "content_hash": "de6d0eeea9274da7"
+  "content_hash": "b638fec0c28d87d7"
 }

--- a/react_app/src/utils/index.md
+++ b/react_app/src/utils/index.md
@@ -1,13 +1,15 @@
 # Utils
 
 **Type:** React Source
-**Last Updated:** 2026-04-07
-**Files:** 3
+**Last Updated:** 2026-08-10
+**Files:** 5
 
 ## Typescript Files
 
 | File | Exports | Lines |
 |------|---------|-------|
-| [beamStatus.ts](beamStatus.ts) | BeamStatus, deriveBeamStatus | 23 |
+| [beamStatus.ts](beamStatus.ts) | BeamStatus, deriveBeamStatus | 30 |
 | [materialOverrides.ts](materialOverrides.ts) | MaterialOverrides, applyMaterialOverrides | 23 |
-| [sampleData.ts](sampleData.ts) | mapSampleBeamsToRows | 21 |
+| [quantities.ts](quantities.ts) | calculateSteelWeightKg | 8 |
+| [sampleData.ts](sampleData.ts) | mapSampleBeamsToRows | 28 |
+| [trustPresentation.ts](trustPresentation.ts) | TrustStatus, TrustPresentation, getTrustPresentation, formatRatio, formatPercent (+1) | 51 |

--- a/scripts/generate_enhanced_index.py
+++ b/scripts/generate_enhanced_index.py
@@ -453,7 +453,6 @@ def scan_folder_enhanced(folder_path: Path) -> dict[str, Any]:
     }
 
     # Analyze files
-    file_hashes = []
     for f in all_files:
         file_info = analyze_file(f)
         if file_info:
@@ -462,15 +461,9 @@ def scan_folder_enhanced(folder_path: Path) -> dict[str, Any]:
                 file_bytes = f.read_bytes()
                 file_hash = hashlib.sha256(file_bytes).hexdigest()[:12]
                 file_info["content_hash"] = file_hash
-                file_hashes.append(file_hash)
             except OSError:
                 pass
             index["files"].append(file_info)
-
-    # Add overall content hash watermark (hash of all file hashes)
-    if file_hashes:
-        combined = "|".join(sorted(file_hashes))
-        index["content_hash"] = hashlib.sha256(combined.encode()).hexdigest()[:16]
 
     # Analyze subfolders
     for d in subfolders:
@@ -538,6 +531,23 @@ def scan_folder_enhanced(folder_path: Path) -> dict[str, Any]:
                     pass
             except (OSError, UnicodeDecodeError):
                 pass
+
+    # Hash every deterministic projection written to the index. Exclude the
+    # generation date so an unchanged folder remains current across days.
+    hash_payload = {
+        key: value
+        for key, value in index.items()
+        if key not in {"content_hash", "last_updated"}
+    }
+    serialized_payload = json.dumps(
+        hash_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    index["content_hash"] = hashlib.sha256(
+        serialized_payload.encode("utf-8")
+    ).hexdigest()[:16]
 
     return index
 

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3266,7 +3266,7 @@
     {
       "name": "generate_enhanced_index.py",
       "type": "python",
-      "size_lines": 817,
+      "size_lines": 827,
       "last_updated": "2026-08-10",
       "description": "Generate enhanced index.json + index.md for ANY folder type.",
       "functions": [
@@ -3344,7 +3344,7 @@
         "SKIP_DIRS",
         "KEY_FOLDERS"
       ],
-      "content_hash": "823559fd035d"
+      "content_hash": "102cdd8402b4"
     },
     {
       "name": "generate_error_docs.py",
@@ -5343,5 +5343,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "ca40eaf638fad4e8"
+  "content_hash": "786eb026437f4245"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -79,7 +79,7 @@
 | [generate_beam_tool_manifest.py](generate_beam_tool_manifest.py) | Generate and byte-check the catalogue-derived beam tool mani | 0 | 4 | 64 |
 | [generate_client_sdks.py](generate_client_sdks.py) | Generate client SDKs from FastAPI OpenAPI specification. | 0 | 6 | 560 |
 | [generate_docs_index.py](generate_docs_index.py) | Generate machine-readable JSON index of documentation. | 0 | 7 | 246 |
-| [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 10 | 817 |
+| [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 10 | 827 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |


### PR DESCRIPTION
## What changed

- synchronize public router, endpoint, and API-function counts after UIX
- regenerate all canonical folder indexes
- make index drift watermarking include subfolder projections, with a focused regression
- record the bounded maintenance session and fresh next-work handoff

## Root cause

The prior index watermark was computed before subfolders were analyzed and covered only direct file hashes. Parent indexes could therefore contain stale child counts while the check reported them current. Recent catalogue and workflow additions also had not refreshed every generated count projection.

## Maintenance actions

Five clean temporary worktrees were removed while their branches were retained. Named external worktrees, environments, dependencies, logs, benchmarks, Hypothesis state, recovery backups, stashes, and remote branches were preserved. No project server was running.

## Verification

- focused session automation: 28 passed
- Ruff check and format
- generated indexes: 32/32 current on a second pass
- generated number scan: zero drift
- health: 100/100
- quick gate: 10/10
- full gate: 30/30
- session closeout: passed

No release, Pages deployment, branch deletion, or professional-use action is included.