### PR TITLE
feat(beam): integrate primary torsion route

### DIFF
--- a/Python/structural_lib/codes/is456/beam/torsion.py
+++ b/Python/structural_lib/codes/is456/beam/torsion.py
@@ -19,9 +19,8 @@ References:
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 
+from structural_lib.core.data_types import TorsionResult
 from structural_lib.core.error_messages import (
     dimension_too_small,
     material_property_out_of_range,
@@ -36,10 +35,6 @@ from structural_lib.core.errors import (
 from .. import tables
 from ..traceability import clause
 
-if TYPE_CHECKING:
-    pass
-
-
 __all__ = [
     "TorsionResult",
     "calculate_equivalent_shear",
@@ -49,55 +44,6 @@ __all__ = [
     "calculate_longitudinal_torsion_steel",
     "design_torsion",
 ]
-
-
-# =============================================================================
-# Data Types
-# =============================================================================
-
-
-@dataclass
-class TorsionResult:
-    """Result of torsion design per IS 456 Clause 41.
-
-    Attributes:
-        Tu_knm: Applied torsional moment (kN·m)
-        Vu_kn: Applied shear force (kN)
-        Mu_knm: Applied bending moment (kN·m)
-        Ve_kn: Equivalent shear force (kN)
-        Me_knm: Equivalent bending moment (kN·m)
-        tau_ve: Equivalent shear stress (N/mm²)
-        tau_c: Design shear strength of concrete (N/mm²)
-        tau_c_max: Maximum shear stress limit (N/mm²)
-        Asv_torsion: Area of stirrups for torsion per unit length (mm²/mm)
-        Asv_shear: Area of stirrups for shear per unit length (mm²/mm)
-        Asv_total: Total stirrup area per unit length (mm²/mm)
-        stirrup_spacing: Designed stirrup spacing (mm)
-        Al_torsion: Longitudinal steel for torsion (mm²)
-        is_safe: True if section is safe
-        requires_closed_stirrups: True (always for torsion)
-        errors: List of structured errors/warnings
-    """
-
-    Tu_knm: float
-    Vu_kn: float
-    Mu_knm: float
-    Ve_kn: float
-    Me_knm: float
-    tau_ve: float
-    tau_c: float
-    tau_c_max: float
-    Asv_torsion: float
-    Asv_shear: float
-    Asv_total: float
-    stirrup_spacing: float
-    Al_torsion: float
-    is_safe: bool
-    requires_closed_stirrups: bool = True
-    errors: list[DesignError] = field(default_factory=list)
-    clause_refs: dict[str, str] = field(
-        default_factory=dict
-    )  # IS 456 clause references
 
 
 # =============================================================================
@@ -465,6 +411,14 @@ def design_torsion(
           fy ≤ 500 N/mm².
     """
     errors: list[DesignError] = []
+    clause_refs = {
+        "Ve": "IS 456 Cl 41.3.1",
+        "Me": "IS 456 Cl 41.4.2",
+        "tau_ve": "IS 456 Cl 41.3.1",
+        "Asv_torsion": "IS 456 Cl 41.4.3",
+        "Al_torsion": "IS 456 Cl 41.4.2",
+        "sv_max": "IS 456 Cl 41.4.3, Cl 26.5.1.5",
+    }
 
     # Validate inputs
     if b <= 0:
@@ -544,6 +498,7 @@ def design_torsion(
             is_safe=False,
             requires_closed_stirrups=True,
             errors=errors,
+            clause_refs=clause_refs,
         )
 
     # Step 6: Calculate stirrup reinforcement
@@ -592,12 +547,5 @@ def design_torsion(
         is_safe=True,
         requires_closed_stirrups=True,
         errors=errors,
-        clause_refs={
-            "Ve": "IS 456 Cl 41.3.1",
-            "Me": "IS 456 Cl 41.4.2",
-            "tau_ve": "IS 456 Cl 41.3.1",
-            "Asv_torsion": "IS 456 Cl 41.4.3",
-            "Al_torsion": "IS 456 Cl 41.4.2",
-            "sv_max": "IS 456 Cl 41.4.3, Cl 26.5.1.5",
-        },
+        clause_refs=clause_refs,
     )

--- a/Python/structural_lib/codes/is456/compliance.py
+++ b/Python/structural_lib/codes/is456/compliance.py
@@ -34,10 +34,11 @@ from structural_lib.core.data_types import (
     FlexureResult,
     ShearResult,
     SupportCondition,
+    TorsionResult,
 )
 from structural_lib.core.errors import Severity
 
-from .beam import flexure, serviceability, shear
+from .beam import flexure, serviceability, shear, torsion
 
 _logger = logging.getLogger(__name__)
 
@@ -187,12 +188,17 @@ def check_compliance_case(
     # Optional serviceability checks
     deflection_params: DeflectionParams | None = None,
     crack_width_params: CrackWidthParams | None = None,
+    # Optional torsion integration (ordinary solid rectangular beams only)
+    tu_knm: float = 0.0,
+    cover_mm: float | None = None,
+    stirrup_dia_mm: float = 8.0,
 ) -> ComplianceCaseResult:
     """Run a single compliance case.
 
     Units:
     - Mu: kN·m (factored)
     - Vu: kN (factored)
+    - Tu: kN·m (factored)
     - b_mm, D_mm, d_mm, d_dash_mm: mm
     - fck_nmm2, fy_nmm2: N/mm²
     - asv_mm2: mm² (area of stirrup legs)
@@ -205,13 +211,26 @@ def check_compliance_case(
 
     failed_checks: list[str] = []
     assumptions: list[str] = []
+    torsion_result: TorsionResult | None = None
+
+    design_mu_knm = mu_knm
+    design_vu_kn = vu_kn
+    if tu_knm > 0:
+        design_mu_knm = torsion.calculate_equivalent_moment(
+            mu_knm, tu_knm, d_mm, b_mm, D_mm=D_mm
+        )
+        design_vu_kn = torsion.calculate_equivalent_shear(vu_kn, tu_knm, b_mm)
+        assumptions.append(
+            "Applied IS 456 torsion equivalent actions Me and Ve to primary "
+            "flexure and shear design."
+        )
 
     flex = flexure.design_doubly_reinforced(
         b=b_mm,
         d=d_mm,
         d_dash=d_dash_mm,
         d_total=D_mm,
-        mu_knm=mu_knm,
+        mu_knm=design_mu_knm,
         fck=fck_nmm2,
         fy=fy_nmm2,
     )
@@ -232,8 +251,27 @@ def check_compliance_case(
                 "pt_percent not provided; using 0.0 (tables clamp internally)."
             )
 
+    if tu_knm > 0:
+        if cover_mm is None:
+            raise ValueError("cover_mm is required when tu_knm > 0.")
+        torsion_result = torsion.design_torsion(
+            tu_knm=tu_knm,
+            vu_kn=vu_kn,
+            mu_knm=mu_knm,
+            b=b_mm,
+            D=D_mm,
+            d=d_mm,
+            fck=fck_nmm2,
+            fy=fy_nmm2,
+            cover=cover_mm,
+            stirrup_dia=stirrup_dia_mm,
+            pt=pt_percent,
+        )
+        design_mu_knm = torsion_result.Me_knm
+        design_vu_kn = torsion_result.Ve_kn
+
     sh = shear.design_shear(
-        vu_kn=vu_kn,
+        vu_kn=design_vu_kn,
         b=b_mm,
         d=d_mm,
         fck=fck_nmm2,
@@ -271,15 +309,29 @@ def check_compliance_case(
             error_msgs = ["shear"]
         failed_checks.extend(error_msgs)
 
+    if torsion_result is not None and not torsion_result.is_safe:
+        error_msgs = [
+            f"torsion ({e.message})"
+            for e in torsion_result.errors
+            if e.severity == Severity.ERROR
+        ]
+        if not error_msgs:
+            error_msgs = ["torsion"]
+        failed_checks.extend(error_msgs)
+
     if defl is not None and not defl.is_ok:
         failed_checks.append("deflection")
     if crack is not None and not crack.is_ok:
         failed_checks.append("crack_width")
 
     utilizations: dict[str, float] = {
-        "flexure": _compute_flexure_utilization(mu_knm, flex),
+        "flexure": _compute_flexure_utilization(design_mu_knm, flex),
         "shear": _compute_shear_utilization(sh),
     }
+    if torsion_result is not None:
+        utilizations["torsion"] = _utilization_safe(
+            torsion_result.tau_ve, torsion_result.tau_c_max
+        )
     if defl is not None:
         utilizations["deflection"] = _compute_deflection_utilization(defl)
     if crack is not None:
@@ -291,6 +343,21 @@ def check_compliance_case(
     remarks = "OK" if is_ok else ("FAIL: " + ", ".join(failed_checks))
     if assumptions:
         remarks = remarks + " | " + " | ".join(assumptions)
+
+    clause_refs = {
+        "flexure": "IS 456 Cl 38.1",
+        "shear": "IS 456 Cl 40",
+        "deflection": "IS 456 Cl 23.2",
+        "crack_width": "IS 456 Cl 35.3.2",
+    }
+    if torsion_result is not None:
+        clause_refs["torsion"] = "IS 456 Cl 41"
+        clause_refs.update(
+            {
+                f"torsion_{key}": value
+                for key, value in torsion_result.clause_refs.items()
+            }
+        )
 
     return ComplianceCaseResult(
         case_id=case_id,
@@ -305,12 +372,11 @@ def check_compliance_case(
         utilizations=utilizations,
         failed_checks=failed_checks,
         remarks=remarks,
-        clause_refs={
-            "flexure": "IS 456 Cl 38.1",
-            "shear": "IS 456 Cl 40",
-            "deflection": "IS 456 Cl 23.2",
-            "crack_width": "IS 456 Cl 35.3.2",
-        },
+        clause_refs=clause_refs,
+        Tu_knm=tu_knm,
+        Me_knm=design_mu_knm if torsion_result is not None else None,
+        Ve_kn=design_vu_kn if torsion_result is not None else None,
+        torsion=torsion_result,
     )
 
 

--- a/Python/structural_lib/core/data_types.py
+++ b/Python/structural_lib/core/data_types.py
@@ -100,8 +100,15 @@ class CrackWidthParams(TypedDict, total=False):
     All fields are optional (total=False).
     """
 
-    exposure: str  # Exposure class: "MILD", "MODERATE", "SEVERE", "VERY_SEVERE"
-    max_crack_width_mm: float  # Maximum allowable crack width
+    exposure_class: str
+    limit_mm: float
+    acr_mm: float
+    cmin_mm: float
+    h_mm: float
+    x_mm: float
+    epsilon_m: float
+    fs_service_nmm2: float
+    es_nmm2: float
 
 
 class OptimizerInputs(TypedDict, total=False):
@@ -508,6 +515,7 @@ class TorsionResult:
     is_safe: bool
     requires_closed_stirrups: bool = True
     errors: list[DesignError] = field(default_factory=list)
+    clause_refs: dict[str, str] = field(default_factory=dict)
 
     @property
     def tu_knm(self) -> float:
@@ -762,6 +770,10 @@ class ComplianceCaseResult:
     failed_checks: list[str] = field(default_factory=list)
     remarks: str = ""
     clause_refs: dict[str, str] = field(default_factory=dict)
+    Tu_knm: float = 0.0
+    Me_knm: float | None = None
+    Ve_kn: float | None = None
+    torsion: TorsionResult | None = None
 
     @property
     def mu_knm(self) -> float:

--- a/Python/structural_lib/services/beam_api.py
+++ b/Python/structural_lib/services/beam_api.py
@@ -1093,6 +1093,9 @@ def design_beam_is456(
     ast_mm2_for_shear: float | None = None,
     deflection_params: DeflectionParams | None = None,
     crack_width_params: CrackWidthParams | None = None,
+    tu_knm: float = 0.0,
+    cover_mm: float | None = None,
+    stirrup_dia_mm: float = 8.0,
 ) -> ComplianceCaseResult:
     """Design/check a single IS 456 beam case (strength + optional serviceability).
 
@@ -1114,6 +1117,10 @@ def design_beam_is456(
         ast_mm2_for_shear: Use this Ast for shear table lookup (optional).
         deflection_params: Per-case deflection params (optional).
         crack_width_params: Per-case crack width params (optional).
+        tu_knm: Factored torsional moment (kN·m). Zero preserves the
+            flexure/shear-only route.
+        cover_mm: Clear cover (mm), required when ``tu_knm > 0``.
+        stirrup_dia_mm: Closed-stirrup diameter (mm) used for torsion design.
 
     Returns:
         ComplianceCaseResult with flexure, shear, and optional serviceability checks.
@@ -1124,6 +1131,7 @@ def design_beam_is456(
     Units (IS456):
     - Mu: kN·m (factored)
     - Vu: kN (factored)
+    - Tu: kN·m (factored)
     - b_mm, D_mm, d_mm, d_dash_mm: mm
     - fck_nmm2, fy_nmm2: N/mm² (MPa)
 
@@ -1153,8 +1161,41 @@ def design_beam_is456(
         ("fy_nmm2", fy_nmm2),
         ("d_dash_mm", d_dash_mm),
         ("asv_mm2", asv_mm2),
+        ("tu_knm", tu_knm),
     ):
         _require_finite_real(name, value)
+
+    if tu_knm < 0:
+        raise ValueError("tu_knm must be >= 0.")
+
+    if tu_knm > 0:
+        if cover_mm is None:
+            raise ValueError(
+                "TORSION_SCOPE_HOLD: cover_mm is required when tu_knm > 0."
+            )
+        _require_finite_real("cover_mm", cover_mm)
+        _require_finite_real("stirrup_dia_mm", stirrup_dia_mm)
+        if not 15 <= fck_nmm2 <= 40:
+            raise ValueError(
+                "TORSION_SCOPE_HOLD: primary-route torsion is limited to "
+                "fck_nmm2 from 15 to 40 N/mm²."
+            )
+        if fy_nmm2 > 500:
+            raise ValueError(
+                "TORSION_SCOPE_HOLD: primary-route torsion is limited to "
+                "fy_nmm2 <= 500 N/mm²."
+            )
+        if cover_mm <= 0 or stirrup_dia_mm <= 0:
+            raise ValueError(
+                "TORSION_SCOPE_HOLD: cover_mm and stirrup_dia_mm must be positive."
+            )
+        b1_mm = b_mm - 2 * (cover_mm + stirrup_dia_mm / 2)
+        d1_mm = D_mm - 2 * (cover_mm + stirrup_dia_mm / 2)
+        if b1_mm <= 0 or d1_mm <= 0:
+            raise ValueError(
+                "TORSION_SCOPE_HOLD: cover and stirrup diameter leave no positive "
+                "closed-stirrup core."
+            )
 
     # Unit plausibility guards (catch common mistakes)
     _validate_plausibility(
@@ -1186,6 +1227,9 @@ def design_beam_is456(
         ast_mm2_for_shear=ast_mm2_for_shear,
         deflection_params=deflection_params,
         crack_width_params=crack_width_params,
+        tu_knm=tu_knm,
+        cover_mm=cover_mm,
+        stirrup_dia_mm=stirrup_dia_mm,
     )
 
 

--- a/Python/structural_lib/services/capabilities.py
+++ b/Python/structural_lib/services/capabilities.py
@@ -20,7 +20,7 @@ __all__ = [
     "get_supported_is456_semantic_contract",
 ]
 
-CAPABILITY_SCHEMA_VERSION = "1.0"
+CAPABILITY_SCHEMA_VERSION = "2.0"
 IS456_CODE_EDITION = "IS 456:2000"
 
 
@@ -98,8 +98,18 @@ _CAPABILITIES = (
     IS456Capability(
         element="beam",
         public_workflows=("design_beam_is456", "check_beam_is456", "detail_beam_is456"),
-        supported_case="Route-specific rectangular/flanged flexure, shear and detailing; torsion is a separate explicit workflow.",
-        held_cases=("The primary combined beam route does not include torsion.",),
+        supported_case=(
+            "Ordinary solid rectangular beam primary design for flexure and shear, "
+            "with optional IS 456 torsion within fck 15-40 N/mm2 and fy <= 500 "
+            "N/mm2, plus maintained Level-A deflection and crack-width checks when "
+            "their explicit inputs are supplied."
+        ),
+        held_cases=(
+            "Flanged, hollow/box, deep, prestressed, or axially loaded torsion cases are excluded.",
+            "Compatibility-versus-equilibrium torsion redistribution decisions are excluded.",
+            "Beam check, detailing, batch, import, and other automation surfaces that do not accept Tu and serviceability inputs remain outside the combined route.",
+            "Serviceability is held unless span, support condition, crack geometry, and service strain or stress are explicitly supplied.",
+        ),
         qualified_review_required=True,
     ),
     IS456Capability(
@@ -186,11 +196,40 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
             fields=(
                 _field("mu_knm", "factored bending moment", "kN m", True, "finite"),
                 _field("vu_kn", "factored shear force", "kN", True, "finite"),
+                _field(
+                    "tu_knm",
+                    "factored torsional moment",
+                    "kN m",
+                    False,
+                    "finite non-negative; zero opts out",
+                ),
                 _field("b_mm", "section width", "mm", True, _MM),
                 _field("D_mm", "overall section depth", "mm", True, _MM),
                 _field("d_mm", "effective section depth", "mm", True, _MM),
                 _field("fck_nmm2", "concrete strength", "N/mm2", True, _N_PER_MM2),
                 _field("fy_nmm2", "steel strength", "N/mm2", True, _N_PER_MM2),
+                _field("cover_mm", "clear cover for torsion core", "mm", False, _MM),
+                _field(
+                    "stirrup_dia_mm",
+                    "closed stirrup diameter",
+                    "mm",
+                    False,
+                    _MM,
+                ),
+                _field(
+                    "deflection_params",
+                    "explicit Level-A deflection inputs",
+                    "structured input",
+                    False,
+                    "span, effective depth, and supported condition",
+                ),
+                _field(
+                    "crack_width_params",
+                    "explicit Level-A crack-width inputs",
+                    "structured input",
+                    False,
+                    "complete maintained crack geometry and strain or service stress",
+                ),
                 _field(
                     "is_ok", "combined compliance outcome", "boolean", True, _BOOLEAN
                 ),
@@ -198,11 +237,18 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
             statuses=(
                 IS456StatusContract(
                     "is_ok",
-                    "The evaluated compliance checks for this beam case passed.",
-                    ("It is software evidence, not professional design approval.",),
+                    "All evaluated flexure, shear, torsion, and enabled serviceability checks passed.",
+                    (
+                        "It is software evidence, not professional design approval.",
+                        "Missing or invalid evidence identity is a HOLD, not a pass.",
+                    ),
                 ),
             ),
-            limitations=("Torsion is a separate explicit workflow.",),
+            limitations=(
+                "Optional torsion is limited to the ordinary solid rectangular route.",
+                "Serviceability requires explicit maintained inputs.",
+                "Qualified engineering review remains required.",
+            ),
         ),
         IS456WorkflowContract(
             workflow="check_beam_is456",

--- a/Python/structural_lib/services/evidence.py
+++ b/Python/structural_lib/services/evidence.py
@@ -21,7 +21,7 @@ from structural_lib.services.capabilities import (
 from structural_lib.services.common_api import get_library_version
 
 BEAM_EVIDENCE_ARTIFACT_SCHEMA = "structural_lib.beam-evidence"
-BEAM_EVIDENCE_SCHEMA_VERSION = "1.0"
+BEAM_EVIDENCE_SCHEMA_VERSION = "2.0"
 BEAM_CAPABILITY_ID = "design_beam_is456"
 CODE_AMENDMENT_IDENTITY = "not-declared-in-artifact"
 QUALIFIED_REVIEW_REQUIREMENT = (
@@ -36,6 +36,8 @@ _CONSUMED_INPUT_DEFAULTS: dict[str, Any] = {
     "asv_mm2": 100.0,
     "pt_percent": None,
     "ast_mm2_for_shear": None,
+    "tu_knm": 0.0,
+    "include_serviceability": False,
 }
 _REQUIRED_CONSUMED_INPUTS = (
     "mu_knm",
@@ -46,6 +48,29 @@ _REQUIRED_CONSUMED_INPUTS = (
     "fck_nmm2",
     "fy_nmm2",
 )
+
+_SUPPORT_ALIASES = {
+    "cant": "cantilever",
+    "cantilever": "cantilever",
+    "cont": "continuous",
+    "continuous": "continuous",
+    "simply": "simply_supported",
+    "simply_supported": "simply_supported",
+    "ss": "simply_supported",
+}
+
+
+def _normalize_nested(value: Any) -> Any:
+    """Normalize a JSON-compatible calculation input without dropping keys."""
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalize_nested(item) for key, item in sorted(value.items())
+        }
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    return str(value).strip().lower()
 
 
 def normalize_beam_design_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
@@ -70,6 +95,44 @@ def normalize_beam_design_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
     for name in ("pt_percent", "ast_mm2_for_shear"):
         value = inputs.get(name, _CONSUMED_INPUT_DEFAULTS[name])
         normalized[name] = None if value is None else float(value)
+    normalized["tu_knm"] = float(
+        inputs.get("tu_knm", _CONSUMED_INPUT_DEFAULTS["tu_knm"])
+    )
+    if normalized["tu_knm"] > 0:
+        for name in ("cover_mm", "stirrup_dia_mm"):
+            if name not in inputs:
+                raise ValueError(f"Missing consumed torsion input: {name}")
+            normalized[name] = float(inputs[name])
+    else:
+        normalized["cover_mm"] = None
+        normalized["stirrup_dia_mm"] = None
+
+    include_serviceability = inputs.get(
+        "include_serviceability",
+        _CONSUMED_INPUT_DEFAULTS["include_serviceability"],
+    )
+    if not isinstance(include_serviceability, bool):
+        raise ValueError("include_serviceability must be a boolean")
+    normalized["include_serviceability"] = include_serviceability
+    if include_serviceability:
+        deflection = inputs.get("deflection_params")
+        crack_width = inputs.get("crack_width_params")
+        if not isinstance(deflection, Mapping) or not isinstance(crack_width, Mapping):
+            raise ValueError(
+                "Enabled serviceability requires deflection_params and "
+                "crack_width_params mappings"
+            )
+        normalized_deflection = _normalize_nested(deflection)
+        support = normalized_deflection.get("support_condition")
+        if support is not None:
+            normalized_deflection["support_condition"] = _SUPPORT_ALIASES.get(
+                support, support
+            )
+        normalized["deflection_params"] = normalized_deflection
+        normalized["crack_width_params"] = _normalize_nested(crack_width)
+    else:
+        normalized["deflection_params"] = None
+        normalized["crack_width_params"] = None
     return normalized
 
 

--- a/Python/structural_lib/services/workflow_catalog.py
+++ b/Python/structural_lib/services/workflow_catalog.py
@@ -30,8 +30,8 @@ __all__ = [
 ]
 
 CATALOG_SCHEMA_VERSION = "1.0"
-CATALOG_VERSION = "1.0.0"
-_COMPATIBLE_VERSIONS = ("1.0", CATALOG_VERSION)
+CATALOG_VERSION = "1.1.0"
+_COMPATIBLE_VERSIONS = ("1.0", "1.0.0", CATALOG_VERSION)
 _APPROVED_ADAPTERS = frozenset({"fastapi.design_beam.v1"})
 _APPROVED_REQUEST_SCHEMAS = frozenset({"fastapi.BeamDesignRequest.v1"})
 _APPROVED_RESULT_SCHEMAS = frozenset({"fastapi.BeamDesignResponse.v1"})
@@ -194,10 +194,13 @@ _CATALOG = WorkflowCatalog(
     capabilities=(
         WorkflowCapability(
             capability_id="is456.beam.design",
-            capability_version="1.0.0",
+            capability_version="1.1.0",
             element="beam",
             title="IS 456 beam design",
-            summary="Design one rectangular reinforced-concrete beam for the declared flexure and shear inputs.",
+            summary=(
+                "Discover the ordinary solid rectangular primary beam route; "
+                "this catalogue adapter exposes declared flexure and shear inputs."
+            ),
             semantic_workflow_id="design_beam_is456",
             service_adapter_id="fastapi.design_beam.v1",
             request_schema_id="fastapi.BeamDesignRequest.v1",
@@ -231,7 +234,9 @@ _CATALOG = WorkflowCatalog(
                 ),
             ),
             limitations=(
-                "Torsion is a separate explicit workflow.",
+                "Optional torsion is supported by the ordinary solid rectangular primary service/manual workbench within its declared material limits; this catalogue automation surface remains held for Tu > 0.",
+                "Level-A serviceability is available in the manual workbench only when explicit maintained inputs are supplied; this catalogue automation surface remains held for serviceability.",
+                "Flanged, hollow/box, deep, prestressed, axially loaded, and torsion-redistribution cases are held.",
                 "The result is software evidence and requires qualified engineering review.",
             ),
             qualified_review_required=True,

--- a/Python/tests/integration/test_beam_primary_route_torsion.py
+++ b/Python/tests/integration/test_beam_primary_route_torsion.py
@@ -1,0 +1,131 @@
+"""Focused contract tests for primary-route beam torsion integration."""
+
+from dataclasses import asdict
+
+import pytest
+
+from structural_lib.services.api import design_beam_is456
+
+
+@pytest.fixture
+def ordinary_beam() -> dict[str, float | str]:
+    return {
+        "units": "IS456",
+        "mu_knm": 150.0,
+        "vu_kn": 75.0,
+        "b_mm": 300.0,
+        "D_mm": 500.0,
+        "d_mm": 457.0,
+        "fck_nmm2": 25.0,
+        "fy_nmm2": 500.0,
+        "d_dash_mm": 43.0,
+    }
+
+
+def test_zero_torsion_preserves_primary_service_result(
+    ordinary_beam: dict[str, float | str],
+) -> None:
+    implicit_zero = design_beam_is456(**ordinary_beam)
+    explicit_zero = design_beam_is456(**ordinary_beam, tu_knm=0.0)
+
+    assert asdict(explicit_zero) == asdict(implicit_zero)
+    assert explicit_zero.flexure.Ast_required == pytest.approx(863.7612750126042)
+    assert explicit_zero.shear.tau_v == pytest.approx(0.5470459518599562)
+    assert explicit_zero.torsion is None
+    assert explicit_zero.Me_knm is None
+    assert explicit_zero.Ve_kn is None
+
+
+def test_safe_torsion_drives_primary_equivalent_action_design(
+    ordinary_beam: dict[str, float | str],
+) -> None:
+    zero = design_beam_is456(**ordinary_beam)
+    result = design_beam_is456(
+        **ordinary_beam,
+        tu_knm=10.0,
+        cover_mm=25.0,
+        stirrup_dia_mm=8.0,
+    )
+
+    assert result.is_ok is True
+    assert result.torsion is not None
+    assert result.Me_knm == pytest.approx(165.68627450980392)
+    assert result.Ve_kn == pytest.approx(128.33333333333334)
+    assert result.flexure.Ast_required > zero.flexure.Ast_required
+    assert result.shear.tau_v == pytest.approx(result.Ve_kn * 1000 / (300.0 * 457.0))
+    assert result.torsion.Asv_total > 0
+    assert result.torsion.Al_torsion > 0
+    assert result.torsion.requires_closed_stirrups is True
+    assert result.torsion.clause_refs["Ve"] == "IS 456 Cl 41.3.1"
+    assert "torsion" in result.utilizations
+
+
+def test_unsafe_torsion_fails_combined_primary_result() -> None:
+    result = design_beam_is456(
+        units="IS456",
+        mu_knm=300.0,
+        vu_kn=200.0,
+        tu_knm=100.0,
+        b_mm=200.0,
+        D_mm=400.0,
+        d_mm=350.0,
+        fck_nmm2=20.0,
+        fy_nmm2=500.0,
+        d_dash_mm=50.0,
+        cover_mm=40.0,
+        stirrup_dia_mm=8.0,
+    )
+
+    assert result.is_ok is False
+    assert result.torsion is not None
+    assert result.torsion.is_safe is False
+    assert any(item.startswith("torsion (") for item in result.failed_checks)
+    assert any(error.code == "E_TORSION_001" for error in result.torsion.errors)
+    assert result.torsion.clause_refs["tau_ve"] == "IS 456 Cl 41.3.1"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"fck_nmm2": 50.0}, "fck_nmm2 from 15 to 40"),
+        ({"fy_nmm2": 550.0}, "fy_nmm2 <= 500"),
+        ({"cover_mm": None}, "cover_mm is required"),
+    ],
+)
+def test_primary_torsion_fails_closed_outside_documented_scope(
+    ordinary_beam: dict[str, float | str],
+    overrides: dict[str, float | None],
+    message: str,
+) -> None:
+    inputs = {**ordinary_beam, "tu_knm": 10.0, "cover_mm": 25.0, **overrides}
+
+    with pytest.raises(ValueError, match=message):
+        design_beam_is456(**inputs)
+
+
+def test_service_contract_returns_existing_serviceability_results(
+    ordinary_beam: dict[str, float | str],
+) -> None:
+    result = design_beam_is456(
+        **ordinary_beam,
+        deflection_params={
+            "span_mm": 5000.0,
+            "d_mm": 457.0,
+            "support_condition": "simply_supported",
+        },
+        crack_width_params={
+            "exposure_class": "moderate",
+            "acr_mm": 40.0,
+            "cmin_mm": 25.0,
+            "h_mm": 500.0,
+            "x_mm": 150.0,
+            "fs_service_nmm2": 180.0,
+        },
+    )
+
+    assert result.deflection is not None
+    assert result.deflection.is_ok is True
+    assert result.deflection.computed["ld_ratio"] == pytest.approx(5000 / 457)
+    assert result.crack_width is not None
+    assert result.crack_width.is_ok is True
+    assert result.crack_width.computed["wcr_mm"] == pytest.approx(0.09947368421052633)

--- a/Python/tests/test_evidence.py
+++ b/Python/tests/test_evidence.py
@@ -6,7 +6,10 @@ import json
 
 import pytest
 
-from structural_lib.services.evidence import build_beam_evidence_envelope
+from structural_lib.services.evidence import (
+    BEAM_EVIDENCE_SCHEMA_VERSION,
+    build_beam_evidence_envelope,
+)
 from structural_lib.services.report import ReportData, export_html, export_json
 
 
@@ -68,6 +71,64 @@ def test_beam_evidence_hash_changes_for_relevant_input() -> None:
 
     assert baseline["normalized_input_hash"] != changed["normalized_input_hash"]
     assert baseline["calculation_identity"] != changed["calculation_identity"]
+
+
+def test_beam_evidence_v2_binds_torsion_and_enabled_serviceability() -> None:
+    baseline = _beam_inputs()
+    torsion = {
+        **baseline,
+        "tu_knm": 12.0,
+        "cover_mm": 25.0,
+        "stirrup_dia_mm": 8.0,
+    }
+    service = {
+        **baseline,
+        "include_serviceability": True,
+        "deflection_params": {
+            "span_mm": 5000.0,
+            "d_mm": 457.0,
+            "support_condition": "SS",
+        },
+        "crack_width_params": {
+            "exposure_class": "moderate",
+            "acr_mm": 45.0,
+            "cmin_mm": 25.0,
+            "h_mm": 500.0,
+            "x_mm": 150.0,
+            "fs_service_nmm2": 180.0,
+            "es_nmm2": 200000.0,
+        },
+    }
+
+    base_evidence = _evidence(baseline)
+    torsion_evidence = _evidence(torsion)
+    service_evidence = _evidence(service)
+
+    assert base_evidence["artifact_schema_version"] == BEAM_EVIDENCE_SCHEMA_VERSION
+    assert BEAM_EVIDENCE_SCHEMA_VERSION == "2.0"
+    assert (
+        torsion_evidence["normalized_input_hash"]
+        != base_evidence["normalized_input_hash"]
+    )
+    assert (
+        service_evidence["normalized_input_hash"]
+        != base_evidence["normalized_input_hash"]
+    )
+
+
+def test_disabled_serviceability_drafts_do_not_change_identity() -> None:
+    baseline = _beam_inputs()
+    with_unused_drafts = {
+        **baseline,
+        "include_serviceability": False,
+        "deflection_params": {"span_mm": 9999.0},
+        "crack_width_params": {"acr_mm": 999.0},
+    }
+
+    assert (
+        _evidence(baseline)["normalized_input_hash"]
+        == _evidence(with_unused_drafts)["normalized_input_hash"]
+    )
 
 
 def test_held_beam_evidence_does_not_present_a_pass_or_fail() -> None:

--- a/Python/tests/test_workflow_catalog.py
+++ b/Python/tests/test_workflow_catalog.py
@@ -28,6 +28,8 @@ def test_catalog_is_deterministic_and_semantically_bound() -> None:
     assert capability.capability_id == "is456.beam.design"
     assert capability.semantic_workflow_id == "design_beam_is456"
     assert capability.qualified_review_required is True
+    assert "catalogue adapter exposes" in capability.summary.lower()
+    assert any("held for Tu > 0" in item for item in capability.limitations)
     assert serialize_workflow_catalog() == serialize_workflow_catalog("1.0")
 
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,253 @@
 
 ---
 
+## 2026-08-10 — Session: BEAM-CORE-ROUTE-001 Phase B
+
+**Agent:** Codex (`frontend` integration role)
+**Branch:** `codex/is456-beam-primary-route`
+**Base:** `origin/main` at `a0e115e17009cc14b3d883e3c291d47c32f7ca4e`
+**Focus:** Bind the accepted primary beam calculation to shared evidence,
+discovery, workbench status, revision identity, and fail-closed export boundaries
+
+### Summary
+
+- Versioned beam evidence to `2.0` and bound original `Mu`/`Vu`/`Tu`, section,
+  materials, derived effective/compression depths, torsion core inputs, and all
+  enabled maintained serviceability values. Supported primary results now always
+  return a non-null evidence envelope; zero-torsion/no-service calculation
+  semantics remain unchanged.
+- Made the combined primary response the only workbench PASS/FAIL authority.
+  Missing/malformed identity, evidence/result disagreement, or any backend hold
+  presents `HOLD` and blocks export instead of falling back to utilization.
+- Replaced the workbench's secondary torsion request/status with canonical `Tu`
+  input and integrated `Me`/`Ve`, combined `Asv/s` (`mm²/mm`), longitudinal
+  torsion steel, closed-stirrup, clause, and serviceability presentation.
+- Added explicit Level-A serviceability controls without deriving the check span
+  or crack inputs from unrelated UI values. Tu/serviceability participate in
+  revision identity; stale responses cannot restore export eligibility.
+- Kept live design on canonical HTTP and made the transport reason visible for
+  Tu/serviceability. Legacy WebSocket results without evidence are quarantined;
+  the separate `/beam/torsion` endpoint and hook remain unchanged.
+- Required report requests to carry the exact current calculation identity and
+  re-ran the complete canonical input contract before export. HTML/JSON reports
+  carry combined actions, torsion, and serviceability results. BBS/DXF and
+  combined/serviceability PDF are explicitly held because their existing formats
+  cannot represent every governing result.
+- Versioned capability discovery to `2.0` and the additive catalogue wording to
+  `1.1.0`. Catalogue automation remains explicitly Mu/Vu-only and held for
+  `Tu > 0` or serviceability; qualified engineering review remains required.
+- This is software implementation and test evidence, not qualified structural-
+  engineering review or approval for engineering/construction use.
+
+### Issues encountered
+
+- The shared evidence identity omitted `Tu` and serviceability, so distinct
+  combined cases could not safely receive identities.
+- Workbench trust presentation fell back to utilization when evidence was absent,
+  while a secondary torsion panel and Mu/Vu-only supplemental checks could show
+  a status inconsistent with the primary combined result.
+- Report export re-ran a Mu/Vu-only calculation and accepted client summary
+  values; BBS/DXF/PDF had no complete representation of combined/serviceability
+  governing results.
+- The linked worktree has no local `.venv` or `react_app/node_modules`. The npm
+  package also has no standalone `typecheck` script.
+- `scripts/safe_file_delete.py` resolves symlinks before type checking, so it
+  dereferenced and refused the authorized temporary `react_app/node_modules`
+  link as “Not a file.”
+- The first direct Vite build was invoked from the repository root and therefore
+  looked for `index.html` in the wrong directory.
+- The final export-panel test found the evidence-identity disable condition was
+  attached to BBS instead of Report.
+- The workbench offered an `extreme` exposure value that the maintained crack-
+  width service does not support; its permissive normalization converted the
+  user's selection to `MODERATE`, allowing calculation and evidence for a
+  different exposure than the explicit request.
+
+### Root causes and resolutions
+
+- Evidence normalization represented only the earlier Mu/Vu contract. Evidence
+  schema `2.0` now normalizes all calculation-relevant primary inputs, ignores
+  disabled serviceability drafts, canonicalizes support aliases, and changes the
+  hash for positive Tu or enabled serviceability. Focused identity and FastAPI
+  tests prove those distinctions.
+- UI trust combined identity, calculation outcome, and holds permissively. It now
+  fails closed unless supported evidence has non-empty hashes, finite exact
+  values, no holds, and a status matching the combined primary outcome. The
+  secondary torsion request was removed, and unsupported supplemental checks and
+  comparisons are held for combined cases.
+- Export requests lacked the canonical input/evidence contract. Reports now
+  require a 64-character calculation identity, reconstruct all Tu/serviceability
+  parameters, return `409 STALE_CALCULATION_IDENTITY` on mismatch, and serialize
+  authoritative combined results. Pydantic validators reject unrepresentable
+  BBS/DXF and combined PDF requests with `EXPORT_SCOPE_HOLD`.
+- Python verification used the primary checkout environment with explicit
+  `PYTHONPATH="$PWD/Python:$PWD"`. React verification used the orchestrator-
+  authorized exact temporary dependency symlink after validating both endpoints;
+  it was removed after tests/typecheck/lint/build and is absent from Git status.
+- The symlink delete helper cannot operate on symlinks because `Path.resolve()`
+  discards link identity. After the helper failed without mutation, the exact
+  link and destination were revalidated and native non-recursive `unlink` removed
+  only the worktree link; the target dependency directory remains present.
+- TypeScript was run directly without emit, and the production Vite build was
+  rerun from `react_app`, where it completed successfully.
+- The export-panel identity guard was bound to the wrong sibling button during
+  the initial UI patch. The focused test exposed the outcome; the guard now
+  disables only Report when identity is absent, while ordinary BBS/DXF retain
+  their existing safe-case behavior.
+- The React exposure options and client type, plus the FastAPI request field,
+  were broader than the maintained service domain. The workbench and TypeScript
+  contract now expose only `mild`, `moderate`, `severe`, and `very_severe`, while
+  the Pydantic literal rejects any other value before service execution. A
+  focused route test proves `extreme` returns `422 REQUEST_VALIDATION_ERROR`.
+
+### Verification
+
+- Focused Python/service/FastAPI/export suite: **116 passed**, including zero-Tu
+  compatibility, safe/unsafe/out-of-domain torsion, serviceability opt-in/out,
+  evidence v2, stale report identity, BBS/DXF holds, and unchanged standalone
+  torsion endpoint behavior.
+- Focused React suite: **33 passed in 7 files** for trust, revision/staleness,
+  WebSocket quarantine/fallback, manual workbench, export holds, and catalogue
+  presentation.
+- React app and config TypeScript checks passed without emit; ESLint passed; Vite
+  production build transformed 2,419 modules successfully.
+- Architecture boundary check: 142 files, 0 violations. Import validation: 534
+  files, 3,649 imports, 0 broken. API manifest check passed.
+- OpenAPI snapshot matches the reviewed regenerated baseline: 69 endpoints and
+  251 schemas. Catalogue-derived beam tool manifest byte-check passed.
+- Post-review exposure correction: **12 focused FastAPI tests passed** and **7
+  focused DesignView tests passed**; the React app typecheck, targeted ESLint,
+  and Vite production build passed. The reviewed OpenAPI enum contains exactly
+  the four maintained exposure values.
+- Orchestrator closeout reran **147 focused Python/FastAPI tests** and **82
+  focused React tests across 8 files** against this worktree; all passed.
+- `./run.sh check --quick`: **10/10 passed**. The final full `./run.sh check`
+  passed **30/30** with this worktree pinned on `PYTHONPATH`; `git diff --check`
+  passed.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: `.venv/bin/pytest` and local React dependencies are absent
+  in the linked worktree -> explicit beam-worktree `PYTHONPATH` plus the maintained
+  primary environments provided authoritative tests without installing packages.
+- ⚠️ TERMINAL ISSUE: `npm run typecheck` is not defined -> direct non-emitting
+  TypeScript project checks and the production build passed.
+- ⚠️ TERMINAL ISSUE: `safe_file_delete.py` dereferences symlinks and refused the
+  temporary dependency link -> exact link validation plus native `unlink` removed
+  only that link; `test ! -e react_app/node_modules` passed.
+- ⚠️ TERMINAL ISSUE: Vite launched from the repository root could not resolve
+  `index.html` -> rerunning from `react_app` built successfully.
+
+## 2026-08-10 — Session: BEAM-CORE-ROUTE-001 Phase A
+
+**Agent:** Codex (`backend` role)
+**Branch:** `codex/is456-beam-primary-route`
+**Base:** `origin/main` at `a0e115e17009cc14b3d883e3c291d47c32f7ca4e`
+**Focus:** Integrate optional torsion into the primary rectangular-beam
+calculation/service/FastAPI contract without changing the separate torsion route
+
+### Summary
+
+- Added optional factored `tu_knm`/`torsion` input with a zero default. The
+  zero-torsion service result remains dataclass-equal to the pre-existing call,
+  including flexure/shear arithmetic, safety, and the absence of a torsion result.
+- For positive torsion, the primary flexure and shear calculations now consume
+  the mature Clause 41 equivalent actions `Me` and `Ve`; the combined result
+  includes original/equivalent actions, stresses, transverse and longitudinal
+  reinforcement, closed-stirrup requirement, structured errors, and clauses.
+- Added fail-closed primary-route guards for the documented ordinary solid
+  rectangular torsion material/core domain. This does not change the standalone
+  `/beam/torsion` endpoint contract.
+- Forwarded primary-route serviceability inputs into the maintained deflection
+  and crack-width services. Opt-in now requires explicit valid span, support,
+  geometry, and service strain/stress inputs; opt-out still returns no checks.
+- Corrected primary `asv_required` to `Asv/s` using effective depth, retained the
+  existing field name, and made its `mm²/mm` unit explicit. With torsion, the
+  field reports the maintained combined transverse demand and torsion spacing.
+- Withheld evidence identities for torsion or serviceability calculations because
+  the frozen shared evidence normalizer does not bind those inputs. The FastAPI
+  result exposes explicit integration holds instead of issuing a misleading hash.
+- This is software implementation and test evidence only. It is not qualified
+  structural-engineering review or approval for engineering/construction use.
+
+### Issues encountered
+
+- Positive torsion was available only through a separate endpoint, so the primary
+  route continued to design flexure and shear from original actions and could
+  advertise a pass that ignored `Tu`.
+- `BeamDesignRequest.include_serviceability`, `span_mm`, and
+  `support_condition` were never forwarded, and the request had no way to supply
+  the maintained crack-width service's required inputs.
+- FastAPI labeled `asv_required` as `mm²/mm` but calculated
+  `Vus × 1000 / (0.87 fy)`, omitting effective depth and returning an area-like
+  value instead of `Asv/s`.
+- Core and beam torsion modules defined separate `TorsionResult` dataclasses; only
+  the beam-local copy carried clause references needed by the combined contract.
+- The shared evidence input normalizer and public API/OpenAPI snapshots do not yet
+  include torsion or serviceability inputs. Updating them is explicitly outside
+  this Phase A path ownership.
+- The linked worktree has no local `.venv`, so the initially instructed direct
+  `.venv/bin/python` and `.venv/bin/pytest` commands failed.
+- One combined verification command guessed a nonexistent packaging test node and
+  pytest stopped before running that set.
+
+### Root causes and resolutions
+
+- The primary compliance orchestrator accepted only `Mu`/`Vu`; the standalone
+  torsion workflow was never connected. Positive `Tu` now derives `Me`/`Ve` via
+  the existing Clause 41 functions before primary flexure/shear design and adds
+  torsion to combined failure/utilization. Focused safe/unsafe tests prove the
+  changed governing outcome.
+- The router ignored all serviceability request fields. It now builds the exact
+  maintained service parameter dictionaries, maps both results into the primary
+  response, and rejects missing/invalid opt-in inputs through explicit 422
+  validation. Focused true/false tests prove forwarding and opt-out behavior.
+- The shear transport formula stopped before dividing by `d`. It now calculates
+  `Asv/s = Vus × 1000 / (0.87 fy d)` and returns the explicit `mm²/mm` unit;
+  the baseline sample changed from the contradictory area-like value to
+  `0.0106473463 mm²/mm`.
+- The duplicate torsion result types had drifted. The beam module now uses the
+  core `TorsionResult`, whose append-only `clause_refs` field also preserves
+  clause evidence for unsafe results. Existing torsion and public-contract tests
+  remain green.
+- The frozen evidence schema would hash distinct torsion/serviceability cases as
+  the same consumed input. Phase A returns `evidence=null` plus explicit pending
+  integration holds for those cases. The integration owner must update the
+  shared evidence/capability/API artifacts before removing the holds.
+- `scripts/python_runtime.sh` is the maintained linked-worktree fallback and was
+  run with `PYTHONPATH="$PWD/Python:$PWD"`; it selected the primary checkout's
+  Python 3.11 environment while importing this worktree's source. All subsequent
+  focused tests and checks used that path successfully.
+- `rg` identified `Python/tests/test_packaging.py::TestAPIStability`; rerunning
+  that exact node passed 4/4 tests.
+
+### Verification
+
+- Baseline probe before edits: sample primary result passed with
+  `Ast=863.7612750 mm²`, `tau_v=0.5470459519 N/mm²`, and governing utilization
+  `0.7167560601`.
+- Focused Python/service/public-contract suite: 164 passed in 0.37 s.
+- Focused FastAPI primary-route plus existing endpoint suite: 66 passed.
+- `./run.sh check --category arch`: 3/3 circular-import, architecture-boundary,
+  and import-validation checks passed.
+- `./run.sh check --quick`: 10/10 passed. No full repository gate was run.
+- `./run.sh session end --agent backend`: handoff, session-log, links, and
+  governance checks passed; it reported the expected 9 uncommitted Phase A
+  paths and 10 stale folder projections, which were not regenerated by scope.
+- Scoped Ruff check and format check passed.
+- Expected frozen shared drift, intentionally not regenerated in Phase A:
+  OpenAPI added three schemas and changed `BeamDesignRequest`,
+  `BeamDesignResponse`, and `ShearResult`; the public API manifest reports only
+  the intended `design_beam_is456` signature change.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: This linked worktree has no `.venv`, so direct
+  `.venv/bin/python`/`pytest` failed -> the maintained
+  `scripts/python_runtime.sh` fallback with this worktree on `PYTHONPATH` passed.
+- ⚠️ TERMINAL ISSUE: A guessed `TestPublicAPI::test_core_result_types_importable`
+  node did not exist -> targeted `rg` found `TestAPIStability`, which passed.
+
 ## 2026-08-10 — Session: Fresh-Start Maintenance Closeout
 
 **Agent:** Codex

--- a/docs/reference/api-manifest.json
+++ b/docs/reference/api-manifest.json
@@ -427,7 +427,7 @@
     {
       "name": "design_beam_is456",
       "kind": "function",
-      "signature": "(*, units: 'str', case_id: 'str' = 'CASE-1', mu_knm: 'float', vu_kn: 'float', b_mm: 'float', D_mm: 'float', d_mm: 'float', fck_nmm2: 'float', fy_nmm2: 'float', d_dash_mm: 'float' = 50.0, asv_mm2: 'float' = 100.0, pt_percent: 'float | None' = None, ast_mm2_for_shear: 'float | None' = None, deflection_params: 'DeflectionParams | None' = None, crack_width_params: 'CrackWidthParams | None' = None) -> 'ComplianceCaseResult'"
+      "signature": "(*, units: 'str', case_id: 'str' = 'CASE-1', mu_knm: 'float', vu_kn: 'float', b_mm: 'float', D_mm: 'float', d_mm: 'float', fck_nmm2: 'float', fy_nmm2: 'float', d_dash_mm: 'float' = 50.0, asv_mm2: 'float' = 100.0, pt_percent: 'float | None' = None, ast_mm2_for_shear: 'float | None' = None, deflection_params: 'DeflectionParams | None' = None, crack_width_params: 'CrackWidthParams | None' = None, tu_knm: 'float' = 0.0, cover_mm: 'float | None' = None, stirrup_dia_mm: 'float' = 8.0) -> 'ComplianceCaseResult'"
     },
     {
       "name": "design_column_axial_is456",

--- a/docs/reference/beam-tool-manifest.json
+++ b/docs/reference/beam-tool-manifest.json
@@ -9,14 +9,14 @@
   "schema_version": "1.0",
   "source": {
     "catalog_schema_version": "1.0",
-    "catalog_sha256": "6a009b46f73ab36b3d15dbb25fff727950a23654b1dee1dd14bf0aa973208383",
-    "catalog_version": "1.0.0"
+    "catalog_sha256": "0aad993b7755b4c34c234652260767247a9396e16d53c5c2d18a3d956c5bdfae",
+    "catalog_version": "1.1.0"
   },
   "tools": [
     {
       "capability_id": "is456.beam.design",
-      "capability_version": "1.0.0",
-      "description": "Design one rectangular reinforced-concrete beam for the declared flexure and shear inputs.",
+      "capability_version": "1.1.0",
+      "description": "Discover the ordinary solid rectangular primary beam route; this catalogue adapter exposes declared flexure and shear inputs.",
       "execution": {
         "adapter_id": "fastapi.design_beam.v1",
         "allowlisted": true,
@@ -108,7 +108,9 @@
       },
       "input_schema_id": "fastapi.BeamDesignRequest.v1",
       "limitations": [
-        "Torsion is a separate explicit workflow.",
+        "Optional torsion is supported by the ordinary solid rectangular primary service/manual workbench within its declared material limits; this catalogue automation surface remains held for Tu > 0.",
+        "Level-A serviceability is available in the manual workbench only when explicit maintained inputs are supplied; this catalogue automation surface remains held for serviceability.",
+        "Flanged, hollow/box, deep, prestressed, axially loaded, and torsion-redistribution cases are held.",
         "The result is software evidence and requires qualified engineering review."
       ],
       "result_schema_id": "fastapi.BeamDesignResponse.v1",

--- a/fastapi_app/models/beam.py
+++ b/fastapi_app/models/beam.py
@@ -22,6 +22,31 @@ class RebarLayerConfig(BaseModel):
     bar_dia_mm: float = Field(ge=8, le=36, description="Bar diameter (mm)")
 
 
+class BeamCrackWidthParams(BaseModel):
+    """Explicit maintained inputs for the primary-route crack-width check."""
+
+    exposure_class: Literal["mild", "moderate", "severe", "very_severe"] = Field(
+        default="moderate"
+    )
+    limit_mm: float | None = Field(default=None, gt=0)
+    acr_mm: float = Field(gt=0)
+    cmin_mm: float = Field(gt=0)
+    h_mm: float = Field(gt=0)
+    x_mm: float = Field(gt=0)
+    epsilon_m: float | None = Field(default=None, gt=0)
+    fs_service_nmm2: float | None = Field(default=None, ge=0)
+    es_nmm2: float = Field(default=200000.0, gt=0)
+
+    @model_validator(mode="after")
+    def validate_crack_width_inputs(self) -> "BeamCrackWidthParams":
+        """Reject inputs that the maintained crack-width service cannot use."""
+        if self.h_mm <= self.x_mm:
+            raise ValueError("h_mm must be greater than x_mm.")
+        if self.epsilon_m is None and self.fs_service_nmm2 is None:
+            raise ValueError("epsilon_m or fs_service_nmm2 is required.")
+        return self
+
+
 class BeamDesignRequest(BaseModel):
     """Request model for beam design calculation."""
 
@@ -33,6 +58,7 @@ class BeamDesignRequest(BaseModel):
                     "depth": 500.0,
                     "moment": 150.0,
                     "shear": 75.0,
+                    "torsion": 0.0,
                     "fck": 25.0,
                     "fy": 415.0,
                     "clear_cover": 25.0,
@@ -68,6 +94,12 @@ class BeamDesignRequest(BaseModel):
         ge=0,
         description="Factored design shear force Vu (kN)",
         examples=[50.0, 150.0, 300.0],
+    )
+    torsion: float = Field(
+        default=0.0,
+        ge=0,
+        description="Factored design torsional moment Tu (kN·m)",
+        examples=[0.0, 10.0, 25.0],
     )
 
     # Material properties
@@ -126,6 +158,12 @@ class BeamDesignRequest(BaseModel):
         default="SIMPLY_SUPPORTED",
         description="Support condition for deflection check",
     )
+    crack_width_params: BeamCrackWidthParams | None = Field(
+        default=None,
+        description=(
+            "Maintained crack-width inputs; required when include_serviceability=True"
+        ),
+    )
 
     # Multi-layer rebar config
     rebar_layers: list[RebarLayerConfig] | None = Field(
@@ -150,6 +188,48 @@ class BeamDesignRequest(BaseModel):
                 f"clear_cover ({self.clear_cover}mm) must be less than "
                 f"depth ({self.depth}mm)"
             )
+        if self.torsion > 0:
+            if self.fck > 40:
+                raise ValueError(
+                    "TORSION_SCOPE_HOLD: primary-route torsion is limited to "
+                    "fck <= 40 N/mm²."
+                )
+            if self.fy > 500:
+                raise ValueError(
+                    "TORSION_SCOPE_HOLD: primary-route torsion is limited to "
+                    "fy <= 500 N/mm²."
+                )
+            core_width = self.width - 2 * (self.clear_cover + self.stirrup_dia_mm / 2)
+            core_depth = self.depth - 2 * (self.clear_cover + self.stirrup_dia_mm / 2)
+            if core_width <= 0 or core_depth <= 0:
+                raise ValueError(
+                    "TORSION_SCOPE_HOLD: cover and stirrup diameter leave no "
+                    "positive closed-stirrup core."
+                )
+        if self.include_serviceability:
+            if self.span_mm is None or self.span_mm <= 0:
+                raise ValueError(
+                    "span_mm must be greater than zero when "
+                    "include_serviceability=True."
+                )
+            support = self.support_condition.strip().lower()
+            if support not in {
+                "cantilever",
+                "cant",
+                "simply_supported",
+                "simply",
+                "ss",
+                "continuous",
+                "cont",
+            }:
+                raise ValueError(
+                    "support_condition must be cantilever, simply_supported, "
+                    "or continuous when include_serviceability=True."
+                )
+            if self.crack_width_params is None:
+                raise ValueError(
+                    "crack_width_params is required when include_serviceability=True."
+                )
         return self
 
 
@@ -335,6 +415,10 @@ class ShearResult(BaseModel):
     tau_c: float = Field(description="Concrete shear strength (N/mm²)")
     tau_c_max: float = Field(description="Maximum shear stress limit (N/mm²)")
     asv_required: float = Field(description="Required stirrup area (mm²/mm)")
+    asv_required_unit: Literal["mm²/mm"] = Field(
+        default="mm²/mm",
+        description="Unit of asv_required (stirrup area per unit spacing)",
+    )
     stirrup_spacing: float = Field(description="Calculated stirrup spacing (mm)")
     sv_max: float = Field(description="Maximum allowed spacing (mm)")
     shear_capacity: float = Field(description="Shear capacity Vu,cap (kN)")
@@ -356,6 +440,34 @@ class CrackWidthCheckResult(BaseModel):
     crack_width_mm: float | None = None
     crack_width_limit_mm: float | None = None
     remarks: str = ""
+
+
+class CombinedBeamActions(BaseModel):
+    """Original and IS 456 equivalent actions used by the primary route."""
+
+    mu_knm: float
+    vu_kn: float
+    tu_knm: float
+    me_knm: float
+    ve_kn: float
+
+
+class IntegratedTorsionResult(BaseModel):
+    """Torsion calculation details embedded in the primary beam result."""
+
+    source: Literal["IS 456:2000"] = "IS 456:2000"
+    is_safe: bool
+    tau_ve: float = Field(description="Equivalent shear stress (N/mm²)")
+    tau_c: float = Field(description="Concrete shear strength (N/mm²)")
+    tau_c_max: float = Field(description="Maximum shear stress (N/mm²)")
+    asv_torsion: float = Field(description="Torsion stirrup demand (mm²/mm)")
+    asv_shear: float = Field(description="Shear stirrup demand (mm²/mm)")
+    asv_total: float = Field(description="Combined stirrup demand (mm²/mm)")
+    stirrup_spacing: float = Field(description="Designed closed-stirrup spacing (mm)")
+    al_torsion: float = Field(description="Longitudinal torsion steel (mm²)")
+    requires_closed_stirrups: bool
+    errors: list[dict[str, Any]] = Field(default_factory=list)
+    clause_refs: dict[str, str] = Field(default_factory=dict)
 
 
 class BeamDesignResponse(BaseModel):
@@ -386,10 +498,16 @@ class BeamDesignResponse(BaseModel):
     deflection_check: DeflectionCheckResult | None = None
     crack_width_check: CrackWidthCheckResult | None = None
 
+    # Combined-action results (populated only when Tu > 0)
+    combined_actions: CombinedBeamActions | None = None
+    torsion: IntegratedTorsionResult | None = None
+    holds: list[str] = Field(default_factory=list)
+
     # Warnings
     warnings: list[str] = Field(default_factory=list, description="Design warnings")
-    evidence: EvidenceEnvelopeResponse = Field(
-        description="Traceable calculation identity and supported-case boundary"
+    evidence: EvidenceEnvelopeResponse | None = Field(
+        default=None,
+        description="Traceable calculation identity and supported-case boundary",
     )
 
 

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -4179,6 +4179,92 @@
         "title": "BeamCheckResponse",
         "type": "object"
       },
+      "BeamCrackWidthParams": {
+        "description": "Explicit maintained inputs for the primary-route crack-width check.",
+        "properties": {
+          "acr_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Acr Mm",
+            "type": "number"
+          },
+          "cmin_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Cmin Mm",
+            "type": "number"
+          },
+          "epsilon_m": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Epsilon M"
+          },
+          "es_nmm2": {
+            "default": 200000.0,
+            "exclusiveMinimum": 0.0,
+            "title": "Es Nmm2",
+            "type": "number"
+          },
+          "exposure_class": {
+            "default": "moderate",
+            "enum": [
+              "mild",
+              "moderate",
+              "severe",
+              "very_severe"
+            ],
+            "title": "Exposure Class",
+            "type": "string"
+          },
+          "fs_service_nmm2": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fs Service Nmm2"
+          },
+          "h_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "H Mm",
+            "type": "number"
+          },
+          "limit_mm": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit Mm"
+          },
+          "x_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "X Mm",
+            "type": "number"
+          }
+        },
+        "required": [
+          "acr_mm",
+          "cmin_mm",
+          "h_mm",
+          "x_mm"
+        ],
+        "title": "BeamCrackWidthParams",
+        "type": "object"
+      },
       "BeamDesignRequest": {
         "description": "Request model for beam design calculation.",
         "examples": [
@@ -4191,6 +4277,7 @@
             "moment": 150.0,
             "shear": 75.0,
             "stirrup_dia_mm": 8.0,
+            "torsion": 0.0,
             "width": 300.0
           }
         ],
@@ -4207,6 +4294,17 @@
             "minimum": 20.0,
             "title": "Clear Cover",
             "type": "number"
+          },
+          "crack_width_params": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BeamCrackWidthParams"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maintained crack-width inputs; required when include_serviceability=True"
           },
           "depth": {
             "description": "Overall beam depth D (mm)",
@@ -4339,6 +4437,18 @@
             "title": "Support Condition",
             "type": "string"
           },
+          "torsion": {
+            "default": 0.0,
+            "description": "Factored design torsional moment Tu (kN\u00b7m)",
+            "examples": [
+              0.0,
+              10.0,
+              25.0
+            ],
+            "minimum": 0.0,
+            "title": "Torsion",
+            "type": "number"
+          },
           "width": {
             "description": "Beam width b (mm)",
             "examples": [
@@ -4374,6 +4484,16 @@
             "title": "Ast Total",
             "type": "number"
           },
+          "combined_actions": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CombinedBeamActions"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "crack_width_check": {
             "anyOf": [
               {
@@ -4407,11 +4527,25 @@
             "title": "Effective Depth Used"
           },
           "evidence": {
-            "$ref": "#/components/schemas/EvidenceEnvelopeResponse",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EvidenceEnvelopeResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Traceable calculation identity and supported-case boundary"
           },
           "flexure": {
             "$ref": "#/components/schemas/FlexureResult"
+          },
+          "holds": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Holds",
+            "type": "array"
           },
           "message": {
             "description": "Summary message",
@@ -4432,6 +4566,16 @@
             "description": "Whether design is valid",
             "title": "Success",
             "type": "boolean"
+          },
+          "torsion": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IntegratedTorsionResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "utilization_ratio": {
             "description": "Governing IS 456 compliance utilization ratio",
@@ -4454,8 +4598,7 @@
           "message",
           "flexure",
           "ast_total",
-          "utilization_ratio",
-          "evidence"
+          "utilization_ratio"
         ],
         "title": "BeamDesignResponse",
         "type": "object"
@@ -7300,6 +7443,40 @@
         "title": "ColumnUniaxialResponse",
         "type": "object"
       },
+      "CombinedBeamActions": {
+        "description": "Original and IS 456 equivalent actions used by the primary route.",
+        "properties": {
+          "me_knm": {
+            "title": "Me Knm",
+            "type": "number"
+          },
+          "mu_knm": {
+            "title": "Mu Knm",
+            "type": "number"
+          },
+          "tu_knm": {
+            "title": "Tu Knm",
+            "type": "number"
+          },
+          "ve_kn": {
+            "title": "Ve Kn",
+            "type": "number"
+          },
+          "vu_kn": {
+            "title": "Vu Kn",
+            "type": "number"
+          }
+        },
+        "required": [
+          "mu_knm",
+          "vu_kn",
+          "tu_knm",
+          "me_knm",
+          "ve_kn"
+        ],
+        "title": "CombinedBeamActions",
+        "type": "object"
+      },
       "ComplianceCaseInput": {
         "description": "A single load case for compliance checking.",
         "properties": {
@@ -9365,6 +9542,11 @@
             "title": "Fy",
             "type": "number"
           },
+          "include_serviceability": {
+            "default": false,
+            "title": "Include Serviceability",
+            "type": "boolean"
+          },
           "moment": {
             "default": 0,
             "description": "Design moment kN\u00b7m",
@@ -9384,6 +9566,13 @@
             "description": "Span in mm",
             "minimum": 0.0,
             "title": "Span Length",
+            "type": "number"
+          },
+          "torsion": {
+            "default": 0,
+            "description": "Design torsion kN m",
+            "minimum": 0.0,
+            "title": "Torsion",
             "type": "number"
           },
           "width": {
@@ -9425,6 +9614,14 @@
             "title": "Beam Id",
             "type": "string"
           },
+          "calculation_identity": {
+            "description": "Exact calculation identity from the current primary response",
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Calculation Identity",
+            "type": "string"
+          },
           "clear_cover": {
             "default": 25,
             "description": "Clear cover used by the source calculation (mm)",
@@ -9432,6 +9629,16 @@
             "minimum": 20.0,
             "title": "Clear Cover",
             "type": "number"
+          },
+          "crack_width_params": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BeamCrackWidthParams"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "depth": {
             "exclusiveMinimum": 0.0,
@@ -9487,6 +9694,11 @@
             "title": "Governing Check",
             "type": "string"
           },
+          "include_serviceability": {
+            "default": false,
+            "title": "Include Serviceability",
+            "type": "boolean"
+          },
           "is_safe": {
             "default": true,
             "title": "Is Safe",
@@ -9512,12 +9724,35 @@
             "title": "Shear",
             "type": "number"
           },
+          "span_mm": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Mm"
+          },
           "stirrup_dia_mm": {
             "default": 8,
             "description": "Stirrup diameter used by the source calculation (mm)",
             "maximum": 16.0,
             "minimum": 6.0,
             "title": "Stirrup Dia Mm",
+            "type": "number"
+          },
+          "support_condition": {
+            "default": "simply_supported",
+            "title": "Support Condition",
+            "type": "string"
+          },
+          "torsion": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Torsion",
             "type": "number"
           },
           "utilization": {
@@ -9537,7 +9772,8 @@
           "width",
           "depth",
           "fck",
-          "fy"
+          "fy",
+          "calculation_identity"
         ],
         "title": "ExportReportRequest",
         "type": "object"
@@ -10814,6 +11050,94 @@
           "note"
         ],
         "title": "ImportFormatsResponse",
+        "type": "object"
+      },
+      "IntegratedTorsionResult": {
+        "description": "Torsion calculation details embedded in the primary beam result.",
+        "properties": {
+          "al_torsion": {
+            "description": "Longitudinal torsion steel (mm\u00b2)",
+            "title": "Al Torsion",
+            "type": "number"
+          },
+          "asv_shear": {
+            "description": "Shear stirrup demand (mm\u00b2/mm)",
+            "title": "Asv Shear",
+            "type": "number"
+          },
+          "asv_torsion": {
+            "description": "Torsion stirrup demand (mm\u00b2/mm)",
+            "title": "Asv Torsion",
+            "type": "number"
+          },
+          "asv_total": {
+            "description": "Combined stirrup demand (mm\u00b2/mm)",
+            "title": "Asv Total",
+            "type": "number"
+          },
+          "clause_refs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Clause Refs",
+            "type": "object"
+          },
+          "errors": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Errors",
+            "type": "array"
+          },
+          "is_safe": {
+            "title": "Is Safe",
+            "type": "boolean"
+          },
+          "requires_closed_stirrups": {
+            "title": "Requires Closed Stirrups",
+            "type": "boolean"
+          },
+          "source": {
+            "const": "IS 456:2000",
+            "default": "IS 456:2000",
+            "title": "Source",
+            "type": "string"
+          },
+          "stirrup_spacing": {
+            "description": "Designed closed-stirrup spacing (mm)",
+            "title": "Stirrup Spacing",
+            "type": "number"
+          },
+          "tau_c": {
+            "description": "Concrete shear strength (N/mm\u00b2)",
+            "title": "Tau C",
+            "type": "number"
+          },
+          "tau_c_max": {
+            "description": "Maximum shear stress (N/mm\u00b2)",
+            "title": "Tau C Max",
+            "type": "number"
+          },
+          "tau_ve": {
+            "description": "Equivalent shear stress (N/mm\u00b2)",
+            "title": "Tau Ve",
+            "type": "number"
+          }
+        },
+        "required": [
+          "is_safe",
+          "tau_ve",
+          "tau_c",
+          "tau_c_max",
+          "asv_torsion",
+          "asv_shear",
+          "asv_total",
+          "stirrup_spacing",
+          "al_torsion",
+          "requires_closed_stirrups"
+        ],
+        "title": "IntegratedTorsionResult",
         "type": "object"
       },
       "LoadAnalysisRequest": {
@@ -13096,6 +13420,13 @@
             "title": "Asv Required",
             "type": "number"
           },
+          "asv_required_unit": {
+            "const": "mm\u00b2/mm",
+            "default": "mm\u00b2/mm",
+            "description": "Unit of asv_required (stirrup area per unit spacing)",
+            "title": "Asv Required Unit",
+            "type": "string"
+          },
           "shear_capacity": {
             "description": "Shear capacity Vu,cap (kN)",
             "title": "Shear Capacity",
@@ -15011,7 +15342,7 @@
     },
     "/api/v1/design/beam": {
       "post": {
-        "description": "Calculate required reinforcement for a beam section under given loading.",
+        "description": "Calculate required reinforcement for a rectangular beam under flexure, shear, and optional torsion.",
         "operationId": "design_beam_api_v1_design_beam_post",
         "requestBody": {
           "content": {

--- a/fastapi_app/routers/design.py
+++ b/fastapi_app/routers/design.py
@@ -20,10 +20,14 @@ from fastapi_app.models.beam import (
     BeamDesignResponse,
     BeamCheckRequest,
     BeamCheckResponse,
+    CombinedBeamActions,
+    CrackWidthCheckResult,
+    DeflectionCheckResult,
     EvidenceEnvelopeResponse,
     EnhancedShearRequest,
     EnhancedShearResponse,
     FlexureResult,
+    IntegratedTorsionResult,
     ShearResult,
     TorsionDesignRequest,
     TorsionDesignResponse,
@@ -65,19 +69,23 @@ router = APIRouter(
     "/beam",
     response_model=APIResponse[BeamDesignResponse],
     summary="Design Beam Section",
-    description="Calculate required reinforcement for a beam section under given loading.",
+    description=(
+        "Calculate required reinforcement for a rectangular beam under flexure, "
+        "shear, and optional torsion."
+    ),
 )
 async def design_beam(request: BeamDesignRequest):
     """
-    Design a beam section for flexure and shear.
+    Design a rectangular beam section for flexure, shear, and optional torsion.
 
     Calculates:
     - Required tension reinforcement (Ast)
     - Required compression reinforcement (Asc) if doubly reinforced
     - Required shear reinforcement (stirrups)
+    - Equivalent actions and torsion reinforcement when Tu > 0
     - Neutral axis depth and capacity checks
 
-    Per IS 456:2000 clauses 38.1 (flexure) and 40 (shear).
+    Per IS 456:2000 clauses 38.1 (flexure), 40 (shear), and 41 (torsion).
     """
     try:
         from structural_lib.services.api import design_beam_is456
@@ -89,6 +97,19 @@ async def design_beam(request: BeamDesignRequest):
             stirrup = request.stirrup_dia_mm
             bar = request.main_bar_dia_mm
             effective_depth = request.depth - request.clear_cover - stirrup - bar / 2
+
+        deflection_params = None
+        crack_width_params = None
+        if request.include_serviceability:
+            deflection_params = {
+                "span_mm": request.span_mm,
+                "d_mm": effective_depth,
+                "support_condition": request.support_condition,
+            }
+            if request.crack_width_params is not None:
+                crack_width_params = request.crack_width_params.model_dump(
+                    exclude_none=True
+                )
 
         # Call the design function with actual API parameter names
         result = design_beam_is456(
@@ -103,6 +124,11 @@ async def design_beam(request: BeamDesignRequest):
             d_dash_mm=request.clear_cover
             + request.stirrup_dia_mm
             + request.main_bar_dia_mm / 2,
+            deflection_params=deflection_params,
+            crack_width_params=crack_width_params,
+            tu_knm=request.torsion,
+            cover_mm=request.clear_cover,
+            stirrup_dia_mm=request.stirrup_dia_mm,
         )
 
         # Extract flexure results directly from ComplianceCaseResult
@@ -122,16 +148,23 @@ async def design_beam(request: BeamDesignRequest):
 
         # Build shear result if shear was provided
         shear_result = None
-        if request.shear > 0 and result.shear:
+        if (request.shear > 0 or request.torsion > 0) and result.shear:
             shear = result.shear
+            asv_required = (
+                shear.Vus * 1000 / (0.87 * request.fy * effective_depth)
+                if shear.Vus > 0
+                else 0.0
+            )
+            stirrup_spacing = shear.spacing
+            if result.torsion is not None:
+                asv_required = result.torsion.Asv_total
+                stirrup_spacing = result.torsion.stirrup_spacing
             shear_result = ShearResult(
                 tau_v=shear.tau_v,
                 tau_c=shear.tau_c,
                 tau_c_max=shear.tau_c_max,
-                asv_required=(
-                    shear.Vus / (0.87 * request.fy) * 1000 if shear.Vus > 0 else 0.0
-                ),
-                stirrup_spacing=shear.spacing,
+                asv_required=asv_required,
+                stirrup_spacing=stirrup_spacing,
                 sv_max=300.0,
                 shear_capacity=(
                     shear.tau_c * request.width * effective_depth / 1000 + shear.Vus
@@ -150,6 +183,7 @@ async def design_beam(request: BeamDesignRequest):
                 "case_id": "CASE-1",
                 "mu_knm": request.moment,
                 "vu_kn": request.shear if request.shear > 0 else 0.0,
+                "tu_knm": request.torsion,
                 "b_mm": request.width,
                 "D_mm": request.depth,
                 "d_mm": effective_depth,
@@ -159,11 +193,60 @@ async def design_beam(request: BeamDesignRequest):
                 + request.stirrup_dia_mm
                 + request.main_bar_dia_mm / 2,
                 "asv_mm2": 100.0,
+                "cover_mm": request.clear_cover,
+                "stirrup_dia_mm": request.stirrup_dia_mm,
+                "include_serviceability": request.include_serviceability,
+                "deflection_params": deflection_params,
+                "crack_width_params": crack_width_params,
             },
             is_ok=result.is_ok,
             governing_utilization=utilization,
             utilizations=result.utilizations,
         )
+        holds: list[str] = []
+
+        deflection_check = None
+        if result.deflection is not None:
+            deflection_check = DeflectionCheckResult(
+                is_ok=result.deflection.is_ok,
+                span_depth_actual=result.deflection.computed.get("ld_ratio"),
+                span_depth_allowable=result.deflection.computed.get("allowable_ld"),
+                remarks=result.deflection.remarks,
+            )
+
+        crack_width_check = None
+        if result.crack_width is not None:
+            crack_width_check = CrackWidthCheckResult(
+                is_ok=result.crack_width.is_ok,
+                crack_width_mm=result.crack_width.computed.get("wcr_mm"),
+                crack_width_limit_mm=result.crack_width.computed.get("limit_mm"),
+                remarks=result.crack_width.remarks,
+            )
+
+        combined_actions = None
+        torsion_result = None
+        if result.torsion is not None:
+            combined_actions = CombinedBeamActions(
+                mu_knm=result.Mu_knm,
+                vu_kn=result.Vu_kn,
+                tu_knm=result.Tu_knm,
+                me_knm=result.torsion.Me_knm,
+                ve_kn=result.torsion.Ve_kn,
+            )
+            torsion_result = IntegratedTorsionResult(
+                is_safe=result.torsion.is_safe,
+                tau_ve=result.torsion.tau_ve,
+                tau_c=result.torsion.tau_c,
+                tau_c_max=result.torsion.tau_c_max,
+                asv_torsion=result.torsion.Asv_torsion,
+                asv_shear=result.torsion.Asv_shear,
+                asv_total=result.torsion.Asv_total,
+                stirrup_spacing=result.torsion.stirrup_spacing,
+                al_torsion=result.torsion.Al_torsion,
+                requires_closed_stirrups=result.torsion.requires_closed_stirrups,
+                errors=[error.to_dict() for error in result.torsion.errors],
+                clause_refs=result.torsion.clause_refs,
+            )
 
         # Collect warnings
         warnings = []
@@ -174,6 +257,10 @@ async def design_beam(request: BeamDesignRequest):
             )
         if flexure_result.xu > flexure_result.xu_max:
             warnings.append("Section is over-reinforced - consider increasing depth")
+        if result.torsion is not None and result.torsion.requires_closed_stirrups:
+            warnings.append("Closed stirrups mandatory for torsion (IS 456 Cl 41.4.3)")
+        for error in result.torsion.errors if result.torsion is not None else []:
+            warnings.append(sanitize_error_string(error.message, "beam design"))
 
         return success_response(
             BeamDesignResponse(
@@ -189,8 +276,17 @@ async def design_beam(request: BeamDesignRequest):
                 asc_total=flexure.asc_required,
                 utilization_ratio=min(utilization, 2.0),
                 effective_depth_used=effective_depth,
+                deflection_check=deflection_check,
+                crack_width_check=crack_width_check,
+                combined_actions=combined_actions,
+                torsion=torsion_result,
+                holds=holds,
                 warnings=warnings,
-                evidence=EvidenceEnvelopeResponse.model_validate(evidence),
+                evidence=(
+                    EvidenceEnvelopeResponse.model_validate(evidence)
+                    if evidence is not None
+                    else None
+                ),
             )
         )
 

--- a/fastapi_app/routers/export.py
+++ b/fastapi_app/routers/export.py
@@ -7,12 +7,15 @@ using StreamingResponse for efficient delivery.
 
 import html as html_lib
 import io
+import json
 import re
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from fastapi_app.models.beam import BeamCrackWidthParams
 
 
 def sanitize_filename(name: str) -> str:
@@ -61,6 +64,18 @@ class ExportBeamRequest(BaseModel):
     )
     moment: float = Field(default=0, ge=0, description="Design moment kN·m")
     shear: float = Field(default=0, ge=0, description="Design shear kN")
+    torsion: float = Field(default=0, ge=0, description="Design torsion kN m")
+    include_serviceability: bool = False
+
+    @model_validator(mode="after")
+    def reject_unrepresentable_combined_result(self) -> "ExportBeamRequest":
+        """BBS/DXF cannot yet preserve the combined governing contract."""
+        if self.torsion > 0 or self.include_serviceability:
+            raise ValueError(
+                "EXPORT_SCOPE_HOLD: BBS/DXF do not represent torsion or "
+                "serviceability governing results; use the canonical report export."
+            )
+        return self
 
 
 class ExportReportRequest(BaseModel):
@@ -75,6 +90,7 @@ class ExportReportRequest(BaseModel):
     fy: float = Field(..., gt=0)
     moment: float = Field(default=0, ge=0)
     shear: float = Field(default=0, ge=0)
+    torsion: float = Field(default=0, ge=0)
     ast_required: float = Field(default=0, ge=0)
     ast_provided: float = Field(default=0, ge=0)
     utilization: float = Field(default=0, ge=0, le=2)
@@ -112,7 +128,36 @@ class ExportReportRequest(BaseModel):
         le=36,
         description="Main bar diameter used by the source calculation (mm)",
     )
+    include_serviceability: bool = False
+    span_mm: float | None = Field(default=None, gt=0)
+    support_condition: str = "simply_supported"
+    crack_width_params: BeamCrackWidthParams | None = None
+    calculation_identity: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-f]{64}$",
+        description="Exact calculation identity from the current primary response",
+    )
     format: str = Field(default="html", pattern="^(html|json|pdf)$")
+
+    @model_validator(mode="after")
+    def validate_combined_report_scope(self) -> "ExportReportRequest":
+        if self.torsion > 0 and (self.fck > 40 or self.fy > 500):
+            raise ValueError(
+                "TORSION_SCOPE_HOLD: report torsion is limited to fck <= 40 and fy <= 500."
+            )
+        if self.include_serviceability and (
+            self.span_mm is None or self.crack_width_params is None
+        ):
+            raise ValueError(
+                "SERVICEABILITY_SCOPE_HOLD: span_mm and crack_width_params are required."
+            )
+        if self.format == "pdf" and (self.torsion > 0 or self.include_serviceability):
+            raise ValueError(
+                "EXPORT_SCOPE_HOLD: PDF does not yet render the complete torsion or "
+                "serviceability result; use HTML or JSON."
+            )
+        return self
 
 
 # =============================================================================
@@ -282,9 +327,22 @@ async def export_report(request: ExportReportRequest):
             - request.stirrup_dia_mm
             - request.main_bar_dia_mm / 2
         )
-    # Re-run the supported calculation from the report inputs.  Evidence must
-    # identify a calculation performed by the server, not a client-supplied
-    # safety flag or rounded utilization value.
+    deflection_params = None
+    crack_width_params = None
+    if request.include_serviceability:
+        deflection_params = {
+            "span_mm": request.span_mm,
+            "d_mm": effective_depth,
+            "support_condition": request.support_condition,
+        }
+        if request.crack_width_params is not None:
+            crack_width_params = request.crack_width_params.model_dump(
+                exclude_none=True
+            )
+
+    # Re-run the exact supported calculation and require its identity to match
+    # the current primary response.  Client safety/utilization claims are never
+    # used as authority.
     design_result = design_beam_is456(
         units="IS456",
         case_id="CASE-1",
@@ -298,6 +356,11 @@ async def export_report(request: ExportReportRequest):
         d_dash_mm=request.clear_cover
         + request.stirrup_dia_mm
         + request.main_bar_dia_mm / 2,
+        tu_knm=request.torsion,
+        cover_mm=request.clear_cover,
+        stirrup_dia_mm=request.stirrup_dia_mm,
+        deflection_params=deflection_params,
+        crack_width_params=crack_width_params,
     )
     governing_utilization = design_result.governing_utilization
     evidence = build_beam_evidence_envelope(
@@ -306,6 +369,7 @@ async def export_report(request: ExportReportRequest):
             "case_id": "CASE-1",
             "mu_knm": request.moment,
             "vu_kn": request.shear,
+            "tu_knm": request.torsion,
             "b_mm": request.width,
             "D_mm": request.depth,
             "d_mm": effective_depth,
@@ -315,11 +379,24 @@ async def export_report(request: ExportReportRequest):
             + request.stirrup_dia_mm
             + request.main_bar_dia_mm / 2,
             "asv_mm2": 100.0,
+            "cover_mm": request.clear_cover,
+            "stirrup_dia_mm": request.stirrup_dia_mm,
+            "include_serviceability": request.include_serviceability,
+            "deflection_params": deflection_params,
+            "crack_width_params": crack_width_params,
         },
         is_ok=design_result.is_ok,
         governing_utilization=governing_utilization,
         utilizations=design_result.utilizations,
     )
+    if evidence["calculation_identity"] != request.calculation_identity:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "STALE_CALCULATION_IDENTITY: report inputs do not match the current "
+                "primary beam response. Recalculate before exporting."
+            ),
+        )
     beam_geom = {
         "b_mm": request.width,
         "D_mm": request.depth,
@@ -332,15 +409,76 @@ async def export_report(request: ExportReportRequest):
             "case_id": "1.5(DL+LL)",
             "mu_knm": request.moment,
             "vu_kn": request.shear,
+            "tu_knm": request.torsion,
         }
     ]
-    results = {
-        "1.5(DL+LL)": {
-            "ast_required_mm2": request.ast_required,
-            "ast_provided_mm2": request.ast_provided,
-            "utilization": request.utilization,
-            "is_ok": design_result.is_ok,
+    torsion_result = None
+    combined_actions = None
+    if design_result.torsion is not None:
+        torsion = design_result.torsion
+        combined_actions = {
+            "mu_knm": design_result.Mu_knm,
+            "vu_kn": design_result.Vu_kn,
+            "tu_knm": design_result.Tu_knm,
+            "me_knm": torsion.Me_knm,
+            "ve_kn": torsion.Ve_kn,
         }
+        torsion_result = {
+            "source": "IS 456:2000",
+            "is_safe": torsion.is_safe,
+            "tau_ve_nmm2": torsion.tau_ve,
+            "tau_c_nmm2": torsion.tau_c,
+            "tau_c_max_nmm2": torsion.tau_c_max,
+            "asv_torsion_mm2_per_mm": torsion.Asv_torsion,
+            "asv_shear_mm2_per_mm": torsion.Asv_shear,
+            "asv_total_mm2_per_mm": torsion.Asv_total,
+            "stirrup_spacing_mm": torsion.stirrup_spacing,
+            "al_torsion_mm2": torsion.Al_torsion,
+            "requires_closed_stirrups": torsion.requires_closed_stirrups,
+            "errors": [error.to_dict() for error in torsion.errors],
+            "clause_refs": torsion.clause_refs,
+        }
+
+    deflection_result = None
+    if design_result.deflection is not None:
+        deflection_result = {
+            "is_ok": design_result.deflection.is_ok,
+            "computed": design_result.deflection.computed,
+            "remarks": design_result.deflection.remarks,
+        }
+    crack_result = None
+    if design_result.crack_width is not None:
+        crack_result = {
+            "is_ok": design_result.crack_width.is_ok,
+            "computed": design_result.crack_width.computed,
+            "remarks": design_result.crack_width.remarks,
+        }
+
+    results = {
+        "cases": [
+            {
+                "case_id": "1.5(DL+LL)",
+                "mu_knm": request.moment,
+                "vu_kn": request.shear,
+                "tu_knm": request.torsion,
+                "utilization": governing_utilization,
+                "is_ok": design_result.is_ok,
+            }
+        ],
+        "summary": {
+            "status": evidence["status"],
+            "ast_required_mm2": design_result.flexure.Ast_required,
+            "asc_required_mm2": design_result.flexure.Asc_required,
+            "combined_stirrup_demand_mm2_per_mm": (
+                torsion_result["asv_total_mm2_per_mm"]
+                if torsion_result is not None
+                else None
+            ),
+            "combined_actions": combined_actions,
+            "torsion": torsion_result,
+            "deflection_check": deflection_result,
+            "crack_width_check": crack_result,
+        },
     }
     report_data = ReportData(
         job_id=request.beam_id,
@@ -371,6 +509,12 @@ async def export_report(request: ExportReportRequest):
         )
     elif request.format == "html":
         content = export_html(report_data)
+        appendix = (
+            '<section class="section"><h2>Canonical Combined Beam Result</h2><pre>'
+            + html_lib.escape(json.dumps(results["summary"], indent=2, sort_keys=True))
+            + "</pre></section>"
+        )
+        content = content.replace("</body>", f"{appendix}</body>")
         return StreamingResponse(
             io.BytesIO(content.encode("utf-8")),
             media_type="text/html",

--- a/fastapi_app/tests/test_beam_primary_route.py
+++ b/fastapi_app/tests/test_beam_primary_route.py
@@ -1,0 +1,310 @@
+"""Focused FastAPI contract tests for the primary IS 456 beam route."""
+
+import pytest
+from fastapi import status
+
+from fastapi_app.tests.conftest import unwrap
+
+
+@pytest.fixture
+def ordinary_payload() -> dict[str, float]:
+    return {
+        "width": 300.0,
+        "depth": 500.0,
+        "moment": 150.0,
+        "shear": 75.0,
+        "fck": 25.0,
+        "fy": 500.0,
+        "clear_cover": 25.0,
+    }
+
+
+def test_zero_torsion_preserves_primary_route_contract(
+    client, ordinary_payload
+) -> None:
+    implicit = unwrap(client.post("/api/v1/design/beam", json=ordinary_payload))
+    explicit = unwrap(
+        client.post("/api/v1/design/beam", json={**ordinary_payload, "torsion": 0.0})
+    )
+
+    for field in ("success", "flexure", "shear", "ast_total", "asc_total"):
+        assert explicit[field] == implicit[field]
+    assert explicit["combined_actions"] is None
+    assert explicit["torsion"] is None
+    assert explicit["holds"] == []
+    assert not any("Closed stirrups" in item for item in explicit["warnings"])
+
+
+def test_safe_torsion_is_integrated_into_primary_demands(
+    client, ordinary_payload
+) -> None:
+    zero = unwrap(client.post("/api/v1/design/beam", json=ordinary_payload))
+    response = client.post(
+        "/api/v1/design/beam", json={**ordinary_payload, "torsion": 10.0}
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = unwrap(response)
+    assert data["success"] is True
+    assert data["combined_actions"] == pytest.approx(
+        {
+            "mu_knm": 150.0,
+            "vu_kn": 75.0,
+            "tu_knm": 10.0,
+            "me_knm": 165.68627450980392,
+            "ve_kn": 128.33333333333334,
+        }
+    )
+    assert data["ast_total"] > zero["ast_total"]
+    assert data["shear"]["tau_v"] == pytest.approx(
+        data["combined_actions"]["ve_kn"] * 1000 / (300.0 * 457.0)
+    )
+    assert data["shear"]["asv_required"] == data["torsion"]["asv_total"]
+    assert data["torsion"]["requires_closed_stirrups"] is True
+    assert data["torsion"]["source"] == "IS 456:2000"
+    assert data["torsion"]["al_torsion"] > 0
+    assert data["torsion"]["clause_refs"]["Me"] == "IS 456 Cl 41.4.2"
+    assert data["evidence"]["support_status"] == "SUPPORTED"
+    assert data["evidence"]["artifact_schema_version"] == "2.0"
+    assert (
+        data["evidence"]["normalized_input_hash"]
+        != zero["evidence"]["normalized_input_hash"]
+    )
+    assert data["holds"] == []
+
+
+def test_unsafe_torsion_fails_primary_result(client) -> None:
+    response = client.post(
+        "/api/v1/design/beam",
+        json={
+            "width": 200.0,
+            "depth": 400.0,
+            "effective_depth": 350.0,
+            "moment": 300.0,
+            "shear": 200.0,
+            "torsion": 100.0,
+            "fck": 20.0,
+            "fy": 500.0,
+            "clear_cover": 40.0,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = unwrap(response)
+    assert data["success"] is False
+    assert data["torsion"]["is_safe"] is False
+    assert any(error["code"] == "E_TORSION_001" for error in data["torsion"]["errors"])
+
+
+def test_out_of_scope_primary_torsion_is_an_explicit_hold(
+    client, ordinary_payload
+) -> None:
+    response = client.post(
+        "/api/v1/design/beam",
+        json={**ordinary_payload, "torsion": 10.0, "fck": 50.0},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "TORSION_SCOPE_HOLD" in str(response.json()["error"]["details"])
+
+
+def test_serviceability_true_forwards_and_false_opts_out(
+    client, ordinary_payload
+) -> None:
+    serviceability = {
+        "span_mm": 5000.0,
+        "support_condition": "simply_supported",
+        "crack_width_params": {
+            "exposure_class": "moderate",
+            "acr_mm": 40.0,
+            "cmin_mm": 25.0,
+            "h_mm": 500.0,
+            "x_mm": 150.0,
+            "fs_service_nmm2": 180.0,
+        },
+    }
+    enabled = unwrap(
+        client.post(
+            "/api/v1/design/beam",
+            json={
+                **ordinary_payload,
+                **serviceability,
+                "include_serviceability": True,
+            },
+        )
+    )
+    disabled = unwrap(
+        client.post(
+            "/api/v1/design/beam",
+            json={
+                **ordinary_payload,
+                **serviceability,
+                "include_serviceability": False,
+            },
+        )
+    )
+
+    assert enabled["deflection_check"]["is_ok"] is True
+    assert enabled["crack_width_check"]["is_ok"] is True
+    assert enabled["evidence"]["support_status"] == "SUPPORTED"
+    assert (
+        enabled["evidence"]["normalized_input_hash"]
+        != disabled["evidence"]["normalized_input_hash"]
+    )
+    assert enabled["holds"] == []
+    assert disabled["deflection_check"] is None
+    assert disabled["crack_width_check"] is None
+    assert disabled["evidence"] is not None
+
+
+def test_unsupported_serviceability_exposure_is_rejected(
+    client, ordinary_payload
+) -> None:
+    response = client.post(
+        "/api/v1/design/beam",
+        json={
+            **ordinary_payload,
+            "include_serviceability": True,
+            "span_mm": 5000.0,
+            "support_condition": "simply_supported",
+            "crack_width_params": {
+                "exposure_class": "extreme",
+                "acr_mm": 40.0,
+                "cmin_mm": 25.0,
+                "h_mm": 500.0,
+                "x_mm": 150.0,
+                "fs_service_nmm2": 180.0,
+            },
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json()["error"]["code"] == "REQUEST_VALIDATION_ERROR"
+    assert "exposure_class" in str(response.json()["error"]["details"])
+
+
+def test_combined_report_binds_current_identity_and_exports_governing_results(
+    client, ordinary_payload
+) -> None:
+    design = unwrap(
+        client.post(
+            "/api/v1/design/beam",
+            json={**ordinary_payload, "torsion": 10.0},
+        )
+    )
+    payload = {
+        **ordinary_payload,
+        "beam_id": "B-TORSION",
+        "torsion": 10.0,
+        "calculation_identity": design["evidence"]["calculation_identity"],
+        "format": "json",
+    }
+
+    response = client.post("/api/v1/export/report", json=payload)
+    assert response.status_code == status.HTTP_200_OK
+    report = response.json()
+    assert report["evidence"]["calculation_identity"] == payload["calculation_identity"]
+    assert report["summary"]["combined_actions"]["tu_knm"] == 10.0
+    assert report["summary"]["torsion"]["requires_closed_stirrups"] is True
+    assert report["summary"]["torsion"]["asv_total_mm2_per_mm"] > 0
+
+
+def test_stale_report_and_combined_bbs_dxf_fail_closed(
+    client, ordinary_payload
+) -> None:
+    stale = client.post(
+        "/api/v1/export/report",
+        json={
+            **ordinary_payload,
+            "beam_id": "B-STALE",
+            "calculation_identity": "0" * 64,
+            "format": "json",
+        },
+    )
+    assert stale.status_code == status.HTTP_409_CONFLICT
+    assert "STALE_CALCULATION_IDENTITY" in stale.json()["detail"]
+
+    export_payload = {
+        **ordinary_payload,
+        "ast_required": 900.0,
+        "torsion": 10.0,
+    }
+    for endpoint in ("bbs", "dxf"):
+        blocked = client.post(f"/api/v1/export/{endpoint}", json=export_payload)
+        assert blocked.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "EXPORT_SCOPE_HOLD" in str(blocked.json())
+
+
+@pytest.mark.parametrize(
+    "serviceability",
+    [
+        {"include_serviceability": True},
+        {
+            "include_serviceability": True,
+            "span_mm": 5000.0,
+            "support_condition": "unsupported",
+        },
+    ],
+)
+def test_serviceability_missing_or_invalid_inputs_are_explicit(
+    client, ordinary_payload, serviceability
+) -> None:
+    response = client.post(
+        "/api/v1/design/beam", json={**ordinary_payload, **serviceability}
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json()["error"]["code"] == "REQUEST_VALIDATION_ERROR"
+
+
+def test_primary_shear_quantity_is_asv_per_spacing(client, ordinary_payload) -> None:
+    data = unwrap(client.post("/api/v1/design/beam", json=ordinary_payload))
+    shear = data["shear"]
+    expected = (
+        (shear["tau_v"] - shear["tau_c"])
+        * ordinary_payload["width"]
+        / (0.87 * ordinary_payload["fy"])
+    )
+
+    assert shear["asv_required"] == pytest.approx(expected)
+    assert shear["asv_required"] == pytest.approx(0.010647346259194997)
+    assert shear["asv_required_unit"] == "mm²/mm"
+
+
+def test_separate_torsion_endpoint_contract_is_unchanged(client) -> None:
+    response = client.post(
+        "/api/v1/design/beam/torsion",
+        json={
+            "width": 300.0,
+            "depth": 500.0,
+            "torsion": 10.0,
+            "moment": 150.0,
+            "shear": 100.0,
+            "fck": 25.0,
+            "fy": 500.0,
+            "clear_cover": 40.0,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = unwrap(response)
+    assert set(data) == {
+        "success",
+        "message",
+        "tu_knm",
+        "vu_kn",
+        "mu_knm",
+        "ve_kn",
+        "me_knm",
+        "tv_equiv",
+        "tc",
+        "tc_max",
+        "asv_torsion",
+        "asv_shear",
+        "asv_total",
+        "stirrup_spacing",
+        "al_torsion",
+        "is_safe",
+        "requires_closed_stirrups",
+        "warnings",
+    }

--- a/fastapi_app/tests/test_endpoints.py
+++ b/fastapi_app/tests/test_endpoints.py
@@ -116,6 +116,7 @@ class TestDesignEndpoints:
                 "ast_provided": design["ast_total"],
                 "utilization": evidence["exact_utilization"],
                 "governing_check": evidence["governing_check"],
+                "calculation_identity": evidence["calculation_identity"],
                 "is_safe": evidence["status"] == "PASS",
                 "format": "json",
             },
@@ -173,6 +174,7 @@ class TestDesignEndpoints:
                 "utilization": 2.0,
                 "exact_utilization": evidence["exact_utilization"],
                 "governing_check": evidence["governing_check"],
+                "calculation_identity": evidence["calculation_identity"],
                 "is_safe": False,
                 "format": "json",
             },
@@ -209,6 +211,7 @@ class TestDesignEndpoints:
                 "utilization": 2.0,
                 "exact_utilization": 9.0,
                 "governing_check": "client_claim",
+                "calculation_identity": design["evidence"]["calculation_identity"],
                 "is_safe": False,
                 "format": "json",
             },
@@ -805,8 +808,8 @@ class TestAnalysisEndpoints:
 class TestExportEndpoints:
     """Tests for export endpoints (BBS, DXF, Report)."""
 
-    def _report_payload(self, fmt="html"):
-        return {
+    def _report_payload(self, client, fmt="html"):
+        payload = {
             "beam_id": "TEST-1",
             "width": 300,
             "depth": 500,
@@ -820,11 +823,16 @@ class TestExportEndpoints:
             "is_safe": True,
             "format": fmt,
         }
+        design = unwrap(client.post("/api/v1/design/beam", json=payload))
+        return {
+            **payload,
+            "calculation_identity": design["evidence"]["calculation_identity"],
+        }
 
     def test_export_report_html(self, client):
         """Test HTML report export."""
         response = client.post(
-            "/api/v1/export/report", json=self._report_payload("html")
+            "/api/v1/export/report", json=self._report_payload(client, "html")
         )
         assert response.status_code == status.HTTP_200_OK
         assert "text/html" in response.headers["content-type"]
@@ -833,7 +841,7 @@ class TestExportEndpoints:
     def test_export_report_json(self, client):
         """Test JSON report export."""
         response = client.post(
-            "/api/v1/export/report", json=self._report_payload("json")
+            "/api/v1/export/report", json=self._report_payload(client, "json")
         )
         assert response.status_code == status.HTTP_200_OK
         assert "application/json" in response.headers["content-type"]
@@ -841,7 +849,7 @@ class TestExportEndpoints:
     def test_export_report_pdf(self, client):
         """Test PDF report export (requires weasyprint)."""
         response = client.post(
-            "/api/v1/export/report", json=self._report_payload("pdf")
+            "/api/v1/export/report", json=self._report_payload(client, "pdf")
         )
         # Accepts either 200 (weasyprint installed) or 503 (not installed)
         if response.status_code == status.HTTP_200_OK:
@@ -854,7 +862,7 @@ class TestExportEndpoints:
     def test_export_report_invalid_format(self, client):
         """Test invalid format is rejected."""
         response = client.post(
-            "/api/v1/export/report", json=self._report_payload("docx")
+            "/api/v1/export/report", json=self._report_payload(client, "docx")
         )
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 

--- a/react_app/src/api/__tests__/endpoints.test.ts
+++ b/react_app/src/api/__tests__/endpoints.test.ts
@@ -520,7 +520,14 @@ describe('Export Router', () => {
     const res = await fetch(`${API}/api/v1/export/dxf`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ beams: [{ beam_id: 'B1' }] }),
+      body: JSON.stringify({
+        beam_id: 'B1',
+        width: 300,
+        depth: 500,
+        fck: 25,
+        fy: 500,
+        ast_required: 850,
+      }),
     });
 
     expect(res.ok).toBe(true);
@@ -531,7 +538,14 @@ describe('Export Router', () => {
     const res = await fetch(`${API}/api/v1/export/report`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ beams: [{ beam_id: 'B1' }] }),
+      body: JSON.stringify({
+        beam_id: 'B1',
+        width: 300,
+        depth: 500,
+        fck: 25,
+        fy: 500,
+        calculation_identity: 'a'.repeat(64),
+      }),
     });
 
     expect(res.ok).toBe(true);

--- a/react_app/src/api/client.ts
+++ b/react_app/src/api/client.ts
@@ -10,11 +10,29 @@ export interface BeamDesignRequest {
   depth: number;
   moment: number;
   shear?: number;
+  torsion?: number;
   fck: number;
   fy: number;
   clear_cover?: number;
   stirrup_dia_mm?: number;
   main_bar_dia_mm?: number;
+  effective_depth?: number;
+  include_serviceability?: boolean;
+  span_mm?: number;
+  support_condition?: string;
+  crack_width_params?: Partial<BeamCrackWidthParams>;
+}
+
+export interface BeamCrackWidthParams {
+  exposure_class: 'mild' | 'moderate' | 'severe' | 'very_severe';
+  limit_mm?: number;
+  acr_mm: number;
+  cmin_mm: number;
+  h_mm: number;
+  x_mm: number;
+  epsilon_m?: number;
+  fs_service_nmm2?: number;
+  es_nmm2?: number;
 }
 
 export interface FlexureResult {
@@ -33,9 +51,48 @@ export interface ShearResult {
   tau_c: number;
   tau_c_max: number;
   asv_required: number;
+  asv_required_unit: 'mm²/mm';
   stirrup_spacing: number;
   sv_max: number;
   shear_capacity: number;
+}
+
+export interface DeflectionCheckResult {
+  is_ok: boolean;
+  span_depth_actual: number | null;
+  span_depth_allowable: number | null;
+  remarks: string;
+}
+
+export interface CrackWidthCheckResult {
+  is_ok: boolean;
+  crack_width_mm: number | null;
+  crack_width_limit_mm: number | null;
+  remarks: string;
+}
+
+export interface CombinedBeamActions {
+  mu_knm: number;
+  vu_kn: number;
+  tu_knm: number;
+  me_knm: number;
+  ve_kn: number;
+}
+
+export interface IntegratedTorsionResult {
+  source: 'IS 456:2000';
+  is_safe: boolean;
+  tau_ve: number;
+  tau_c: number;
+  tau_c_max: number;
+  asv_torsion: number;
+  asv_shear: number;
+  asv_total: number;
+  stirrup_spacing: number;
+  al_torsion: number;
+  requires_closed_stirrups: boolean;
+  errors: Array<Record<string, unknown>>;
+  clause_refs: Record<string, string>;
 }
 
 export interface BeamDesignResponse {
@@ -47,8 +104,13 @@ export interface BeamDesignResponse {
   asc_total: number;
   utilization_ratio: number;
   effective_depth_used?: number;
+  deflection_check?: DeflectionCheckResult | null;
+  crack_width_check?: CrackWidthCheckResult | null;
+  combined_actions?: CombinedBeamActions | null;
+  torsion?: IntegratedTorsionResult | null;
+  holds?: string[];
   warnings?: string[];
-  evidence?: EvidenceEnvelope;
+  evidence?: EvidenceEnvelope | null;
 }
 
 export interface EvidenceEnvelope {
@@ -188,7 +250,8 @@ export async function designBeam(
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ detail: response.statusText }));
-    throw new Error(`Design failed: ${error.detail || response.status}`);
+    const message = error?.error?.message ?? error?.detail ?? response.status;
+    throw new Error(`Design failed: ${message}`);
   }
 
   return response.json().then(unwrapResponse<BeamDesignResponse>);

--- a/react_app/src/components/__tests__/DesignView.test.tsx
+++ b/react_app/src/components/__tests__/DesignView.test.tsx
@@ -1,7 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { DesignView } from '../../components/design/DesignView';
+
+const mockDesignInputs = vi.hoisted(() => ({
+  width: 300,
+  depth: 450,
+  moment: 150,
+  shear: 80,
+  torsion: 0,
+  fck: 25,
+  fy: 500,
+  include_serviceability: false,
+}));
 
 // Mock react-router-dom
 vi.mock('react-router-dom', () => ({
@@ -26,6 +37,7 @@ vi.mock('../../hooks/useLiveDesign', () => ({
       error: null,
       geometry: null,
       isFallbackActive: true,
+      transportExplanation: 'Verified HTTP mode.',
     },
     actions: {
       triggerDesign: vi.fn(),
@@ -48,11 +60,6 @@ vi.mock('../../hooks/useExport', () => ({
   useExportBBS: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useExportDXF: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useExportReport: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
-}));
-
-// Mock torsion design hook
-vi.mock('../../hooks/useTorsionDesign', () => ({
-  useTorsionDesign: vi.fn(() => ({ mutate: vi.fn(), data: null, isPending: false })),
 }));
 
 // Mock load analysis hook
@@ -87,12 +94,16 @@ vi.mock('../../features/catalog/CatalogBeamInputPanel', () => ({
 // Mock design store
 vi.mock('../../store/designStore', () => ({
   useDesignStore: vi.fn(() => ({
-    inputs: { width: 300, depth: 450, moment: 150, shear: 80, fck: 25, fy: 500 },
+    inputs: mockDesignInputs,
     length: 4000,
   })),
 }));
 
 describe('DesignView', () => {
+  beforeEach(() => {
+    mockDesignInputs.include_serviceability = false;
+  });
+
   it('renders without crashing', () => {
     render(React.createElement(DesignView));
     expect(screen.getByRole('heading', { name: 'Quick beam design' })).toBeInTheDocument();
@@ -119,8 +130,25 @@ describe('DesignView', () => {
     expect(screen.getAllByRole('button', { name: 'Design beam' })).toHaveLength(1);
     expect(screen.getByLabelText('Width in mm')).toBeInTheDocument();
     expect(screen.getByLabelText('Moment (Mu) in kN·m')).toBeInTheDocument();
+    expect(screen.getByLabelText('Torsion (Tu) in kN·m')).toHaveValue(0);
+    fireEvent.click(screen.getByRole('button', { name: 'Serviceability' }));
+    expect(screen.getByLabelText(/Include maintained Level-A/)).not.toBeChecked();
     expect(screen.getByText('Not evaluated')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Compare options' })).toBeDisabled();
+  });
+
+  it('offers only maintained serviceability exposure classes', () => {
+    mockDesignInputs.include_serviceability = true;
+    render(React.createElement(DesignView));
+    fireEvent.click(screen.getByRole('button', { name: 'Serviceability' }));
+
+    const exposure = screen.getByLabelText('Exposure') as HTMLSelectElement;
+    expect(Array.from(exposure.options, (option) => option.value)).toEqual([
+      'mild',
+      'moderate',
+      'severe',
+      'very_severe',
+    ]);
   });
 
   it('renders one schema-owned control per field in catalogue mode', () => {
@@ -128,6 +156,5 @@ describe('DesignView', () => {
     expect(screen.getAllByLabelText('Shear (Vu) in kN')).toHaveLength(1);
     expect(screen.getAllByLabelText('Concrete in N/mm2')).toHaveLength(1);
     expect(screen.queryByLabelText('Load Calculator')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Include Torsion')).not.toBeInTheDocument();
   });
 });

--- a/react_app/src/components/__tests__/ExportPanel.test.tsx
+++ b/react_app/src/components/__tests__/ExportPanel.test.tsx
@@ -46,11 +46,23 @@ describe('ExportPanel', () => {
   });
 
   it('all three export buttons are enabled for a passing design', () => {
-    render(React.createElement(ExportPanel, { beamParams: defaultParams, isSafe: true }));
+    render(React.createElement(ExportPanel, {
+      beamParams: defaultParams,
+      isSafe: true,
+      calculationIdentity: 'a'.repeat(64),
+    }));
     const buttons = screen.getAllByRole('button');
     buttons.forEach((btn) => {
       expect(btn).not.toBeDisabled();
     });
+  });
+
+  it('holds only the report when a passing result has no exact identity', () => {
+    render(React.createElement(ExportPanel, { beamParams: defaultParams, isSafe: true }));
+    expect(screen.getByRole('button', { name: 'BBS' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'DXF' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Report' })).toBeDisabled();
+    expect(screen.getByRole('status')).toHaveTextContent('evidence identity');
   });
 
   it.each([false, undefined])('holds all exports when safety is %s', (isSafe) => {

--- a/react_app/src/components/design/BeamDetailPanel.tsx
+++ b/react_app/src/components/design/BeamDetailPanel.tsx
@@ -73,6 +73,8 @@ export function BeamDetailPanel({ beam, onClose }: BeamDetailPanelProps) {
   const status = deriveBeamStatus(beam);
   const utilPct = beam.utilization != null ? beam.utilization * 100 : null;
   const exportHeld = beam.is_valid !== true;
+  // Imported/batch rows do not retain the canonical primary evidence identity.
+  const reportIdentityAvailable = false;
 
   // Track backend-computed sv_max from design response
   const [designSvMax, setDesignSvMax] = useState<number | null>(null);
@@ -122,7 +124,7 @@ export function BeamDetailPanel({ beam, onClose }: BeamDetailPanelProps) {
           stirrup_spacing: data.shear?.stirrup_spacing ?? b.stirrup_spacing,
           utilization: trust.exactUtilization,
           is_valid: trust.status === "PASS",
-          status: trust.status === "PASS" ? "pass" : "fail",
+          status: trust.status === "PASS" ? "pass" : trust.status === "HOLD" ? "warning" : "fail",
         }
       ));
     },
@@ -422,12 +424,17 @@ export function BeamDetailPanel({ beam, onClose }: BeamDetailPanelProps) {
           <div className="flex gap-2">
             <ExportBtn label="BBS" icon={<Download className="w-3.5 h-3.5" />} loading={bbsPending} disabled={exportHeld} onClick={() => exportBBS(exportParams)} />
             <ExportBtn label="DXF" icon={<Ruler className="w-3.5 h-3.5" />} loading={dxfPending} disabled={exportHeld} onClick={() => exportDXF(exportParams)} />
-            <ExportBtn label="Report" icon={<FileText className="w-3.5 h-3.5" />} loading={reportPending} disabled={exportHeld}
+            <ExportBtn label="Report" icon={<FileText className="w-3.5 h-3.5" />} loading={reportPending} disabled={exportHeld || !reportIdentityAvailable}
               onClick={() => exportReport({ ...exportParams, ast_provided: beam.ast_provided, utilization: beam.utilization, is_safe: beam.is_valid })} />
           </div>
           {exportHeld && (
             <p className="mt-2 text-[10px] text-amber-400/80" role="status">
               Exports held until this beam has a PASS result.
+            </p>
+          )}
+          {!exportHeld && !reportIdentityAvailable && (
+            <p className="mt-2 text-[10px] text-amber-400/80" role="status">
+              Report held: this imported row does not retain an exact primary-response evidence identity.
             </p>
           )}
         </div>

--- a/react_app/src/components/design/DesignView.tsx
+++ b/react_app/src/components/design/DesignView.tsx
@@ -10,9 +10,7 @@ import { Calculator, CheckCircle, AlertCircle, Loader2, ChevronDown, ChevronRigh
 import { useExportBBS, useExportDXF, useExportReport } from "../../hooks/useExport";
 import { useLoadAnalysis } from "../../hooks/useLoadAnalysis";
 import type { LoadAnalysisResponse } from "../../api/client";
-import { useTorsionDesign } from "../../hooks/useTorsionDesign";
-import type { TorsionDesignResponse } from "../../hooks/useTorsionDesign";
-import type { BeamDesignResponse } from "../../api/client";
+import type { BeamCrackWidthParams, BeamDesignResponse } from "../../api/client";
 import { useDesignStore } from "../../store/designStore";
 import { useLiveDesign } from "../../hooks/useLiveDesign";
 import { useCodeChecks, useRebarSuggestions } from "../../hooks/useInsights";
@@ -57,8 +55,6 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
   const [resultsCollapsed, setResultsCollapsed] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showCompare, setShowCompare] = useState(false);
-  const [torsionEnabled, setTorsionEnabled] = useState(false);
-  const [torsionMoment, setTorsionMoment] = useState(10); // kN·m
   const [loadCalcEnabled, setLoadCalcEnabled] = useState(false);
   const [loadCalcType, setLoadCalcType] = useState<'udl' | 'point'>('udl');
   const [loadCalcMagnitude, setLoadCalcMagnitude] = useState(20); // kN/m or kN
@@ -74,6 +70,8 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
     ast_required: 0, // filled below when result exists
     moment: inputs.moment,
     shear: inputs.shear ?? 0,
+    torsion: inputs.torsion ?? 0,
+    include_serviceability: inputs.include_serviceability ?? false,
   };
   const { mutate: exportBBS, isPending: bbsPending } = useExportBBS();
   const { mutate: exportDXF, isPending: dxfPending } = useExportDXF();
@@ -88,30 +86,44 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
 
   const codeChecks = useCodeChecks();
   const rebarSuggestions = useRebarSuggestions();
-  const torsionDesign = useTorsionDesign();
   const loadAnalysis = useLoadAnalysis();
+  const combinedCase = (inputs.torsion ?? 0) > 0 || Boolean(inputs.include_serviceability);
 
   const spanMeters = Number((length / 1000).toFixed(2));
   const updateCatalogInput = (name: CatalogBeamTransportName, value: number) => {
     actions.updateInputs({ [name]: value });
+  };
+  const updateCrackWidthInput = (
+    name: keyof BeamCrackWidthParams,
+    value: string | number | undefined,
+  ) => {
+    actions.updateInputs({
+      crack_width_params: {
+        exposure_class: inputs.crack_width_params?.exposure_class ?? "moderate",
+        ...inputs.crack_width_params,
+        [name]: value,
+      },
+    });
   };
 
   // Auto-trigger code checks + rebar suggestions when design result changes
   useEffect(() => {
     if (!state.result || state.resultLifecycle !== "current") return;
     const r = state.result;
-    codeChecks.mutate({
-      beam: {
-        b_mm: inputs.width,
-        D_mm: inputs.depth,
-        span_mm: length,
-        fck_mpa: inputs.fck,
-        fy_mpa: inputs.fy,
-        mu_knm: inputs.moment,
-        vu_kn: inputs.shear,
-      },
-      config: r.ast_total ? { ast_mm2: r.ast_total } : null,
-    });
+    if (!combinedCase) {
+      codeChecks.mutate({
+        beam: {
+          b_mm: inputs.width,
+          D_mm: inputs.depth,
+          span_mm: length,
+          fck_mpa: inputs.fck,
+          fy_mpa: inputs.fy,
+          mu_knm: inputs.moment,
+          vu_kn: inputs.shear,
+        },
+        config: r.ast_total ? { ast_mm2: r.ast_total } : null,
+      });
+    }
     if (r.flexure?.ast_required) {
       rebarSuggestions.mutate({
         ast_required: r.flexure.ast_required,
@@ -122,21 +134,6 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.result, state.resultLifecycle]);
-
-  // Auto-trigger torsion design when enabled and flexure result exists
-  useEffect(() => {
-    if (!torsionEnabled || !state.result || state.resultLifecycle !== "current") return;
-    torsionDesign.mutate({
-      width: inputs.width,
-      depth: inputs.depth,
-      torsion: torsionMoment,
-      moment: inputs.moment,
-      shear: inputs.shear ?? 0,
-      fck: inputs.fck,
-      fy: inputs.fy,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [torsionEnabled, torsionMoment, state.result, state.resultLifecycle]);
 
   return (
     <div className="h-screen pt-14">
@@ -159,7 +156,8 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
               <>
                 <button
                   onClick={() => setShowCompare((visible) => !visible)}
-                  disabled={!state.exportEligible}
+                  disabled={!state.exportEligible || combinedCase}
+                  title={combinedCase ? "Comparison automation does not carry torsion or serviceability inputs." : undefined}
                   aria-pressed={showCompare}
                   className="rounded-lg border border-white/10 px-3 py-2 text-xs text-zinc-300 hover:bg-white/5 disabled:opacity-40"
                 >
@@ -305,20 +303,31 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
                 {loadAnalysis.data && <MiniDiagram data={loadAnalysis.data} />}
               </>
             )}
-            <div className="col-span-2 flex items-center gap-2 px-1 pt-1">
-              <label className="flex items-center gap-2 text-xs text-white/60 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={torsionEnabled}
-                  onChange={(e) => setTorsionEnabled(e.target.checked)}
-                  className="accent-purple-500 w-3.5 h-3.5"
-                />
-                <RotateCcw className="w-3 h-3 text-purple-400" />
-                Include Torsion
-              </label>
-            </div>
-            {torsionEnabled && (
-              <InputField label="Torsion (Tu)" value={torsionMoment} onChange={setTorsionMoment} unit="kN·m" min={0.1} max={200} step={0.5} />
+            <InputField label="Torsion (Tu)" value={inputs.torsion ?? 0} onChange={(v) => actions.updateInputs({ torsion: v })} unit="kN·m" min={0} max={200} step={0.5} />
+          </AccordionSection>
+
+          <AccordionSection title="Serviceability" defaultOpen={false}>
+            <label className="col-span-2 flex items-center gap-2 text-xs text-white/60 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={inputs.include_serviceability ?? false}
+                onChange={(e) => actions.updateInputs({ include_serviceability: e.target.checked })}
+                className="accent-blue-500 w-3.5 h-3.5"
+              />
+              Include maintained Level-A deflection and crack-width checks
+            </label>
+            {inputs.include_serviceability && (
+              <>
+                <OptionalInputField label="Check span" value={inputs.span_mm} onChange={(v) => actions.updateInputs({ span_mm: v })} unit="mm" min={1} />
+                <DropdownField label="Check support" value={inputs.support_condition ?? "simply_supported"} onChange={(v) => actions.updateInputs({ support_condition: v })} options={["simply_supported", "continuous", "cantilever"]} format={(v) => v.replaceAll("_", " ")} />
+                <DropdownField label="Exposure" value={inputs.crack_width_params?.exposure_class ?? "moderate"} onChange={(v) => updateCrackWidthInput("exposure_class", v)} options={["mild", "moderate", "severe", "very_severe"]} format={(v) => v.replaceAll("_", " ")} />
+                <OptionalInputField label="acr" value={inputs.crack_width_params?.acr_mm} onChange={(v) => updateCrackWidthInput("acr_mm", v)} unit="mm" min={0.1} />
+                <OptionalInputField label="cmin" value={inputs.crack_width_params?.cmin_mm} onChange={(v) => updateCrackWidthInput("cmin_mm", v)} unit="mm" min={0.1} />
+                <OptionalInputField label="h" value={inputs.crack_width_params?.h_mm} onChange={(v) => updateCrackWidthInput("h_mm", v)} unit="mm" min={0.1} />
+                <OptionalInputField label="x" value={inputs.crack_width_params?.x_mm} onChange={(v) => updateCrackWidthInput("x_mm", v)} unit="mm" min={0.1} />
+                <OptionalInputField label="fs,service" value={inputs.crack_width_params?.fs_service_nmm2} onChange={(v) => updateCrackWidthInput("fs_service_nmm2", v)} unit="N/mm²" min={0} />
+                <p className="col-span-2 text-[10px] leading-4 text-zinc-500">Span, crack geometry, and service stress are required explicitly. Empty values are not inferred from the 3D span or reinforcement.</p>
+              </>
             )}
           </AccordionSection>
           </>
@@ -328,8 +337,9 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
         {/* Bottom actions */}
         <div className="px-3 pb-3 space-y-2">
           {state.isFallbackActive && (
-            <p className="text-center text-[10px] text-zinc-400">Verified REST request mode · cancelled and stale responses are ignored</p>
+            <p className="text-center text-[10px] text-zinc-400">{state.transportExplanation}</p>
           )}
+          {combinedCase && <p className="text-center text-[10px] text-amber-300/70">BBS, DXF, and PDF are held for combined/serviceability cases; use the identity-bound HTML or JSON report.</p>}
         </div>
       </div>
 
@@ -348,7 +358,7 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
                   : "Export and detailing are held until the outer result is PASS."
                 : "Fill in dimensions, materials, and forces in the left panel, then click 'Design Beam'."
             }
-            nextAction={state.result ? (canExport ? "Export → BBS/DXF/Report" : "Recalculate or resolve FAIL/HOLD") : "Design Beam"}
+            nextAction={state.result ? (canExport ? (combinedCase ? "Export → HTML/JSON Report" : "Export → BBS/DXF/Report") : "Recalculate or resolve FAIL/HOLD") : "Design Beam"}
             storageKey="workflow_hint_design_view"
           />
         </div>
@@ -369,12 +379,36 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
             {showExportMenu && (
               <div className="absolute right-0 mt-1.5 w-44 rounded-xl bg-zinc-900 border border-white/10 shadow-2xl shadow-black/50 overflow-hidden">
                 {[
-                  { label: "BBS (CSV)", icon: <Download className="w-3.5 h-3.5" />, loading: bbsPending, onClick: () => { exportBBS({ ...exportParams, ast_required: state.result?.flexure?.ast_required ?? 0 }); setShowExportMenu(false); } },
-                  { label: "DXF Drawing", icon: <Ruler className="w-3.5 h-3.5" />, loading: dxfPending, onClick: () => { exportDXF({ ...exportParams, ast_required: state.result?.flexure?.ast_required ?? 0 }); setShowExportMenu(false); } },
-                  { label: "HTML Report", icon: <FileText className="w-3.5 h-3.5" />, loading: reportPending, onClick: () => { exportReport({ ...exportParams, ast_required: state.result?.flexure?.ast_required, ast_provided: state.result?.ast_total, utilization: state.result?.utilization_ratio, is_safe: state.result?.success }); setShowExportMenu(false); } },
-                  { label: "PDF Report", icon: <FileText className="w-3.5 h-3.5" />, loading: reportPending, onClick: () => { exportReport({ ...exportParams, ast_required: state.result?.flexure?.ast_required, ast_provided: state.result?.ast_total, utilization: state.result?.utilization_ratio, is_safe: state.result?.success, format: "pdf" }); setShowExportMenu(false); } },
+                  { label: "BBS (CSV)", blocked: combinedCase, icon: <Download className="w-3.5 h-3.5" />, loading: bbsPending, onClick: () => { exportBBS({ ...exportParams, ast_required: state.result?.flexure?.ast_required ?? 0 }); setShowExportMenu(false); } },
+                  { label: "DXF Drawing", blocked: combinedCase, icon: <Ruler className="w-3.5 h-3.5" />, loading: dxfPending, onClick: () => { exportDXF({ ...exportParams, ast_required: state.result?.flexure?.ast_required ?? 0 }); setShowExportMenu(false); } },
+                  ...(["html", "json", "pdf"] as const).map((format) => ({
+                    label: `${format.toUpperCase()} Report`,
+                    blocked: combinedCase && format === "pdf",
+                    icon: <FileText className="w-3.5 h-3.5" />,
+                    loading: reportPending,
+                    onClick: () => {
+                      exportReport({
+                        ...exportParams,
+                        ast_required: state.result?.flexure?.ast_required,
+                        ast_provided: state.result?.ast_total,
+                        utilization: state.result?.utilization_ratio,
+                        is_safe: state.result?.success,
+                        effective_depth: state.result?.effective_depth_used,
+                        clear_cover: inputs.clear_cover,
+                        stirrup_dia_mm: inputs.stirrup_dia_mm,
+                        main_bar_dia_mm: inputs.main_bar_dia_mm,
+                        span_mm: inputs.span_mm,
+                        support_condition: inputs.support_condition,
+                        crack_width_params: inputs.crack_width_params,
+                        calculation_identity: trust!.calculationIdentity!,
+                        format,
+                      });
+                      setShowExportMenu(false);
+                    },
+                  })),
                 ].map((item) => (
-                  <button key={item.label} onClick={item.onClick} disabled={item.loading || !canExport}
+                  <button key={item.label} onClick={item.onClick} disabled={item.loading || !canExport || item.blocked}
+                    title={item.blocked ? "This format cannot represent the combined governing result." : undefined}
                     className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-xs text-white/60 hover:bg-white/5 hover:text-white/90 transition-colors disabled:opacity-40">
                     {item.loading ? <div className="w-3.5 h-3.5 rounded-full border border-white/30 border-t-white/70 animate-spin" /> : item.icon}
                     {item.label}
@@ -436,10 +470,9 @@ export function DesignView({ inputMode = "manual" }: DesignViewProps) {
               </button>
               <div className="flex-1 overflow-y-auto px-4 pb-4 space-y-3">
                 <CompactResults result={state.result} />
-                {torsionDesign.data && <TorsionResultsPanel data={torsionDesign.data} isPending={torsionDesign.isPending} />}
-                <CodeChecksPanel data={codeChecks.data} isPending={codeChecks.isPending} />
+                {!combinedCase && <CodeChecksPanel data={codeChecks.data} isPending={codeChecks.isPending} />}
                 <RebarSuggestionsPanel data={rebarSuggestions.data} isPending={rebarSuggestions.isPending} />
-                {showCompare ? <ParetoPanel spanMm={length} muKnm={inputs.moment} vuKn={inputs.shear ?? 0} /> : null}
+                {showCompare && !combinedCase ? <ParetoPanel spanMm={length} muKnm={inputs.moment} vuKn={inputs.shear ?? 0} /> : null}
               </div>
             </div>
           )
@@ -468,7 +501,7 @@ function CompactResultsBar({ result }: { result: BeamDesignResponse }) {
   const barColor = trust.exactUtilization > 1 ? "bg-rose-500" : trust.exactUtilization > 0.9 ? "bg-amber-400" : "bg-emerald-400";
   return (
     <div className="flex items-center gap-3 flex-1 min-w-0">
-      <span className={`text-xs font-semibold ${isOk ? "text-emerald-400" : "text-rose-400"}`}>
+      <span className={`text-xs font-semibold ${isOk ? "text-emerald-400" : trust.status === "HOLD" ? "text-amber-400" : "text-rose-400"}`}>
         {isOk ? "✓ PASS" : trust.status === "HOLD" ? "◼ HOLD" : "✕ FAIL"}
       </span>
       <div className="flex items-center gap-1.5 flex-1 min-w-0">
@@ -497,10 +530,10 @@ function CompactResults({ result }: { result: BeamDesignResponse }) {
   return (
     <div className="space-y-3">
       {/* Status */}
-      <div className={`p-3 rounded-xl border flex items-center gap-2.5 ${isSuccess ? "bg-green-500/10 border-green-500/30" : "bg-red-500/10 border-red-500/30"}`}>
-        {isSuccess ? <CheckCircle className="w-5 h-5 text-green-400" /> : <AlertCircle className="w-5 h-5 text-red-400" />}
+      <div className={`p-3 rounded-xl border flex items-center gap-2.5 ${isSuccess ? "bg-green-500/10 border-green-500/30" : trust.status === "HOLD" ? "bg-amber-500/10 border-amber-500/30" : "bg-red-500/10 border-red-500/30"}`}>
+        {isSuccess ? <CheckCircle className="w-5 h-5 text-green-400" /> : <AlertCircle className={`w-5 h-5 ${trust.status === "HOLD" ? "text-amber-400" : "text-red-400"}`} />}
         <div>
-          <p className={`font-semibold text-sm ${isSuccess ? "text-green-400" : "text-red-400"}`}>
+          <p className={`font-semibold text-sm ${isSuccess ? "text-green-400" : trust.status === "HOLD" ? "text-amber-400" : "text-red-400"}`}>
             {isSuccess ? "Design PASS" : trust.status === "HOLD" ? "Design HOLD" : "Requires Revision"}
           </p>
           <p className="text-[11px] text-white/50">{result.message || "IS 456:2000"}</p>
@@ -528,15 +561,52 @@ function CompactResults({ result }: { result: BeamDesignResponse }) {
         ]} />
         <ResultMiniCard title="Shear" items={[
           { l: "τv", v: result.shear?.tau_v ? `${result.shear.tau_v.toFixed(2)} MPa` : "-" },
+          { l: "Asv/s", v: result.shear ? `${result.shear.asv_required.toFixed(4)} ${result.shear.asv_required_unit}` : "-" },
           { l: "Sv", v: result.shear?.stirrup_spacing ? `${result.shear.stirrup_spacing} mm` : "-" },
-          { l: "Vu,cap", v: result.shear?.shear_capacity ? `${result.shear.shear_capacity.toFixed(0)} kN` : "-" },
         ]} />
         <ResultMiniCard title="Summary" items={[
           { l: "Ast total", v: `${result.ast_total?.toFixed(0) || "-"} mm²` },
           { l: "Asc", v: `${result.asc_total?.toFixed(0) || "0"} mm²` },
-          { l: "Status", v: result.success ? "SAFE" : "FAIL" },
+          { l: "Status", v: trust.status },
         ]} />
       </div>
+
+      {result.combined_actions && result.torsion && (
+        <div className="grid grid-cols-2 gap-2.5">
+          <ResultMiniCard title="Original / Equivalent Actions" items={[
+            { l: "Mu / Me", v: `${result.combined_actions.mu_knm.toFixed(1)} / ${result.combined_actions.me_knm.toFixed(1)} kN·m` },
+            { l: "Vu / Ve", v: `${result.combined_actions.vu_kn.toFixed(1)} / ${result.combined_actions.ve_kn.toFixed(1)} kN` },
+            { l: "Tu", v: `${result.combined_actions.tu_knm.toFixed(1)} kN·m` },
+          ]} />
+          <ResultMiniCard title={`Torsion · ${result.torsion.source}`} items={[
+            { l: "Asv/s total", v: `${result.torsion.asv_total.toFixed(4)} mm²/mm` },
+            { l: "Al", v: `${result.torsion.al_torsion.toFixed(1)} mm²` },
+            { l: "Closed stirrups", v: result.torsion.requires_closed_stirrups ? "Required" : "Not required" },
+          ]} />
+          <p className="col-span-2 text-[10px] text-zinc-500">{Object.values(result.torsion.clause_refs).join(" · ")}</p>
+        </div>
+      )}
+
+      {(result.deflection_check || result.crack_width_check) && (
+        <div className="grid grid-cols-2 gap-2.5">
+          {result.deflection_check && <ResultMiniCard title="Deflection" items={[
+            { l: "Status", v: result.deflection_check.is_ok ? "PASS" : "FAIL" },
+            { l: "L/d actual", v: result.deflection_check.span_depth_actual?.toFixed(2) ?? "-" },
+            { l: "L/d allowable", v: result.deflection_check.span_depth_allowable?.toFixed(2) ?? "-" },
+          ]} />}
+          {result.crack_width_check && <ResultMiniCard title="Crack width" items={[
+            { l: "Status", v: result.crack_width_check.is_ok ? "PASS" : "FAIL" },
+            { l: "Calculated", v: result.crack_width_check.crack_width_mm == null ? "-" : `${result.crack_width_check.crack_width_mm.toFixed(3)} mm` },
+            { l: "Limit", v: result.crack_width_check.crack_width_limit_mm == null ? "-" : `${result.crack_width_check.crack_width_limit_mm.toFixed(3)} mm` },
+          ]} />}
+        </div>
+      )}
+
+      {result.holds && result.holds.length > 0 && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-2.5">
+          {result.holds.map((hold) => <p key={hold} className="text-xs text-amber-300">• {hold}</p>)}
+        </div>
+      )}
 
       {/* Warnings */}
       {result.warnings && result.warnings.length > 0 && (
@@ -728,6 +798,32 @@ function InputField({ label, value, onChange, unit, min, max, step = 1, disabled
   );
 }
 
+function OptionalInputField({ label, value, onChange, unit, min, max, step = 1 }: {
+  label: string; value: number | undefined; onChange: (v: number | undefined) => void;
+  unit: string; min?: number; max?: number; step?: number;
+}) {
+  const fieldId = `design-optional-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+  return (
+    <div>
+      <label htmlFor={fieldId} className="block text-[10px] text-zinc-400 mb-0.5">{label}</label>
+      <div className="relative">
+        <input
+          id={fieldId}
+          type="number"
+          value={value ?? ""}
+          onChange={(event) => onChange(event.target.value === "" ? undefined : Number(event.target.value))}
+          min={min}
+          max={max}
+          step={step}
+          aria-label={`${label} in ${unit}`}
+          className="w-full px-2.5 py-1.5 pr-12 text-xs text-white bg-white/[0.04] border border-white/8 rounded-lg focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+        />
+        <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[10px] text-zinc-500" aria-hidden="true">{unit}</span>
+      </div>
+    </div>
+  );
+}
+
 function DropdownField<T extends string | number>({ label, value, onChange, options, format }: {
   label: string; value: T; onChange: (v: T) => void; options: T[]; format: (v: T) => string;
 }) {
@@ -753,84 +849,6 @@ function DropdownField<T extends string | number>({ label, value, onChange, opti
           <option key={String(opt)} value={String(opt)} className="bg-zinc-900">{format(opt)}</option>
         ))}
       </select>
-    </div>
-  );
-}
-
-/* ---------- Torsion Results Panel ---------- */
-
-function TorsionResultsPanel({ data, isPending }: { data: TorsionDesignResponse | undefined; isPending: boolean }) {
-  const [expanded, setExpanded] = useState(true);
-  if (isPending) {
-    return (
-      <div className="flex items-center gap-2 px-3 py-2 rounded-xl bg-white/[0.02] border border-white/5">
-        <Loader2 className="w-3.5 h-3.5 text-purple-400 animate-spin" />
-        <span className="text-xs text-zinc-400">Calculating torsion...</span>
-      </div>
-    );
-  }
-  if (!data) return null;
-
-  return (
-    <div className={`rounded-xl border ${data.is_safe ? "bg-purple-500/5 border-purple-500/20" : "bg-red-500/5 border-red-500/20"}`}>
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2.5 px-3 py-2.5"
-      >
-        <RotateCcw className={`w-4 h-4 ${data.is_safe ? "text-purple-400" : "text-red-400"}`} />
-        <span className="text-xs font-semibold text-white/80">
-          Torsion (IS 456 Cl 41) — {data.is_safe ? "Safe" : "UNSAFE"}
-        </span>
-        <span className="ml-auto text-[10px] text-zinc-400 mr-2">
-          Sv {data.stirrup_spacing}mm · Al {data.al_torsion} mm²
-        </span>
-        {expanded ? <ChevronDown className="w-3.5 h-3.5 text-zinc-400" /> : <ChevronRight className="w-3.5 h-3.5 text-zinc-400" />}
-      </button>
-      {expanded && (
-        <div className="px-3 pb-3 space-y-2.5">
-          {/* Equivalent forces */}
-          <div className="grid grid-cols-2 gap-2">
-            <div className="p-2.5 rounded-lg bg-white/[0.03] border border-white/8">
-              <h5 className="text-[10px] font-semibold text-white/50 uppercase tracking-wider mb-1.5">Equivalent Forces</h5>
-              <div className="space-y-1">
-                <div className="flex justify-between text-xs"><span className="text-zinc-400">Ve</span><span className="text-white font-medium">{data.ve_kn.toFixed(1)} kN</span></div>
-                <div className="flex justify-between text-xs"><span className="text-zinc-400">Me</span><span className="text-white font-medium">{data.me_knm.toFixed(1)} kN·m</span></div>
-              </div>
-            </div>
-            <div className="p-2.5 rounded-lg bg-white/[0.03] border border-white/8">
-              <h5 className="text-[10px] font-semibold text-white/50 uppercase tracking-wider mb-1.5">Shear Stress</h5>
-              <div className="space-y-1">
-                <div className="flex justify-between text-xs"><span className="text-zinc-400">τve</span><span className={`font-medium ${data.tv_equiv <= data.tc_max ? "text-white" : "text-red-400"}`}>{data.tv_equiv.toFixed(3)} MPa</span></div>
-                <div className="flex justify-between text-xs"><span className="text-zinc-400">τc</span><span className="text-white font-medium">{data.tc.toFixed(3)} MPa</span></div>
-                <div className="flex justify-between text-xs"><span className="text-zinc-400">τc,max</span><span className="text-white font-medium">{data.tc_max.toFixed(2)} MPa</span></div>
-              </div>
-            </div>
-          </div>
-
-          {/* Reinforcement */}
-          <div className="p-2.5 rounded-lg bg-white/[0.03] border border-white/8">
-            <h5 className="text-[10px] font-semibold text-white/50 uppercase tracking-wider mb-1.5">Reinforcement (Closed Stirrups)</h5>
-            <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-              <div className="flex justify-between text-xs"><span className="text-zinc-400">Asv (torsion)</span><span className="text-white font-medium">{data.asv_torsion.toFixed(4)} mm²/mm</span></div>
-              <div className="flex justify-between text-xs"><span className="text-zinc-400">Asv (shear)</span><span className="text-white font-medium">{data.asv_shear.toFixed(4)} mm²/mm</span></div>
-              <div className="flex justify-between text-xs"><span className="text-zinc-400">Asv (total)</span><span className="text-purple-300 font-semibold">{data.asv_total.toFixed(4)} mm²/mm</span></div>
-              <div className="flex justify-between text-xs"><span className="text-zinc-400">Spacing Sv</span><span className="text-purple-300 font-semibold">{data.stirrup_spacing} mm</span></div>
-            </div>
-            <div className="mt-2 pt-2 border-t border-white/5">
-              <div className="flex justify-between text-xs"><span className="text-zinc-400">Longitudinal Al</span><span className="text-purple-300 font-semibold">{data.al_torsion} mm²</span></div>
-            </div>
-          </div>
-
-          {/* Warnings */}
-          {data.warnings && data.warnings.length > 0 && (
-            <div className="p-2 rounded-lg bg-amber-500/10 border border-amber-500/30">
-              {data.warnings.map((w, i) => (
-                <p key={i} className="text-[10px] text-amber-400/80">• {w}</p>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/react_app/src/components/design/ExportPanel.tsx
+++ b/react_app/src/components/design/ExportPanel.tsx
@@ -13,9 +13,10 @@ interface ExportPanelProps {
   utilization?: number;
   isSafe?: boolean;
   astProvided?: number;
+  calculationIdentity?: string;
 }
 
-export function ExportPanel({ beamParams, utilization, isSafe, astProvided }: ExportPanelProps) {
+export function ExportPanel({ beamParams, utilization, isSafe, astProvided, calculationIdentity }: ExportPanelProps) {
   const bbs = useExportBBS();
   const dxf = useExportDXF();
   const report = useExportReport();
@@ -46,7 +47,7 @@ export function ExportPanel({ beamParams, utilization, isSafe, astProvided }: Ex
           label="Report"
           icon={<FileText className="w-3.5 h-3.5" />}
           loading={report.isPending}
-          disabled={exportDisabled}
+          disabled={exportDisabled || !calculationIdentity}
           onClick={() =>
             report.mutate({
               beam_id: beamParams.beam_id,
@@ -60,6 +61,7 @@ export function ExportPanel({ beamParams, utilization, isSafe, astProvided }: Ex
               ast_provided: astProvided,
               utilization: utilization,
               is_safe: isSafe,
+              calculation_identity: calculationIdentity,
               format: "html",
             })
           }
@@ -68,6 +70,11 @@ export function ExportPanel({ beamParams, utilization, isSafe, astProvided }: Ex
       {exportHeld && (
         <p className="mt-2 text-[10px] text-amber-400/80" role="status">
           Exports held until the outer design result is PASS.
+        </p>
+      )}
+      {!exportHeld && !calculationIdentity && (
+        <p className="mt-2 text-[10px] text-amber-400/80" role="status">
+          Report held until an exact primary-response evidence identity is available.
         </p>
       )}
       {(bbs.error || dxf.error || report.error) && (

--- a/react_app/src/components/design/ResultsPanel.tsx
+++ b/react_app/src/components/design/ResultsPanel.tsx
@@ -106,13 +106,58 @@ export function ResultsPanel() {
               <span className="text-sm font-semibold text-white">{shear.tau_c.toFixed(2)} N/mm²</span>
             </div>
             <div className="flex flex-col gap-0.5 p-2 bg-[#2d2d2d] rounded">
-              <span className="text-[11px] text-zinc-400">Stirrup Asv</span>
-              <span className="text-sm font-semibold text-white">{shear.asv_required.toFixed(0)} mm²</span>
+              <span className="text-[11px] text-zinc-400">Stirrup Asv/s</span>
+              <span className="text-sm font-semibold text-white">{shear.asv_required.toFixed(4)} {shear.asv_required_unit}</span>
             </div>
             <div className="flex flex-col gap-0.5 p-2 bg-[#2d2d2d] rounded">
               <span className="text-[11px] text-zinc-400">Spacing</span>
               <span className="text-sm font-semibold text-white">{shear.stirrup_spacing.toFixed(0)} mm</span>
             </div>
+          </div>
+        </div>
+      )}
+
+      {result.combined_actions && result.torsion && (
+        <div className="mb-4">
+          <h3 className="m-0 mb-2 text-[13px] text-zinc-400 uppercase tracking-wide">Combined actions and torsion</h3>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="p-2 bg-[#2d2d2d] rounded text-sm">
+              <p className="text-[11px] text-zinc-400">Original Mu / Vu / Tu</p>
+              <p>{result.combined_actions.mu_knm.toFixed(1)} kN·m / {result.combined_actions.vu_kn.toFixed(1)} kN / {result.combined_actions.tu_knm.toFixed(1)} kN·m</p>
+            </div>
+            <div className="p-2 bg-[#2d2d2d] rounded text-sm">
+              <p className="text-[11px] text-zinc-400">Equivalent Me / Ve</p>
+              <p>{result.combined_actions.me_knm.toFixed(1)} kN·m / {result.combined_actions.ve_kn.toFixed(1)} kN</p>
+            </div>
+            <div className="p-2 bg-[#2d2d2d] rounded text-sm">
+              <p className="text-[11px] text-zinc-400">Combined Asv/s · Al</p>
+              <p>{result.torsion.asv_total.toFixed(4)} mm²/mm · {result.torsion.al_torsion.toFixed(1)} mm²</p>
+            </div>
+            <div className="p-2 bg-[#2d2d2d] rounded text-sm">
+              <p className="text-[11px] text-zinc-400">Closed stirrups</p>
+              <p>{result.torsion.requires_closed_stirrups ? 'Required' : 'Not required'}</p>
+            </div>
+            <p className="col-span-2 text-[11px] text-zinc-400">{result.torsion.source} · {Object.values(result.torsion.clause_refs).join(' · ')}</p>
+          </div>
+        </div>
+      )}
+
+      {(result.deflection_check || result.crack_width_check) && (
+        <div className="mb-4">
+          <h3 className="m-0 mb-2 text-[13px] text-zinc-400 uppercase tracking-wide">Serviceability</h3>
+          <div className="grid grid-cols-2 gap-2">
+            {result.deflection_check && (
+              <div className="p-2 bg-[#2d2d2d] rounded text-sm">
+                <p className="text-[11px] text-zinc-400">Deflection</p>
+                <p>{result.deflection_check.is_ok ? 'PASS' : 'FAIL'} · L/d {result.deflection_check.span_depth_actual?.toFixed(2) ?? '—'} / {result.deflection_check.span_depth_allowable?.toFixed(2) ?? '—'}</p>
+              </div>
+            )}
+            {result.crack_width_check && (
+              <div className="p-2 bg-[#2d2d2d] rounded text-sm">
+                <p className="text-[11px] text-zinc-400">Crack width</p>
+                <p>{result.crack_width_check.is_ok ? 'PASS' : 'FAIL'} · {result.crack_width_check.crack_width_mm?.toFixed(3) ?? '—'} / {result.crack_width_check.crack_width_limit_mm?.toFixed(3) ?? '—'} mm</p>
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -163,6 +208,12 @@ export function ResultsPanel() {
               <li key={i} className="text-[13px] text-[#ccc] mb-1">{w}</li>
             ))}
           </ul>
+        </div>
+      )}
+      {result.holds && result.holds.length > 0 && (
+        <div className="mt-3 bg-amber-500/10 p-3 rounded border-l-[3px] border-amber-500">
+          <h3 className="m-0 mb-2 text-[13px] text-amber-500 uppercase tracking-wide">Holds</h3>
+          {result.holds.map((hold) => <p key={hold} className="text-[13px] text-[#ccc]">{hold}</p>)}
         </div>
       )}
     </div>

--- a/react_app/src/features/catalog/__tests__/CatalogBeamInputPanel.test.tsx
+++ b/react_app/src/features/catalog/__tests__/CatalogBeamInputPanel.test.tsx
@@ -4,12 +4,12 @@ import { CatalogBeamInputPanel } from '../CatalogBeamInputPanel';
 
 const CATALOG = {
   schema_version: '1.0',
-  catalog_version: '1.0.0',
+  catalog_version: '1.1.0',
   code_edition: 'IS 456:2000',
-  compatible_versions: ['1.0', '1.0.0'],
+  compatible_versions: ['1.0', '1.0.0', '1.1.0'],
   capabilities: [{
     capability_id: 'is456.beam.design',
-    capability_version: '1.0.0',
+    capability_version: '1.1.0',
     element: 'beam',
     title: 'IS 456 beam design',
     summary: 'One beam',
@@ -51,7 +51,7 @@ describe('CatalogBeamInputPanel', () => {
     const width = await screen.findByLabelText('Width in mm');
     fireEvent.change(width, { target: { value: '350' } });
     expect(onChange).toHaveBeenCalledWith('width', 350);
-    expect(screen.getByText(/Catalogue 1.0.0/)).toBeInTheDocument();
+    expect(screen.getByText(/Catalogue 1.1.0/)).toBeInTheDocument();
   });
 
   it('shows the reviewed manual escape hatch on contract failure', async () => {

--- a/react_app/src/features/catalog/__tests__/validation.test.ts
+++ b/react_app/src/features/catalog/__tests__/validation.test.ts
@@ -3,12 +3,12 @@ import { parseWorkflowCatalog } from '../validation';
 
 const VALID_CATALOG = {
   schema_version: '1.0',
-  catalog_version: '1.0.0',
+  catalog_version: '1.1.0',
   code_edition: 'IS 456:2000',
-  compatible_versions: ['1.0', '1.0.0'],
+  compatible_versions: ['1.0', '1.0.0', '1.1.0'],
   capabilities: [{
     capability_id: 'is456.beam.design',
-    capability_version: '1.0.0',
+    capability_version: '1.1.0',
     element: 'beam',
     title: 'Beam design',
     summary: 'One beam',

--- a/react_app/src/features/catalog/client.ts
+++ b/react_app/src/features/catalog/client.ts
@@ -4,7 +4,7 @@ import type { WorkflowCatalog } from './types';
 import { parseWorkflowCatalog } from './validation';
 
 export async function fetchWorkflowCatalog(signal?: AbortSignal): Promise<WorkflowCatalog> {
-  const response = await fetch(`${API_BASE_URL}/api/v1/catalog/workflows?version=1.0.0`, {
+  const response = await fetch(`${API_BASE_URL}/api/v1/catalog/workflows?version=1.1.0`, {
     headers: { Accept: 'application/json' },
     signal,
   });

--- a/react_app/src/features/catalog/types.ts
+++ b/react_app/src/features/catalog/types.ts
@@ -30,7 +30,7 @@ export interface CatalogExample {
 
 export interface WorkflowCapability {
   capability_id: 'is456.beam.design';
-  capability_version: '1.0.0';
+  capability_version: '1.1.0';
   element: 'beam';
   title: string;
   summary: string;
@@ -50,7 +50,7 @@ export interface WorkflowCapability {
 
 export interface WorkflowCatalog {
   schema_version: '1.0';
-  catalog_version: '1.0.0';
+  catalog_version: '1.1.0';
   code_edition: 'IS 456:2000';
   compatible_versions: string[];
   capabilities: WorkflowCapability[];

--- a/react_app/src/features/catalog/validation.ts
+++ b/react_app/src/features/catalog/validation.ts
@@ -96,7 +96,7 @@ function parseCapability(value: unknown): WorkflowCapability {
   if (value.capability_id !== 'is456.beam.design') {
     throw new Error(`Unsupported capability '${String(value.capability_id)}'`);
   }
-  if (value.capability_version !== '1.0.0') {
+  if (value.capability_version !== '1.1.0') {
     throw new Error(`Unsupported capability version '${String(value.capability_version)}'`);
   }
   if (value.semantic_workflow_id !== 'design_beam_is456') {
@@ -140,7 +140,7 @@ export function parseWorkflowCatalog(value: unknown): WorkflowCatalog {
   if (value.schema_version !== '1.0') {
     throw new Error(`Unsupported catalogue schema '${String(value.schema_version)}'`);
   }
-  if (value.catalog_version !== '1.0.0') {
+  if (value.catalog_version !== '1.1.0') {
     throw new Error(`Unsupported catalogue version '${String(value.catalog_version)}'`);
   }
   if (value.code_edition !== 'IS 456:2000') {

--- a/react_app/src/hooks/__tests__/useDesignWebSocket.test.ts
+++ b/react_app/src/hooks/__tests__/useDesignWebSocket.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeWebSocketDesignResult } from '../useDesignWebSocket';
+import { normalizeWebSocketDesignResult, requiresCanonicalHttp } from '../useDesignWebSocket';
 
 describe('normalizeWebSocketDesignResult', () => {
   it('preserves the complete design response contract', () => {
@@ -39,6 +39,8 @@ describe('normalizeWebSocketDesignResult', () => {
     expect(result.effective_depth_used).toBe(402);
     expect(result.shear?.tau_c_max).toBe(3.1);
     expect(result.shear?.shear_capacity).toBe(92);
+    expect(result.shear?.asv_required_unit).toBe('mm²/mm');
+    expect(result.holds).toContain('WEBSOCKET_EVIDENCE_IDENTITY_MISSING');
   });
 
   it('continues to read legacy WebSocket field names', () => {
@@ -51,5 +53,11 @@ describe('normalizeWebSocketDesignResult', () => {
     expect(result.flexure.moment_capacity).toBe(140);
     expect(result.shear?.tau_v).toBe(0.7);
     expect(result.shear?.stirrup_spacing).toBe(250);
+  });
+
+  it('requires canonical HTTP for torsion or serviceability inputs', () => {
+    expect(requiresCanonicalHttp({ torsion: 10 })).toBe(true);
+    expect(requiresCanonicalHttp({ include_serviceability: true })).toBe(true);
+    expect(requiresCanonicalHttp({ torsion: 0, include_serviceability: false })).toBe(false);
   });
 });

--- a/react_app/src/hooks/__tests__/useLiveDesign.test.tsx
+++ b/react_app/src/hooks/__tests__/useLiveDesign.test.tsx
@@ -35,6 +35,27 @@ function designResult(message: string, utilization = 0.8): BeamDesignResponse {
     ast_total: 500,
     asc_total: 0,
     utilization_ratio: utilization,
+    holds: [],
+    evidence: {
+      artifact_schema: 'structural_lib.beam-evidence',
+      artifact_schema_version: '2.0',
+      library_version: '0.23.0',
+      code_edition: 'IS 456:2000',
+      code_amendment_identity: 'not-declared-in-artifact',
+      capability_id: 'design_beam_is456',
+      support_status: 'SUPPORTED',
+      unit_system: 'IS456',
+      explicit_units: { length: 'mm' },
+      normalized_input_hash: `input-${message}`,
+      calculation_identity: `calculation-${message}`,
+      governing_check: 'flexure',
+      exact_utilization: utilization,
+      margin: 1 - utilization,
+      status: 'PASS',
+      generated_at: '2026-08-10T00:00:00Z',
+      qualified_review_required: true,
+      qualified_review_requirement: 'Qualified review required.',
+    },
   };
 }
 
@@ -157,5 +178,40 @@ describe('useLiveDesign request truth', () => {
     expect(createQuickDesignIdentity(state.inputs, state.length, state.inputRevision)).toEqual(
       createQuickDesignIdentity({ ...state.inputs }, state.length, state.inputRevision),
     );
+  });
+
+  it('binds torsion and enabled serviceability to revision identity', () => {
+    const state = useDesignStore.getState();
+    const baseline = createQuickDesignIdentity(state.inputs, state.length, 1);
+    const torsion = createQuickDesignIdentity({ ...state.inputs, torsion: 10 }, state.length, 1);
+    const service = createQuickDesignIdentity({
+      ...state.inputs,
+      include_serviceability: true,
+      span_mm: 5000,
+      crack_width_params: {
+        exposure_class: 'moderate',
+        acr_mm: 40,
+        cmin_mm: 25,
+        h_mm: 500,
+        x_mm: 150,
+        fs_service_nmm2: 180,
+      },
+    }, state.length, 1);
+
+    expect(torsion.inputHash).not.toBe(baseline.inputHash);
+    expect(service.inputHash).not.toBe(baseline.inputHash);
+  });
+
+  it('withholds export eligibility when identity evidence is missing', async () => {
+    const response = designResult('missing-evidence');
+    response.evidence = null;
+    mocks.designBeam.mockResolvedValue(response);
+    const { result } = renderHook(() => useLiveDesign({ autoDesign: false }));
+
+    act(() => {
+      result.current.actions.triggerDesign();
+    });
+    await waitFor(() => expect(result.current.state.resultLifecycle).toBe('current'));
+    expect(result.current.state.exportEligible).toBe(false);
   });
 });

--- a/react_app/src/hooks/useDesignWebSocket.ts
+++ b/react_app/src/hooks/useDesignWebSocket.ts
@@ -23,6 +23,13 @@ export interface WebSocketState {
   lastConnectedAt: Date | null;
 }
 
+export function requiresCanonicalHttp(inputs: {
+  torsion?: number;
+  include_serviceability?: boolean;
+}): boolean {
+  return (inputs.torsion ?? 0) > 0 || Boolean(inputs.include_serviceability);
+}
+
 type WebSocketDesignData = Omit<Partial<BeamDesignResponse>, 'flexure' | 'shear'> & {
   flexure?: Partial<BeamDesignResponse['flexure']> & {
     // Legacy field used by servers before the REST/WebSocket contract was aligned.
@@ -61,6 +68,7 @@ export function normalizeWebSocketDesignResult(data: WebSocketDesignData): BeamD
           tau_c: shear.tau_c ?? shear.tc ?? 0,
           tau_c_max: shear.tau_c_max ?? 0,
           asv_required: shear.asv_required ?? 0,
+          asv_required_unit: 'mm²/mm',
           stirrup_spacing: shear.stirrup_spacing ?? shear.spacing ?? 0,
           sv_max: shear.sv_max ?? 0,
           shear_capacity: shear.shear_capacity ?? 0,
@@ -72,6 +80,7 @@ export function normalizeWebSocketDesignResult(data: WebSocketDesignData): BeamD
     effective_depth_used: data.effective_depth_used,
     warnings: data.warnings ?? [],
     evidence: data.evidence,
+    holds: data.evidence ? data.holds ?? [] : ['WEBSOCKET_EVIDENCE_IDENTITY_MISSING'],
   };
 }
 
@@ -87,6 +96,7 @@ const RWS_OPTIONS = {
 export function useDesignWebSocket(sessionId: string, enabled: boolean = true) {
   const { inputs, setResult, setLoading, setError, length } = useDesignStore();
   const wsRef = useRef<ReconnectingWebSocket | null>(null);
+  const webSocketAllowed = enabled && !requiresCanonicalHttp(inputs);
   const retryCountRef = useRef(0);
   const [state, setState] = useState<WebSocketState>({
     isConnected: false,
@@ -151,7 +161,7 @@ export function useDesignWebSocket(sessionId: string, enabled: boolean = true) {
         setState((s) => ({
           ...s,
           isConnected: false,
-          status: enabled ? 'reconnecting' : 'disconnected',
+          status: webSocketAllowed ? 'reconnecting' : 'disconnected',
         }));
       };
 
@@ -182,7 +192,7 @@ export function useDesignWebSocket(sessionId: string, enabled: boolean = true) {
         error: (err as Error).message,
       }));
     }
-  }, [sessionId, enabled, handleMessage]);
+  }, [sessionId, webSocketAllowed, handleMessage]);
 
   // Send design request
   const sendDesign = useCallback(() => {
@@ -214,7 +224,7 @@ export function useDesignWebSocket(sessionId: string, enabled: boolean = true) {
 
   // Connect on mount
   useEffect(() => {
-    if (enabled) {
+    if (webSocketAllowed) {
       connect();
     }
 
@@ -223,14 +233,14 @@ export function useDesignWebSocket(sessionId: string, enabled: boolean = true) {
         wsRef.current.close();
       }
     };
-  }, [enabled, connect]);
+  }, [webSocketAllowed, connect]);
 
   // Send design on input changes when connected
   useEffect(() => {
-    if (enabled && state.isConnected) {
+    if (webSocketAllowed && state.isConnected) {
       sendDesign();
     }
-  }, [enabled, state.isConnected, inputs, sendDesign]);
+  }, [webSocketAllowed, state.isConnected, inputs, sendDesign]);
 
   // Reconnect function for manual retry
   const reconnect = useCallback(() => {

--- a/react_app/src/hooks/useExport.ts
+++ b/react_app/src/hooks/useExport.ts
@@ -25,6 +25,8 @@ export interface ExportBeamParams {
   asc_required?: number;
   moment?: number;
   shear?: number;
+  torsion?: number;
+  include_serviceability?: boolean;
 }
 
 export interface ExportReportParams {
@@ -35,10 +37,20 @@ export interface ExportReportParams {
   fy: number;
   moment?: number;
   shear?: number;
+  torsion?: number;
   ast_required?: number;
   ast_provided?: number;
   utilization?: number;
   is_safe?: boolean;
+  effective_depth?: number;
+  clear_cover?: number;
+  stirrup_dia_mm?: number;
+  main_bar_dia_mm?: number;
+  include_serviceability?: boolean;
+  span_mm?: number;
+  support_condition?: string;
+  crack_width_params?: import('../api/client').BeamDesignRequest['crack_width_params'];
+  calculation_identity?: string;
   format?: "html" | "json" | "pdf";
 }
 

--- a/react_app/src/hooks/useLiveDesign.ts
+++ b/react_app/src/hooks/useLiveDesign.ts
@@ -17,6 +17,7 @@ import type { BeamDesignRequest } from '../api/client';
 import type { Beam3DGeometry, BeamGeometryRequest } from './useBeamGeometry';
 import { LatestRequestCoordinator } from '../workspace/requestCoordinator';
 import type { ResultLifecycle, RevisionIdentity } from '../workspace/types';
+import { isBeamResultExportable } from '../utils/trustPresentation';
 
 interface LiveDesignOptions {
   /** Enable WebSocket connection */
@@ -54,6 +55,8 @@ interface LiveDesignState {
   connectionStatus: 'connecting' | 'connected' | 'disconnected' | 'reconnecting' | 'error';
   /** Whether REST fallback is active (WS unavailable) */
   isFallbackActive: boolean;
+  /** Why the canonical HTTP transport is being used. */
+  transportExplanation: string;
 }
 
 interface LiveDesignActions {
@@ -71,23 +74,38 @@ interface LiveDesignActions {
 
 const QUICK_REQUEST_KEY = 'quick-design';
 
-export function createQuickDesignIdentity(
-  inputs: BeamDesignRequest,
-  length: number,
-  inputRevision: number,
-): RevisionIdentity {
-  const canonicalInputs = JSON.stringify({
+function canonicalQuickInputs(inputs: BeamDesignRequest, length: number): string {
+  const includeServiceability = inputs.include_serviceability ?? false;
+  return JSON.stringify({
     width: inputs.width,
     depth: inputs.depth,
     length,
     moment: inputs.moment,
     shear: inputs.shear ?? 0,
+    torsion: inputs.torsion ?? 0,
     fck: inputs.fck,
     fy: inputs.fy,
     clearCover: inputs.clear_cover ?? 40,
+    effectiveDepth: inputs.effective_depth ?? null,
     stirrupDiameter: inputs.stirrup_dia_mm ?? 8,
     mainBarDiameter: inputs.main_bar_dia_mm ?? 20,
+    includeServiceability,
+    serviceability: includeServiceability
+      ? {
+          span: inputs.span_mm ?? null,
+          support: inputs.support_condition ?? null,
+          crackWidth: inputs.crack_width_params ?? null,
+        }
+      : null,
   });
+}
+
+export function createQuickDesignIdentity(
+  inputs: BeamDesignRequest,
+  length: number,
+  inputRevision: number,
+): RevisionIdentity {
+  const canonicalInputs = canonicalQuickInputs(inputs, length);
   let hash = 2166136261;
   for (let index = 0; index < canonicalInputs.length; index += 1) {
     hash ^= canonicalInputs.charCodeAt(index);
@@ -159,7 +177,7 @@ export function useLiveDesign(options: LiveDesignOptions = {}): {
 
   // Debounce ref for auto-design
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastInputsRef = useRef(inputs);
+  const lastInputsRef = useRef(canonicalQuickInputs(inputs, length));
   const coordinatorRef = useRef(new LatestRequestCoordinator());
   const requestSequenceRef = useRef(0);
 
@@ -242,19 +260,11 @@ export function useLiveDesign(options: LiveDesignOptions = {}): {
     if (!autoDesign || !enabled) return;
 
     // Check if inputs actually changed
-    const inputsChanged =
-      lastInputsRef.current.width !== inputs.width ||
-      lastInputsRef.current.depth !== inputs.depth ||
-      lastInputsRef.current.moment !== inputs.moment ||
-      lastInputsRef.current.shear !== inputs.shear ||
-      lastInputsRef.current.fck !== inputs.fck ||
-      lastInputsRef.current.fy !== inputs.fy ||
-      lastInputsRef.current.clear_cover !== inputs.clear_cover ||
-      lastInputsRef.current.stirrup_dia_mm !== inputs.stirrup_dia_mm ||
-      lastInputsRef.current.main_bar_dia_mm !== inputs.main_bar_dia_mm;
+    const currentInputs = canonicalQuickInputs(inputs, length);
+    const inputsChanged = lastInputsRef.current !== currentInputs;
 
     if (!inputsChanged) return;
-    lastInputsRef.current = { ...inputs };
+    lastInputsRef.current = currentInputs;
 
     // Debounce the design request
     if (debounceRef.current) {
@@ -270,7 +280,7 @@ export function useLiveDesign(options: LiveDesignOptions = {}): {
         clearTimeout(debounceRef.current);
       }
     };
-  }, [inputs, autoDesign, enabled, debounceMs, runRestDesign]);
+  }, [inputs, length, autoDesign, enabled, debounceMs, runRestDesign]);
 
   // Actions
   const triggerDesign = useCallback(() => {
@@ -325,12 +335,18 @@ export function useLiveDesign(options: LiveDesignOptions = {}): {
     exportEligible: Boolean(
       result
       && resultLifecycle === 'current'
-      && resultRevision === inputRevision,
+      && resultRevision === inputRevision
+      && isBeamResultExportable(result),
     ),
     geometry: geometry ?? null,
     error: error || (geometryError as Error | null)?.message || null,
     connectionStatus: enabled ? 'connected' : 'disconnected',
     isFallbackActive: true,
+    transportExplanation: (inputs.torsion ?? 0) > 0
+      ? 'Canonical HTTP is required because the WebSocket contract does not carry torsion.'
+      : inputs.include_serviceability
+        ? 'Canonical HTTP is required because the WebSocket contract does not carry serviceability inputs.'
+        : 'Verified HTTP mode ignores cancelled and stale responses.',
   };
 
   // Combined actions

--- a/react_app/src/store/designStore.ts
+++ b/react_app/src/store/designStore.ts
@@ -42,11 +42,14 @@ const DEFAULT_INPUTS: BeamDesignRequest = {
   depth: 450, // mm
   moment: 150, // kN·m
   shear: 80, // kN
+  torsion: 0, // kN·m
   fck: 25.0, // N/mm² (M25)
   fy: 500.0, // N/mm² (Fe500)
   clear_cover: 40, // mm
   stirrup_dia_mm: 8, // mm
   main_bar_dia_mm: 20, // mm
+  include_serviceability: false,
+  support_condition: 'simply_supported',
 };
 
 const DEFAULT_LENGTH = 4000; // mm

--- a/react_app/src/utils/__tests__/trustPresentation.test.ts
+++ b/react_app/src/utils/__tests__/trustPresentation.test.ts
@@ -20,7 +20,7 @@ function result(utilization: number, status: 'PASS' | 'FAIL' | 'HOLD'): BeamDesi
     utilization_ratio: utilization,
     evidence: {
       artifact_schema: 'structural_lib.beam-evidence',
-      artifact_schema_version: '1.0',
+      artifact_schema_version: '2.0',
       library_version: '0.23.0',
       code_edition: 'IS 456:2000',
       code_amendment_identity: 'not-declared-in-artifact',
@@ -52,5 +52,23 @@ describe('trust presentation', () => {
 
   it.each(['FAIL', 'HOLD'] as const)('quarantines %s results', (status) => {
     expect(getTrustPresentation(result(status === 'FAIL' ? 1.01 : 0, status)).canExport).toBe(false);
+  });
+
+  it('fails closed when evidence identity is absent or a backend hold exists', () => {
+    const missing = result(0.5, 'PASS');
+    missing.evidence = null;
+    expect(getTrustPresentation(missing).status).toBe('HOLD');
+    expect(getTrustPresentation(missing).canExport).toBe(false);
+
+    const held = result(0.5, 'PASS');
+    held.holds = ['TORSION_SCOPE_HOLD'];
+    expect(getTrustPresentation(held).status).toBe('HOLD');
+    expect(getTrustPresentation(held).canExport).toBe(false);
+  });
+
+  it('fails closed when evidence contradicts the combined primary result', () => {
+    const contradictory = result(0.5, 'PASS');
+    contradictory.success = false;
+    expect(getTrustPresentation(contradictory).status).toBe('HOLD');
   });
 });

--- a/react_app/src/utils/trustPresentation.ts
+++ b/react_app/src/utils/trustPresentation.ts
@@ -12,19 +12,39 @@ export interface TrustPresentation {
   canExport: boolean;
 }
 
+function hasText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function isBeamResultExportable(result: BeamDesignResponse): boolean {
+  return getTrustPresentation(result).canExport;
+}
+
 /** Keep decision logic on exact values while presenting enough precision to audit it. */
 export function getTrustPresentation(result: BeamDesignResponse): TrustPresentation {
   const evidence = result.evidence;
   const exactUtilization = evidence?.exact_utilization ?? result.utilization_ratio;
   const margin = evidence?.margin ?? 1 - exactUtilization;
-  const evidenceStatus = evidence?.status;
-  const status: TrustStatus = evidenceStatus
-    ?? (result.success && exactUtilization <= 1 ? 'PASS' : 'FAIL');
+  const hasIdentity = Boolean(
+    evidence
+    && evidence.support_status === 'SUPPORTED'
+    && (evidence.status === 'PASS' || evidence.status === 'FAIL')
+    && Number.isFinite(evidence.exact_utilization)
+    && Number.isFinite(evidence.margin)
+    && hasText(evidence.normalized_input_hash)
+    && hasText(evidence.calculation_identity),
+  );
+  const hasHold = (result.holds?.length ?? 0) > 0;
+  const outcomeMatches = evidence?.status === (result.success ? 'PASS' : 'FAIL');
+  const status: TrustStatus = hasIdentity && !hasHold && outcomeMatches
+    ? evidence.status as 'PASS' | 'FAIL'
+    : 'HOLD';
   const canExport =
     status === 'PASS'
     && result.success
     && exactUtilization <= 1
-    && evidence?.support_status !== 'HELD';
+    && hasIdentity
+    && !hasHold;
 
   return {
     status,


### PR DESCRIPTION
## Summary

- integrate optional ordinary rectangular-beam torsion into the canonical primary design route
- forward maintained Level-A serviceability inputs and correct the primary shear-reinforcement quantity to Asv/s in mm2/mm
- bind torsion and serviceability into evidence identity, workbench revision status, and fail-closed export behavior
- keep one primary PASS/FAIL authority and quarantine incomplete WebSocket or secondary-check results

## Supported scope

Ordinary solid rectangular beams with optional IS 456 torsion within the declared material limits, plus explicit maintained Level-A deflection and crack-width inputs.

Flanged, hollow/box, deep, prestressed, axial-torsion, and redistribution cases remain held. Combined/serviceability BBS, DXF, and PDF exports also remain held; HTML/JSON reports require the exact calculation identity.

## Validation

- independent focused Python/FastAPI regression: 147 passed
- independent focused React regression: 82 passed
- React TypeScript, ESLint, and production build passed
- full repository gate: 30/30 passed
- mypy, Ruff/Black, Bandit, API contract, manifest, and commit hooks passed

This PR contains software verification evidence only. Qualified structural-engineering review remains required before engineering or construction use.