### PR TITLE
docs(git): close workflow recovery packet

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,3 +1,47 @@
+## 2026-08-12 — Session: GIT-001 Packet 7A Integration Closeout
+
+**Agent:** Codex
+**Branch:** `codex/git-recovery-closeout`
+**Focus:** Record exact integration and safely retire only the local lanes proven
+superseded by the workflow replacement
+
+### Summary
+
+- PR #736 passed unchanged-head required CI and was squash-merged to `main` as
+  `30ec598d`.
+- Verified `task brief` and non-writing index help from integrated `main`; the
+  command left the main worktree clean.
+- Closed stale/conflicted PR #723 with a replacement note linking PR #736.
+- Removed the clean temporary PMM recovery, workflow recovery, and old PR #723
+  local worktrees and local branch names after exact reachability checks.
+- Retained the original PMM local/remote branch and retained remote workflow
+  branches for audit and recovery.
+
+### Issues encountered
+
+- The first integrated packet record correctly described PR #736 as under
+  review, but that state became stale after merge and local retirement.
+
+### Root causes and resolutions
+
+- Review-state documentation was committed with the implementation so CI could
+  validate the candidate before any retirement. This small follow-up changes
+  only the task/handoff/packet state and generated indexes after exact merge,
+  integrated-command, PR closure, and cleanup receipts were available.
+
+### Verification
+
+- PR #736 required `PR Gate` passed at unchanged head `aec9fbb2`; merge commit is
+  `30ec598d`.
+- Integrated `main` reported branch `main` at `30ec598d` from `task brief`, and
+  `generate indexes --help` printed usage without changing the tree.
+- Removed local paths are absent. Remote recovery refs remain exact:
+  workflow `aec9fbb2`, historical PR #723 `75d66681`, PMM `8a52ed0f`.
+
+### Terminal issues
+
+- None encountered.
+
 ## 2026-08-12 — Session: GIT-001 Preservation and Workflow Recovery
 
 **Agent:** Codex

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-12 — GIT-001 packet 7A selectively recovered stale workflow controls; PMM preserved and held
+**Updated:** 2026-08-12 — GIT-001 packet 7A integrated; PMM preserved and held; Phase 1 research continues
 
 ---
 
@@ -128,7 +128,7 @@
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
 | SPARK-001 | Establish a measured GPT-5.3-Codex-Spark work program for bounded high-throughput tasks | Main Agent + repository owner | ✅ PHASE 2 COMPLETE — recovery/integration verified; implementation held for G0 |
-| GIT-001 | Research and propose an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🔬 PHASE 1 IN PROGRESS + PACKET 7A REVIEW — PMM preserved; PR #723 controls selectively recovered; broad policy held |
+| GIT-001 | Research and propose an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🔬 PHASE 1 IN PROGRESS + PACKET 7A COMPLETE — PMM preserved/held; PR #723 replacement integrated; broad policy held |
 
 ## Up Next
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,10 +17,10 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 2826,
+      "size_lines": 2877,
       "last_updated": "2026-08-12",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "c13a9865593f"
+      "content_hash": "22a52746d7c8"
     },
     {
       "name": "TASKS.md",
@@ -29,7 +29,7 @@
       "last_updated": "2026-08-12",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "19fcc7c46c57"
+      "content_hash": "450ca18c369d"
     },
     {
       "name": "WORKLOG.md",
@@ -211,5 +211,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "219c4425d9b061ed"
+  "content_hash": "666748583314aaf6"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -111,7 +111,7 @@
       "last_updated": "2026-08-12",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-12",
-      "content_hash": "e46fedd48359"
+      "content_hash": "49a89d7017a8"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "752dfff740ce464e"
+  "content_hash": "387cee81455c63e7"
 }

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,19 +4,19 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-12
-- Focus: GIT-001 Phase 1 continues; packet 7A replacement is under review
+- Focus: GIT-001 Phase 1 continues; packet 7A replacement is integrated
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha
-**Branch:** `codex/workflow-intake-recovery`
-**Integration base:** `origin/main` at `9778a4c2`; immutable Alpha tag `v0.23.1a1` remains unchanged
+**Branch:** `codex/git-recovery-closeout`
+**Integration base:** `origin/main` at `30ec598d`; immutable Alpha tag `v0.23.1a1` remains unchanged
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
 | **Current** | GIT-001 Phase 1 | Complete primary-source coverage and factual lifecycle research without changing canonical policy |
 | **Next** | GIT-001 Phase 2 | Forensic incident study only after the Phase 1 coverage review passes |
-| **Held** | Broad policy implementation and cleanup | Packet 7A is bounded; uncertain lanes stay preserved until exact replacement evidence passes |
+| **Held** | Broad policy implementation and remote cleanup | Packet 7A is complete; PMM and historical remote refs stay preserved |
 
 ## Integrated footing scope
 
@@ -60,12 +60,12 @@
 - Phase 0 records eight clean worktrees, sixteen local branches, eight open PRs,
   the active main ruleset, no stashes, protected unique work, and explicit unknowns.
 - Column PMM is remotely preserved and held for an independent full-surface
-  benchmark. PR #723 stays intact while its bounded replacement is reviewed.
+  benchmark. PR #723 is closed after its bounded replacement merged via #736.
 - Phase 1 has begun with official Git, GitHub, and OpenAI sources. Research facts,
   project observations, proposed decisions, and normative policy stay separate.
 - Existing conflicting Git guides and retired-wrapper learning text are Phase 2
   evidence candidates, not early rewrite targets.
-- Packet 7A selectively restores lane-safe intake and index-runtime behavior;
+- Integrated packet 7A restores lane-safe intake and index-runtime behavior;
   canonical policy, GitHub settings, broad cleanup, and release remain held.
 - SPARK-001 remains integrated at PR #734, but Wave 0 stays behind owner gate G0.
 

--- a/docs/research/git-governance/GIT-001-README.md
+++ b/docs/research/git-governance/GIT-001-README.md
@@ -34,7 +34,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 | Integration anchor | primary checkout / `main` | Clean at `6bc356c3`; no implementation work |
 | GIT-001 research lane | `structural_engineering_lib-git-governance-research` / `codex/git-governance-research` | Created from refreshed `origin/main` at `6bc356c3` |
 | Preserved engineering lane | `structural_engineering_lib-column-pmm` / `codex/column-pmm-experimental` | Exact commit published; integration held for independent benchmark |
-| Preserved workflow lane | `structural_engineering_lib-parallel-policy` / `codex/parallel-task-policy` | Reference only while selective replacement is reviewed |
+| Preserved workflow lane | remote `codex/parallel-task-policy` | PR #723 closed after replacement; remote retained for audit |
 
 ## Phase ledger
 
@@ -47,7 +47,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 | 4 | Operating-model design | Not started | Lifecycle, states, permissions, topology, merge and recovery proposals |
 | 5 | Scenario validation | Not started | Disposable simulations and read-only project checks pass |
 | 6 | Canonical policy proposal | Not started | Owner accepts, revises, or rejects proposal |
-| 7 | Controlled implementation | Packet 7A in replacement review | Separate owner authorization for each implementation packet |
+| 7 | Controlled implementation | Packet 7A complete; broader work held | Separate owner authorization for each implementation packet |
 | 8 | Adoption and closeout | Not started | Integrated workflow verified; supersession and maintenance established |
 
 ## Artifact map

--- a/docs/research/git-governance/GIT-001-phase-7A-preservation-workflow-recovery.md
+++ b/docs/research/git-governance/GIT-001-phase-7A-preservation-workflow-recovery.md
@@ -64,3 +64,18 @@ unrelated product/runtime work already superseded by current `main`.
 
 This packet records a selective replacement, not a claim that all historical PR
 #723 work was desirable or recovered.
+
+## Integration receipt
+
+- Replacement PR: #736, required CI green at unchanged head `aec9fbb2`.
+- Integrated main commit: `30ec598d`.
+- Integrated verification: `task brief` reports `main` at that commit and index
+  help remains non-writing.
+- Historical disposition: PR #723 closed at head `75d66681`; its remote branch
+  remains available for audit.
+- Local cleanup: the clean temporary PMM recovery, workflow recovery, and old
+  PR #723 worktrees/branches were removed after exact status and reachability
+  checks.
+- Preserved engineering artifact: `codex/column-pmm-experimental` remains local
+  and remote at `8a52ed0f`; independent full-surface benchmarking remains its
+  integration gate.

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -11,7 +11,7 @@
       "size_lines": 91,
       "last_updated": "2026-08-12",
       "description": "This directory is the task-owned, non-normative research record for GIT-001. Its contents may describe official Git/GitHub/Codex facts, observed project",
-      "content_hash": "22b1175b5461"
+      "content_hash": "c6c9777e4f0f"
     },
     {
       "name": "GIT-001-lifecycle-research.md",
@@ -40,12 +40,12 @@
     {
       "name": "GIT-001-phase-7A-preservation-workflow-recovery.md",
       "type": "documentation",
-      "size_lines": 67,
+      "size_lines": 82,
       "last_updated": "2026-08-12",
       "description": "The repository owner authorized Git operations, merge/deletion when proven safe, parallel subagents, preservation of Column PMM, and selective recovery of",
-      "content_hash": "6a2c183c939f"
+      "content_hash": "3a5222567115"
     }
   ],
   "subfolders": [],
-  "content_hash": "37987f0b57c1e581"
+  "content_hash": "32c2f9c0475d6d4f"
 }

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -12,4 +12,4 @@
 | [GIT-001-lifecycle-research.md](GIT-001-lifecycle-research.md) |  | This is a factual, non-normative lifecycle model under resea | 114 |
 | [GIT-001-official-evidence-register.md](GIT-001-official-evidence-register.md) |  | Only primary, official sources belong in this register. A ve | 47 |
 | [GIT-001-phase-0-preservation-baseline.md](GIT-001-phase-0-preservation-baseline.md) |  | - Observation time: 2026-08-12T21:17:05+05:30 - Repository:  | 165 |
-| [GIT-001-phase-7A-preservation-workflow-recovery.md](GIT-001-phase-7A-preservation-workflow-recovery.md) |  | The repository owner authorized Git operations, merge/deleti | 67 |
+| [GIT-001-phase-7A-preservation-workflow-recovery.md](GIT-001-phase-7A-preservation-workflow-recovery.md) |  | The repository owner authorized Git operations, merge/deleti | 82 |


### PR DESCRIPTION
## What changed

- mark GIT-001 packet 7A complete after PR #736 merged
- record integrated `main` verification and the exact PR #723 closure receipt
- record safe removal of three redundant local worktrees/branches while retaining remote recovery refs and the original PMM artifact
- refresh only affected documentation indexes and the current task/handoff state

## Why

The implementation PR correctly recorded its state as under review. This small follow-up makes the durable governance record match the post-CI, post-merge, and post-cleanup state.

## Verification

- documentation validation: 5/5
- `./run.sh check --quick`: 10/10
- session end: all checks passed on a clean tree
- commit hooks and `git diff --check`: passed
