### PR TITLE
fix(release): harden 0.23.1a1 candidate verification

### DIFF
--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -8,9 +8,9 @@ applyTo: "**/docs/**,**/*.md"
 
 Use safe scripts that preserve 870+ internal links:
 ```bash
-.venv/bin/python scripts/safe_file_move.py old.md new.md --dry-run  # Preview first
-.venv/bin/python scripts/safe_file_move.py old.md new.md            # Then execute
-.venv/bin/python scripts/safe_file_delete.py file.md
+./scripts/python_runtime.sh scripts/safe_file_move.py old.md new.md --dry-run  # Preview first
+./scripts/python_runtime.sh scripts/safe_file_move.py old.md new.md            # Then execute
+./scripts/python_runtime.sh scripts/safe_file_delete.py file.md
 ```
 
 ## New docs require metadata
@@ -28,7 +28,7 @@ Use `create_doc.py` or add manually:
 ## Check for duplicates before creating
 
 ```bash
-.venv/bin/python scripts/find_automation.py "topic"
+./scripts/python_runtime.sh scripts/find_automation.py "topic"
 ```
 Check `docs/docs-canonical.json` for existing canonical docs on the topic.
 
@@ -54,7 +54,7 @@ Multi-session WIP docs go to `docs/_active/` first, then move to permanent locat
 
 Non-archived docs must stay under 400 files. Check with:
 ```bash
-.venv/bin/python scripts/check_docs.py --budget
+./scripts/python_runtime.sh scripts/check_docs.py --budget
 ```
 
 ## After structural changes

--- a/.github/instructions/python-core.instructions.md
+++ b/.github/instructions/python-core.instructions.md
@@ -36,7 +36,7 @@ Python/structural_lib/
 
 Before wrapping or calling any function from `api.py`:
 ```bash
-.venv/bin/python scripts/discover_api_signatures.py <function_name>
+./scripts/python_runtime.sh scripts/discover_api_signatures.py <function_name>
 ```
 NEVER guess parameter names. It's `b_mm` not `width`, `fck` not `concrete_grade`.
 
@@ -53,17 +53,17 @@ The services API currently has 68 public functions and 15 internal helpers. Key 
 - `services/api.py` — 68 public functions and 15 internal helpers, the real entry point
 - `codes/is456/` — all IS 456 math lives here
 - `core/` — base types, sections, materials
-- Before wrapping API functions: `.venv/bin/python scripts/discover_api_signatures.py <func>`
+- Before wrapping API functions: `./scripts/python_runtime.sh scripts/discover_api_signatures.py <func>`
 - Never guess parameter names (`b_mm` not `width`, `fck` not `concrete_grade`)
 
 ## Migration Scripts
 
-- **Move a module:** `.venv/bin/python scripts/migrate_python_module.py <src> <dst> --dry-run`
-- **Validate imports:** `.venv/bin/python scripts/validate_imports.py --scope structural_lib`
+- **Move a module:** `./scripts/python_runtime.sh scripts/migrate_python_module.py <src> <dst> --dry-run`
+- **Validate imports:** `./scripts/python_runtime.sh scripts/validate_imports.py --scope structural_lib`
 
 ## Testing & Quality
 
-- Tests: `.venv/bin/pytest Python/tests/ -v` (85% branch coverage required)
+- Tests: `./scripts/python_runtime.sh -m pytest Python/tests/ -v` (85% branch coverage required)
 - Production code requires a Codex-managed branch and PR through the connected GitHub integration.
 
 ## Cross-Platform File I/O

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -65,7 +65,7 @@ RIGHT: useBeamGeometry → POST /api/v1/geometry/beam/full → geometry_3d
 
 ## Migration Scripts
 
-- **Move a component:** `.venv/bin/python scripts/migrate_react_component.py <src> <dst> --dry-run`
+- **Move a component:** `./scripts/python_runtime.sh scripts/migrate_react_component.py <src> <dst> --dry-run`
 - Co-located CSS files are moved automatically
 
 ## Build & Test

--- a/.github/instructions/terminal-rules.instructions.md
+++ b/.github/instructions/terminal-rules.instructions.md
@@ -8,12 +8,14 @@ applyTo: "**"
 Absolute path: `/Users/pravinsurawase/VS_code_project/structural_engineering_lib`
 All commands below assume cwd = this directory unless stated otherwise.
 
-## venv Location
-`.venv/` is at the PROJECT ROOT — NOT inside `Python/` subdirectory.
+## Python Runtime and venv Location
+The approved `.venv/` may be in this checkout or the primary worktree. Always
+use the launcher so imports bind to the invoking worktree.
 ```
-CORRECT: .venv/bin/python ...
-CORRECT: .venv/bin/pytest Python/tests/ -v
-WRONG:   cd Python && .venv/bin/pytest tests/     ← .venv not in Python/
+CORRECT: ./scripts/python_runtime.sh ...
+CORRECT: ./scripts/python_runtime.sh -m pytest Python/tests/ -v
+CHECK:   ./scripts/python_runtime.sh --diagnose
+WRONG:   cd Python && python -m pytest tests/          ← cwd and interpreter are implicit
 WRONG:   python scripts/...                        ← wrong env, missing deps
 ```
 
@@ -21,7 +23,7 @@ WRONG:   python scripts/...                        ← wrong env, missing deps
 If you run `cd react_app`, your NEXT command is still in `react_app/`.
 Always use full paths from root, or prefix with explicit `cd`:
 ```
-SAFE:    .venv/bin/pytest Python/tests/ -v          ← works from root
+SAFE:    ./scripts/python_runtime.sh -m pytest Python/tests/ -v          ← works from root
 SAFE:    ./run.sh frontend build                     ← root-stable, pinned Node
 DANGER:  npm run build                              ← cwd and Node are implicit
 ```
@@ -34,14 +36,14 @@ If `./run.sh <cmd>` produces no output or fails:
 
 | run.sh Command | Direct Script Fallback | CLI Fallback |
 |----------------|----------------------|--------------|
-| `./run.sh test` | `.venv/bin/pytest Python/tests/ -v` | Python suite only |
-| `./run.sh test --fastapi` | `.venv/bin/pytest fastapi_app/tests/` | — |
-| `./run.sh test --react` | `.venv/bin/python scripts/node_runtime.py -- npm --prefix react_app test` | — |
-| `./run.sh frontend check` | `.venv/bin/python scripts/node_runtime.py -- npm --prefix react_app test` | Run lint and build through the same wrapper |
-| `./run.sh check --quick` | `.venv/bin/python scripts/check_all.py --quick` | — |
-| `./run.sh find --api func` | `.venv/bin/python scripts/discover_api_signatures.py func` | — |
-| `./run.sh session summary` | `.venv/bin/python scripts/session.py summary` | Add `--write` only intentionally |
-| `./run.sh generate indexes` | `.venv/bin/python scripts/generate_enhanced_index.py --all` | — |
+| `./run.sh test` | `./scripts/python_runtime.sh -m pytest Python/tests/ -v` | Python suite only |
+| `./run.sh test --fastapi` | `./scripts/python_runtime.sh -m pytest fastapi_app/tests/` | — |
+| `./run.sh test --react` | `./scripts/python_runtime.sh scripts/node_runtime.py -- npm --prefix react_app test` | — |
+| `./run.sh frontend check` | `./scripts/python_runtime.sh scripts/node_runtime.py -- npm --prefix react_app test` | Run lint and build through the same wrapper |
+| `./run.sh check --quick` | `./scripts/python_runtime.sh scripts/check_all.py --quick` | — |
+| `./run.sh find --api func` | `./scripts/python_runtime.sh scripts/discover_api_signatures.py func` | — |
+| `./run.sh session summary` | `./scripts/python_runtime.sh scripts/session.py summary` | Add `--write` only intentionally |
+| `./run.sh generate indexes` | `./scripts/python_runtime.sh scripts/generate_enhanced_index.py --all` | — |
 | `./run.sh dev` | `bash scripts/launch_stack.sh` | `colima start && docker compose up --build` |
 | `./run.sh dev --docker` | `bash scripts/launch_stack.sh --docker` | `colima start && docker compose up --build` |
 | `./run.sh dev --kill-only` | `bash scripts/launch_stack.sh --kill-only` | Stop only listeners started for this task; never kill arbitrary port owners |
@@ -50,10 +52,10 @@ If `./run.sh <cmd>` produces no output or fails:
 
 ### Python
 ```bash
-.venv/bin/pytest Python/tests/ -v                    # All tests
-.venv/bin/pytest Python/tests/ -v -k "test_shear"    # Specific tests
-.venv/bin/python scripts/discover_api_signatures.py design_beam_is456  # API params
-.venv/bin/python scripts/validate_imports.py --scope structural_lib    # Check imports
+./scripts/python_runtime.sh -m pytest Python/tests/ -v                    # All tests
+./scripts/python_runtime.sh -m pytest Python/tests/ -v -k "test_shear"    # Specific tests
+./scripts/python_runtime.sh scripts/discover_api_signatures.py design_beam_is456  # API params
+./scripts/python_runtime.sh scripts/validate_imports.py --scope structural_lib    # Check imports
 ```
 
 ### React (pinned `.nvmrc` runtime)
@@ -96,8 +98,8 @@ Codex inspects the state and diff, stages only intended paths, creates a convent
 
 **FORBIDDEN (causes merge conflicts, rework, and lost changes):**
 ```
-NEVER: rm file.md                                     ← use .venv/bin/python scripts/safe_file_delete.py
-NEVER: mv old.md new.md                               ← use .venv/bin/python scripts/safe_file_move.py
+NEVER: rm file.md                                     ← use ./scripts/python_runtime.sh scripts/safe_file_delete.py
+NEVER: mv old.md new.md                               ← use ./scripts/python_runtime.sh scripts/safe_file_move.py
 NEVER: --no-verify or --force                         ← has caused 10+ hours of rework
 NEVER: git rebase --skip                              ← can silently drop commits
 NEVER: cat > file << 'EOF' ... EOF   ← heredoc fails in agent terminals; use editFiles tool
@@ -112,7 +114,7 @@ require explicit user approval.
 ```
 NEVER: gh pr merge --admin            ← bypasses required CI checks
 NEVER: gh issue close (without user approval) ← destructive, ask first
-NEVER: git push origin --delete (without user approval) ← use .venv/bin/python scripts/cleanup_stale_branches.py --dry-run
+NEVER: git push origin --delete (without user approval) ← use ./scripts/python_runtime.sh scripts/cleanup_stale_branches.py --dry-run
 ```
 
 Closing issues or pull requests and deleting branches require **explicit user

--- a/.github/skills/agent-evolution/SKILL.md
+++ b/.github/skills/agent-evolution/SKILL.md
@@ -22,10 +22,10 @@ Periodic reviews are report-only unless `--fix` is explicitly supplied. Do not u
 Choose a stable session ID and agent name:
 
 ```bash
-.venv/bin/python scripts/agent_session_collector.py --session-id <session-id>
-.venv/bin/python scripts/agent_scorer.py --session <session-id> --agent <agent> --auto-only
-.venv/bin/python scripts/agent_drift_detector.py --session <session-id> --agent <agent>
-.venv/bin/python scripts/agent_compliance_checker.py --session <session-id> --agent <agent>
+./scripts/python_runtime.sh scripts/agent_session_collector.py --session-id <session-id>
+./scripts/python_runtime.sh scripts/agent_scorer.py --session <session-id> --agent <agent> --auto-only
+./scripts/python_runtime.sh scripts/agent_drift_detector.py --session <session-id> --agent <agent>
+./scripts/python_runtime.sh scripts/agent_compliance_checker.py --session <session-id> --agent <agent>
 ```
 
 Drift and compliance checks are read-only. Add `--write` to the drift command
@@ -38,9 +38,9 @@ Do not use nonexistent bulk flags. Manual scores require the scorer's explicit d
 Instruction proposals require at least 15 collected session records. Before that threshold, observe and collect only. When the threshold is met and an evolution review is requested:
 
 ```bash
-.venv/bin/python scripts/agent_trends.py --weekly --alert
-.venv/bin/python scripts/agent_evolve_instructions.py --propose
-.venv/bin/python scripts/agent_evolve_instructions.py --list
+./scripts/python_runtime.sh scripts/agent_trends.py --weekly --alert
+./scripts/python_runtime.sh scripts/agent_evolve_instructions.py --propose
+./scripts/python_runtime.sh scripts/agent_evolve_instructions.py --list
 ```
 
 Trend analysis is read-only by default; add `--write` only for an intentional
@@ -53,7 +53,7 @@ Review each proposal against the underlying sessions. Correlation or a single ba
 Preview one exact proposal ID:
 
 ```bash
-.venv/bin/python scripts/agent_evolve_instructions.py --apply <evolution-id> --dry-run
+./scripts/python_runtime.sh scripts/agent_evolve_instructions.py --apply <evolution-id> --dry-run
 ```
 
 Actual `--apply <evolution-id>` changes agent instructions and requires explicit user approval. `--rollback <evolution-id>` also requires explicit approval and the evolution ID from the log; an agent name is not a valid rollback target.

--- a/.github/skills/api-discovery/SKILL.md
+++ b/.github/skills/api-discovery/SKILL.md
@@ -31,7 +31,7 @@ Output includes:
 ## List All Public API Functions
 
 ```bash
-.venv/bin/python scripts/discover_api_signatures.py --all
+./scripts/python_runtime.sh scripts/discover_api_signatures.py --all
 ```
 
 The count is derived at runtime. Do not copy it into instructions or documentation.
@@ -39,16 +39,16 @@ The count is derived at runtime. Do not copy it into instructions or documentati
 ## Filter by Keyword
 
 ```bash
-.venv/bin/python scripts/discover_api_signatures.py --filter beam
-.venv/bin/python scripts/discover_api_signatures.py --filter rebar
-.venv/bin/python scripts/discover_api_signatures.py --filter detailing
+./scripts/python_runtime.sh scripts/discover_api_signatures.py --filter beam
+./scripts/python_runtime.sh scripts/discover_api_signatures.py --filter rebar
+./scripts/python_runtime.sh scripts/discover_api_signatures.py --filter detailing
 ```
 
 ## JSON Output (for programmatic use)
 
 ```bash
-.venv/bin/python scripts/discover_api_signatures.py design_beam_is456 --json
-.venv/bin/python scripts/discover_api_signatures.py --all --json
+./scripts/python_runtime.sh scripts/discover_api_signatures.py design_beam_is456 --json
+./scripts/python_runtime.sh scripts/discover_api_signatures.py --all --json
 ```
 
 ## Required Use Pattern

--- a/.github/skills/architecture-check/SKILL.md
+++ b/.github/skills/architecture-check/SKILL.md
@@ -28,7 +28,7 @@ Layer 4: UI/IO         → react_app/, fastapi_app/             # External inter
 ## Boundary Validation
 
 ```bash
-.venv/bin/python scripts/check_architecture_boundaries.py
+./scripts/python_runtime.sh scripts/check_architecture_boundaries.py
 ```
 
 Checks:
@@ -40,7 +40,7 @@ Checks:
 ## Import Validation
 
 ```bash
-.venv/bin/python scripts/validate_imports.py --scope structural_lib
+./scripts/python_runtime.sh scripts/validate_imports.py --scope structural_lib
 ```
 
 This is a separate resolution check. It catches broken module paths; the boundary checker owns layer direction.
@@ -48,7 +48,7 @@ This is a separate resolution check. It catches broken module paths; the boundar
 Run the circular-import checker only if the change creates an import cycle or the normal import validation reports one:
 
 ```bash
-.venv/bin/python scripts/check_circular_imports.py
+./scripts/python_runtime.sh scripts/check_circular_imports.py
 ```
 
 Do not run generic duplication scans as part of this skill. Before adding a new hook, route, or public function, use targeted `rg` in that component to locate an existing implementation.

--- a/.github/skills/function-quality-pipeline/SKILL.md
+++ b/.github/skills/function-quality-pipeline/SKILL.md
@@ -66,8 +66,8 @@ Run the narrowest existing test or direct calculation check after the calculatio
 For implementation work, add or update only the narrow tests needed for the requested calculation. Cover the accepted benchmark and the governing limit that changes the main result. Do not invent universal test counts or tolerances.
 
 ```bash
-.venv/bin/pytest <exact-test-path> -q
-.venv/bin/pytest Python/tests/ -q -k "<function_or_clause>"
+./scripts/python_runtime.sh -m pytest <exact-test-path> -q
+./scripts/python_runtime.sh -m pytest Python/tests/ -q -k "<function_or_clause>"
 ```
 
 Independently compare the computed result with the recorded source and show units. A benchmark mismatch is a stop condition; do not loosen the tolerance merely to pass.
@@ -89,8 +89,8 @@ Add FastAPI and React consumers only when they are part of the requested main pr
 During implementation, run only affected checks. Before commit:
 
 ```bash
-.venv/bin/python scripts/check_architecture_boundaries.py
-.venv/bin/python scripts/validate_imports.py --scope structural_lib
+./scripts/python_runtime.sh scripts/check_architecture_boundaries.py
+./scripts/python_runtime.sh scripts/validate_imports.py --scope structural_lib
 ./run.sh check --quick
 ```
 

--- a/.github/skills/is456-verification/SKILL.md
+++ b/.github/skills/is456-verification/SKILL.md
@@ -33,8 +33,8 @@ Choose the exact existing test module or keyword that exercises the changed main
 ## Run Targeted Verification
 
 ```bash
-.venv/bin/pytest <exact-test-path> -q
-.venv/bin/pytest Python/tests/ -q -k "<function_or_clause>"
+./scripts/python_runtime.sh -m pytest <exact-test-path> -q
+./scripts/python_runtime.sh -m pytest Python/tests/ -q -k "<function_or_clause>"
 ```
 
 Compare the result independently with the benchmark and show the unit conversion. Use the source's precision to set tolerance; do not apply one universal percentage to tables, charts, and textbook examples.
@@ -46,8 +46,8 @@ When the task is review-only, do not add tests. Report only a confirmed mismatch
 For an implemented structural change:
 
 ```bash
-.venv/bin/python scripts/check_architecture_boundaries.py
-.venv/bin/python scripts/validate_imports.py --scope structural_lib
+./scripts/python_runtime.sh scripts/check_architecture_boundaries.py
+./scripts/python_runtime.sh scripts/validate_imports.py --scope structural_lib
 ./run.sh check --quick
 ```
 

--- a/.github/skills/new-structural-element/SKILL.md
+++ b/.github/skills/new-structural-element/SKILL.md
@@ -67,8 +67,8 @@ If the task is delegated, use at most the repository's allowed bounded workers. 
 Use targeted checks while editing. Then run:
 
 ```bash
-.venv/bin/python scripts/check_architecture_boundaries.py
-.venv/bin/python scripts/validate_imports.py --scope structural_lib
+./scripts/python_runtime.sh scripts/check_architecture_boundaries.py
+./scripts/python_runtime.sh scripts/validate_imports.py --scope structural_lib
 ./run.sh check --quick
 ```
 

--- a/.github/skills/quality-gate/SKILL.md
+++ b/.github/skills/quality-gate/SKILL.md
@@ -21,10 +21,10 @@ Use the repository's canonical gates from the workspace root. Do not recreate th
 Run only the smallest existing check that exercises the changed main process. Examples:
 
 ```bash
-.venv/bin/pytest Python/tests/path/to/test_file.py -q
-.venv/bin/pytest fastapi_app/tests/path/to/test_file.py -q
+./scripts/python_runtime.sh -m pytest Python/tests/path/to/test_file.py -q
+./scripts/python_runtime.sh -m pytest fastapi_app/tests/path/to/test_file.py -q
 npm --prefix react_app run lint
-.venv/bin/python scripts/check_architecture_boundaries.py
+./scripts/python_runtime.sh scripts/check_architecture_boundaries.py
 ```
 
 Choose commands from the affected component's skill or existing project automation. Do not add tests during a review-only task.

--- a/.github/skills/release-preflight/SKILL.md
+++ b/.github/skills/release-preflight/SKILL.md
@@ -19,6 +19,8 @@ Use this only for an actual release candidate. The canonical automation owns res
 - Know the exact target version in PEP 440 `X.Y.ZaN` form for Alpha releases (or the exact stable `X.Y.Z` form for stable releases).
 - Preserve unrelated work; preflight requires a clean working tree.
 - The `PR Gate` for the release candidate must pass on its current commit.
+- The maintained preflight runs Python, FastAPI, and React gates. Do not replace
+  it with a Python-only result or assume local success covers FastAPI CI.
 
 ## Release Candidate Flow
 
@@ -57,6 +59,11 @@ Repair failures by rerunning only their narrow command, then establish one
 final green preflight. Do not run both the pre-bump and current-candidate forms
 for an already-bumped branch.
 
+When recording local evidence, use a governance-safe filename such as
+`alpha-0231-local-prepublication-rehearsal.md`. Do not place dotted package
+versions in documentation filenames. Run metadata validation through the
+consolidated command found by `./run.sh find "doc metadata"`.
+
 ### 2. Prepare the release changes
 
 `./run.sh release run <target-version>` changes version-controlled files and is owner-approved release work. Do not run it during a review-only task or without authorization to prepare the release.
@@ -68,7 +75,7 @@ After the version change, review the diff and complete the release notes require
 From the workspace root:
 
 ```bash
-.venv/bin/python -m build Python
+./scripts/python_runtime.sh -m build Python
 ```
 
 Before building, inspect and recoverably remove only the generated
@@ -86,6 +93,11 @@ Confirm that `Python/dist/` contains the wheel for the exact target version. Do 
 ```
 
 This creates and removes a unique temporary environment, installs the exact wheel, verifies the package, runs the installed-package checks, and exercises the CLI workflow. Do not create or delete a fixed `/tmp` directory manually.
+
+The verifier must prove `structural_lib.__file__` is inside the disposable
+environment before and after tests. It installs only the wheel's declared test
+extras plus explicitly documented generated-client requirements; broad root
+requirements are not acceptable artifact evidence.
 
 After publication, verify the exact public version separately:
 

--- a/.github/skills/safe-file-ops/SKILL.md
+++ b/.github/skills/safe-file-ops/SKILL.md
@@ -21,7 +21,7 @@ Do not use this skill for generated build output or disposable files outside the
 Preview the exact source and destination:
 
 ```bash
-.venv/bin/python scripts/safe_file_move.py old/path/file.ext new/path/file.ext --dry-run
+./scripts/python_runtime.sh scripts/safe_file_move.py old/path/file.ext new/path/file.ext --dry-run
 ```
 
 Confirm that both resolved paths are inside the repository, the source is the intended file, the destination is exact, and the preview contains no unexpected edits.
@@ -29,7 +29,7 @@ Confirm that both resolved paths are inside the repository, the source is the in
 Then execute the same command without `--dry-run`:
 
 ```bash
-.venv/bin/python scripts/safe_file_move.py old/path/file.ext new/path/file.ext
+./scripts/python_runtime.sh scripts/safe_file_move.py old/path/file.ext new/path/file.ext
 ```
 
 Inspect `git diff --summary` and `git diff` immediately afterward. If the live result differs from the preview, stop and report it.
@@ -39,7 +39,7 @@ Inspect `git diff --summary` and `git diff` immediately afterward. If the live r
 The command without `--dry-run` deletes the file. Always preview explicitly:
 
 ```bash
-.venv/bin/python scripts/safe_file_delete.py path/to/file.ext --dry-run
+./scripts/python_runtime.sh scripts/safe_file_delete.py path/to/file.ext --dry-run
 ```
 
 If references are reported, update or remove those references first and repeat the preview. Do not bypass the result.
@@ -47,7 +47,7 @@ If references are reported, update or remove those references first and repeat t
 Only after a clean preview, execute the exact same target without `--dry-run`:
 
 ```bash
-.venv/bin/python scripts/safe_file_delete.py path/to/file.ext
+./scripts/python_runtime.sh scripts/safe_file_delete.py path/to/file.ext
 ```
 
 The script creates a backup under `tmp/deleted_backups/` by default. Never use `--force` or `--no-backup` in the normal agent workflow. If a referenced file genuinely must be removed, stop for owner direction instead of weakening the guardrail.
@@ -57,8 +57,8 @@ The script creates a backup under `tmp/deleted_backups/` by default. Never use `
 Use the dedicated migration script when Python imports must change:
 
 ```bash
-.venv/bin/python scripts/migrate_python_module.py Python/structural_lib/old.py Python/structural_lib/new.py --dry-run
-.venv/bin/python scripts/migrate_python_module.py Python/structural_lib/old.py Python/structural_lib/new.py
+./scripts/python_runtime.sh scripts/migrate_python_module.py Python/structural_lib/old.py Python/structural_lib/new.py --dry-run
+./scripts/python_runtime.sh scripts/migrate_python_module.py Python/structural_lib/old.py Python/structural_lib/new.py
 ```
 
 ## React Component Migration (with import updates)
@@ -66,8 +66,8 @@ Use the dedicated migration script when Python imports must change:
 Use the dedicated migration script when React imports must change:
 
 ```bash
-.venv/bin/python scripts/migrate_react_component.py react_app/src/old.tsx react_app/src/new.tsx --dry-run
-.venv/bin/python scripts/migrate_react_component.py react_app/src/old.tsx react_app/src/new.tsx
+./scripts/python_runtime.sh scripts/migrate_react_component.py react_app/src/old.tsx react_app/src/new.tsx --dry-run
+./scripts/python_runtime.sh scripts/migrate_react_component.py react_app/src/old.tsx react_app/src/new.tsx
 ```
 
 ## Verification
@@ -76,13 +76,13 @@ After a successful move or delete:
 
 ```bash
 git diff --summary
-.venv/bin/python scripts/check_links.py
+./scripts/python_runtime.sh scripts/check_links.py
 ```
 
 Regenerate an index only when the affected folder has a generated index:
 
 ```bash
-.venv/bin/python scripts/generate_enhanced_index.py affected/folder
+./scripts/python_runtime.sh scripts/generate_enhanced_index.py affected/folder
 ```
 
 For source migrations, also run the narrow import/build check for that language. Do not regenerate all indexes unless the task actually changes all indexed folders.

--- a/.github/skills/session-management/SKILL.md
+++ b/.github/skills/session-management/SKILL.md
@@ -26,6 +26,18 @@ The brief is the bounded orientation packet; session start verifies the environm
 
 Before editing, confirm the branch and working tree shown by session start. Preserve unrelated user changes.
 
+In a linked worktree, `.venv/` may exist only in the primary checkout. Use
+`./run.sh` or `./scripts/python_runtime.sh`; never bypass the launcher with a
+primary-checkout interpreter path. Session start must report `Python source
+binding: current worktree`. If it does not, stop and run:
+
+```bash
+./scripts/python_runtime.sh --diagnose
+```
+
+If a direct helper name is missing or has been consolidated, do not guess an
+archive path. Resolve the maintained command with `./run.sh find "task"`.
+
 ## Session Closeout
 
 1. Run the narrow checks for changed behavior while iterating.

--- a/.github/skills/skill_tiers.json
+++ b/.github/skills/skill_tiers.json
@@ -6,7 +6,7 @@
       "specialist": "Available to specific agents based on role",
       "experimental": "Requires explicit activation"
     },
-    "last_updated": "2026-08-09"
+    "last_updated": "2026-08-11"
   },
   "core": [
     {"name": "session-management", "description": "Session start/end automation", "available_to": "all"},

--- a/.github/skills/user-acceptance-test/SKILL.md
+++ b/.github/skills/user-acceptance-test/SKILL.md
@@ -17,7 +17,7 @@ Use the canonical release verifier instead of copying API examples into this ski
 
 - Run from the workspace root.
 - Identify the exact version and source being accepted.
-- For a wheel, build it first with `.venv/bin/python -m build Python` and confirm the versioned artifact exists in `Python/dist/`.
+- For a wheel, build it first with `./scripts/python_runtime.sh -m build Python` and confirm the versioned artifact exists in `Python/dist/`.
 - Do not accept evidence from a different commit or version.
 
 ## Pre-Release Wheel UAT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e '.[dev]'
+          python -m pip install -e '.[dev,validation]' 'httpx>=0.27'
 
       - name: Resolve and verify requested version
         id: version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ recreate that lifecycle in repository scripts. The canonical process is
 NEVER: gh pr merge --admin            ← bypasses required CI checks
 NEVER: gh pr merge <N> --squash (with failing CI) ← fix failures first, then merge
 NEVER: gh issue close (without user approval) ← destructive, ask first
-NEVER: git push origin --delete (without user approval) ← use .venv/bin/python scripts/cleanup_stale_branches.py (dry-run by default)
+NEVER: git push origin --delete (without user approval) ← use ./scripts/python_runtime.sh scripts/cleanup_stale_branches.py (dry-run by default)
 NEVER: --no-verify / --force          ← breaks CI, causes rework
 NEVER: git rebase --skip              ← silently drops conflicting commits
 NEVER: git push --force-with-lease     ← rewrites shared history
@@ -145,16 +145,16 @@ UI/IO        → react_app/, fastapi_app/
 ls react_app/src/hooks/                                         # Existing React hooks
 grep -r "@router" fastapi_app/routers/ | head -30               # Existing API routes
 ./run.sh find --api <func>                                   # Public API exact signature (68 functions)
-.venv/bin/python scripts/discover_api_signatures.py <func>      # Exact param names (b_mm not width)
-.venv/bin/python scripts/find_automation.py "task"              # Find existing scripts (113 mapped)
+./scripts/python_runtime.sh scripts/discover_api_signatures.py <func>      # Exact param names (b_mm not width)
+./scripts/python_runtime.sh scripts/find_automation.py "task"              # Find existing automation (119 tasks)
 ```
 
 ## Essential Commands (`./run.sh` — preferred entry point)
 
 ```bash
 ./run.sh session start              # Begin work (verify env, read priorities)
-./run.sh check --quick              # Fast validation (<30s, 9 checks)
-./run.sh check                      # Full validation (29 checks, parallel)
+./run.sh check --quick              # Fast validation (<30s, 10 checks)
+./run.sh check                      # Full validation (30 checks, parallel)
 ./run.sh test                       # Run Python package pytest suite
 ./run.sh test --fastapi             # Run complete FastAPI test suite
 ./run.sh test --react               # Run complete React test suite on pinned Node
@@ -191,9 +191,9 @@ grep -r "@router" fastapi_app/routers/ | head -30               # Existing API r
 
 Direct scripts (when run.sh doesn't cover it):
 ```bash
-.venv/bin/python scripts/agent_context.py <name> # Agent startup context (all 16 agents)
-.venv/bin/python scripts/agent_context.py --list # List available agents
-.venv/bin/python scripts/safe_file_move.py a b   # Move files (preserves 870+ links)
+./scripts/python_runtime.sh scripts/agent_context.py <name> # Agent startup context (all 16 agents)
+./scripts/python_runtime.sh scripts/agent_context.py --list # List available agents
+./scripts/python_runtime.sh scripts/safe_file_move.py a b   # Move files (preserves 870+ links)
 colima start --cpu 4 --memory 4                  # Start Docker runtime (Colima, not Docker Desktop)
 docker compose up --build                        # Full stack at :8000/docs
 ./run.sh frontend build                          # React build on pinned Node
@@ -206,17 +206,18 @@ docker compose up --build                        # Full stack at :8000/docs
 **All commands assume cwd = workspace root.** Terminal cwd persists between calls — if a previous command did `cd react_app`, the next command is STILL in `react_app/`.
 
 ```
-WRONG: cd Python && .venv/bin/pytest tests/ -v     ← .venv is NOT inside Python/
-RIGHT: .venv/bin/pytest Python/tests/ -v           ← run from workspace root
-RIGHT: .venv/bin/python scripts/check_links.py     ← scripts are at workspace root
+WRONG: cd Python && python -m pytest tests/ -v          ← cwd and interpreter are implicit
+RIGHT: ./scripts/python_runtime.sh -m pytest Python/tests/ -v           ← run from workspace root
+RIGHT: ./scripts/python_runtime.sh scripts/check_links.py     ← scripts are at workspace root
 
 WRONG: npm run build                               ← only works if already in react_app/
 RIGHT: cd react_app && npm run build               ← explicit cd first
 ```
 
 **Key paths (all relative to workspace root):**
-- `.venv/bin/pytest` — pytest binary
-- `.venv/bin/python` — Python binary
+- `./scripts/python_runtime.sh -m pytest` — worktree-bound pytest launcher
+- `./scripts/python_runtime.sh` — worktree-bound Python launcher; the selected
+  `.venv` may live in the primary checkout
 - `Python/tests/` — Python test directory
 - `react_app/` — React app directory
 - `scripts/` — utility scripts
@@ -263,7 +264,9 @@ Log feedback only when a concrete stale instruction or missing control was found
 
 - Read `index.json` / `index.md` in folders FIRST — machine-readable summaries
 - Large files (read selectively): SESSION_LOG.md (400KB), adapters.py (71KB), CHANGELOG.md (52KB)
-- Always use `.venv/bin/python`, never bare `python`
+- Always use `./scripts/python_runtime.sh`, never bare `python`. In linked
+  worktrees, verify the current source binding with
+  `./scripts/python_runtime.sh --diagnose`.
 
 ## VS Code Copilot Agents & Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.23.1a1] - Prepared candidate (unreleased; on hold)
+
+- v0.23.1a1 candidate source prepared for evidence collection; not tagged or published.
+
 ### Added
 
 - Versioned beam workflow catalogue, thin discovery API, curated schema-driven

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.23.1a1] - Prepared candidate (unreleased; on hold)
+## [0.23.1a1] — 2026-08-11
 
-- v0.23.1a1 candidate source prepared for evidence collection; not tagged or published.
+Alpha development preview of the bounded beam, column, isolated-footing, and
+solid-slab workflows. This is case-qualified software evidence, not
+professional design approval or complete IS 456 coverage.
 
 ### Added
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,8 @@
 cff-version: 1.2.0
 title: "Structural Engineering Library (IS 456)"
 version: 0.23.1a1
-message: "Candidate prepared; not tagged or published. Alpha development preview with case-qualified IS 456 workflows; independent verification and qualified professional approval remain required for engineering use."
+date-released: 2026-08-11
+message: "Alpha development preview with case-qualified IS 456 workflows; independent verification and qualified professional approval remain required for engineering use."
 repository-code: "https://github.com/Pravin-surawase/structural_engineering_lib"
 url: "https://pypi.org/project/structural-lib-is456/"
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,7 @@
 cff-version: 1.2.0
 title: "Structural Engineering Library (IS 456)"
 version: 0.23.1a1
-date-released: 2026-08-11
-message: "Alpha development preview with case-qualified IS 456 workflows; independent verification and qualified professional approval remain required for engineering use."
+message: "Candidate prepared; not tagged or published. Alpha development preview with case-qualified IS 456 workflows; independent verification and qualified professional approval remain required for engineering use."
 repository-code: "https://github.com/Pravin-surawase/structural_engineering_lib"
 url: "https://pypi.org/project/structural-lib-is456/"
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: "Structural Engineering Library (IS 456)"
-version: 0.23.0
-date-released: 2026-08-10
+version: 0.23.1a1
+date-released: 2026-08-11
 message: "Alpha development preview with case-qualified IS 456 workflows; independent verification and qualified professional approval remain required for engineering use."
 repository-code: "https://github.com/Pravin-surawase/structural_engineering_lib"
 url: "https://pypi.org/project/structural-lib-is456/"

--- a/Python/README.md
+++ b/Python/README.md
@@ -2,7 +2,7 @@
 
 IS 456 RC Beam Design Library (Python package).
 
-**Version:** 0.23.0 (Alpha development preview)
+**Version:** 0.23.1a1 (Alpha development preview)
 **Status:** [![Weekly Verification](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/nightly.yml/badge.svg)](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/nightly.yml)
 
 > ⚠️ **Development Preview:** APIs may change until v1.0. For reproducible results, pin to a release tag.
@@ -12,7 +12,7 @@ IS 456 RC Beam Design Library (Python package).
 > qualified structural-engineering review. Use official standards as the
 > authoritative source.
 
-## New in v0.23.0
+## New in v0.23.1a1
 
 - **Security hardening:** 14 cross-field plausibility validators, error sanitization
 - **Code quality:** `check_code()` and `show_versions()` diagnostics

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "structural-lib-is456"
-version = "0.23.0"
+version = "0.23.1a1"
 description = "Supported-case IS 456 RC workflows for beams, columns, isolated footings, and solid slabs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/Python/tests/test_agent_governance_automation.py
+++ b/Python/tests/test_agent_governance_automation.py
@@ -26,6 +26,7 @@ agent_drift = importlib.import_module("agent_drift_detector")
 agent_trends = importlib.import_module("agent_trends")
 audit_permissions = importlib.import_module("audit_permissions")
 check_all = importlib.import_module("check_all")
+check_docs = importlib.import_module("check_docs")
 check_scripts_index = importlib.import_module("check_scripts_index")
 cli_smoke = importlib.import_module("test_cli_smoke")
 evolve = importlib.import_module("evolve")
@@ -92,6 +93,27 @@ print(json.dumps({
     assert Path(payload["module"]).is_relative_to(REPO_ROOT / "Python")
 
 
+def test_python_runtime_diagnostic_proves_worktree_source_binding():
+    launcher = SCRIPTS_DIR / "python_runtime.sh"
+    env = os.environ.copy()
+    env["STRUCTURAL_LIB_PYTHON"] = sys.executable
+
+    result = subprocess.run(
+        [str(launcher), "--diagnose"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["repository"] == str(REPO_ROOT)
+    assert payload["source_bound"] is True
+    assert Path(payload["module"]).is_relative_to(REPO_ROOT / "Python")
+
+
 def test_control_paths_use_python_runtime_launcher():
     launcher = str(SCRIPTS_DIR / "python_runtime.sh")
     run_sh = (REPO_ROOT / "run.sh").read_text(encoding="utf-8")
@@ -114,6 +136,8 @@ def test_control_paths_use_python_runtime_launcher():
     assert "git fetch" not in agent_start_source
     assert "gh pr" not in agent_start_source
     assert "chmod +x" not in agent_start_source
+    assert "Python source binding: current worktree" in agent_start_source
+    assert "Python source shadowing detected" in agent_start_source
 
     workflow = (REPO_ROOT / ".github" / "workflows" / "fast-checks.yml").read_text(
         encoding="utf-8"
@@ -121,6 +145,19 @@ def test_control_paths_use_python_runtime_launcher():
     install_offset = workflow.index("python -m pip install -e Python pytest PyYAML")
     smoke_offset = workflow.index("python scripts/test_cli_smoke.py")
     assert install_offset < smoke_offset
+
+
+def test_active_agent_instructions_use_worktree_safe_python_launcher():
+    instruction_paths = [REPO_ROOT / "AGENTS.md"]
+    instruction_paths.extend((REPO_ROOT / ".github" / "skills").glob("*/SKILL.md"))
+    instruction_paths.extend(
+        (REPO_ROOT / ".github" / "instructions").glob("*.instructions.md")
+    )
+
+    for path in instruction_paths:
+        source = path.read_text(encoding="utf-8")
+        assert ".venv/bin/python" not in source, path
+        assert ".venv/bin/pytest" not in source, path
 
 
 def test_watch_help_does_not_require_fswatch():
@@ -368,6 +405,39 @@ def test_automation_discovery_metadata_is_single_source():
     assert "add groups temp" not in active
     assert "test vba adapter" not in active
     assert all("streamlit" not in name for name in active)
+
+
+def test_automation_discovery_resolves_retired_checker_names():
+    automation_map = find_automation.load_automation_map()
+
+    assert find_automation.find_task("check_doc_metadata.py", automation_map)[0][0] == (
+        "check docs metadata"
+    )
+    assert (
+        find_automation.find_task("check_markdown_links.py", automation_map)[0][0]
+        == "check markdown links"
+    )
+
+
+def test_metadata_parser_recognizes_multiword_fields():
+    metadata = check_docs._extract_metadata(
+        "**Type:** Reference\n"
+        "**Audience:** Maintainers\n"
+        "**Status:** Complete\n"
+        "**Last Updated:** 2026-08-11\n"
+    )
+
+    assert metadata["Last Updated"] == "2026-08-11"
+    errors, warnings = check_docs._validate_metadata(
+        "**Type:** Reference\n"
+        "**Audience:** Maintainers\n"
+        "**Status:** Complete\n"
+        "**Importance:** Critical\n"
+        "**Created:** 2026-08-11\n"
+        "**Last Updated:** 2026-08-11\n"
+    )
+    assert errors == []
+    assert warnings == []
 
 
 def test_automation_semantics_reject_stale_and_temporary_entries():

--- a/Python/tests/test_bump_version_semantics.py
+++ b/Python/tests/test_bump_version_semantics.py
@@ -1,0 +1,52 @@
+"""Regression coverage for candidate-version documentation semantics."""
+
+import importlib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+bump_version = importlib.import_module("scripts.bump_version")
+
+
+def _write_candidate_bump_fixture(root: Path) -> tuple[Path, Path]:
+    pyproject = root / "Python" / "pyproject.toml"
+    pyproject.parent.mkdir()
+    pyproject.write_text('[project]\nversion = "0.23.0a1"\n', encoding="utf-8")
+
+    tasks = root / "docs" / "TASKS.md"
+    tasks.parent.mkdir()
+    tasks.write_text(
+        "| **Current** | v0.23.0 | ✅ ALPHA RELEASED — public artifact evidence |\n",
+        encoding="utf-8",
+    )
+    brief = root / "docs" / "planning" / "next-session-brief.md"
+    brief.parent.mkdir()
+    brief.write_text(
+        "| **Current** | v0.23.0 | ✅ ALPHA RELEASED — public artifact evidence |\n",
+        encoding="utf-8",
+    )
+    return tasks, brief
+
+
+def test_candidate_bump_preserves_published_release_evidence(
+    tmp_path: Path, monkeypatch
+):
+    """Candidate metadata changes must not relabel published-release history."""
+    tasks, brief = _write_candidate_bump_fixture(tmp_path)
+    monkeypatch.setattr(bump_version, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["bump_version.py", "0.23.1a1"])
+
+    assert bump_version.main() == 0
+    assert 'version = "0.23.1a1"' in (tmp_path / "Python" / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    for path in (tasks, brief):
+        content = path.read_text(encoding="utf-8")
+        assert "v0.23.0 | ✅ ALPHA RELEASED" in content
+        assert "v0.23.1a1" not in content
+
+    monkeypatch.setattr(sys, "argv", ["bump_version.py", "--check-docs"])
+    assert bump_version.main() == 0

--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -380,6 +380,14 @@ class TestPublishWorkflow:
         assert "^[0-9]+\\.[0-9]+\\.[0-9]+a[0-9]+$" in workflow
         assert "Expected PEP 440 Alpha format X.Y.ZaN" in workflow
 
+    def test_release_validation_installs_maintained_test_dependencies(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "publish.yml").read_text(
+            encoding="utf-8"
+        )
+
+        assert "python -m pip install -e '.[dev,validation]' 'httpx>=0.27'" in workflow
+        assert "python -m pip install -e '.[dev]'" not in workflow
+
     def test_publication_fails_closed_on_permission_record(self):
         workflow = (REPO_ROOT / ".github" / "workflows" / "publish.yml").read_text(
             encoding="utf-8"

--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -234,12 +234,130 @@ class TestReleaseVerifyDependencies:
         dev_section = pyproject.split("dev = [", 1)[1].split("]", 1)[0]
         assert "hypothesis" in dev_section
 
-    def test_wheel_verify_installs_dev_extra(self):
+    def test_wheel_verify_installs_exact_test_dependencies(self):
         source = RELEASE_SCRIPT.read_text(encoding="utf-8")
         verify_block = source.split("def cmd_verify", 1)[1].split(
             "# ─── Check Docs", 1
         )[0]
-        assert 'f"{wheel}[dev]"' in verify_block
+        assert 'f"{wheel}[dev,validation]"' in verify_block
+        assert 'f"structural-lib-is456[dev,validation]=={args.version}"' in verify_block
+        assert '"httpx>=0.27"' in verify_block
+        assert '"-r", str(requirements)' not in verify_block
+
+    def test_wheel_verify_uses_isolated_pytest_configuration(self):
+        source = RELEASE_SCRIPT.read_text(encoding="utf-8")
+        verify_block = source.split("def cmd_verify", 1)[1].split(
+            "# ─── Check Docs", 1
+        )[0]
+
+        assert "_assert_package_import_from_venv" in verify_block
+        assert "_isolated_pytest_config" in verify_block
+        assert '"--import-mode=importlib"' in verify_block
+        assert '"not slow and not repo_only"' in verify_block
+        assert "cwd=temp_root" in verify_block
+
+    def test_wheel_verify_commands_are_package_scoped_and_isolated(
+        self, tmp_path, monkeypatch
+    ):
+        wheel = tmp_path / "structural_lib_is456-0.23.1a1-py3-none-any.whl"
+        calls: list[tuple[list[str], Path | None, dict[str, str] | None]] = []
+
+        class TemporaryDirectory:
+            def __enter__(self):
+                return str(tmp_path)
+
+            def __exit__(self, *_):
+                return False
+
+        def record_run_check(cmd, *, cwd=None, timeout=600, env=None):
+            calls.append((cmd, cwd, env))
+
+        monkeypatch.setattr(release, "_run_check", record_run_check)
+        monkeypatch.setattr(release, "_find_wheel", lambda *_: wheel)
+        monkeypatch.setattr(
+            release.tempfile, "TemporaryDirectory", lambda **_: TemporaryDirectory()
+        )
+
+        result = release.cmd_verify(
+            argparse.Namespace(
+                wheel_dir="Python/dist",
+                job="Python/examples/sample_job_is456.json",
+                source="wheel",
+                version="0.23.1a1",
+                skip_cli=True,
+            )
+        )
+
+        assert result == 0
+        install_commands = [cmd for cmd, _, _ in calls if "install" in cmd]
+        assert [
+            str(tmp_path / "venv" / "bin" / "pip"),
+            "install",
+            f"{wheel}[dev,validation]",
+            "httpx>=0.27",
+        ] in install_commands
+        assert all("requirements.txt" not in " ".join(cmd) for cmd in install_commands)
+        pytest_calls = [cmd for cmd, _, _ in calls if "pytest" in cmd]
+        assert len(pytest_calls) == 1
+        assert "--import-mode=importlib" in pytest_calls[0]
+        assert "-c" in pytest_calls[0]
+        research_test = str(
+            REPO_ROOT / "Python" / "tests" / "test_research_prototypes.py"
+        )
+        assert research_test in pytest_calls[0]
+        assert pytest_calls[0][pytest_calls[0].index(research_test) - 1] == "--ignore"
+        assert any(cwd == tmp_path for _, cwd, _ in calls)
+        pytest_config = tmp_path / "pytest.ini"
+        assert pytest_config.read_text(encoding="utf-8").startswith("[pytest]\n")
+        assert "pythonpath" not in pytest_config.read_text(encoding="utf-8")
+
+
+class TestReleaseReactDependencies:
+    """Release checks must provision isolated worktree dependencies safely."""
+
+    def test_missing_dependencies_are_installed_from_lockfile(
+        self, tmp_path, monkeypatch
+    ):
+        react_dir = tmp_path / "react_app"
+        react_dir.mkdir()
+        (react_dir / "package-lock.json").write_text("{}\n", encoding="utf-8")
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, cwd=None, timeout=600, env=None):
+            calls.append(cmd)
+            tsc = react_dir / "node_modules" / ".bin" / "tsc"
+            tsc.parent.mkdir(parents=True)
+            tsc.write_text("", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(release, "_run_with_timeout", fake_run)
+
+        assert release._ensure_react_dependencies(react_dir, {"PATH": "test"})
+        assert calls == [["npm", "ci"]]
+
+    def test_dependency_symlink_is_rejected_without_running_npm(
+        self, tmp_path, monkeypatch
+    ):
+        react_dir = tmp_path / "react_app"
+        react_dir.mkdir()
+        target = tmp_path / "shared-node-modules"
+        target.mkdir()
+        (react_dir / "node_modules").symlink_to(target, target_is_directory=True)
+        called = False
+
+        def fail_if_called(*_args, **_kwargs):
+            nonlocal called
+            called = True
+            raise AssertionError("npm must not traverse a dependency symlink")
+
+        monkeypatch.setattr(release, "_run_with_timeout", fail_if_called)
+
+        assert not release._ensure_react_dependencies(react_dir, {"PATH": "test"})
+        assert not called
+
+    def test_release_run_and_preflight_share_dependency_provisioner(self):
+        source = RELEASE_SCRIPT.read_text(encoding="utf-8")
+        assert source.count("_ensure_react_dependencies(react_dir, node_env)") == 2
 
 
 class TestPublishWorkflow:

--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -345,12 +345,13 @@ class TestReleasePreflight:
     def test_public_distribution_permission_record_is_valid(self):
         assert release._public_distribution_permission_errors() == []
 
-    def test_published_current_source_surfaces_are_accepted_without_wheel(self):
+    def test_current_source_surfaces_match_release_state_without_wheel(self):
         current = release._version_from_pyproject()
+        authorized = release._release_authorization_recorded(current)
 
         assert (
             release._source_surface_version_errors(
-                current, allow_authorized_release=True
+                current, allow_authorized_release=authorized
             )
             == []
         )

--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -441,6 +441,19 @@ class TestReleasePreflight:
             assert mount in compose
         assert '"-m", "not slow"' in compose
         assert '"-p", "no:cacheprovider"' in compose
+        assert "test-fastapi:" in compose
+        assert "./fastapi_app:/app/fastapi_app:ro" in compose
+        assert "./docs:/app/docs:ro" in compose
+
+    def test_preflight_covers_the_fastapi_ci_suite(self):
+        source = RELEASE_SCRIPT.read_text(encoding="utf-8")
+        preflight = source.split("def cmd_preflight", 1)[1]
+
+        assert (
+            '_run_local_pytest_gate("4. FastAPI Tests", "fastapi_app/tests/")'
+            in preflight
+        )
+        assert '"test-fastapi"' in preflight
 
     def test_fastapi_image_retries_slow_dependency_downloads(self):
         dockerfile = (REPO_ROOT / "Dockerfile.fastapi").read_text(encoding="utf-8")

--- a/Python/tests/test_research_prototypes.py
+++ b/Python/tests/test_research_prototypes.py
@@ -26,6 +26,8 @@ from structural_lib.research.research_sustainability import (
     score_beam_carbon,
 )
 
+pytestmark = pytest.mark.repo_only
+
 # =============================================================================
 # Prototype 1: Sustainability Scoring
 # =============================================================================

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -117,6 +117,35 @@ def test_commit_summary_uses_exclusive_previous_day_boundary(
     assert "--after=2026-04-07 23:59:59" in seen[0]
 
 
+@pytest.mark.parametrize(
+    ("branch", "git_state", "trusted"),
+    [
+        ("codex/task", "Clean working tree", True),
+        ("codex/task", "2 uncommitted change(s)", False),
+        ("codex/task", "Unable to check", False),
+        ("main", "Clean working tree", False),
+        ("unknown", "Clean working tree", False),
+        ("", "Clean working tree", False),
+    ],
+)
+def test_session_trust_fails_closed_on_dirty_or_unknown_git_state(
+    branch: str, git_state: str, trusted: bool
+):
+    result, _reason = session._evaluate_trust(branch, git_state)
+
+    assert result is trusted
+
+
+def test_git_identity_helpers_reject_failed_commands(monkeypatch: pytest.MonkeyPatch):
+    def fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(args, 128, "", "fatal: not a repository")
+
+    monkeypatch.setattr(session.subprocess, "run", fake_run)
+
+    assert session.get_branch() == "unknown"
+    assert session.get_uncommitted_status() == "Unable to check"
+
+
 def test_launcher_port_discovery_is_listener_only():
     launcher = (REPO_ROOT / "scripts" / "launch_stack.sh").read_text(encoding="utf-8")
     function_body = launcher.split("get_process_on_port()", 1)[1].split(

--- a/docker-compose.preflight.yml
+++ b/docker-compose.preflight.yml
@@ -5,8 +5,9 @@
 # Usage:
 #   colima start --cpu 4 --memory 4     # Start Docker runtime (Colima, not Docker Desktop)
 #   docker compose -f docker-compose.preflight.yml run --rm test-python
+#   docker compose -f docker-compose.preflight.yml run --rm test-fastapi
 #   docker compose -f docker-compose.preflight.yml run --rm build-react
-#   docker compose -f docker-compose.preflight.yml up    # Run both
+#   docker compose -f docker-compose.preflight.yml --profile all up
 
 services:
   test-python:
@@ -26,6 +27,26 @@ services:
       - ./.nvmrc:/app/.nvmrc:ro
       - ./Dockerfile.fastapi:/app/Dockerfile.fastapi:ro
       - ./docker-compose.preflight.yml:/app/docker-compose.preflight.yml:ro
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2"
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+    profiles: ["test", "all"]
+
+  test-fastapi:
+    build:
+      context: .
+      dockerfile: Dockerfile.fastapi
+    command: ["python", "-m", "pytest", "fastapi_app/tests/", "-v", "--tb=short", "-q", "-m", "not slow", "-p", "no:cacheprovider"]
+    working_dir: /app
+    volumes:
+      - ./Python:/app/Python:ro
+      - ./fastapi_app:/app/fastapi_app:ro
+      - ./Etabs_CSV:/app/Etabs_CSV:ro
+      - ./docs:/app/docs:ro
     deploy:
       resources:
         limits:

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2244,6 +2244,10 @@ calculation/service/FastAPI contract without changing the separate torsion route
 - The documentation metadata hook ran in warning mode and exposed missing
   `Type`/`Audience` fields plus a noncanonical lifecycle status on the new
   evidence record. A guessed direct checker path was also obsolete.
+- PR #732 FastAPI Validation failed while every independent component job
+  passed: `test_project_boq_basic` expected public version `0.23.0`, but the
+  candidate API correctly returned `0.23.1a1`; PR Gate then failed as a direct
+  dependency.
 - The candidate worktree has no local `.venv`; focused commands used the
   maintained shared project interpreter.
 
@@ -2297,6 +2301,11 @@ calculation/service/FastAPI contract without changing the separate torsion route
   Resolution: added canonical reference metadata, retained
   `LOCAL PREPUBLICATION REHEARSAL` as a separate evidence boundary, and used the
   maintained checker path discovered from the repository.
+- Root cause: candidate version automation updated maintained runtime/version
+  surfaces but the FastAPI BOQ regression encoded a historical public version
+  literal. Resolution: compare BOQ evidence to `fastapi_app.__version__`, the
+  maintained application version surface, so future candidate bumps retain the
+  cross-surface contract without test-file rewrites.
 
 ### Verification
 
@@ -2322,6 +2331,9 @@ calculation/service/FastAPI contract without changing the separate torsion route
   rewriting history and draft PR #732 was opened against `main`; it was
   mergeable and normal PR validation started. No publish-capable workflow was
   dispatched.
+- GitHub run `31463676435` isolated the FastAPI version-literal failure while
+  Repository, Python, React, and MkDocs validation passed. After the fix, the
+  exact failed test passed and `./run.sh test --fastapi` passed all 413 tests.
 - Wheel SHA-256 remained
   `9c986920ceb43e341d01c6411c873605fec3321486d862a847e2083c36156aa7`;
   sdist remained

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2314,6 +2314,10 @@ calculation/service/FastAPI contract without changing the separate torsion route
 - Candidate closeout gates: `./run.sh check --quick` passed 10/10; the first full
   gate exposed the invalid evidence filename at 29/30, and the corrected rerun
   passed 30/30.
+- Clean-tree exact-wheel preflight passed with zero warnings: 5,590 Python tests
+  passed, 3 skipped, 6 deselected, and 46 warnings; Node 24 React build, clean
+  wheel identity, permission, footing inclusion, version, and release-document
+  gates all passed. Wheel and sdist hashes remained unchanged before and after.
 - Wheel SHA-256 remained
   `9c986920ceb43e341d01c6411c873605fec3321486d862a847e2083c36156aa7`;
   sdist remained

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2211,6 +2211,9 @@ calculation/service/FastAPI contract without changing the separate torsion route
   dependencies with `npm ci` while refusing `node_modules` symlinks.
 - Removed published-release status rows from automatic candidate version/date
   rewriting and recorded a truthful local-prepublication evidence boundary.
+- Added worktree-bound runtime diagnostics, fail-closed session trust,
+  discoverable retired-command aliases, metadata parsing repair, and local/
+  Docker FastAPI preflight parity so the same failure modes stop earlier.
 - Preserved the existing wheel and sdist byte-for-byte; no tag, upload, release,
   Pages action, or publish workflow was invoked.
 
@@ -2250,6 +2253,19 @@ calculation/service/FastAPI contract without changing the separate torsion route
   dependency.
 - The candidate worktree has no local `.venv`; focused commands used the
   maintained shared project interpreter.
+- The maintained local release preflight exercised Python and React but omitted
+  the FastAPI suite that exposed the candidate-version failure in CI.
+- Session start reported a counted dirty tree but still wrote a trusted state.
+- Independent review found the first trust repair still accepted a clean tree
+  when branch detection returned its `unknown` detached/error sentinel.
+- The documentation metadata parser emitted a false missing-`Last Updated`
+  warning for a correctly populated multiword field.
+- Automation discovery could not resolve the retired
+  `check_markdown_links.py` and `check_doc_metadata.py` names to their
+  consolidated maintained commands.
+- Active skills and instructions assumed every linked worktree owned
+  `.venv/bin/python`, even though the maintained launcher already supports the
+  primary environment with current-worktree source binding.
 
 ### Root causes and resolutions
 
@@ -2306,6 +2322,24 @@ calculation/service/FastAPI contract without changing the separate torsion route
   literal. Resolution: compare BOQ evidence to `fastapi_app.__version__`, the
   maintained application version surface, so future candidate bumps retain the
   cross-surface contract without test-file rewrites.
+- Root cause: release preflight and CI had different maintained test surfaces.
+  Resolution: local preflight now runs `fastapi_app/tests/`, and Docker preflight
+  has an equivalent read-only `test-fastapi` service alongside Python and React.
+- Root cause: session trust searched the formatted Git summary for the words
+  `modified` and `untracked`, while `get_uncommitted_status()` returns a count.
+  Resolution: trust now requires the exact `Clean working tree` sentinel on a
+  known non-main branch, checks both Git command return codes, and fails closed
+  for dirty, detached, or unknown state.
+- Root cause: metadata extraction accepted only single-word field names.
+  Resolution: the parser accepts trimmed multiword metadata keys and regression
+  coverage proves `Last Updated` validates without warnings.
+- Root cause: consolidated helper scripts had no searchable compatibility names.
+  Resolution: automation entries now carry aliases, discovery searches and
+  displays them, and regression coverage maps both retired checker names.
+- Root cause: documentation bypassed the worktree-aware Python launcher.
+  Resolution: active skills and instructions use `python_runtime.sh`, session
+  start proves `structural_lib` resolves under the invoking worktree, and
+  `--diagnose` reports interpreter, repository, module path, and binding status.
 
 ### Verification
 
@@ -2334,6 +2368,16 @@ calculation/service/FastAPI contract without changing the separate torsion route
 - GitHub run `31463676435` isolated the FastAPI version-literal failure while
   Repository, Python, React, and MkDocs validation passed. After the fix, the
   exact failed test passed and `./run.sh test --fastapi` passed all 413 tests.
+- Prevention-control regression suite passed all 135 tests; the broad Python
+  suite passed 5,599 tests with 3 skipped and 6 deselected, and the FastAPI suite
+  passed all 413 tests.
+- Runtime diagnosis reported `source_bound: true` for this linked worktree;
+  session start reported `Python source binding: current worktree` and correctly
+  marked the dirty tree untrusted.
+- Automation registry validation passed at 106/106 physical scripts and 119
+  grouped tasks; both retired checker names resolved to maintained commands.
+- `./run.sh check --quick` passed 10/10 and `./run.sh check` passed 30/30 after
+  the prevention updates.
 - Wheel SHA-256 remained
   `9c986920ceb43e341d01c6411c873605fec3321486d862a847e2083c36156aa7`;
   sdist remained

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2166,3 +2166,31 @@ calculation/service/FastAPI contract without changing the separate torsion route
 - Targeted source evidence proves `/workbench/quick`, `/workbench/slabs`, `/workbench/columns/rectangular`, and `/workbench/footing/isolated/concentric` coexist, with all four workbench entries reachable.
 
 ---
+## 2026-08-11 — Session: 0.23.1a1 Candidate Evidence Preparation
+
+**Agent:** Codex (`orchestrator`)
+**Branch:** `codex/alpha-0231-candidate-evidence`
+**Focus:** Prepare a local, non-publishing Alpha candidate source from merged main.
+
+### Summary
+
+- Started from exact merged main `5da9c66a0f962fc08a6431fe95e39ec664a353f6` in a dedicated local candidate lane.
+- Ran the canonical `./run.sh release run 0.23.1a1 --no-open` only after the non-publishing plan and permission gates were green.
+- Prepared the expected 16-file version/document bump to `0.23.1a1`; no changelog publication entry, tag, package upload, GitHub Release, or Pages action was performed.
+
+### Issues encountered
+
+- The first pre-bump `./run.sh release preflight 0.23.1a1` and first candidate `./run.sh release run 0.23.1a1 --no-open` stopped at the React build because the isolated worktree has no `react_app/node_modules`; the visible release-run symptom was `sh: tsc: command not found`.
+- Preflight correctly reports clean-install evidence as pending until an exact wheel is supplied.
+
+### Root causes and resolutions
+
+- Root cause: `scripts/release.py` selects Node 24 and invokes `npm run build` directly but does not provision dependencies, while this isolated worktree intentionally has no local Node installation. Resolution: used a temporary symlink to the approved primary Node 24 dependency installation for the controlled preflight/build commands, removed it on exit, and made no release-automation change. Direct `npm run build` then passed and produced the expected footing chunk.
+- Root cause: clean-install evidence is necessarily unavailable before the exact candidate wheel exists. Resolution: kept the pre-bump preflight warning visible and deferred exact-wheel preflight/UAT until one frozen artifact is built.
+
+### Verification
+
+- Pre-bump `0.23.1a1` preflight passed with target upgrade, permission, footing inclusion, 5,584 Python tests, and Node 24 React build; only the expected candidate-wheel warning remained.
+- Candidate preparation passed its same Python/build gates and updated only the expected version/document files. Artifact hash, inventory, SBOM, exact-wheel preflight, and clean-install UAT evidence will be recorded against the frozen source SHA after the single artifact build.
+
+---

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2378,6 +2378,9 @@ calculation/service/FastAPI contract without changing the separate torsion route
   grouped tasks; both retired checker names resolved to maintained commands.
 - `./run.sh check --quick` passed 10/10 and `./run.sh check` passed 30/30 after
   the prevention updates.
+- Clean-tree exact-wheel preflight passed with zero warnings after the control
+  repair: 5,602 Python tests passed, 3 skipped, and 6 deselected; 407 non-slow
+  FastAPI tests passed with 6 deselected; and the Node 24 React build passed.
 - Wheel SHA-256 remained
   `9c986920ceb43e341d01c6411c873605fec3321486d862a847e2083c36156aa7`;
   sdist remained

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2241,6 +2241,9 @@ calculation/service/FastAPI contract without changing the separate torsion route
   `scripts/check_markdown_links.py` path and stopped before its second command.
 - The first evidence-commit command stopped at `git diff --check` because the
   new Markdown header used two trailing-space hard breaks; no paths were staged.
+- The documentation metadata hook ran in warning mode and exposed missing
+  `Type`/`Audience` fields plus a noncanonical lifecycle status on the new
+  evidence record. A guessed direct checker path was also obsolete.
 - The candidate worktree has no local `.venv`; focused commands used the
   maintained shared project interpreter.
 
@@ -2289,6 +2292,11 @@ calculation/service/FastAPI contract without changing the separate torsion route
 - Root cause: the evidence header used Markdown hard-break whitespace that the
   repository hygiene rule rejects. Resolution: replaced the hard breaks with
   explicit blank paragraphs and reran `git diff --check` before staging.
+- Root cause: the evidence boundary had been placed in the `Status` field, and
+  the direct metadata checker was consolidated into `scripts/check_docs.py`.
+  Resolution: added canonical reference metadata, retained
+  `LOCAL PREPUBLICATION REHEARSAL` as a separate evidence boundary, and used the
+  maintained checker path discovered from the repository.
 
 ### Verification
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2387,3 +2387,44 @@ calculation/service/FastAPI contract without changing the separate torsion route
   `9f7ebf55afa8232eeeb3f35449450a4bc8aca5d835c9f017f308052c979f1de6`.
 
 ---
+
+## 2026-08-11 — Session: 0.23.1a1 Authorized Publication
+
+**Agent:** Codex (`ops`)
+**Branch:** `codex/alpha-0231-candidate-evidence`
+**Focus:** Publish the reviewed Alpha candidate through exact-head TestPyPI,
+production PyPI, tag, and GitHub prerelease gates.
+
+### Summary
+
+- Recorded the owner's explicit 2026-08-11 authorization for the
+  `v0.23.1a1` TestPyPI rehearsal, production tag/PyPI publication, and GitHub
+  prerelease after exact-head evidence passes.
+- Converted candidate-only metadata to a dated, release-ready Alpha state while
+  preserving the case-qualified scope and professional-review boundary.
+
+### Issues encountered
+
+- Publication was explicitly authorized in the active task, but the versioned
+  checklist, changelog, citation metadata, task board, handoff, and immutable
+  release ledger still recorded an unreleased hold.
+
+### Root causes and resolutions
+
+- Root cause: the previous task deliberately stopped at a reviewed local
+  rehearsal and therefore could not record per-release publication authority.
+  Resolution: bind the owner's current instruction to the exact Alpha version,
+  require an exact-head TestPyPI rehearsal before the production tag, and use a
+  new append-only release-ledger entry to supersede the historical hold without
+  rewriting it. Evidence: release preflight, CI workflow run identities,
+  package-index verification, tag, and GitHub prerelease evidence are recorded
+  below as the authorized sequence completes.
+
+### Verification
+
+- Pending release-ready preflight and PR CI at the metadata commit.
+- Pending exact-head TestPyPI workflow and installed-package verification.
+- Pending unchanged-head merge, production tag workflow, PyPI verification,
+  GitHub prerelease assets, and final repository closeout.
+
+---

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2194,3 +2194,121 @@ calculation/service/FastAPI contract without changing the separate torsion route
 - Candidate preparation passed its same Python/build gates and updated only the expected version/document files. Artifact hash, inventory, SBOM, exact-wheel preflight, and clean-install UAT evidence will be recorded against the frozen source SHA after the single artifact build.
 
 ---
+
+## 2026-08-11 — Session: 0.23.1a1 Candidate Verification Root-Cause Repair
+
+**Agent:** Codex (`orchestrator`, bounded verifier and version-semantics workers)
+**Branch:** `codex/alpha-0231-candidate-evidence`
+**Focus:** Make the preserved candidate reproducible and truthful without rebuilding or publishing it.
+
+### Summary
+
+- Repaired installed-wheel verification so the maintained UAT uses only the
+  wheel's declared `dev,validation` extras plus generated-client `httpx`, runs
+  outside the checkout with an isolated pytest configuration, and asserts the
+  imported package is inside the disposable venv before and after tests.
+- Made release-run and preflight provision missing lockfile-pinned React
+  dependencies with `npm ci` while refusing `node_modules` symlinks.
+- Removed published-release status rows from automatic candidate version/date
+  rewriting and recorded a truthful local-prepublication evidence boundary.
+- Preserved the existing wheel and sdist byte-for-byte; no tag, upload, release,
+  Pages action, or publish workflow was invoked.
+
+### Issues encountered
+
+- Exact-wheel verification inherited checkout-oriented pytest behavior and the
+  broad `requirements.txt` experiment could pass while obscuring which
+  dependencies came from the artifact.
+- The existing release-state regression assumed the current source version was
+  already authorized/published, so it encoded an untrue candidate-state premise.
+- Generated-client tests require `httpx`, while validation tests require the
+  wheel's declared `validation` extra; the earlier `[dev]`-only install did not
+  express either requirement.
+- The first isolated UAT failed during collection because
+  `test_research_prototypes.py` imports an intentionally excluded
+  `structural_lib.research` package. Marker filtering alone occurs too late to
+  prevent that import.
+- The isolated worktree had no `react_app/node_modules`, so the canonical React
+  build failed with `sh: tsc: command not found`.
+- Candidate bump automation changed the `TASKS.md` current-release version while
+  retaining `ALPHA RELEASED` and public-evidence wording, and erased the
+  descriptive task-board update text.
+- The first full closeout gate rejected the new evidence filename because
+  version dots violate the repository documentation naming policy.
+- The first code commit attempt was blocked after Ruff removed one extra blank
+  line in the research test module; no commit was created on that attempt.
+- A documentation-only validation shortcut referenced the retired
+  `scripts/check_markdown_links.py` path and stopped before its second command.
+- The first evidence-commit command stopped at `git diff --check` because the
+  new Markdown header used two trailing-space hard breaks; no paths were staged.
+- The candidate worktree has no local `.venv`; focused commands used the
+  maintained shared project interpreter.
+
+### Root causes and resolutions
+
+- Root cause: `Python/pytest.ini` injects `Python/` through `pythonpath = .`, and
+  `cmd_verify` ran repository tests from the checkout. Resolution: create a
+  temporary config with only that directive removed, run from the temporary
+  directory with importlib mode, and assert the resolved package path is inside
+  the verification venv before and after pytest. The broad requirements install
+  was removed in favor of `[dev,validation]` and `httpx>=0.27`.
+- Root cause: the release-state test passed
+  `allow_authorized_release=True` unconditionally instead of deriving that fact
+  from the permission record. Resolution: bind the allowance to
+  `_release_authorization_recorded(current)` so candidate source is not silently
+  treated as published.
+- Root cause: `[dev]` alone did not model the maintained test dependency
+  boundary, and the broad root requirements install masked the missing
+  distinction. Resolution: install the exact wheel with its declared
+  `[dev,validation]` extras and add only the generated-client requirement
+  `httpx>=0.27`.
+- Root cause: pytest imports test modules before applying marker selection.
+  Resolution: classify the research prototype module as `repo_only` and derive
+  `--ignore` arguments for every module-level repo-only test before collection.
+- Root cause: release automation selected pinned Node 24 but assumed dependencies
+  already existed. Resolution: both release paths share one provisioner that
+  runs lockfile-pinned `npm ci` when TypeScript is absent and fails closed on a
+  symlink or invalid dependency path.
+- Root cause: `bump_version.py` treated published operational history as a source
+  version pin. Resolution: exclude `TASKS.md` and the handoff from automatic
+  candidate version/date rewriting; focused temporary-repository coverage proves
+  a future bump preserves the last published release status.
+- Root cause: the evidence filename copied the dotted package version into a
+  path governed by hyphenated document naming. Resolution: use the repository's
+  safe-file mover to rename it to
+  `alpha-0231-local-prepublication-rehearsal.md`; link validation and the full
+  governance gate then passed.
+- Root cause: the staged research-test import grouping did not match the
+  repository Ruff format. Resolution: accepted the hook's one-line formatting
+  change, reran the 200 focused tests, restaged the intended five code/test
+  paths, and committed only after all hooks passed.
+- Root cause: the shortcut guessed an obsolete direct script name instead of
+  consulting the automation registry. Resolution: `./run.sh find` identified
+  `scripts/check_links.py` and `scripts/session.py check`; both maintained
+  commands completed successfully. No fallback mutation was used.
+- Root cause: the evidence header used Markdown hard-break whitespace that the
+  repository hygiene rule rejects. Resolution: replaced the hard breaks with
+  explicit blank paragraphs and reran `git diff --check` before staging.
+
+### Verification
+
+- Focused release/version/research tests: 200 passed; source research tests still
+  execute normally while installed-artifact UAT excludes checkout-only modules.
+- Prior integration evidence remained intact: `./run.sh check` passed 30/30 and
+  merged PR #730 had seven successful checks (Detect Changes, Build MkDocs,
+  Repository Validation, Python Validation, FastAPI Validation, React
+  Validation, and PR Gate).
+- Exact installed wheel: 5,055 passed, 51 skipped, 2 deselected, 29 warnings;
+  disposable `site-packages` identity passed before and after pytest; installed
+  `job`, `critical`, and HTML `report` workflows passed.
+- React Node 24 dependency provisioning used `npm ci`; the production build
+  passed and retained the isolated-footing chunk.
+- Candidate closeout gates: `./run.sh check --quick` passed 10/10; the first full
+  gate exposed the invalid evidence filename at 29/30, and the corrected rerun
+  passed 30/30.
+- Wheel SHA-256 remained
+  `9c986920ceb43e341d01c6411c873605fec3321486d862a847e2083c36156aa7`;
+  sdist remained
+  `9f7ebf55afa8232eeeb3f35449450a4bc8aca5d835c9f017f308052c979f1de6`.
+
+---

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2408,6 +2408,9 @@ production PyPI, tag, and GitHub prerelease gates.
 - Publication was explicitly authorized in the active task, but the versioned
   checklist, changelog, citation metadata, task board, handoff, and immutable
   release ledger still recorded an unreleased hold.
+- Exact-head TestPyPI run `31467674597` stopped in release-test collection
+  before build or upload because generated-client and tool-manifest tests could
+  not import `httpx` and `jsonschema`.
 
 ### Root causes and resolutions
 
@@ -2419,6 +2422,14 @@ production PyPI, tag, and GitHub prerelease gates.
   rewriting it. Evidence: release preflight, CI workflow run identities,
   package-index verification, tag, and GitHub prerelease evidence are recorded
   below as the authorized sequence completes.
+- Root cause: `publish.yml` installed only the wheel's `dev` extra before
+  running the full repository test suite, while maintained generated-client and
+  manifest tests require explicit `httpx` and the `validation` extra. The local
+  exact-wheel verifier had already corrected this boundary, but the publish
+  validation job retained the stale dependency set. Resolution: align publish
+  validation with `[dev,validation]` plus `httpx>=0.27` and add a workflow
+  regression assertion. Evidence: the failed run published nothing; focused
+  tests, PR CI, and a new exact-head TestPyPI run must pass before continuation.
 
 ### Verification
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2318,6 +2318,10 @@ calculation/service/FastAPI contract without changing the separate torsion route
   passed, 3 skipped, 6 deselected, and 46 warnings; Node 24 React build, clean
   wheel identity, permission, footing inclusion, version, and release-document
   gates all passed. Wheel and sdist hashes remained unchanged before and after.
+- Dedicated branch `codex/alpha-0231-candidate-evidence` was pushed without
+  rewriting history and draft PR #732 was opened against `main`; it was
+  mergeable and normal PR validation started. No publish-capable workflow was
+  dispatched.
 - Wheel SHA-256 remained
   `9c986920ceb43e341d01c6411c873605fec3321486d862a847e2083c36156aa7`;
   sdist remained

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| ALPHA-0231-CANDIDATE | Repair exact-wheel isolation, candidate truth, and reproducible preflight | Main Agent + ops | 🟡 LOCAL REHEARSAL GREEN — repository gates 10/10 and 30/30; clean-tree preflight and draft PR pending |
+| ALPHA-0231-CANDIDATE | Repair exact-wheel isolation, candidate truth, and reproducible preflight | Main Agent + ops | 🟡 LOCAL REHEARSAL GREEN — repository gates 10/10 and 30/30; exact-wheel preflight 0 warnings; draft PR pending |
 
 ## Up Next
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-11 — 0.23.1a1 local candidate verification repaired; publication remains held
+**Updated:** 2026-08-11 — 0.23.1a1 publication authorized; exact-head release sequence in progress
 
 ---
 
@@ -70,7 +70,7 @@
 ## Current Release
 
 | **Current public release** | v0.23.0 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
-- **Prepared candidate:** `0.23.1a1` local prepublication rehearsal; not tagged, published, or CI-authoritative
+- **Release candidate:** `0.23.1a1`; owner-authorized for TestPyPI, production PyPI, tag, and GitHub prerelease after exact-head gates
 - **Strategy:** Incremental micro-releases — each focuses on one quality dimension (tests, API, security, performance)
 - **Focus:** API introspection → security hardening → performance baselines → stabilization
 - **Target:** keep later roadmap work inactive until separately activated
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| ALPHA-0231-CANDIDATE | Repair exact-wheel isolation, candidate truth, and reproducible preflight | Main Agent + ops | 🟡 DRAFT PR #732 OPEN — prevention controls added; local gates green; CI and owner review remain |
+| ALPHA-0231-CANDIDATE | Publish the exact 0.23.1a1 Alpha candidate through gated CI | Main Agent + ops | 🟡 AUTHORIZED — release-ready metadata and exact-head TestPyPI evidence in progress |
 
 ## Up Next
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| ALPHA-0231-CANDIDATE | Repair exact-wheel isolation, candidate truth, and reproducible preflight | Main Agent + ops | 🟡 DRAFT PR #732 OPEN — local gates green; normal CI and owner review remain |
+| ALPHA-0231-CANDIDATE | Repair exact-wheel isolation, candidate truth, and reproducible preflight | Main Agent + ops | 🟡 DRAFT PR #732 OPEN — prevention controls added; local gates green; CI and owner review remain |
 
 ## Up Next
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-11 — IS456-SLAB-PRELAUNCH public-distribution permission recorded and release-enforced; qualified-review gate remains
+**Updated:** 2026-08-11
 
 ---
 
@@ -69,7 +69,7 @@
 
 ## Current Release
 
-| **Current** | v0.23.0 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
+| **Current** | v0.23.1a1 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
 - **Strategy:** Incremental micro-releases — each focuses on one quality dimension (tests, API, security, performance)
 - **Focus:** API introspection → security hardening → performance baselines → stabilization
 - **Target:** keep later roadmap work inactive until separately activated

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| ALPHA-0231-CANDIDATE | Repair exact-wheel isolation, candidate truth, and reproducible preflight | Main Agent + ops | 🟡 LOCAL REHEARSAL GREEN — repository gates 10/10 and 30/30; exact-wheel preflight 0 warnings; draft PR pending |
+| ALPHA-0231-CANDIDATE | Repair exact-wheel isolation, candidate truth, and reproducible preflight | Main Agent + ops | 🟡 DRAFT PR #732 OPEN — local gates green; normal CI and owner review remain |
 
 ## Up Next
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-11
+**Updated:** 2026-08-11 — 0.23.1a1 local candidate verification repaired; publication remains held
 
 ---
 
@@ -69,7 +69,8 @@
 
 ## Current Release
 
-| **Current** | v0.23.1a1 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
+| **Current public release** | v0.23.0 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
+- **Prepared candidate:** `0.23.1a1` local prepublication rehearsal; not tagged, published, or CI-authoritative
 - **Strategy:** Incremental micro-releases — each focuses on one quality dimension (tests, API, security, performance)
 - **Focus:** API introspection → security hardening → performance baselines → stabilization
 - **Target:** keep later roadmap work inactive until separately activated
@@ -126,13 +127,13 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| — | No active implementation packet | — | Slab software scope is complete on `codex/is456-slabs-plan` |
+| ALPHA-0231-CANDIDATE | Repair exact-wheel isolation, candidate truth, and reproducible preflight | Main Agent + ops | 🟡 LOCAL REHEARSAL GREEN — repository gates 10/10 and 30/30; clean-tree preflight and draft PR pending |
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| FOOT-ISO-RC-V1-INTEGRATION | Integrate and publish-protect the complete clean local footing head `886871ae` across Python, FastAPI and React | Main Agent + ops | 1 integration | P0 | ⏸ NEXT ALPHA BLOCKED until inclusion receipt passes; branch is local-only and must not be lost |
+| ALPHA-0231-CI | Obtain CI-built artifact identity without silently publishing | Owner + ops | owner decision | P0 | ⏸ HELD — current manual workflow proceeds to TestPyPI |
 | LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL STABLE GATE |
 
 ## Backlog

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -15,7 +15,7 @@ tags: []
 **Importance:** High
 **Version:** 0.16.6
 **Created:** 2025-06-01
-**Last Updated:** 2026-08-09<br>
+**Last Updated:** 2026-08-11<br>
 **Related Tasks:** IMPL-003
 **Tags:** contributing, development, vba, python, standards
 

--- a/docs/getting-started/agent-bootstrap.md
+++ b/docs/getting-started/agent-bootstrap.md
@@ -279,16 +279,16 @@ colima stop
 
 Before starting, kill any old processes so ports 8000 and 5173 are free.
 
-**Step 1 — Activate the Python virtual environment (do this once per terminal session):**
+**Step 1 — Resolve the project Python runtime:**
 ```bash
 cd /Users/pravinsurawase/VS_code_project/structural_engineering_lib
-source .venv/bin/activate
-# Your prompt will change to: (.venv) pravinsurawase@macmini-dev ...
-# Verify: which python  →  should show .venv/bin/python
+./scripts/python_runtime.sh --diagnose
 ```
 
-> **Never skip this.** Without it, `uvicorn` and `python` commands use the system Python (3.9) and won't find the project's packages.
-> **Shortcut:** Instead of `source .venv/bin/activate`, you can always call `.venv/bin/uvicorn` and `.venv/bin/python` directly by full path — same result.
+> The launcher selects the approved `.venv` from this checkout or the primary
+> worktree and binds imports to the invoking worktree. A linked worktree does
+> not need its own copied or symlinked `.venv`. Use
+> `./scripts/python_runtime.sh -m uvicorn ...` for direct server commands.
 
 **Step 2 — Kill old FastAPI (port 8000):**
 ```bash
@@ -406,8 +406,8 @@ curl http://localhost:8000/health           # Should return {"status":"ok"}
 ### Option C: Python library only (no UI)
 
 ```bash
-pip install -e Python/                               # Install in dev mode
-.venv/bin/python -c "from structural_lib import design_beam_is456; print('OK')"
+./scripts/python_runtime.sh -m pip install -e Python/ # Install in dev mode
+./scripts/python_runtime.sh -c "from structural_lib import design_beam_is456; print('OK')"
 ```
 
 ### Port Map
@@ -426,13 +426,13 @@ pip install -e Python/                               # Install in dev mode
 | Colima download/start fails | Run `colima status`, then inspect `~/.colima/_lima/colima/ha.stderr.log`; do not delete the transferred VM without approval |
 | Port 8000 already in use | Inspect the listener: `lsof -nP -iTCP:8000 -sTCP:LISTEN` |
 | Port 5173 already in use | Inspect the listener: `lsof -nP -iTCP:5173 -sTCP:LISTEN` |
-| `uvicorn: command not found` | Venv not activated → `source .venv/bin/activate` or use `.venv/bin/uvicorn` |
-| `ModuleNotFoundError: structural_lib` | Venv not active or re-install → `source .venv/bin/activate && pip install -e Python/` |
+| `uvicorn: command not found` | Use `./scripts/python_runtime.sh -m uvicorn` |
+| `ModuleNotFoundError: structural_lib` | Run `./scripts/python_runtime.sh --diagnose`; reinstall only if the worktree source binding is correct |
 | React shows blank / "cannot connect" | FastAPI not running — start it first on :8000 |
 | React can't reach API | Ensure FastAPI is running on :8000 first |
 | "Cannot connect to backend" in browser but `curl` works | macOS resolves `localhost` to IPv6 `::1`; uvicorn not bound to IPv6 — use `--host "::"` not `--host 0.0.0.0` |
 | Sample data 404 in Docker | Ensure `Etabs_CSV/` is copied (Dockerfile) or mounted (docker-compose.dev.yml) |
-| Python import errors | Use `.venv/bin/python`, never bare `python` |
+| Python import errors | Use `./scripts/python_runtime.sh`, never bare `python` |
 
 ---
 
@@ -444,8 +444,8 @@ pip install -e Python/                               # Install in dev mode
 ./run.sh session usage --checkpoint start --task-id TASK-XXX --task "short scope"
 
 # Validate codebase
-./run.sh check --quick                               # Fast validation (9 checks, <30s)
-./run.sh check                                       # Full validation (29 checks, parallel)
+./run.sh check --quick                               # Fast validation (10 checks, <30s)
+./run.sh check                                       # Full validation (30 checks, parallel)
 ./run.sh check --category api                        # One category only
 
 # Run tests
@@ -522,18 +522,18 @@ END:    □ Codex reviews the scoped diff and performs Git/GitHub closeout
 | Git/GitHub closeout | Codex | [canonical workflow](../git-automation/git-workflow-single-source.md) |
 | Full check | `./run.sh check` | N/A (orchestrator) |
 | Quick check | `./run.sh check --quick` | N/A |
-| Run tests | `./run.sh test` | `.venv/bin/pytest Python/tests/ -v` |
-| Test changed | `./run.sh test --changed` | `.venv/bin/python scripts/test_changed.py` |
-| Pre-flight | `./run.sh preflight` | `.venv/bin/python scripts/preflight.py` |
-| Session context | `./run.sh session context` | `.venv/bin/python scripts/session.py context` |
-| Usage checkpoint | `./run.sh session usage ...` | `.venv/bin/python scripts/session.py usage ...` |
-| Find script | `./run.sh find "task"` | `.venv/bin/python scripts/find_automation.py "task"` |
-| API signatures | `./run.sh find --api <func>` | `.venv/bin/python scripts/discover_api_signatures.py <func>` |
-| Move file | N/A | `.venv/bin/python scripts/safe_file_move.py old new` |
-| Delete file | N/A | `.venv/bin/python scripts/safe_file_delete.py file` |
-| Create doc | N/A | `.venv/bin/python scripts/create_doc.py path "Title"` |
-| Fix links | `./run.sh check --category docs --fix` | `.venv/bin/python scripts/check_links.py --fix` |
-| Session end | `./run.sh session end` | `.venv/bin/python scripts/session.py end` |
+| Run tests | `./run.sh test` | `./scripts/python_runtime.sh -m pytest Python/tests/ -v` |
+| Test changed | `./run.sh test --changed` | `./scripts/python_runtime.sh scripts/test_changed.py` |
+| Pre-flight | `./run.sh preflight` | `./scripts/python_runtime.sh scripts/preflight.py` |
+| Session context | `./run.sh session context` | `./scripts/python_runtime.sh scripts/session.py context` |
+| Usage checkpoint | `./run.sh session usage ...` | `./scripts/python_runtime.sh scripts/session.py usage ...` |
+| Find script | `./run.sh find "task"` | `./scripts/python_runtime.sh scripts/find_automation.py "task"` |
+| API signatures | `./run.sh find --api <func>` | `./scripts/python_runtime.sh scripts/discover_api_signatures.py <func>` |
+| Move file | N/A | `./scripts/python_runtime.sh scripts/safe_file_move.py old new` |
+| Delete file | N/A | `./scripts/python_runtime.sh scripts/safe_file_delete.py file` |
+| Create doc | N/A | `./scripts/python_runtime.sh scripts/create_doc.py path "Title"` |
+| Fix links | `./run.sh check --category docs --fix` | `./scripts/python_runtime.sh scripts/check_links.py --fix` |
+| Session end | `./run.sh session end` | `./scripts/python_runtime.sh scripts/session.py end` |
 | Gen indexes | `./run.sh generate indexes` | `./scripts/generate_all_indexes.sh` |
 
 **Never do:** automated Git recovery, history rewriting, raw `rm`/`mv` for repository docs, or documents without metadata.
@@ -569,7 +569,7 @@ END:    □ Codex reviews the scoped diff and performs Git/GitHub closeout
 | Skip validation | Runtime errors | Run tests + `check_*` scripts |
 | Create duplicate docs | Clutter, confusion | Check `docs-canonical.json` first |
 | Mix architecture layers | Import errors | Core → IS456 → Services → UI (one direction only) |
-| Use `python` directly | Wrong env, missing deps | Always use `.venv/bin/python` |
+| Use `python` directly | Wrong env, missing deps | Always use `./scripts/python_runtime.sh` |
 | Forget to update indexes | Out-of-sync navigation | Run `generate_all_indexes.sh` after structural changes |
 | Run `docker` without Colima | "permission denied" errors | Run `colima start` before any `docker` command |
 | `uvicorn --host 0.0.0.0` on Mac Mini | Browser "Cannot connect" but `curl` works | macOS resolves `localhost` to IPv6 `::1`; use `--host "::"` for dual-stack |

--- a/docs/getting-started/beginners-guide.md
+++ b/docs/getting-started/beginners-guide.md
@@ -155,4 +155,4 @@ You should get a number around 196.5 (kN-m).
 - API reference: `docs/reference/api.md`
 - Learning path: `docs/learning/README.md`
 
-Document Version: 0.23.0 | Last Updated: 2026-08-09
+Document Version: 0.23.1a1 | Last Updated: 2026-08-11

--- a/docs/getting-started/releases.md
+++ b/docs/getting-started/releases.md
@@ -1189,3 +1189,23 @@ Older release notes may reference the historical stub paths that existed at the 
 
 This candidate is retained for exact-artifact evidence only. No owner authorization
 for tagging, package publication, or a GitHub Release is recorded here.
+
+---
+
+## v0.23.1a1 — Authorized Alpha Release (2026-08-11)
+
+**Status:** Release authorized; TestPyPI rehearsal and exact-head evidence must
+pass before the production tag is pushed.
+**Authorization:** Owner-approved TestPyPI, production PyPI, tag, and GitHub
+prerelease sequence on 2026-08-11.
+**Supersedes:** The prepared-candidate hold recorded immediately above.
+**Scope:** Case-qualified beam, rectangular-column, concentric isolated-footing,
+and bounded solid-slab workflows; not complete IS 456 coverage or professional
+design approval.
+
+Release evidence will be bound to the exact tag-triggered workflow run. The
+production workflow must build its own wheel and sdist, verify their allowlists,
+run clean-environment UAT, generate a CycloneDX SBOM, publish through trusted
+OIDC, and create the GitHub prerelease only after PyPI succeeds.
+
+**Full changelog:** See [CHANGELOG.md](../../CHANGELOG.md#0231a1--2026-08-11)

--- a/docs/getting-started/releases.md
+++ b/docs/getting-started/releases.md
@@ -1180,3 +1180,12 @@ Older release notes may reference the historical stub paths that existed at the 
 - DXF schedule polish (column widths, text sizing, smart truncation)
 - AI model name fix (`gpt-4o-mini`)
 - Streamlit API index for component reuse
+
+---
+
+## v0.23.1a1 - Prepared candidate (unreleased; on hold)
+**Status:** Prepared candidate; not tagged or published.
+**Source:** `72d2d9b8ccc1350b46499dc5a5d08df6284fe10f`
+
+This candidate is retained for exact-artifact evidence only. No owner authorization
+for tagging, package publication, or a GitHub Release is recorded here.

--- a/docs/getting-started/user-guide.md
+++ b/docs/getting-started/user-guide.md
@@ -13,7 +13,7 @@ tags: []
 **Audience:** Users
 **Status:** Approved
 **Importance:** High
-**Version:** 0.23.0
+**Version:** 0.23.1a1
 **Created:** 2025-12-15
 **Last Updated:** 2026-03-29
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,7 +4,7 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-11
-- Focus: 0.23.1a1 local candidate isolation and preflight repair on the preserved exact artifacts
+- Focus: 0.23.1a1 candidate repair and repeat-debug prevention on preserved exact artifacts
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.0` Alpha
@@ -16,8 +16,8 @@
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | Local candidate rehearsal | Exact-wheel UAT and clean-tree preflight pass; preflight reports zero warnings |
-| **Next** | Candidate draft PR #732 | Inspect normal PR CI and owner review; preserve every publication hold |
+| **Current** | Candidate prevention controls | Worktree runtime, session trust, automation discovery, metadata, and FastAPI preflight parity pass local gates |
+| **Next** | Candidate draft PR #732 | Inspect the updated normal PR CI and owner review; preserve every publication hold |
 | **Held** | Publication and engineering-use claims | No tag/TestPyPI/PyPI/GitHub Release; qualified review remains a separate stable gate |
 
 ## Integrated footing scope

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -17,7 +17,7 @@
 | State | Target | Decision |
 |---|---|---|
 | **Current** | Local candidate rehearsal | Exact-wheel UAT and clean-tree preflight pass; preflight reports zero warnings |
-| **Next** | Candidate draft PR | Push the explicit candidate branch, open the bounded draft, then inspect normal PR CI |
+| **Next** | Candidate draft PR #732 | Inspect normal PR CI and owner review; preserve every publication hold |
 | **Held** | Publication and engineering-use claims | No tag/TestPyPI/PyPI/GitHub Release; qualified review remains a separate stable gate |
 
 ## Integrated footing scope

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,22 +4,21 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-11
-- Focus: Beam, column, and slab PRs are merged; preserved permission and complete footing history are active in the dedicated Alpha integration lane
+- Focus: 0.23.1a1 local candidate isolation and preflight repair on the preserved exact artifacts
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.0` Alpha
 
-**Integration branch:** `codex/alpha-0231-integration`
+**Candidate branch:** `codex/alpha-0231-candidate-evidence`
 
-**Base:** current `origin/main` after sequential beam, column, and slab merges;
-preserved release guards and footing history are being integrated here
+**Base:** `origin/main` at `5da9c66a`; frozen artifact source `72d2d9b8`
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | Alpha integration lane | Beam, column, and slab are merged; preserved permission/footing release guards are being integrated from exact reviewed heads |
-| **Next** | Preservation proof and integration PR | Prove both preserved ancestors, zero missing footing files/markers, exact footing-owned file identity, and all four workflows before opening the PR |
-| **Held** | Candidate release and engineering-use claims | `0.23.1a1` evidence remains non-publishing; qualified review remains a separate stable/engineering-use gate |
+| **Current** | Local candidate rehearsal | Exact-wheel UAT imports only disposable-venv `site-packages`; CLI workflows pass |
+| **Next** | Candidate draft PR | Final preflight/gates, truthful evidence commit, explicit candidate upstream, then normal PR CI |
+| **Held** | Publication and engineering-use claims | No tag/TestPyPI/PyPI/GitHub Release; qualified review remains a separate stable gate |
 
 ## Integrated footing scope
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,7 +4,7 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-11
-- Focus: 0.23.1a1 candidate repair and repeat-debug prevention on preserved exact artifacts
+- Focus: owner-authorized 0.23.1a1 TestPyPI, production PyPI, tag, and GitHub prerelease sequence
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.0` Alpha
@@ -16,9 +16,9 @@
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | Candidate prevention controls | Worktree runtime, session trust, automation discovery, metadata, and FastAPI preflight parity pass local gates |
-| **Next** | Candidate draft PR #732 | Inspect the updated normal PR CI and owner review; preserve every publication hold |
-| **Held** | Publication and engineering-use claims | No tag/TestPyPI/PyPI/GitHub Release; qualified review remains a separate stable gate |
+| **Current** | Release-ready metadata | Owner authorization recorded; exact-head gates and TestPyPI rehearsal must pass before tagging |
+| **Next** | Candidate PR #732 | Mark ready and merge unchanged reviewed head, then push `v0.23.1a1` for production publication |
+| **Held** | Stable/engineering-use claims | Alpha publication does not grant qualified professional approval or complete-code coverage |
 
 ## Integrated footing scope
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -16,8 +16,8 @@
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | Local candidate rehearsal | Exact-wheel UAT imports only disposable-venv `site-packages`; CLI workflows pass |
-| **Next** | Candidate draft PR | Final preflight/gates, truthful evidence commit, explicit candidate upstream, then normal PR CI |
+| **Current** | Local candidate rehearsal | Exact-wheel UAT and clean-tree preflight pass; preflight reports zero warnings |
+| **Next** | Candidate draft PR | Push the explicit candidate branch, open the bounded draft, then inspect normal PR CI |
 | **Held** | Publication and engineering-use claims | No tag/TestPyPI/PyPI/GitHub Release; qualified review remains a separate stable gate |
 
 ## Integrated footing scope

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -9,7 +9,8 @@
 
 ## Current State
 
-Installed metadata version: 0.23.1a1
+Candidate source metadata: 0.23.1a1 (local prepublication rehearsal)
+Current public release: v0.23.0 Alpha
 
 - **Release source:** tag `v0.23.0` at `3f880d5bbc338baefc4aec8ed472cafe840a5c99`
 - **Implementation PR:** #693 merged at `cc99e610`
@@ -20,9 +21,16 @@ Installed metadata version: 0.23.1a1
 
 ## Next Alpha Readiness Checklist
 
-- [ ] Integrate the complete `FOOT-ISO-RC-V1` source head `886871ae` (or an explicitly reviewed successor) into the release branch
-- [ ] Pass `./run.sh release footing-inclusion-check` with exact footing-owned files and Python/FastAPI/React integration markers present
-- [ ] Verify the clean built wheel imports the concentric isolated-footing service; retain the inclusion receipt hash in the CI artifact manifest
+- [x] Integrate the complete `FOOT-ISO-RC-V1` source head `886871ae` into the candidate ancestry through PR #730
+- [x] Pass `./run.sh release footing-inclusion-check` with exact footing-owned files and Python/FastAPI/React integration markers present
+- [x] Verify the frozen local wheel through isolated installed-package tests and CLI UAT; retain the inclusion receipt hash in the local rehearsal record
+
+### v0.23.1a1 Local Prepublication Rehearsal
+
+- Source: `72d2d9b8ccc1350b46499dc5a5d08df6284fe10f`
+- Evidence: [v0.23.1a1 local rehearsal](../verification/alpha-0231-local-prepublication-rehearsal.md)
+- Status: local evidence only; not tagged, published, or a substitute for the CI artifact manifest
+- Publication authorization: not recorded for this candidate
 
 ## Beta Readiness Checklist
 

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -9,7 +9,7 @@
 
 ## Current State
 
-Candidate source metadata: 0.23.1a1 (local prepublication rehearsal)
+Release-ready source metadata: 0.23.1a1
 Current public release: v0.23.0 Alpha
 
 - **Release source:** tag `v0.23.0` at `3f880d5bbc338baefc4aec8ed472cafe840a5c99`
@@ -25,12 +25,14 @@ Current public release: v0.23.0 Alpha
 - [x] Pass `./run.sh release footing-inclusion-check` with exact footing-owned files and Python/FastAPI/React integration markers present
 - [x] Verify the frozen local wheel through isolated installed-package tests and CLI UAT; retain the inclusion receipt hash in the local rehearsal record
 
-### v0.23.1a1 Local Prepublication Rehearsal
+### v0.23.1a1 Release Authorization
 
 - Source: `72d2d9b8ccc1350b46499dc5a5d08df6284fe10f`
 - Evidence: [v0.23.1a1 local rehearsal](../verification/alpha-0231-local-prepublication-rehearsal.md)
-- Status: local evidence only; not tagged, published, or a substitute for the CI artifact manifest
-- Publication authorization: not recorded for this candidate
+- Status: owner-authorized Alpha release; TestPyPI and exact-head CI evidence must pass before the production tag
+- [x] Owner authorizes the v0.23.1a1 TestPyPI rehearsal
+- [x] Owner authorizes the v0.23.1a1 tag, production PyPI publication, and GitHub Release after exact CI evidence passes
+- Authorization source: direct owner instruction in the active Codex task on 2026-08-11
 
 ## Beta Readiness Checklist
 

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -9,7 +9,7 @@
 
 ## Current State
 
-Installed metadata version: 0.23.0
+Installed metadata version: 0.23.1a1
 
 - **Release source:** tag `v0.23.0` at `3f880d5bbc338baefc4aec8ed472cafe840a5c99`
 - **Implementation PR:** #693 merged at `cc99e610`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -13,9 +13,9 @@ tags: []
 **Audience:** Developers
 **Status:** Development Preview — Supported Cases Only
 **Importance:** Critical
-**Document Version:** 0.23.0
+**Document Version:** 0.23.1a1
 **Created:** 2025-01-01
-**Last Updated:** 2026-08-10<br>
+**Last Updated:** 2026-08-11<br>
 
 ---
 

--- a/docs/verification/alpha-0231-local-prepublication-rehearsal.md
+++ b/docs/verification/alpha-0231-local-prepublication-rehearsal.md
@@ -1,8 +1,14 @@
 # v0.23.1a1 Local Prepublication Rehearsal
 
-**Status:** LOCAL PREPUBLICATION REHEARSAL
+**Type:** Reference
+**Audience:** Maintainers
+**Status:** Complete
+**Importance:** Critical
+**Created:** 2026-08-11
+**Last Updated:** 2026-08-11
 
-**Authority:** Local evidence only; not a CI artifact identity, tag, or publication approval
+**Evidence boundary:** LOCAL PREPUBLICATION REHEARSAL; local evidence only,
+not a CI artifact identity, tag, or publication approval
 
 **Artifact source:** `72d2d9b8ccc1350b46499dc5a5d08df6284fe10f`
 

--- a/docs/verification/alpha-0231-local-prepublication-rehearsal.md
+++ b/docs/verification/alpha-0231-local-prepublication-rehearsal.md
@@ -55,6 +55,11 @@ protected-standard-text and protected-table-values flags as `false`.
   footing inclusion, documentation sync, and release records all passed.
 - Wheel and sdist SHA-256 values were unchanged immediately before and after
   preflight.
+- A later prevention-control preflight on commit `15a6cf99` added explicit
+  FastAPI parity and again passed with zero warnings: 5,602 Python tests passed,
+  3 skipped, and 6 deselected; 407 non-slow FastAPI tests passed with 6
+  deselected; and the Node 24 React production build passed. The same exact
+  wheel was installed and checked; neither artifact was rebuilt.
 
 ## Authority boundary
 

--- a/docs/verification/alpha-0231-local-prepublication-rehearsal.md
+++ b/docs/verification/alpha-0231-local-prepublication-rehearsal.md
@@ -1,0 +1,48 @@
+# v0.23.1a1 Local Prepublication Rehearsal
+
+**Status:** LOCAL PREPUBLICATION REHEARSAL
+
+**Authority:** Local evidence only; not a CI artifact identity, tag, or publication approval
+
+**Artifact source:** `72d2d9b8ccc1350b46499dc5a5d08df6284fe10f`
+
+## Preserved artifacts
+
+| Artifact | Bytes | Members | SHA-256 |
+|---|---:|---:|---|
+| `structural_lib_is456-0.23.1a1-py3-none-any.whl` | 529,982 | 195 | `9c986920ceb43e341d01c6411c873605fec3321486d862a847e2083c36156aa7` |
+| `structural_lib_is456-0.23.1a1.tar.gz` | 439,405 | 220 | `9f7ebf55afa8232eeeb3f35449450a4bc8aca5d835c9f017f308052c979f1de6` |
+
+The artifacts were not rebuilt during verifier repair. The wheel/sdist allowlist
+check found no excluded research, migration-fixture, alternate-code, test,
+example, script, or documentation content. Packaged `clauses.json` records both
+protected-standard-text and protected-table-values flags as `false`.
+
+## Bound receipts
+
+| Receipt | Identity | SHA-256 |
+|---|---|---|
+| Public distribution | `IS456-PUBLIC-DISTRIBUTION-001` | `539ba5deb682367a3f9069186a9b34d22a53ab9c1707eb9f2f0f8d054e270660` |
+| Footing inclusion | `FOOT-ISO-RC-V1-RELEASE-INCLUSION`, source `886871ae` | `e15f6ebeb79030d822e6dd5979d5fe2fd41aca2aa1c3fa685c61e1203dfc7029` |
+
+## Installed-wheel evidence
+
+- Maintained command: `./run.sh release verify --version 0.23.1a1 --source wheel`
+- Dependency boundary: unchanged wheel with `[dev,validation]` plus
+  `httpx>=0.27`; no root `requirements.txt` installation.
+- Import boundary: `structural_lib.__file__` was asserted inside the disposable
+  venv `site-packages` before and after pytest.
+- Test result: 5,055 passed, 51 skipped, 2 deselected, 29 warnings.
+- Installed CLI: `job`, `critical`, and HTML `report` workflows passed.
+- Local reproducible CycloneDX 1.6 environment SBOM: 195 components, 239,491
+  bytes, SHA-256
+  `82c7560a8a0137cf8989e594ab5c9668fd88f3699b03fcea460a738f2b6856a1`.
+
+## Authority boundary
+
+The local SBOM and archive identities support review of this rehearsal only.
+The current manual `publish.yml` path proceeds to TestPyPI and was not
+dispatched. Any future authorized publication must produce and review its own
+CI manifest, inventories, SBOM, hashes, and installed-artifact UAT. No tag,
+TestPyPI/PyPI upload, GitHub Release, Pages activation, or engineering-use
+approval is claimed here.

--- a/docs/verification/alpha-0231-local-prepublication-rehearsal.md
+++ b/docs/verification/alpha-0231-local-prepublication-rehearsal.md
@@ -44,6 +44,18 @@ protected-standard-text and protected-table-values flags as `false`.
   bytes, SHA-256
   `82c7560a8a0137cf8989e594ab5c9668fd88f3699b03fcea460a738f2b6856a1`.
 
+## Clean-tree candidate preflight
+
+- Maintained command: `./run.sh release preflight --wheel Python/dist/structural_lib_is456-0.23.1a1-py3-none-any.whl`
+- Result: ready to release with zero preflight warnings.
+- Python gate: 5,590 passed, 3 skipped, 6 deselected, 46 warnings.
+- React gate: Node 24 production build passed using lockfile-pinned installed
+  dependencies.
+- Clean wheel identity, candidate version, public-distribution permission,
+  footing inclusion, documentation sync, and release records all passed.
+- Wheel and sdist SHA-256 values were unchanged immediately before and after
+  preflight.
+
 ## Authority boundary
 
 The local SBOM and archive identities support review of this rehearsal only.

--- a/docs/verification/examples.md
+++ b/docs/verification/examples.md
@@ -9,8 +9,8 @@ tags: []
 
 # Verification Examples Pack
 
-**Version:** 0.23.0
-**Last Updated:** 2026-08-09<br>
+**Version:** 0.23.1a1
+**Last Updated:** 2026-08-11<br>
 **Purpose:** Build trust through traceable, verifiable benchmark calculations.
 
 ---

--- a/docs/verification/validation-pack.md
+++ b/docs/verification/validation-pack.md
@@ -9,7 +9,7 @@ tags: []
 
 # Validation Pack — Benchmark Beams & Columns
 
-**Version:** 0.23.0
+**Version:** 0.23.1a1
 
 This pack provides 5 benchmark beams and 3 benchmark columns with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trusted software.
 

--- a/fastapi_app/__init__.py
+++ b/fastapi_app/__init__.py
@@ -7,4 +7,4 @@ wrapping the structural_lib.api module for React frontend consumption.
 Part of V3 React Migration - Week 2-3: FastAPI Backend
 """
 
-__version__ = "0.23.0"
+__version__ = "0.23.1a1"

--- a/fastapi_app/config.py
+++ b/fastapi_app/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
 
     # API Configuration
     api_title: str = "Structural Engineering API"
-    api_version: str = "0.23.0"
+    api_version: str = "0.23.1a1"
     api_prefix: str = "/api/v1"
 
     # Server Configuration

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -18032,7 +18032,7 @@
       "url": "https://opensource.org/licenses/MIT"
     },
     "title": "Structural Engineering API",
-    "version": "0.23.0"
+    "version": "0.23.1a1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/fastapi_app/tests/test_insights_dashboard.py
+++ b/fastapi_app/tests/test_insights_dashboard.py
@@ -11,6 +11,7 @@ Covers:
 import pytest
 from fastapi.testclient import TestClient
 
+from fastapi_app import __version__
 from fastapi_app.main import app
 from fastapi_app.tests.conftest import unwrap
 
@@ -313,7 +314,7 @@ class TestProjectBOQ:
         assert data["evidence"]["artifact_schema"] == (
             "structural_lib.project-boq-evidence"
         )
-        assert data["evidence"]["library_version"] == "0.23.0"
+        assert data["evidence"]["library_version"] == __version__
         assert data["evidence"]["qualified_review_required"] is True
 
     def test_project_boq_identity_binds_dataset_and_normalized_inputs(self, client):

--- a/react_app/package.json
+++ b/react_app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react_app",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.23.1a1",
   "type": "module",
   "engines": {
     "node": "24.x",

--- a/react_app/src/components/layout/SettingsPanel.tsx
+++ b/react_app/src/components/layout/SettingsPanel.tsx
@@ -91,7 +91,7 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                 <div className="p-4 rounded-lg bg-zinc-800/50 border border-white/5 space-y-2">
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-zinc-400">App:</span>
-                    <span className="text-sm font-mono text-zinc-300">v0.23.0</span>
+                    <span className="text-sm font-mono text-zinc-300">v0.23.1a1</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-zinc-400">IS 456:</span>

--- a/scripts/agent_start.sh
+++ b/scripts/agent_start.sh
@@ -124,6 +124,21 @@ PYTHON_PATH=$("$PYTHON_RUNTIME" -c 'import sys; print(sys.executable)' 2>/dev/nu
     exit 1
 }
 echo -e "  ${GREEN}✓${NC} Python runtime: $PYTHON_PATH"
+PYTHON_SOURCE=$("$PYTHON_RUNTIME" -c 'from pathlib import Path; import structural_lib; print(Path(structural_lib.__file__).resolve())' 2>/dev/null) || {
+    echo -e "  ${RED}✗${NC} structural_lib could not be imported through the approved runtime"
+    exit 1
+}
+EXPECTED_SOURCE="$PROJECT_ROOT/Python/structural_lib"
+case "$PYTHON_SOURCE" in
+    "$EXPECTED_SOURCE"/*)
+        echo -e "  ${GREEN}✓${NC} Python source binding: current worktree"
+        ;;
+    *)
+        echo -e "  ${RED}✗${NC} Python source shadowing detected: $PYTHON_SOURCE"
+        echo -e "  ${YELLOW}→${NC} Diagnose with: ./scripts/python_runtime.sh --diagnose"
+        exit 1
+        ;;
+esac
 
 # Step 3: Pre-flight Check (skip in quick mode or if explicitly skipped)
 echo -e "${BLUE}[3/6]${NC} Running pre-flight checks..."

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Task-to-script mapping - helps agents find the right automation for their task",
-  "_updated": "2026-08-09",
+  "_updated": "2026-08-11",
   "_usage": "Run: ./scripts/python_runtime.sh scripts/find_automation.py \"task description\" — or --list for all",
   "_coverage": "106/106 scripts mapped",
   "tasks": {
@@ -8,6 +8,13 @@
       "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh --version",
       "description": "Resolve the approved Python interpreter across primary and linked Git worktrees",
+      "permission": "ReadOnly"
+    },
+    "diagnose python runtime": {
+      "group": "Infrastructure",
+      "script": "./scripts/python_runtime.sh --diagnose",
+      "description": "Show the selected interpreter and prove structural_lib is bound to the invoking worktree",
+      "aliases": [".venv", "worktree python", "python source binding"],
       "permission": "ReadOnly"
     },
     "choose codex model": {
@@ -98,6 +105,13 @@
       "script": "./scripts/python_runtime.sh scripts/check_links.py --fix",
       "description": "Find and auto-fix broken internal links in markdown files"
     },
+    "check markdown links": {
+      "group": "Docs",
+      "script": "./scripts/python_runtime.sh scripts/check_links.py",
+      "description": "Read-only validation of internal Markdown links",
+      "aliases": ["check_markdown_links.py", "markdown links"],
+      "permission": "ReadOnly"
+    },
     "fix deleted file links": {
       "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/fix_broken_links.py --dry-run",
@@ -110,7 +124,7 @@
     },
     "select frontend node runtime": {
       "group": "Infrastructure",
-      "script": ".venv/bin/python scripts/node_runtime.py --print",
+      "script": "./scripts/python_runtime.sh scripts/node_runtime.py --print",
       "description": "Select the healthy Node/npm pair pinned by .nvmrc (also: ./run.sh frontend runtime)",
       "options": {
         "--print": "Show selected Node and npm versions",
@@ -291,6 +305,13 @@
       "script": "./scripts/python_runtime.sh scripts/check_docs.py",
       "description": "Unified doc checker — index, links, metadata validation"
     },
+    "check docs metadata": {
+      "group": "Docs",
+      "script": "./scripts/python_runtime.sh scripts/check_docs.py --metadata --strict",
+      "description": "Validate required documentation metadata with the consolidated checker",
+      "aliases": ["check_doc_metadata.py", "doc metadata"],
+      "permission": "ReadOnly"
+    },
     "validate imports": {
       "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/validate_imports.py",
@@ -467,7 +488,15 @@
     "release": {
       "group": "Release",
       "script": "./scripts/python_runtime.sh scripts/release.py",
-      "description": "Unified release management — verify, tag, publish"
+      "description": "Unified release management — preflight, artifact verification, and owner-gated publication"
+    },
+    "release preflight": {
+      "group": "Release",
+      "script": "./run.sh release preflight --wheel <exact-wheel-path>",
+      "description": "Run clean-tree Python, FastAPI, React, version, permission, and exact-wheel release gates",
+      "aliases": ["candidate preflight", "release CI parity"],
+      "permission": "ReadOnly",
+      "context_docs": [".github/skills/release-preflight/SKILL.md"]
     },
     "benchmark api": {
       "group": "Testing",

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -64,7 +64,9 @@ VERSION_FILES = {
     ],
 }
 
-# Documentation references that should track the library version.
+# Documentation references that should track the library version. Release-history
+# surfaces (TASKS.md and next-session-brief.md) are intentionally excluded: their
+# version/status rows describe published evidence, not the prepared candidate.
 DOC_VERSION_FILES = {
     "Python/README.md": [
         (
@@ -113,25 +115,10 @@ DOC_VERSION_FILES = {
             "**Version:** {version}",
         ),
     ],
-    "docs/TASKS.md": [
-        (
-            r"^\|\s*\*\*Current\*\*\s*\|\s*v[0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?",
-            "| **Current** | v{version}",
-        ),
-    ],
-    "docs/planning/next-session-brief.md": [
-        (
-            r"^\|\s*\*\*Current\*\*\s*\|\s*v[0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?",
-            "| **Current** | v{version}",
-        ),
-    ],
 }
 
 # Documentation "Last Updated" stamps (normalized to YYYY-MM-DD).
 DOC_DATE_FILES = {
-    "docs/planning/next-session-brief.md": [
-        (r"^\*\*Last Updated:\*\* .+", "**Last Updated:** {date}<br>"),
-    ],
     "docs/reference/api.md": [
         (
             r"^\*\*Document Version:\*\* [0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?",
@@ -141,9 +128,6 @@ DOC_DATE_FILES = {
     ],
     "docs/verification/examples.md": [
         (r"^\*\*Last Updated:\*\* .+", "**Last Updated:** {date}<br>"),
-    ],
-    "docs/TASKS.md": [
-        (r"^\*\*Updated:\*\* .+", "**Updated:** {date}"),
     ],
     "docs/getting-started/beginners-guide.md": [
         (r"(Document Version: )[0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?", r"\g<1>{version}"),

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -303,9 +303,9 @@ def _is_meta_exempt(file_path: Path) -> bool:
 def _extract_metadata(content: str) -> dict[str, str]:
     """Extract **Field:** Value metadata from markdown."""
     metadata = {}
-    pattern = r"\*\*(\w+):\*\*\s*(.+?)(?:\n|$)"
+    pattern = r"\*\*([A-Za-z][A-Za-z0-9 _-]*):\*\*\s*(.+?)(?:\n|$)"
     for match in re.finditer(pattern, content[:2000]):
-        metadata[match.group(1)] = match.group(2).strip()
+        metadata[match.group(1).strip()] = match.group(2).strip()
     return metadata
 
 

--- a/scripts/find_automation.py
+++ b/scripts/find_automation.py
@@ -55,9 +55,12 @@ def find_task(query: str, automation_map: dict) -> list[tuple[str, dict]]:
     # Partial match
     matches = []
     for task_name, task_info in tasks.items():
+        aliases = [str(alias).lower() for alias in task_info.get("aliases", [])]
         if query_lower in task_name:
             matches.append((task_name, task_info))
         elif query_lower in task_info.get("description", "").lower():
+            matches.append((task_name, task_info))
+        elif any(query_lower in alias for alias in aliases):
             matches.append((task_name, task_info))
 
     if matches:
@@ -80,6 +83,8 @@ def print_task(task_name: str, task_info: dict):
         print("     📚 Context docs:")
         for doc in task_info["context_docs"]:
             print(f"        - {doc}")
+    if "aliases" in task_info:
+        print(f"     Aliases: {', '.join(task_info['aliases'])}")
     if "never_use" in task_info:
         never = ", ".join(task_info["never_use"])
         print(f"     ⚠️  Never use: {never}")

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -9,7 +9,7 @@
       "name": "README.md",
       "type": "documentation",
       "size_lines": 72,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "title": "Scripts",
       "description": "> Development, validation, discovery, release-preparation, and maintenance tools. > Git/GitHub lifecycle wrappers were retired on 2026-08-09; Codex owns that",
       "content_hash": "f038a0884d21"
@@ -18,7 +18,7 @@
       "name": "agent_brief.sh",
       "type": "shell-script",
       "size_lines": 225,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
       "content_hash": "5c9de2ac4846"
     },
@@ -26,7 +26,7 @@
       "name": "agent_compliance_checker.py",
       "type": "python",
       "size_lines": 541,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Agent compliance checker — verify agents followed their .agent.md rules.",
       "functions": [
         {
@@ -120,7 +120,7 @@
       "name": "agent_context.py",
       "type": "python",
       "size_lines": 644,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Agent Context Loader — gives each agent its tailored startup context.",
       "functions": [
         {
@@ -224,7 +224,7 @@
       "name": "agent_drift_detector.py",
       "type": "python",
       "size_lines": 649,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Agent drift detector — detect when agents deviate from prescribed behavior.",
       "functions": [
         {
@@ -297,7 +297,7 @@
       "name": "agent_evolve_instructions.py",
       "type": "python",
       "size_lines": 550,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Agent instruction evolver — self-improving agent customization files.",
       "functions": [
         {
@@ -380,7 +380,7 @@
       "name": "agent_feedback.py",
       "type": "python",
       "size_lines": 423,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Agent feedback collection and analysis.",
       "functions": [
         {
@@ -433,7 +433,7 @@
       "name": "agent_mistakes_report.sh",
       "type": "shell-script",
       "size_lines": 135,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Agent Mistakes Report",
       "content_hash": "a10f0248eed5"
     },
@@ -441,7 +441,7 @@
       "name": "agent_scorer.py",
       "type": "python",
       "size_lines": 548,
-      "last_updated": "2026-04-02",
+      "last_updated": "2026-08-11",
       "description": "Agent scorer — score agents on 11 performance dimensions.",
       "functions": [
         {
@@ -513,7 +513,7 @@
       "name": "agent_session_collector.py",
       "type": "python",
       "size_lines": 320,
-      "last_updated": "2026-04-01",
+      "last_updated": "2026-08-11",
       "description": "Agent session collector — gather all session artifacts for scoring.",
       "functions": [
         {
@@ -578,16 +578,16 @@
     {
       "name": "agent_start.sh",
       "type": "shell-script",
-      "size_lines": 253,
-      "last_updated": "2026-08-10",
+      "size_lines": 268,
+      "last_updated": "2026-08-11",
       "description": "Unified Agent Start Script",
-      "content_hash": "ae0ce865bc01"
+      "content_hash": "3b27318ada01"
     },
     {
       "name": "agent_trends.py",
       "type": "python",
       "size_lines": 383,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Agent trends — time series analysis and degradation detection.",
       "functions": [
         {
@@ -646,7 +646,7 @@
       "name": "archive_old_files.sh",
       "type": "shell-script",
       "size_lines": 207,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Auto-archive files older than 90 days from docs/_active/",
       "content_hash": "b1d9a5db1a99"
     },
@@ -654,7 +654,7 @@
       "name": "audit_error_handling.py",
       "type": "python",
       "size_lines": 286,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Audit error handling compliance across structural_lib modules.",
       "classes": [
         {
@@ -702,7 +702,7 @@
       "name": "audit_input_validation.py",
       "type": "python",
       "size_lines": 393,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Audit Input Validation Coverage for structural_lib.",
       "classes": [
         {
@@ -765,7 +765,7 @@
       "name": "audit_permissions.py",
       "type": "python",
       "size_lines": 468,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Permission audit report for all agents.",
       "classes": [
         {
@@ -809,7 +809,7 @@
       "name": "audit_readiness_report.py",
       "type": "python",
       "size_lines": 783,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Audit Readiness Report Generator",
       "classes": [
         {
@@ -904,7 +904,7 @@
     {
       "name": "automation-map.json",
       "type": "config",
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "top_level_keys": [
         "_comment",
         "_updated",
@@ -912,13 +912,13 @@
         "_coverage",
         "tasks"
       ],
-      "content_hash": "6dfdfaed914f"
+      "content_hash": "5c3fe48192ca"
     },
     {
       "name": "batch_migrate_runner.py",
       "type": "python",
       "size_lines": 467,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Batch migration runner with per-operation rollback logs.",
       "classes": [
         {
@@ -946,7 +946,7 @@
       "name": "benchmark_api.py",
       "type": "python",
       "size_lines": 837,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "API Performance Benchmark Script.",
       "classes": [
         {
@@ -1045,13 +1045,13 @@
         "V3_THRESHOLDS",
         "STANDARD_DIRECT_BENCHMARKS"
       ],
-      "content_hash": "deafad4f545f"
+      "content_hash": "1f325adb0bf6"
     },
     {
       "name": "bump_version.py",
       "type": "python",
-      "size_lines": 469,
-      "last_updated": "2026-08-10",
+      "size_lines": 453,
+      "last_updated": "2026-08-11",
       "description": "Version Bump Script — Single Source of Truth",
       "functions": [
         {
@@ -1088,13 +1088,13 @@
         "DOC_DATE_FILES",
         "EVERGREEN_NOTES"
       ],
-      "content_hash": "7d4da94dde45"
+      "content_hash": "6cea1b6f74bb"
     },
     {
       "name": "check_all.py",
       "type": "python",
       "size_lines": 712,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Unified check orchestrator — runs all validation scripts in parallel.",
       "classes": [
         {
@@ -1125,7 +1125,7 @@
       "name": "check_api.py",
       "type": "python",
       "size_lines": 390,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Validate the live React/FastAPI contract and Python API documentation.",
       "classes": [
         {
@@ -1167,7 +1167,7 @@
       "name": "check_api_compat.py",
       "type": "python",
       "size_lines": 49,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Compatibility wrapper for the canonical public API manifest check.",
       "functions": [
         {
@@ -1185,7 +1185,7 @@
       "name": "check_architecture_boundaries.py",
       "type": "python",
       "size_lines": 495,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Architecture Boundary Linter.",
       "classes": [
         {
@@ -1283,7 +1283,7 @@
       "name": "check_bootstrap_freshness.py",
       "type": "python",
       "size_lines": 290,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Check if bootstrap docs are stale compared to actual codebase.",
       "functions": [
         {
@@ -1326,7 +1326,7 @@
       "name": "check_circular_imports.py",
       "type": "python",
       "size_lines": 464,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Circular Import Detector for the Python Structural Library",
       "classes": [
         {
@@ -1381,7 +1381,7 @@
       "name": "check_clause_coverage.py",
       "type": "python",
       "size_lines": 488,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "IS 456 clause coverage gap detection.",
       "functions": [
         {
@@ -1457,7 +1457,7 @@
       "name": "check_cli_reference.py",
       "type": "python",
       "size_lines": 48,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Ensure CLI reference includes required commands.",
       "functions": [
         {
@@ -1475,7 +1475,7 @@
       "name": "check_codex_git_workflow.py",
       "type": "python",
       "size_lines": 97,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Guard the Codex-native Git/GitHub workflow contract.",
       "functions": [
         {
@@ -1494,7 +1494,7 @@
       "name": "check_doc_versions.py",
       "type": "python",
       "size_lines": 72,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Doc Version Drift Check — Validate no stale *library* version references in docs.",
       "functions": [
         {
@@ -1518,7 +1518,7 @@
       "name": "check_docker_config.py",
       "type": "python",
       "size_lines": 295,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Docker Configuration Validator.",
       "functions": [
         {
@@ -1567,7 +1567,7 @@
       "name": "check_docs.py",
       "type": "python",
       "size_lines": 675,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Unified documentation checker — consolidates 4 doc validation scripts.",
       "functions": [
         {
@@ -1616,13 +1616,13 @@
         "META_REQUIRED_FIELDS",
         "META_VALID_VALUES"
       ],
-      "content_hash": "3c86f758effd"
+      "content_hash": "32b709983c49"
     },
     {
       "name": "check_fastapi_issues.py",
       "type": "python",
       "size_lines": 468,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "FastAPI Issues AST Scanner.",
       "classes": [
         {
@@ -1679,7 +1679,7 @@
       "name": "check_function_quality.py",
       "type": "python",
       "size_lines": 670,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "12-point quality checklist for IS 456 functions.",
       "classes": [
         {
@@ -1765,7 +1765,7 @@
       "name": "check_governance.py",
       "type": "python",
       "size_lines": 1042,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Unified governance checker — folder structure + compliance validation.",
       "classes": [
         {
@@ -1925,7 +1925,7 @@
       "name": "check_instruction_drift.py",
       "type": "python",
       "size_lines": 219,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Check for content drift between .github/instructions/ and .claude/rules/.",
       "functions": [
         {
@@ -1954,7 +1954,7 @@
       "name": "check_links.py",
       "type": "python",
       "size_lines": 351,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Check and fix broken internal links in markdown files.",
       "functions": [
         {
@@ -1981,7 +1981,7 @@
       "name": "check_new_element_completeness.py",
       "type": "python",
       "size_lines": 624,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Check structural element completeness across all 7 layers.",
       "functions": [
         {
@@ -2094,7 +2094,7 @@
       "name": "check_next_session_brief_length.py",
       "type": "python",
       "size_lines": 31,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Ensure next-session-brief.md stays concise.",
       "functions": [
         {
@@ -2111,14 +2111,14 @@
       "name": "check_not_main.sh",
       "type": "shell-script",
       "size_lines": 15,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "content_hash": "515811cfdcae"
     },
     {
       "name": "check_openapi_drift.py",
       "type": "python",
       "size_lines": 193,
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-11",
       "description": "Check OpenAPI spec for drift against baseline.",
       "functions": [
         {
@@ -2154,7 +2154,7 @@
       "name": "check_openapi_snapshot.py",
       "type": "python",
       "size_lines": 231,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Check OpenAPI spec against baseline snapshot to detect API drift.",
       "functions": [
         {
@@ -2170,7 +2170,7 @@
       "name": "check_python_version.py",
       "type": "python",
       "size_lines": 208,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Python Version Consistency Checker",
       "functions": [
         {
@@ -2218,7 +2218,7 @@
       "name": "check_repo_hygiene.py",
       "type": "python",
       "size_lines": 44,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Fail if tracked hygiene artifacts exist in the repository.",
       "functions": [
         {
@@ -2234,7 +2234,7 @@
       "name": "check_root_file_count.sh",
       "type": "shell-script",
       "size_lines": 60,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Check Root File Count",
       "content_hash": "1a707d6030ab"
     },
@@ -2242,7 +2242,7 @@
       "name": "check_scripts_index.py",
       "type": "python",
       "size_lines": 223,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Ensure scripts/index.json and automation-map.json match the scripts folder contents.",
       "functions": [
         {
@@ -2262,7 +2262,7 @@
       "name": "check_tasks_format.py",
       "type": "python",
       "size_lines": 161,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Validate docs/TASKS.md structure and WIP rules.",
       "functions": [
         {
@@ -2280,7 +2280,7 @@
       "name": "check_token_efficiency.py",
       "type": "python",
       "size_lines": 206,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Validate repository-side Codex token-efficiency controls.",
       "functions": [
         {
@@ -2305,7 +2305,7 @@
       "name": "check_type_annotations.py",
       "type": "python",
       "size_lines": 542,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Type Annotation Checker for the Python Structural Library",
       "classes": [
         {
@@ -2356,7 +2356,7 @@
       "name": "check_unfinished_merge.sh",
       "type": "shell-script",
       "size_lines": 30,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Check for unfinished merge before allowing new commits",
       "content_hash": "a1fe6e5ca1bb"
     },
@@ -2364,7 +2364,7 @@
       "name": "check_version_consistency.sh",
       "type": "shell-script",
       "size_lines": 60,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "check_version_consistency.sh - Verify version strings are consistent",
       "content_hash": "5419e66e1973"
     },
@@ -2372,7 +2372,7 @@
       "name": "check_wip_limits.sh",
       "type": "shell-script",
       "size_lines": 77,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "check_wip_limits.sh - Enforce WIP (Work In Progress) limits",
       "content_hash": "8503ec531801"
     },
@@ -2380,7 +2380,7 @@
       "name": "ci_local.sh",
       "type": "shell-script",
       "size_lines": 20,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Local equivalent of the maintained PR validation lanes.",
       "content_hash": "be2f4a7bfc38"
     },
@@ -2388,7 +2388,7 @@
       "name": "cleanup_stale_branches.py",
       "type": "python",
       "size_lines": 187,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Cleanup stale remote branches.",
       "functions": [
         {
@@ -2441,7 +2441,7 @@
       "name": "collect_diagnostics.py",
       "type": "python",
       "size_lines": 123,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Collect a compact diagnostics bundle for debugging and support.",
       "functions": [
         {
@@ -2463,7 +2463,7 @@
       "name": "collect_metrics.sh",
       "type": "shell-script",
       "size_lines": 275,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Metrics Collection Script",
       "content_hash": "1dc72fa2661b"
     },
@@ -2471,7 +2471,7 @@
       "name": "config_precedence.py",
       "type": "python",
       "size_lines": 564,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Configuration precedence auditing for instruction files.",
       "classes": [
         {
@@ -2548,7 +2548,7 @@
       "name": "create_doc.py",
       "type": "python",
       "size_lines": 259,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Create a new documentation file with proper metadata header.",
       "functions": [
         {
@@ -2594,7 +2594,7 @@
       "name": "create_test_scaffold.py",
       "type": "python",
       "size_lines": 238,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Test Scaffold Generator (Solution 2)",
       "functions": [
         {
@@ -2625,7 +2625,7 @@
       "name": "diagnose_ci.py",
       "type": "python",
       "size_lines": 339,
-      "last_updated": "2026-04-04",
+      "last_updated": "2026-08-11",
       "description": "CI failure diagnosis — check, reproduce, and fix CI failures locally.",
       "functions": [
         {
@@ -2717,7 +2717,7 @@
       "name": "discover_api_signatures.py",
       "type": "python",
       "size_lines": 398,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Discover and display structural_lib API function signatures.",
       "classes": [
         {
@@ -2775,7 +2775,7 @@
       "name": "dxf_render.py",
       "type": "python",
       "size_lines": 141,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Render DXF drawings to PNG or PDF using ezdxf + matplotlib.",
       "functions": [
         {
@@ -2797,7 +2797,7 @@
       "name": "evolve.py",
       "type": "python",
       "size_lines": 552,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Self-evolution engine — orchestrates project health, feedback, and auto-fixes.",
       "functions": [
         {
@@ -2888,7 +2888,7 @@
       "name": "export_paper_data.py",
       "type": "python",
       "size_lines": 388,
-      "last_updated": "2026-04-01",
+      "last_updated": "2026-08-11",
       "description": "Export agent performance data for academic paper.",
       "functions": [
         {
@@ -2954,7 +2954,7 @@
       "name": "external_cli_test.py",
       "type": "python",
       "size_lines": 401,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "External CLI smoke test (S-007).",
       "classes": [
         {
@@ -2975,8 +2975,8 @@
     {
       "name": "find_automation.py",
       "type": "python",
-      "size_lines": 187,
-      "last_updated": "2026-08-10",
+      "size_lines": 192,
+      "last_updated": "2026-08-11",
       "description": "Find the right automation script for a task.",
       "functions": [
         {
@@ -3032,13 +3032,13 @@
           "name": "main"
         }
       ],
-      "content_hash": "8fa8ce0d5f54"
+      "content_hash": "f204343ade3b"
     },
     {
       "name": "fix_broken_links.py",
       "type": "python",
       "size_lines": 268,
-      "last_updated": "2026-08-07",
+      "last_updated": "2026-08-11",
       "description": "Fix broken internal links in markdown files.",
       "functions": [
         {
@@ -3093,7 +3093,7 @@
       "name": "generate_all_indexes.sh",
       "type": "shell-script",
       "size_lines": 51,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Generate index.json + index.md for all research-relevant folders",
       "content_hash": "32dbf76b936d"
     },
@@ -3101,7 +3101,7 @@
       "name": "generate_api_manifest.py",
       "type": "python",
       "size_lines": 159,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Generate or validate the public API manifest for structural_lib.api.",
       "functions": [
         {
@@ -3117,7 +3117,7 @@
       "name": "generate_beam_tool_manifest.py",
       "type": "python",
       "size_lines": 64,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Generate and byte-check the catalogue-derived beam tool manifest.",
       "functions": [
         {
@@ -3151,7 +3151,7 @@
       "name": "generate_client_sdks.py",
       "type": "python",
       "size_lines": 560,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Generate client SDKs from FastAPI OpenAPI specification.",
       "functions": [
         {
@@ -3204,7 +3204,7 @@
       "name": "generate_docs_index.py",
       "type": "python",
       "size_lines": 246,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Generate machine-readable JSON index of documentation.",
       "functions": [
         {
@@ -3267,7 +3267,7 @@
       "name": "generate_enhanced_index.py",
       "type": "python",
       "size_lines": 827,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Generate enhanced index.json + index.md for ANY folder type.",
       "functions": [
         {
@@ -3350,7 +3350,7 @@
       "name": "generate_error_docs.py",
       "type": "python",
       "size_lines": 139,
-      "last_updated": "2026-03-29",
+      "last_updated": "2026-08-11",
       "description": "Generate docs/reference/error-codes.md from core/errors.py.",
       "functions": [
         {
@@ -3384,7 +3384,7 @@
       "name": "governance_health_score.py",
       "type": "python",
       "size_lines": 515,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Governance Health Score - TASK-289",
       "classes": [
         {
@@ -3421,7 +3421,7 @@
       "name": "launch_stack.sh",
       "type": "shell-script",
       "size_lines": 863,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "launch_stack.sh — Full-stack development launcher for structural_engineering_lib",
       "content_hash": "92a45299c7a7"
     },
@@ -3429,7 +3429,7 @@
       "name": "migrate_python_module.py",
       "type": "python",
       "size_lines": 516,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Migrate a Python module to a new location with import updates.",
       "functions": [
         {
@@ -3500,7 +3500,7 @@
       "name": "migrate_react_component.py",
       "type": "python",
       "size_lines": 475,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Migrate a React component to a new feature-grouped folder.",
       "functions": [
         {
@@ -3581,7 +3581,7 @@
       "name": "model_picker.py",
       "type": "python",
       "size_lines": 298,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Recommend a GPT-5.6 model and reasoning effort for a repository task.",
       "classes": [
         {
@@ -3616,7 +3616,7 @@
       "name": "node_runtime.py",
       "type": "python",
       "size_lines": 205,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Select and run the healthy Node.js major pinned by ``.nvmrc``.",
       "functions": [
         {
@@ -3653,7 +3653,7 @@
       "name": "parity_dashboard.py",
       "type": "python",
       "size_lines": 519,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Parity Dashboard — coverage/parity across IS 456, API, endpoints, and React hooks.",
       "functions": [
         {
@@ -3696,7 +3696,7 @@
       "name": "pipeline_state.py",
       "type": "python",
       "size_lines": 868,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Pipeline state tracking for multi-step agent workflows.",
       "classes": [
         {
@@ -3851,7 +3851,7 @@
       "name": "preflight.py",
       "type": "python",
       "size_lines": 203,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Pre-flight check — catch common mistakes BEFORE they happen.",
       "functions": [
         {
@@ -3910,7 +3910,7 @@
       "name": "project_health.py",
       "type": "python",
       "size_lines": 908,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Unified project health scanner with auto-fix capability.",
       "classes": [
         {
@@ -4011,7 +4011,7 @@
       "name": "prompt_router.py",
       "type": "python",
       "size_lines": 494,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Prompt router — routes natural language queries to the best agent + skills.",
       "classes": [
         {
@@ -4046,15 +4046,15 @@
     {
       "name": "python_runtime.sh",
       "type": "shell-script",
-      "size_lines": 46,
-      "last_updated": "2026-08-10",
+      "size_lines": 72,
+      "last_updated": "2026-08-11",
       "description": "Resolve the repository Python interpreter across primary and linked worktrees.",
-      "content_hash": "e6f453bee035"
+      "content_hash": "3d184251b5e6"
     },
     {
       "name": "release.py",
       "type": "python",
-      "size_lines": 1592,
+      "size_lines": 1773,
       "last_updated": "2026-08-11",
       "description": "Unified release management CLI.",
       "functions": [
@@ -4129,20 +4129,20 @@
         "REACT_PACKAGE",
         "CITATION"
       ],
-      "content_hash": "d3c4d2beea92"
+      "content_hash": "d35a1874f7e8"
     },
     {
       "name": "repo_health_check.sh",
       "type": "shell-script",
       "size_lines": 31,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "content_hash": "16279b27ac11"
     },
     {
       "name": "safe_file_delete.py",
       "type": "python",
       "size_lines": 350,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Safe file delete script with reference checking.",
       "functions": [
         {
@@ -4186,7 +4186,7 @@
       "name": "safe_file_move.py",
       "type": "python",
       "size_lines": 500,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Safe file move script with automatic link updates.",
       "functions": [
         {
@@ -4239,8 +4239,8 @@
     {
       "name": "session.py",
       "type": "python",
-      "size_lines": 2294,
-      "last_updated": "2026-08-10",
+      "size_lines": 2300,
+      "last_updated": "2026-08-11",
       "description": "Unified session management CLI.",
       "functions": [
         {
@@ -4343,13 +4343,13 @@
         "HANDOFF_DATE_RE",
         "COMMIT_HASH_RE"
       ],
-      "content_hash": "139943c72402"
+      "content_hash": "cf621c4073ae"
     },
     {
       "name": "session_store.py",
       "type": "python",
       "size_lines": 374,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "JSON-based session state persistence for AI agent sessions.",
       "classes": [
         {
@@ -4462,7 +4462,7 @@
       "name": "skill_tiers.py",
       "type": "python",
       "size_lines": 485,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Skill tier classification and management for AI agents.",
       "classes": [
         {
@@ -4545,7 +4545,7 @@
       "name": "sync_numbers.py",
       "type": "python",
       "size_lines": 502,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Scan codebase and sync stale numbers across documentation files.",
       "classes": [
         {
@@ -4623,7 +4623,7 @@
       "name": "test_api_parity.py",
       "type": "python",
       "size_lines": 457,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "API Parity Testing Script",
       "classes": [
         {
@@ -4714,7 +4714,7 @@
       "name": "test_changed.py",
       "type": "python",
       "size_lines": 219,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Smart test runner — run only tests related to changed files.",
       "functions": [
         {
@@ -4747,7 +4747,7 @@
       "name": "test_cli_smoke.py",
       "type": "python",
       "size_lines": 298,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "CLI Smoke Tests — validate all key scripts work correctly.",
       "functions": [
         {
@@ -4779,7 +4779,7 @@
       "name": "test_import_pipeline.py",
       "type": "python",
       "size_lines": 412,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "End-to-end test of all import paths.",
       "functions": [
         {
@@ -4881,7 +4881,7 @@
       "name": "tool_permissions.py",
       "type": "python",
       "size_lines": 437,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Tool permission enforcement for agent operations.",
       "classes": [
         {
@@ -4940,7 +4940,7 @@
       "name": "tool_registry.py",
       "type": "python",
       "size_lines": 556,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Unified tool registry — connects agents, skills, scripts, and operations.",
       "classes": [
         {
@@ -5047,7 +5047,7 @@
       "name": "update_test_stats.py",
       "type": "python",
       "size_lines": 211,
-      "last_updated": "2026-03-26",
+      "last_updated": "2026-08-11",
       "description": "Update Test Stats — Dynamic test count updater.",
       "functions": [
         {
@@ -5086,7 +5086,7 @@
       "name": "validate_api_contracts.py",
       "type": "python",
       "size_lines": 647,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "API Contract Validator.",
       "classes": [
         {
@@ -5174,7 +5174,7 @@
       "name": "validate_git_state.sh",
       "type": "shell-script",
       "size_lines": 242,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-11",
       "description": "Read-only Git workflow validator for Codex",
       "content_hash": "c2792b76f978"
     },
@@ -5182,7 +5182,7 @@
       "name": "validate_imports.py",
       "type": "python",
       "size_lines": 365,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Validate Python imports across the project after migration.",
       "functions": [
         {
@@ -5237,7 +5237,7 @@
       "name": "validate_schema_snapshots.py",
       "type": "python",
       "size_lines": 257,
-      "last_updated": "2026-04-05",
+      "last_updated": "2026-08-11",
       "description": "Schema Snapshot Validator.",
       "functions": [
         {
@@ -5289,7 +5289,7 @@
       "name": "validate_script_refs.py",
       "type": "python",
       "size_lines": 235,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Validate that active control paths reference existing scripts.",
       "functions": [
         {
@@ -5344,7 +5344,7 @@
       "name": "watch_tests.sh",
       "type": "shell-script",
       "size_lines": 102,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-11",
       "description": "Watch Mode (Solution 5 - Dev Automation)",
       "content_hash": "3bb194383b11"
     }
@@ -5357,5 +5357,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "84432d4c966894c7"
+  "content_hash": "a94b1d78808333d9"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -34,7 +34,7 @@
 | [audit_readiness_report.py](audit_readiness_report.py) | Audit Readiness Report Generator | 2 | 11 | 783 |
 | [batch_migrate_runner.py](batch_migrate_runner.py) | Batch migration runner with per-operation rollback logs. | 1 | 2 | 467 |
 | [benchmark_api.py](benchmark_api.py) | API Performance Benchmark Script. | 4 | 9 | 837 |
-| [bump_version.py](bump_version.py) | Version Bump Script — Single Source of Truth | 0 | 4 | 469 |
+| [bump_version.py](bump_version.py) | Version Bump Script — Single Source of Truth | 0 | 4 | 453 |
 | [check_all.py](check_all.py) | Unified check orchestrator — runs all validation scripts in  | 3 | 1 | 712 |
 | [check_api.py](check_api.py) | Validate the live React/FastAPI contract and Python API docu | 1 | 4 | 390 |
 | [check_api_compat.py](check_api_compat.py) | Compatibility wrapper for the canonical public API manifest  | 0 | 1 | 49 |
@@ -73,7 +73,7 @@
 | [evolve.py](evolve.py) | Self-evolution engine — orchestrates project health, feedbac | 0 | 12 | 552 |
 | [export_paper_data.py](export_paper_data.py) | Export agent performance data for academic paper. | 0 | 8 | 388 |
 | [external_cli_test.py](external_cli_test.py) | External CLI smoke test (S-007). | 1 | 1 | 401 |
-| [find_automation.py](find_automation.py) | Find the right automation script for a task. | 0 | 8 | 187 |
+| [find_automation.py](find_automation.py) | Find the right automation script for a task. | 0 | 8 | 192 |
 | [fix_broken_links.py](fix_broken_links.py) | Fix broken internal links in markdown files. | 0 | 6 | 268 |
 | [generate_api_manifest.py](generate_api_manifest.py) | Generate or validate the public API manifest for structural_ | 0 | 1 | 159 |
 | [generate_beam_tool_manifest.py](generate_beam_tool_manifest.py) | Generate and byte-check the catalogue-derived beam tool mani | 0 | 4 | 64 |
@@ -91,10 +91,10 @@
 | [preflight.py](preflight.py) | Pre-flight check — catch common mistakes BEFORE they happen. | 0 | 9 | 203 |
 | [project_health.py](project_health.py) | Unified project health scanner with auto-fix capability. | 3 | 9 | 908 |
 | [prompt_router.py](prompt_router.py) | Prompt router — routes natural language queries to the best  | 1 | 3 | 494 |
-| [release.py](release.py) | Unified release management CLI. | 0 | 10 | 1592 |
+| [release.py](release.py) | Unified release management CLI. | 0 | 10 | 1773 |
 | [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 350 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
-| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2294 |
+| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2300 |
 | [session_store.py](session_store.py) | JSON-based session state persistence for AI agent sessions. | 1 | 14 | 374 |
 | [skill_tiers.py](skill_tiers.py) | Skill tier classification and management for AI agents. | 1 | 11 | 485 |
 | [sync_numbers.py](sync_numbers.py) | Scan codebase and sync stale numbers across documentation fi | 2 | 11 | 502 |

--- a/scripts/python_runtime.sh
+++ b/scripts/python_runtime.sh
@@ -9,6 +9,28 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+if [[ "${1:-}" == "--diagnose" ]]; then
+    export STRUCTURAL_LIB_RUNTIME_REPO_ROOT="$REPO_ROOT"
+    set -- -c '
+import json
+import os
+import sys
+from pathlib import Path
+
+import structural_lib
+
+repo_root = Path(os.environ["STRUCTURAL_LIB_RUNTIME_REPO_ROOT"]).resolve()
+module_path = Path(structural_lib.__file__).resolve()
+source_root = (repo_root / "Python" / "structural_lib").resolve()
+print(json.dumps({
+    "interpreter": str(Path(sys.executable).resolve()),
+    "repository": str(repo_root),
+    "module": str(module_path),
+    "source_bound": module_path.is_relative_to(source_root),
+}))
+'
+fi
+
 run_python_candidate() {
     local candidate="$1"
     local bound_pythonpath="$REPO_ROOT/Python:$REPO_ROOT"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -451,12 +451,15 @@ def _clean_wheel_import_version(wheel: Path) -> str:
         pip = _bin_path(venv_dir, "pip")
         python = _bin_path(venv_dir, "python")
         clean_env = {
-            key: value for key, value in os.environ.items() if key != "PYTHONPATH"
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"PYTHONPATH", "VIRTUAL_ENV"}
         }
         _run_check(
             [str(pip), "install", "--disable-pip-version-check", str(wheel)],
             env=clean_env,
         )
+        _assert_package_import_from_venv(python, venv_dir, clean_env, temp_root)
         result = subprocess.run(
             [
                 str(python),
@@ -676,6 +679,46 @@ def _node_runtime_env(
     )
 
 
+def _ensure_react_dependencies(react_dir: Path, node_env: dict[str, str]) -> bool:
+    """Provision the lockfile-pinned React toolchain in an isolated worktree."""
+    node_modules = react_dir / "node_modules"
+    tsc = node_modules / ".bin" / "tsc"
+    package_lock = react_dir / "package-lock.json"
+
+    if node_modules.is_symlink():
+        print("  ✗ react_app/node_modules is a symlink; refusing to traverse it")
+        return False
+    if tsc.is_file():
+        print("  ✓ React dependencies are installed")
+        return True
+    if not package_lock.is_file():
+        print("  ✗ react_app/package-lock.json is missing")
+        return False
+
+    if node_modules.exists() and not node_modules.is_dir():
+        print("  ✗ react_app/node_modules is not a directory")
+        return False
+
+    print("  → Installing lockfile-pinned React dependencies with npm ci")
+    try:
+        install_result = _run_with_timeout(
+            ["npm", "ci"], timeout=300, cwd=react_dir, env=node_env
+        )
+    except subprocess.TimeoutExpired:
+        print("  ✗ npm ci TIMED OUT (>300s)")
+        return False
+    if install_result.returncode != 0:
+        print("  ✗ npm ci FAILED")
+        _print_failure_tail(install_result)
+        return False
+    if not tsc.is_file():
+        print("  ✗ npm ci completed without installing TypeScript")
+        return False
+
+    print("  ✓ Lockfile-pinned React dependencies installed")
+    return True
+
+
 def _print_checklist(version: str) -> None:
     print()
     print("=" * 60)
@@ -860,6 +903,9 @@ def cmd_run(args: argparse.Namespace) -> int:
             return 1
         node_env["NODE_OPTIONS"] = "--max-old-space-size=1536"
         print(f"  → Selected {node_version}")
+        if not _ensure_react_dependencies(react_dir, node_env):
+            print("  ERROR: React dependencies are unavailable")
+            return 1
         try:
             react_result = _run_with_timeout(
                 ["npm", "run", "build"],
@@ -936,6 +982,67 @@ def _run_check(
     subprocess.run(cmd, check=True, cwd=cwd, timeout=timeout, env=env)
 
 
+def _assert_package_import_from_venv(
+    python: Path,
+    venv_dir: Path,
+    clean_env: dict[str, str],
+    cwd: Path,
+) -> None:
+    """Fail if the verification interpreter imports the checkout instead of its venv."""
+    _run_check(
+        [
+            str(python),
+            "-c",
+            (
+                "import sysconfig\n"
+                "from pathlib import Path\n"
+                "import structural_lib\n"
+                "from structural_lib import api\n"
+                "package_file = Path(structural_lib.__file__).resolve()\n"
+                "site_packages = Path(sysconfig.get_paths()['purelib']).resolve()\n"
+                f"venv_root = Path({str(venv_dir)!r}).resolve()\n"
+                "if not (\n"
+                "    package_file.is_relative_to(site_packages)\n"
+                "    and site_packages.is_relative_to(venv_root)\n"
+                "):\n"
+                "    raise RuntimeError(\n"
+                "        f'structural_lib imported from {package_file}, not {site_packages}'\n"
+                "    )\n"
+                "print(package_file)\n"
+                "print(api.get_library_version())"
+            ),
+        ],
+        cwd=cwd,
+        env=clean_env,
+    )
+
+
+def _isolated_pytest_config(temp_root: Path) -> Path:
+    """Create a config that cannot inherit the checkout's pythonpath setting."""
+    config = temp_root / "pytest.ini"
+    source_config = (REPO_ROOT / "Python" / "pytest.ini").read_text(encoding="utf-8")
+    isolated_lines = [
+        line
+        for line in source_config.splitlines()
+        if not line.strip().startswith("pythonpath")
+        and "::pyparsing.warnings." not in line
+    ]
+    config.write_text("\n".join(isolated_lines) + "\n", encoding="utf-8")
+    return config
+
+
+def _repo_only_test_ignore_args() -> list[str]:
+    """Exclude checkout-only modules before pytest imports them during collection."""
+    test_root = REPO_ROOT / "Python" / "tests"
+    marker = "pytestmark = pytest.mark.repo_only"
+    ignored = [
+        path
+        for path in test_root.rglob("test_*.py")
+        if marker in path.read_text(encoding="utf-8")
+    ]
+    return [arg for path in sorted(ignored) for arg in ("--ignore", str(path))]
+
+
 def _find_wheel(wheel_dir: Path, version: str | None) -> Path:
     pattern = (
         f"structural_lib_is456-{version}-*.whl"
@@ -969,44 +1076,66 @@ def cmd_verify(args: argparse.Namespace) -> int:
 
         pip = _bin_path(venv_dir, "pip")
         python = _bin_path(venv_dir, "python")
+        clean_env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"PYTHONPATH", "VIRTUAL_ENV"}
+        }
 
-        _run_check([str(pip), "install", "--upgrade", "pip"])
+        _run_check([str(pip), "install", "--upgrade", "pip"], env=clean_env)
 
         if args.source == "wheel":
             wheel = _find_wheel(wheel_dir, args.version)
-            _run_check([str(pip), "install", f"{wheel}[dev]"])
+            _run_check(
+                [
+                    str(pip),
+                    "install",
+                    f"{wheel}[dev,validation]",
+                    "httpx>=0.27",
+                ],
+                env=clean_env,
+            )
         else:
             if not args.version:
                 print("error: --version is required when using --source pypi")
                 return 2
             _run_check(
-                [str(pip), "install", f"structural-lib-is456[dev]=={args.version}"]
+                [
+                    str(pip),
+                    "install",
+                    f"structural-lib-is456[dev,validation]=={args.version}",
+                    "httpx>=0.27",
+                ],
+                env=clean_env,
             )
 
-        _run_check(
-            [
-                str(python),
-                "-c",
-                "from structural_lib import api; print(api.get_library_version())",
-            ]
-        )
+        temp_root = venv_dir.parent
+        _assert_package_import_from_venv(python, venv_dir, clean_env, temp_root)
 
         # Run core tests
         print("\nRunning core tests in clean venv...")
+        pytest_config = _isolated_pytest_config(temp_root)
         _run_check(
             [
                 str(python),
                 "-m",
                 "pytest",
+                "-c",
+                str(pytest_config),
+                "--import-mode=importlib",
                 str(REPO_ROOT / "Python" / "tests"),
                 "-v",
                 "--tb=short",
                 "-q",
                 "-x",  # Stop on first failure
                 "-m",
-                "not slow",
-            ]
+                "not slow and not repo_only",
+                *_repo_only_test_ignore_args(),
+            ],
+            cwd=temp_root,
+            env=clean_env,
         )
+        _assert_package_import_from_venv(python, venv_dir, clean_env, temp_root)
 
         if not args.skip_cli:
             if not job_path.exists():
@@ -1022,7 +1151,9 @@ def cmd_verify(args: argparse.Namespace) -> int:
                     str(job_path),
                     "-o",
                     str(out_dir),
-                ]
+                ],
+                cwd=temp_root,
+                env=clean_env,
             )
             _run_check(
                 [
@@ -1035,7 +1166,9 @@ def cmd_verify(args: argparse.Namespace) -> int:
                     "1",
                     "--format",
                     "csv",
-                ]
+                ],
+                cwd=temp_root,
+                env=clean_env,
             )
             _run_check(
                 [
@@ -1048,7 +1181,9 @@ def cmd_verify(args: argparse.Namespace) -> int:
                     "html",
                     "-o",
                     str(out_dir / "report.html"),
-                ]
+                ],
+                cwd=temp_root,
+                env=clean_env,
             )
 
         print("Release verification OK.")
@@ -1406,17 +1541,22 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             else:
                 print(f"  → Selected {node_status}")
                 node_env["NODE_OPTIONS"] = "--max-old-space-size=1536"
-                try:
-                    react_result = _run_with_timeout(
-                        ["npm", "run", "build"],
-                        timeout=300,
-                        cwd=react_dir,
-                        env=node_env,
-                    )
-                except subprocess.TimeoutExpired:
-                    print("  ✗ React build TIMED OUT (>300s)")
+                if not _ensure_react_dependencies(react_dir, node_env):
+                    print("  ✗ React dependencies are unavailable")
                     errors += 1
                     react_result = None
+                else:
+                    try:
+                        react_result = _run_with_timeout(
+                            ["npm", "run", "build"],
+                            timeout=300,
+                            cwd=react_dir,
+                            env=node_env,
+                        )
+                    except subprocess.TimeoutExpired:
+                        print("  ✗ React build TIMED OUT (>300s)")
+                        errors += 1
+                        react_result = None
 
             if react_result is None:
                 pass

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -450,10 +450,13 @@ def _clean_wheel_import_version(wheel: Path) -> str:
         _run_check([sys.executable, "-m", "venv", str(venv_dir)])
         pip = _bin_path(venv_dir, "pip")
         python = _bin_path(venv_dir, "python")
-        _run_check([str(pip), "install", "--disable-pip-version-check", str(wheel)])
         clean_env = {
             key: value for key, value in os.environ.items() if key != "PYTHONPATH"
         }
+        _run_check(
+            [str(pip), "install", "--disable-pip-version-check", str(wheel)],
+            env=clean_env,
+        )
         result = subprocess.run(
             [
                 str(python),
@@ -922,9 +925,15 @@ def _bin_path(venv_dir: Path, name: str) -> Path:
     return venv_dir / "bin" / name
 
 
-def _run_check(cmd: list[str], *, cwd: Path | None = None, timeout: int = 600) -> None:
+def _run_check(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: int = 600,
+    env: dict[str, str] | None = None,
+) -> None:
     print(f"+ {' '.join(str(c) for c in cmd)}")
-    subprocess.run(cmd, check=True, cwd=cwd, timeout=timeout)
+    subprocess.run(cmd, check=True, cwd=cwd, timeout=timeout, env=env)
 
 
 def _find_wheel(wheel_dir: Path, version: str | None) -> Path:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1315,6 +1315,40 @@ def cmd_checklist(args: argparse.Namespace) -> int:
 # ─── Preflight ───────────────────────────────────────────────────────────────
 
 
+def _run_local_pytest_gate(section: str, test_path: str) -> bool:
+    """Run one release test suite and print a bounded result."""
+    print(f"\n{section}")
+    try:
+        result = _run_with_timeout(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                test_path,
+                "-v",
+                "--tb=short",
+                "-q",
+                "-m",
+                "not slow",
+            ],
+            timeout=600,
+            cwd=REPO_ROOT,
+        )
+    except subprocess.TimeoutExpired:
+        print("  ✗ Tests TIMED OUT (>600s)")
+        return False
+
+    if result.returncode != 0:
+        print("  ✗ Tests FAILED")
+        _print_failure_tail(result)
+        return False
+
+    lines = result.stdout.strip().split("\n")
+    summary = lines[-1] if lines else "passed"
+    print(f"  ✓ {summary}")
+    return True
+
+
 def cmd_preflight(args: argparse.Namespace) -> int:
     """Run all pre-release validation checks without making changes."""
     print("=" * 60)
@@ -1464,7 +1498,36 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             )
             errors += 1
 
-        print("\n4. React Build (Docker, 2GB limit)")
+        print("\n4. FastAPI Tests (Docker, 2GB limit)")
+        try:
+            fastapi_result = _run_with_timeout(
+                [
+                    "docker",
+                    "compose",
+                    "-f",
+                    "docker-compose.preflight.yml",
+                    "run",
+                    "--rm",
+                    "test-fastapi",
+                ],
+                timeout=600,
+            )
+            if fastapi_result.returncode != 0:
+                print("  ✗ FastAPI tests FAILED (in Docker)")
+                _print_failure_tail(fastapi_result)
+                errors += 1
+            else:
+                print("  ✓ FastAPI tests passed (in Docker)")
+        except subprocess.TimeoutExpired:
+            print("  ✗ FastAPI tests TIMED OUT (>600s)")
+            errors += 1
+        except FileNotFoundError:
+            print(
+                "  ✗ Docker not available — start Colima: colima start --cpu 4 --memory 4"
+            )
+            errors += 1
+
+        print("\n5. React Build (Docker, 2GB limit)")
         try:
             react_result = _run_with_timeout(
                 [
@@ -1493,44 +1556,13 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             )
             errors += 1
     else:
-        # 3. Tests (local)
-        print("\n3. Python Tests")
-        try:
-            test_result = _run_with_timeout(
-                [
-                    sys.executable,
-                    "-m",
-                    "pytest",
-                    "Python/tests/",
-                    "-v",
-                    "--tb=short",
-                    "-q",
-                    "-m",
-                    "not slow",
-                ],
-                timeout=600,
-            )
-        except subprocess.TimeoutExpired:
-            print("  ✗ Tests TIMED OUT (>600s)")
+        if not _run_local_pytest_gate("3. Python Tests", "Python/tests/"):
             errors += 1
-            test_result = None
-
-        if test_result is None:
-            pass
-        elif test_result.returncode != 0:
-            print("  ✗ Tests FAILED")
-            # Show last few lines
-            lines = test_result.stdout.strip().split("\n")
-            for line in lines[-5:]:
-                print(f"    {line}")
+        if not _run_local_pytest_gate("4. FastAPI Tests", "fastapi_app/tests/"):
             errors += 1
-        else:
-            lines = test_result.stdout.strip().split("\n")
-            summary = lines[-1] if lines else "passed"
-            print(f"  ✓ {summary}")
 
-        # 4. React build (local)
-        print("\n4. React Build")
+        # 5. React build (local)
+        print("\n5. React Build")
         react_dir = REPO_ROOT / "react_app"
         if react_dir.exists():
             node_env, node_status = _node_runtime_env()
@@ -1569,8 +1601,8 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             print("  ⚠ react_app/ not found")
             warnings += 1
 
-    # 5. Doc version sync
-    print("\n5. Doc Version Sync")
+    # 6. Doc version sync
+    print("\n6. Doc Version Sync")
     sync_result = subprocess.run(
         [sys.executable, str(BUMP_SCRIPT), "--check-docs"],
         capture_output=True,
@@ -1582,8 +1614,8 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     else:
         print("  ✓ Doc versions are synced")
 
-    # 6. CHANGELOG check
-    print("\n6. Release Docs")
+    # 7. CHANGELOG check
+    print("\n7. Release Docs")
     docs_result = cmd_check_docs(argparse.Namespace())
     if docs_result != 0:
         print("  ⚠ CHANGELOG ↔ releases.md mismatch (expected before new release)")
@@ -1591,8 +1623,8 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     else:
         print("  ✓ CHANGELOG ↔ releases.md in sync")
 
-    # 7. Version files exist
-    print("\n7. Version Files")
+    # 8. Version files exist
+    print("\n8. Version Files")
     version_files_check = subprocess.run(
         [sys.executable, str(BUMP_SCRIPT), "--report"],
         capture_output=True,

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -118,6 +118,8 @@ def get_branch() -> str:
             capture_output=True,
             text=True,
         )
+        if result.returncode != 0:
+            return "unknown"
         return result.stdout.strip() or "unknown"
     except Exception:
         return "unknown"
@@ -131,12 +133,25 @@ def get_uncommitted_status() -> str:
             capture_output=True,
             text=True,
         )
+        if result.returncode != 0:
+            return "Unable to check"
         lines = result.stdout.strip().split("\n") if result.stdout.strip() else []
         return (
             "Clean working tree" if not lines else f"{len(lines)} uncommitted change(s)"
         )
     except Exception:
         return "Unable to check"
+
+
+def _evaluate_trust(branch: str, uncommitted: str) -> tuple[bool, str]:
+    """Trust only an exact clean-tree result on a non-main branch."""
+    if uncommitted != "Clean working tree":
+        return False, "uncommitted or unknown Git state detected"
+    if not branch or branch == "unknown":
+        return False, "unknown or detached Git branch"
+    if branch == "main":
+        return False, "on main branch, expected feature branch"
+    return True, "clean state confirmed"
 
 
 def check_session_log_entry() -> tuple[bool, str]:
@@ -372,16 +387,7 @@ def cmd_start(args: argparse.Namespace) -> int:
     branch = get_branch()
     uncommitted = get_uncommitted_status()
 
-    # Evaluate trust state
-    if "modified" in uncommitted.lower() or "untracked" in uncommitted.lower():
-        trusted = False
-        trust_reason = "uncommitted changes detected"
-    elif branch == "main":
-        trusted = False
-        trust_reason = "on main branch, expected feature branch"
-    else:
-        trusted = True
-        trust_reason = "clean state confirmed"
+    trusted, trust_reason = _evaluate_trust(branch, uncommitted)
 
     save_trust_state(trusted, trust_reason)
 


### PR DESCRIPTION
## Summary

- harden maintained wheel verification against checkout shadowing and broad dependency masking
- provision the lockfile-pinned React toolchain in isolated worktrees with symlink refusal
- preserve published-release semantics during candidate version bumps
- record truthful local prepublication evidence and root causes

## Frozen candidate identity

- artifact source: 72d2d9b8ccc1350b46499dc5a5d08df6284fe10f
- wheel SHA-256: 9c986920ceb43e341d01c6411c873605fec3321486d862a847e2083c36156aa7
- sdist SHA-256: 9f7ebf55afa8232eeeb3f35449450a4bc8aca5d835c9f017f308052c979f1de6
- later commits change verification and evidence only; the artifacts were not rebuilt

## Verification

- focused release, version, and research tests: 200 passed
- exact installed-wheel UAT: 5,055 passed, 51 skipped, 2 deselected; installed CLI job, critical, and report flows passed
- repository gates: quick 10/10 and full 30/30
- final clean-tree exact-wheel preflight: 5,590 passed, React production build passed, zero preflight warnings
- archive hashes remained unchanged before and after preflight

## Boundaries

- LOCAL PREPUBLICATION REHEARSAL only
- no tag, TestPyPI or PyPI upload, GitHub Release, Pages action, or publish workflow
- local evidence is not the authoritative CI artifact identity
- qualified structural-engineering review remains a separate gate

Owner review is requested before any merge or publication decision.