### PR TITLE
docs(release): document Alpha version policy

### DIFF
--- a/.github/skills/release-preflight/SKILL.md
+++ b/.github/skills/release-preflight/SKILL.md
@@ -16,7 +16,7 @@ Use this only for an actual release candidate. The canonical automation owns res
 ## Preconditions
 
 - Run from the workspace root on the intended release branch.
-- Know the exact target version in `X.Y.Z` form.
+- Know the exact target version in PEP 440 `X.Y.ZaN` form for Alpha releases (or the exact stable `X.Y.Z` form for stable releases).
 - Preserve unrelated work; preflight requires a clean working tree.
 - The `PR Gate` for the release candidate must pass on its current commit.
 


### PR DESCRIPTION
Update `.github/skills/release-preflight/SKILL.md` to distinguish PEP 440 Alpha targets `X.Y.ZaN` from stable `X.Y.Z` targets. This reconciles the skill with the repository's current `0.23.1a1` policy before release evidence work.

Validation:
- `./run.sh check --quick`: 10/10 passed.
- Commit hooks passed.

No version bump, tag, publication, GitHub Release, Pages change, or branch deletion is included.