### PR TITLE
docs(is456): close column PMM recovery

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,3 +1,42 @@
+## 2026-08-12 — Session: COLUMN-PMM-001 Integration Closeout
+
+**Agent:** Codex
+**Branch:** `codex/column-pmm-closeout`
+**Focus:** Record the exact merge and integrated-main verification for the
+experimental rectangular-column P-Mx-My recovery
+
+### Summary
+
+- PR #738 passed required CI at unchanged head `a481d1ab` and was squash-merged
+  to `main` as `402bf22c`.
+- Fast-forwarded the primary worktree to the exact merge and reran the PMM and
+  function-quality regressions from integrated `main`.
+- Moved COLUMN-PMM-001 from active work to recently done while retaining its
+  explicit experimental, non-stable-API boundary.
+
+### Issues encountered
+
+- The feature candidate's task and handoff records correctly described a
+  pre-merge state that became stale when PR #738 merged.
+
+### Root causes and resolutions
+
+- Merge receipts cannot exist before CI and integration. This bounded follow-up
+  records the exact reviewed head, merge commit, and integrated-main evidence
+  without changing calculation code or widening the support contract.
+
+### Verification
+
+- PR #738: required Python Validation, Repository Validation, Build MkDocs, and
+  PR Gate passed at head `a481d1ab`; GitHub reported CLEAN and MERGEABLE.
+- Integrated `main`: `HEAD=origin/main=402bf22c`, working tree clean, and
+  `python_runtime.sh --diagnose` reports `source_bound=true`.
+- Integrated PMM plus checker regressions: 15 passed; focused strict scan: 2/2.
+
+### Terminal issues
+
+- None encountered.
+
 ## 2026-08-12 — Session: COLUMN-PMM-001 Experimental Recovery
 
 **Agent:** Codex

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-12 — COLUMN-PMM-001 benchmark-backed experimental recovery in progress
+**Updated:** 2026-08-12 — COLUMN-PMM-001 integrated through PR #738; GIT-001 Phase 1 continues
 
 ---
 
@@ -127,8 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| GIT-001 | Research and propose an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🔬 PHASE 1 IN PROGRESS + PACKET 7A COMPLETE — PMM preserved/held; PR #723 replacement integrated; broad policy held |
-| COLUMN-PMM-001 | Recover and independently benchmark the experimental rectangular-column P-Mx-My fiber surface | Main Agent + repository owner | 🧪 IMPLEMENTATION — analytical 45-degree benchmark established; experimental module recovery in verification |
+| GIT-001 | Research and propose an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🔬 PHASE 1 IN PROGRESS + PACKET 7A COMPLETE — PMM and PR #723 recovery integrated; broad policy held |
 
 ## Up Next
 
@@ -152,6 +151,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| COLUMN-PMM-001 | Recovered and independently benchmarked the experimental rectangular-column P-Mx-My fiber surface | Main Agent | ✅ SOFTWARE COMPLETE — PR #738 merged; module remains experimental and outside the stable API |
 | ALPHA-0231-CANDIDATE | Published the exact 0.23.1a1 Alpha through exact-head CI, TestPyPI, production PyPI, and GitHub prerelease gates | Main Agent + ops | ✅ DONE — production run `31468341946`; exact public package UAT green |
 | IS456-SLAB-PRELAUNCH | Record and enforce source/licensing permission for public distribution of approved-scope normalized IS 456 data | Owner + Main Agent | ✅ DONE — owner confirmed 2026-08-11; canonical record, preflight, candidate, and publish-CI gates added |
 | IS456-SLAB-001 | Implemented simply supported/continuous one-way and common two-way solid slabs with built-in/external coefficients, topology, strips, corner torsion, detailing, serviceability, shear, FastAPI and a revision-safe React workbench | Main Agent | ✅ SOFTWARE COMPLETE — 5,532 Python, 388 FastAPI, 241 React, 30/30 integrated checks and live browser pass; flat slabs held |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,10 +17,10 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 2966,
+      "size_lines": 3005,
       "last_updated": "2026-08-12",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "e1059af3d0bd"
+      "content_hash": "47a26a300cd4"
     },
     {
       "name": "TASKS.md",
@@ -29,7 +29,7 @@
       "last_updated": "2026-08-12",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "ab11509fe8e5"
+      "content_hash": "32e1af2e93fd"
     },
     {
       "name": "WORKLOG.md",
@@ -211,5 +211,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "8d2b52e752b927fd"
+  "content_hash": "e3da7f5617103568"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -111,7 +111,7 @@
       "last_updated": "2026-08-12",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-12",
-      "content_hash": "a1fa22a2e3ab"
+      "content_hash": "66f0b90ce258"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "b67d5d6b90d9ec0a"
+  "content_hash": "bf9c2655bed83479"
 }

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,17 +4,17 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-12
-- Focus: COLUMN-PMM-001 candidate complete; GIT-001 Phase 1 continues
+- Focus: COLUMN-PMM-001 integrated; GIT-001 Phase 1 continues
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha
-**Branch:** `codex/column-pmm-completion`
-**Integration base:** `origin/main` at `b069428b`; immutable Alpha tag `v0.23.1a1` remains unchanged
+**Branch:** `codex/column-pmm-closeout`
+**Integration base:** `origin/main` at `402bf22c`; immutable Alpha tag `v0.23.1a1` remains unchanged
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | COLUMN-PMM-001 | Review and integrate the independently benchmarked experimental PMM candidate without stable API exposure |
+| **Current** | GIT-001 Phase 1 | Complete primary-source coverage and factual lifecycle research without changing canonical policy |
 | **Next** | GIT-001 Phase 2 | Forensic incident study only after the Phase 1 coverage review passes |
 | **Held** | Broad policy implementation and remote cleanup | Historical refs stay preserved; PMM production/public support remains a separately approved contract |
 


### PR DESCRIPTION
## Summary

- record the exact unchanged-head CI and merge receipt for PR #738
- move COLUMN-PMM-001 from active work to recently done
- restore GIT-001 Phase 1 as the current research focus
- preserve the PMM experimental and non-stable-API boundary

## Validation

- integrated main PMM/checker regressions: 15 passed
- focused PMM function-quality scan: 2/2 passed
- closeout quick gate: 10/10 passed
- documentation pre-commit hooks: passed

This PR changes documentation and generated documentation indexes only.