### PR TITLE
fix(release): harden Alpha publication closeout

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -22,9 +22,8 @@ IS 456 RC Beam Design Library (Python package).
 ## Install
 
 ```bash
-pip install structural-lib-is456           # from PyPI
-pip install "structural-lib-is456[dxf]"    # with DXF export support
-pip install structural-lib-is456==0.23.0   # pin this release exactly
+pip install structural-lib-is456===0.23.1a1       # current Alpha preview
+pip install "structural-lib-is456[dxf]===0.23.1a1" # Alpha with DXF export
 ```
 
 > **Requires Python 3.11+.** On Python 3.9–3.10, pip installs the older v0.16.x (beam-only, no column/footing).

--- a/Python/tests/test_bump_version_semantics.py
+++ b/Python/tests/test_bump_version_semantics.py
@@ -11,7 +11,7 @@ if str(REPO_ROOT) not in sys.path:
 bump_version = importlib.import_module("scripts.bump_version")
 
 
-def _write_candidate_bump_fixture(root: Path) -> tuple[Path, Path]:
+def _write_candidate_bump_fixture(root: Path) -> tuple[Path, Path, Path]:
     pyproject = root / "Python" / "pyproject.toml"
     pyproject.parent.mkdir()
     pyproject.write_text('[project]\nversion = "0.23.0a1"\n', encoding="utf-8")
@@ -28,14 +28,22 @@ def _write_candidate_bump_fixture(root: Path) -> tuple[Path, Path]:
         "| **Current** | v0.23.0 | ✅ ALPHA RELEASED — public artifact evidence |\n",
         encoding="utf-8",
     )
-    return tasks, brief
+    readme = root / "Python" / "README.md"
+    readme.write_text(
+        "**Version:** 0.23.0a1 (Alpha development preview)\n"
+        "## New in v0.23.0a1\n"
+        "pip install structural-lib-is456==0.23.0a1\n"
+        'pip install "structural-lib-is456[dxf]===0.23.0a1"\n',
+        encoding="utf-8",
+    )
+    return tasks, brief, readme
 
 
 def test_candidate_bump_preserves_published_release_evidence(
     tmp_path: Path, monkeypatch
 ):
     """Candidate metadata changes must not relabel published-release history."""
-    tasks, brief = _write_candidate_bump_fixture(tmp_path)
+    tasks, brief, readme = _write_candidate_bump_fixture(tmp_path)
     monkeypatch.setattr(bump_version, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(sys, "argv", ["bump_version.py", "0.23.1a1"])
 
@@ -47,6 +55,11 @@ def test_candidate_bump_preserves_published_release_evidence(
         content = path.read_text(encoding="utf-8")
         assert "v0.23.0 | ✅ ALPHA RELEASED" in content
         assert "v0.23.1a1" not in content
+    readme_content = readme.read_text(encoding="utf-8")
+    assert "**Version:** 0.23.1a1" in readme_content
+    assert "## New in v0.23.1a1" in readme_content
+    assert "structural-lib-is456===0.23.1a1" in readme_content
+    assert "structural-lib-is456[dxf]===0.23.1a1" in readme_content
 
     monkeypatch.setattr(sys, "argv", ["bump_version.py", "--check-docs"])
     assert bump_version.main() == 0

--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -240,8 +240,13 @@ class TestReleaseVerifyDependencies:
             "# ─── Check Docs", 1
         )[0]
         assert 'f"{wheel}[dev,validation]"' in verify_block
-        assert 'f"structural-lib-is456[dev,validation]=={args.version}"' in verify_block
+        assert (
+            'f"structural-lib-is456[dev,validation]==={args.version}"' in verify_block
+        )
         assert '"httpx>=0.27"' in verify_block
+        assert '"--pre"' not in verify_block
+        assert '"--no-cache-dir"' in verify_block
+        assert '"https://pypi.org/simple/"' in verify_block
         assert '"-r", str(requirements)' not in verify_block
 
     def test_wheel_verify_uses_isolated_pytest_configuration(self):
@@ -310,6 +315,45 @@ class TestReleaseVerifyDependencies:
         pytest_config = tmp_path / "pytest.ini"
         assert pytest_config.read_text(encoding="utf-8").startswith("[pytest]\n")
         assert "pythonpath" not in pytest_config.read_text(encoding="utf-8")
+
+    def test_pypi_verify_forces_fresh_official_index(self, tmp_path, monkeypatch):
+        calls: list[list[str]] = []
+
+        class TemporaryDirectory:
+            def __enter__(self):
+                return str(tmp_path)
+
+            def __exit__(self, *_):
+                return False
+
+        def record_run_check(cmd, *, cwd=None, timeout=600, env=None):
+            calls.append(cmd)
+
+        monkeypatch.setattr(release, "_run_check", record_run_check)
+        monkeypatch.setattr(
+            release.tempfile, "TemporaryDirectory", lambda **_: TemporaryDirectory()
+        )
+
+        result = release.cmd_verify(
+            argparse.Namespace(
+                wheel_dir="Python/dist",
+                job="Python/examples/sample_job_is456.json",
+                source="pypi",
+                version="0.23.1a1",
+                skip_cli=True,
+            )
+        )
+
+        assert result == 0
+        assert [
+            str(tmp_path / "venv" / "bin" / "pip"),
+            "install",
+            "--no-cache-dir",
+            "--index-url",
+            "https://pypi.org/simple/",
+            "structural-lib-is456[dev,validation]===0.23.1a1",
+            "httpx>=0.27",
+        ] in calls
 
 
 class TestReleaseReactDependencies:

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2391,7 +2391,8 @@ calculation/service/FastAPI contract without changing the separate torsion route
 ## 2026-08-11 — Session: 0.23.1a1 Authorized Publication
 
 **Agent:** Codex (`ops`)
-**Branch:** `codex/alpha-0231-candidate-evidence`
+**Branches:** `codex/alpha-0231-candidate-evidence`, then
+`codex/alpha-0231-release-closeout`
 **Focus:** Publish the reviewed Alpha candidate through exact-head TestPyPI,
 production PyPI, tag, and GitHub prerelease gates.
 
@@ -2402,6 +2403,12 @@ production PyPI, tag, and GitHub prerelease gates.
   prerelease after exact-head evidence passes.
 - Converted candidate-only metadata to a dated, release-ready Alpha state while
   preserving the case-qualified scope and professional-review boundary.
+- Published the reviewed tree through TestPyPI, merged PR #732 unchanged,
+  pushed annotated tag `v0.23.1a1`, and verified production PyPI and the GitHub
+  prerelease against workflow-generated hashes.
+- Hardened the maintained public verifier and version-bump documentation
+  contract after post-publication checks exposed prerelease-selection and stale
+  install-pin gaps.
 
 ### Issues encountered
 
@@ -2411,6 +2418,15 @@ production PyPI, tag, and GitHub prerelease gates.
 - Exact-head TestPyPI run `31467674597` stopped in release-test collection
   before build or upload because generated-client and tool-manifest tests could
   not import `httpx` and `jsonschema`.
+- After production publication succeeded, two maintained `--source pypi`
+  verification attempts reported versions only through `0.23.0` even though
+  official PyPI JSON and Simple API responses already listed `0.23.1a1` with
+  the production manifest hashes.
+- The public PyPI description still showed the prior `0.23.0` exact-install pin
+  even though its version heading and package metadata were `0.23.1a1`.
+- The README's unqualified primary install examples selected `0.23.0`, and the
+  append-only ledger retained a historical sentence calling that version
+  current after `v0.23.1a1` was published.
 
 ### Root causes and resolutions
 
@@ -2430,12 +2446,51 @@ production PyPI, tag, and GitHub prerelease gates.
   validation with `[dev,validation]` plus `httpx>=0.27` and add a workflow
   regression assertion. Evidence: the failed run published nothing; focused
   tests, PR CI, and a new exact-head TestPyPI run must pass before continuation.
+- Root cause: pip's candidate selection omitted the Alpha version unless
+  `--pre` was explicit, even with the exact equality pin; `pip index versions`
+  reproduced `0.23.0` without `--pre` and `0.23.1a1` with it. Official PyPI
+  HTML, PEP 691 JSON, and release JSON all already contained the new files, and
+  pip configuration showed no alternate index. A global `--pre` did find the
+  package but also selected prerelease dependencies, so it was rejected.
+  Resolution: use package-scoped arbitrary equality `===0.23.1a1`, which selects
+  the exact Alpha while retaining stable dependency resolution; also force
+  `https://pypi.org/simple/` and disable cache. Regression coverage asserts the
+  exact command. Evidence: the maintained public-version verifier is rerun
+  below.
+- Root cause: `scripts/bump_version.py` updated the Python README's version and
+  release heading but did not own its exact package-install pin. Resolution:
+  add the pin to the automated documentation version patterns, normalize Alpha
+  pins to package-scoped `===`, and add fixture coverage that proves the heading,
+  metadata label, and install pin advance together.
+- Root cause: prerelease selection semantics were handled only by the later
+  exact-pin example, while the first README commands remained unqualified; the
+  ledger correctly preserved prior text but lacked an explicit successor for
+  its old current-state sentence. Resolution: make exact Alpha pins primary for
+  both base and DXF installs, teach the bump control to update optional-extra
+  pins, and append a current-state clarification to the immutable ledger.
 
 ### Verification
 
-- Pending release-ready preflight and PR CI at the metadata commit.
-- Pending exact-head TestPyPI workflow and installed-package verification.
-- Pending unchanged-head merge, production tag workflow, PyPI verification,
-  GitHub prerelease assets, and final repository closeout.
+- Release-ready preflight passed with zero warnings: 5,602 Python tests passed,
+  3 skipped, and 6 deselected; 407 FastAPI tests passed with 6 deselected; the
+  React production build passed.
+- PR #732 passed all seven exact-head checks. Corrected TestPyPI run
+  `31467980119` completed validation, build, protected-content allowlisting,
+  exact-wheel UAT, a 61-component CycloneDX SBOM, and TestPyPI publication.
+- PR #732 merged with release tree unchanged at `95bed562`; annotated tag
+  `v0.23.1a1` dereferences to that commit.
+- Production run `31468341946` completed all gates, trusted PyPI publication,
+  and GitHub prerelease creation. Public PyPI hashes match the production
+  manifest: wheel `e586db493bbb80c56474a4855f162b9d647911648f68331c950f1ab2deafd622`;
+  sdist `5cd0e1cefe486ed3188a6cca67e728d2df162578cc17eb135583852afd6f4bb4`.
+- The maintained public verifier passed from a disposable installed package:
+  5,055 tests passed, 51 skipped, 2 deselected, with `job`, `critical`, and
+  `report` CLI workflows green and stable dependency versions selected.
+- Post-release prevention coverage passed all 58 focused release and version-
+  bump tests; Black and Ruff passed on the four changed Python files.
+- The closeout quick gate passed 10/10 and the full repository gate passed
+  30/30. A final live recheck confirmed successful production run
+  `31468341946`, immutable tag target `95bed562`, non-draft GitHub prerelease
+  assets, and PyPI file sizes and hashes matching the production evidence.
 
 ---

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -69,8 +69,8 @@
 
 ## Current Release
 
-| **Current public release** | v0.23.0 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
-- **Release candidate:** `0.23.1a1`; owner-authorized for TestPyPI, production PyPI, tag, and GitHub prerelease after exact-head gates
+| **Current public release** | v0.23.1a1 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
+- **Release evidence:** production run `31468341946`; tag `95bed562`; public installed-package UAT green
 - **Strategy:** Incremental micro-releases — each focuses on one quality dimension (tests, API, security, performance)
 - **Focus:** API introspection → security hardening → performance baselines → stabilization
 - **Target:** keep later roadmap work inactive until separately activated
@@ -127,20 +127,19 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| ALPHA-0231-CANDIDATE | Publish the exact 0.23.1a1 Alpha candidate through gated CI | Main Agent + ops | 🟡 AUTHORIZED — release-ready metadata and exact-head TestPyPI evidence in progress |
+| — | No active release task | — | Published Alpha closeout complete |
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| ALPHA-0231-CI | Obtain CI-built artifact identity without silently publishing | Owner + ops | owner decision | P0 | ⏸ HELD — current manual workflow proceeds to TestPyPI |
 | LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL STABLE GATE |
 
 ## Backlog
 
 The version roadmap and historical backlog remain below. The owner-selected next
 program is [IS456-SLAB-001](planning/is456-solid-slabs-master-plan.md); broad
-multi-code infrastructure remains future work. The v0.23.0 Alpha is published.
+multi-code infrastructure remains future work. The v0.23.1a1 Alpha is published.
 UIX-001 P0-P15 is accepted: the revision-safe workbench, authoritative
 3D inspection, versioned capability catalogue, curated renderer, bounded
 development workflow, generated beam manifest, canonical routes, and integrated
@@ -151,12 +150,13 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| ALPHA-0231-CANDIDATE | Published the exact 0.23.1a1 Alpha through exact-head CI, TestPyPI, production PyPI, and GitHub prerelease gates | Main Agent + ops | ✅ DONE — production run `31468341946`; exact public package UAT green |
 | IS456-SLAB-PRELAUNCH | Record and enforce source/licensing permission for public distribution of approved-scope normalized IS 456 data | Owner + Main Agent | ✅ DONE — owner confirmed 2026-08-11; canonical record, preflight, candidate, and publish-CI gates added |
 | IS456-SLAB-001 | Implemented simply supported/continuous one-way and common two-way solid slabs with built-in/external coefficients, topology, strips, corner torsion, detailing, serviceability, shear, FastAPI and a revision-safe React workbench | Main Agent | ✅ SOFTWARE COMPLETE — 5,532 Python, 388 FastAPI, 241 React, 30/30 integrated checks and live browser pass; flat slabs held |
 | UIX-001 | Built one compact 3D-first structural workbench and schema-driven bounded workflow foundation | Main Agent | ✅ DONE — PR #721 merged; Pages/release/public runner remain held |
 | DEPS-MAINT-001 | Replaced incompatible Python and React dependency PRs with coherent Python 3.11/Node 24 packets and added recurrence guards | Main Agent | ✅ DONE — PRs #708, #709, and #712 merged |
 | ADOPT-001 | Completed executable public truth, capability discovery, typed API contracts, production auth fail-close, evidence identity, React/BOQ trust presentation, and truthful Alpha/docs policy | Main Agent | ✅ DONE — PR #707 merged; release holds retained |
-| LIB-IS456-V1 | Completed C0-C4, bounded evidence, exact artifacts, public Alpha UAT, and v0.23.0 publication | Main Agent + owner | ✅ DONE |
+| LIB-IS456-V1 | Completed C0-C4, bounded evidence, exact artifacts, public Alpha UAT, and v0.23.1a1 publication | Main Agent + owner | ✅ DONE |
 | MAINT-009 | Integrated automation and Actions updates, repaired Weekly Verification compatibility, and cleared obsolete GitHub/session state | Main Agent | ✅ DONE |
 | MAINT-001 | Preserve the inherited worktree, recover the Mac baseline, and close PR #676 required checks | Main Agent | ✅ DONE |
 | MAINT-006 | Add enforceable low-token defaults, context rules, analytics-calibrated model routing, and automation | Main Agent | ✅ DONE |

--- a/docs/getting-started/releases.md
+++ b/docs/getting-started/releases.md
@@ -1209,3 +1209,41 @@ run clean-environment UAT, generate a CycloneDX SBOM, publish through trusted
 OIDC, and create the GitHub prerelease only after PyPI succeeds.
 
 **Full changelog:** See [CHANGELOG.md](../../CHANGELOG.md#0231a1--2026-08-11)
+
+---
+
+## v0.23.1a1 — Published Alpha Evidence (2026-08-11)
+
+**Status:** Published to PyPI and GitHub Releases as an Alpha development
+preview. This entry supersedes the authorization state above without rewriting
+the retained release history.
+
+**Current-state clarification:** Earlier statements calling `v0.23.0` the
+current release describe the historical state when they were appended. The
+current public Alpha is `v0.23.1a1`; an unqualified pip install continues to
+select `0.23.0`, so evaluation of the current Alpha must use the exact command
+below.
+
+**Source:** Annotated tag `v0.23.1a1` at
+`95bed5621c2ff6e5bbcf1a25b7ac476f92ae4307`; PR #732 merged the reviewed
+`adb161b8` source with an identical tree.
+
+**Publication evidence:** TestPyPI run `31467980119`; production run
+`31468341946`. The production wheel is 529,982 bytes with SHA-256
+`e586db493bbb80c56474a4855f162b9d647911648f68331c950f1ab2deafd622`;
+the sdist is 438,007 bytes with SHA-256
+`5cd0e1cefe486ed3188a6cca67e728d2df162578cc17eb135583852afd6f4bb4`.
+The 61-component CycloneDX 1.6 SBOM has SHA-256
+`29810e0e7e0e3e7e4380db635d9808797b6ddc241493616f0764991fa551c3b5`.
+
+**Public verification:** The maintained verifier installed the exact Alpha with
+package-scoped arbitrary equality, retained stable dependencies, passed 5,055
+tests with 51 skipped and 2 deselected, and passed installed `job`, `critical`,
+and `report` CLI workflows. Use:
+
+```bash
+pip install structural-lib-is456===0.23.1a1
+```
+
+This remains case-qualified software evidence, not complete IS 456 coverage,
+professional validation, or engineering-use approval.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,20 +4,20 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-11
-- Focus: owner-authorized 0.23.1a1 TestPyPI, production PyPI, tag, and GitHub prerelease sequence
+- Focus: published 0.23.1a1 Alpha closeout and next-task handoff
 <!-- HANDOFF:END -->
 
-**Current release:** `v0.23.0` Alpha
+**Current release:** `v0.23.1a1` Alpha
 
-**Candidate branch:** `codex/alpha-0231-candidate-evidence`
+**Closeout branch:** `codex/alpha-0231-release-closeout`
 
-**Base:** `origin/main` at `5da9c66a`; frozen artifact source `72d2d9b8`
+**Base:** `origin/main` at release merge `95bed562`; immutable tag `v0.23.1a1`
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | Release-ready metadata | Owner authorization recorded; exact-head gates and TestPyPI rehearsal must pass before tagging |
-| **Next** | Candidate PR #732 | Mark ready and merge unchanged reviewed head, then push `v0.23.1a1` for production publication |
+| **Current** | Published Alpha | PyPI and GitHub prerelease are public; exact package hashes and installed-package UAT are recorded |
+| **Next** | Owner-selected packet | Start from post-closeout `main`; do not rewrite or move the published tag |
 | **Held** | Stable/engineering-use claims | Alpha publication does not grant qualified professional approval or complete-code coverage |
 
 ## Integrated footing scope

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -10,12 +10,11 @@
 ## Current State
 
 Release-ready source metadata: 0.23.1a1
-Current public release: v0.23.0 Alpha
+Current public release: v0.23.1a1 Alpha
 
-- **Release source:** tag `v0.23.0` at `3f880d5bbc338baefc4aec8ed472cafe840a5c99`
-- **Implementation PR:** #693 merged at `cc99e610`
-- **Closeout PR:** #696 merged at `71e74a7e`; CI portability fix #697 merged at `3f880d5b`
-- **Release target:** v0.23.0 Alpha, published 2026-08-10 local time
+- **Release source:** tag `v0.23.1a1` at `95bed5621c2ff6e5bbcf1a25b7ac476f92ae4307`
+- **Candidate PR:** #732 merged unchanged at `95bed562`; reviewed head `adb161b8` has the same tree
+- **Release target:** v0.23.1a1 Alpha, published 2026-08-11 local time
 - **Publication state:** PyPI and GitHub prerelease published; exact public-version UAT green
 - **Review policy:** qualified structural-engineering review is required before stable/engineering-use approval, not before this Alpha release
 
@@ -33,6 +32,16 @@ Current public release: v0.23.0 Alpha
 - [x] Owner authorizes the v0.23.1a1 TestPyPI rehearsal
 - [x] Owner authorizes the v0.23.1a1 tag, production PyPI publication, and GitHub Release after exact CI evidence passes
 - Authorization source: direct owner instruction in the active Codex task on 2026-08-11
+
+### v0.23.1a1 Publication Evidence
+
+- TestPyPI run: `31467980119`, reviewed source `adb161b8`
+- Production run: `31468341946`, source/tag `95bed562` / `v0.23.1a1`
+- Wheel: 529,982 bytes, SHA-256 `e586db493bbb80c56474a4855f162b9d647911648f68331c950f1ab2deafd622`
+- Sdist: 438,007 bytes, SHA-256 `5cd0e1cefe486ed3188a6cca67e728d2df162578cc17eb135583852afd6f4bb4`
+- CycloneDX 1.6 SBOM: 61 components, SHA-256 `29810e0e7e0e3e7e4380db635d9808797b6ddc241493616f0764991fa551c3b5`
+- Exact public PyPI verification: 5,055 passed, 51 skipped, 2 deselected; installed `job`, `critical`, and `report` workflows green
+- GitHub prerelease and its manifest, SBOM, inventories, wheel, and sdist assets are public and digest-matched
 
 ## Beta Readiness Checklist
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -75,6 +75,11 @@ DOC_VERSION_FILES = {
         ),
         (r"@v[0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?", "@v{version}"),
         (r"^## New in v[0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?", "## New in v{version}"),
+        (
+            r"(structural-lib-is456(?:\[[^\]]+\])?)={2,3}"
+            r"[0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?",
+            r"\g<1>==={version}",
+        ),
     ],
     "docs/getting-started/python-quickstart.md": [
         (r"@v[0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?", "@v{version}"),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1103,7 +1103,10 @@ def cmd_verify(args: argparse.Namespace) -> int:
                 [
                     str(pip),
                     "install",
-                    f"structural-lib-is456[dev,validation]=={args.version}",
+                    "--no-cache-dir",
+                    "--index-url",
+                    "https://pypi.org/simple/",
+                    f"structural-lib-is456[dev,validation]==={args.version}",
                     "httpx>=0.27",
                 ],
                 env=clean_env,


### PR DESCRIPTION
## Summary
- make public PyPI verification select the exact Alpha without enabling prerelease dependencies globally
- keep README install pins synchronized through the version-bump contract
- record immutable v0.23.1a1 publication evidence and current release state

## Verification
- 58 focused release/version-bump tests
- Black and Ruff on changed Python files
- `./run.sh check --quick` (10/10)
- `./run.sh check` (30/30)
- live PyPI, tag, workflow, and GitHub prerelease hash recheck

The published `v0.23.1a1` tag is unchanged.