### PR TITLE
docs(git): capture PMM recovery lessons

### DIFF
--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -3332,7 +3332,7 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 598,
+      "size_lines": 634,
       "last_updated": "2026-08-12",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
@@ -3445,7 +3445,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "e197dd5a389c"
+      "content_hash": "0e1b8b42022c"
     },
     {
       "name": "test_session_store.py",
@@ -4203,5 +4203,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "b3d7cf5f37c04c96"
+  "content_hash": "5e9817f8dc46e6ec"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -64,7 +64,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 910 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 598 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 634 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -461,6 +461,42 @@ def test_generated_index_hash_tracks_subfolder_projection(
     assert initial["content_hash"] != updated["content_hash"]
 
 
+def test_index_generator_requires_opt_in_for_new_index_folder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    generator = importlib.import_module("scripts.generate_enhanced_index")
+    unmaintained = tmp_path / "tests" / "new-area"
+    unmaintained.mkdir(parents=True)
+    (unmaintained / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setattr(generator, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(generator, "KEY_FOLDERS", [])
+    monkeypatch.setattr(sys, "argv", ["generate_enhanced_index.py", str(unmaintained)])
+
+    with pytest.raises(SystemExit, match="2"):
+        generator.main()
+
+    output = capsys.readouterr().out
+    assert "Refusing to create indexes in unmaintained folder" in output
+    assert not (unmaintained / "index.json").exists()
+    assert not (unmaintained / "index.md").exists()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_enhanced_index.py",
+            str(unmaintained),
+            "--allow-new-index",
+        ],
+    )
+    generator.main()
+
+    assert (unmaintained / "index.json").is_file()
+    assert (unmaintained / "index.md").is_file()
+
+
 def test_session_end_preserves_current_same_day_handoff(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,3 +1,69 @@
+## 2026-08-12 — Session: COLUMN-PMM-001 Git Learning Update
+
+**Agent:** Codex
+**Branch:** `codex/git-pmm-learning-update`
+**Focus:** Convert the PMM preservation, selective recovery, validation, merge,
+and cleanup experience into reusable Git teaching and executable script controls
+
+### Summary
+
+- Added a repository case study explaining why a stale clean commit was
+  preserved but not merged, why a fresh branch and worktree were both needed,
+  and how squash integration changes cleanup evidence.
+- Updated canonical Git guidance and the compact AI-agent guide with the
+  preservation-first selective-recovery rule and case-study route.
+- Expanded the external personal workbook, study notebook, and quick reference
+  with the four-commit PMM graph, exercises, script modes, and teach-back prompts.
+- Added a requested reusable memory-extension note with the exact issues,
+  root causes, solutions, commit identities, and evidence boundaries.
+- Changed `generate_enhanced_index.py` to refuse live creation in previously
+  unmaintained folders unless `--allow-new-index` is explicit; existing indexes
+  and canonical key folders remain normal update targets.
+- Clarified `task brief`, linked-worktree runtime diagnosis, function-quality
+  scanning, index generation, and safe deletion in maintained script guidance.
+
+### Issues encountered
+
+- The first attempt to create this learning worktree used the future directory
+  as the process working directory and could not start.
+- During the PMM session, index generation created six untracked files in nested
+  test folders that did not own maintained indexes.
+- A shell inspection using an unmatched `docs/git-automation/index.*` glob
+  stopped that command before the following inspection could run.
+
+### Root causes and resolutions
+
+- A process cannot start inside a directory before `git worktree add` creates
+  it. The worktree was created from the existing primary checkout and only then
+  used as the command directory; session start and runtime diagnosis passed.
+- The generator treated every requested folder as an implicit decision to add
+  repository index topology. Live generation now distinguishes maintained
+  folders from new targets and exits 2 before writing unless
+  `--allow-new-index` is supplied. A temporary-folder CLI regression and live
+  probe prove refusal and explicit opt-in behavior.
+- Zsh treats an unmatched glob as an error. The absence of a maintained
+  `docs/git-automation` index was already established; subsequent commands use
+  literal or `find`/`rg --files` paths instead of an optional bare glob.
+
+### Verification
+
+- Focused session-automation and function-quality regressions: 41 passed.
+- Live unmaintained-folder probe: exit 2 and no generated index files.
+- All 16 existing `generate_all_indexes.sh` targets remain maintained under the
+  new guard.
+- Ruff and Black: pass on the changed generator and regression test.
+- Script reference validation: zero runtime breaks and zero misleading output;
+  Codex-native Git workflow validation passed.
+- `./run.sh check --quick`: 10/10; `./run.sh check`: 30/30.
+- GitHub unchanged-head evidence is recorded at publication closeout.
+
+### Terminal issues
+
+- `exec` could not launch with the not-yet-created worktree as `workdir`; the
+  maintained sequence is create from an existing checkout, then enter the lane.
+- Zsh rejected unmatched glob `docs/git-automation/index.*`; use exact paths or
+  `rg --files` when a file may not exist.
+
 ## 2026-08-12 — Session: COLUMN-PMM-001 Integration Closeout
 
 **Agent:** Codex

--- a/docs/contributing/git-workflow-ai-agents.md
+++ b/docs/contributing/git-workflow-ai-agents.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-09
+last_updated: 2026-08-12
 doc_type: guide
 complexity: beginner
 tags: [git, github, codex]
@@ -21,3 +21,8 @@ Destructive or history-changing actions—including merge, branch deletion,
 issue closure, release, force push, amend of published history, and reset—need
 explicit user confirmation. Unclear Git state is a stop condition, not a reason
 to invoke automated recovery.
+
+For a complete repository example of preserving a stale unique branch,
+selectively recovering it onto current `main`, proving linked-worktree runtime
+identity, handling squash ancestry, and retiring only clean local lanes, read the
+[Column PMM recovery case study](../git-automation/git-recovery-case-study-column-pmm.md).

--- a/docs/contributing/index.json
+++ b/docs/contributing/index.json
@@ -2,14 +2,14 @@
   "folder": "docs/contributing",
   "type": "documentation",
   "description": "Guides for developers and maintainers of the structural engineering library.",
-  "last_updated": "2026-08-11",
+  "last_updated": "2026-08-12",
   "file_count": 24,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 99,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "title": "Contributing",
       "description": "Guides for developers and maintainers of the structural engineering library. | I want to... | Do this |",
       "content_hash": "2380100c5572"
@@ -18,7 +18,7 @@
       "name": "agent-coding-standards.md",
       "type": "documentation",
       "size_lines": 753,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "This guide ensures AI agents write code that is: - ✅ Compatible with existing structural_lib code",
       "content_hash": "9ff3bdbaf9cc"
     },
@@ -26,7 +26,7 @@
       "name": "agent-collaboration-framework.md",
       "type": "documentation",
       "size_lines": 685,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "This project uses **agent-assisted maintenance** where specialist names describe quality roles. One parent task owns the outcome. It may use up to **2 concurrent",
       "content_hash": "e332e2485aad"
     },
@@ -34,7 +34,7 @@
       "name": "agent-onboarding-message.md",
       "type": "documentation",
       "size_lines": 54,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "> **Copy-paste this exact message to any new agent starting work on this project.** ",
       "content_hash": "32346386a56f"
     },
@@ -42,7 +42,7 @@
       "name": "background-agent-guide.md",
       "type": "documentation",
       "size_lines": 594,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "- **Background AI Agents:** Other AI assistant instances (Claude, Copilot, ChatGPT) working on assigned tasks - **MAIN Agent/User:** You (the project owner) coordinating work and handling all remote G",
       "content_hash": "52410753ee6d"
     },
@@ -50,7 +50,7 @@
       "name": "changelog-deprecation-template.md",
       "type": "documentation",
       "size_lines": 186,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-12",
       "description": "This template guides you when adding deprecation entries to CHANGELOG.md. Deprecations go under the **### Deprecated** section for the **current unreleased version**.",
       "content_hash": "275198126a80"
     },
@@ -58,7 +58,7 @@
       "name": "commit-message-conventions.md",
       "type": "documentation",
       "size_lines": 205,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": " <type>(<scope>): <subject>",
       "content_hash": "9711fc2fd5b2"
     },
@@ -66,15 +66,15 @@
       "name": "development-guide.md",
       "type": "documentation",
       "size_lines": 1522,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-12",
       "description": "1. Overview 2. Project Structure",
-      "content_hash": "22ca5108a9df"
+      "content_hash": "d319f0976e62"
     },
     {
       "name": "doc-template.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-12",
       "description": "Copy this header to new documentation files and fill in the metadata. - owner: Who maintains this doc (Main Agent, Agent 9, User)",
       "content_hash": "26a72045dd70"
     },
@@ -82,7 +82,7 @@
       "name": "docstring-style-guide.md",
       "type": "documentation",
       "size_lines": 377,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-12",
       "description": "> **Purpose:** Standard docstring format for all Python modules in structural_lib > **Style:** Google Style (readable, widely adopted in scientific Python)",
       "content_hash": "d3d735663a66"
     },
@@ -90,23 +90,23 @@
       "name": "end-of-session-workflow.md",
       "type": "documentation",
       "size_lines": 498,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "> **Standard procedure for ALL agents when ending a session.** bash",
       "content_hash": "4fb720ae571f"
     },
     {
       "name": "git-workflow-ai-agents.md",
       "type": "documentation",
-      "size_lines": 24,
-      "last_updated": "2026-08-09",
+      "size_lines": 29,
+      "last_updated": "2026-08-12",
       "description": "The canonical workflow is git-workflow-single-source.md.",
-      "content_hash": "f91bb9c737d3"
+      "content_hash": "7be09837c9ca"
     },
     {
       "name": "git-workflow-testing.md",
       "type": "documentation",
       "size_lines": 346,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "> Historical test strategy for the retired wrapper layer. Do not execute these > commands; current enforcement is scripts/check_codex_git_workflow.py.",
       "content_hash": "8e9b091fe332"
     },
@@ -114,7 +114,7 @@
       "name": "github-workflow.md",
       "type": "documentation",
       "size_lines": 55,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "Codex owns the repository's Git and GitHub lifecycle. The old shell wrappers that staged everything, synchronized branches, pushed, created PRs, or attempted",
       "content_hash": "ff959d36734a"
     },
@@ -122,7 +122,7 @@
       "name": "handoff.md",
       "type": "documentation",
       "size_lines": 96,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-12",
       "description": "Goal: enable the next agent to resume in under 2 minutes. 1. Run: ./scripts/agent_start.sh --quick (or with --agent governance for governance work)",
       "content_hash": "b1e2ef6f85ed"
     },
@@ -130,7 +130,7 @@
       "name": "learning-paths.md",
       "type": "documentation",
       "size_lines": 99,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "Pick the smallest reading path that still protects quality. Each path lists the minimum docs to read before you work. | Task type | Path | Read first |",
       "content_hash": "3ab159a5ad1c"
     },
@@ -138,7 +138,7 @@
       "name": "lesson-incomplete-implementation.md",
       "type": "documentation",
       "size_lines": 374,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "> Historical incident lesson. Wrapper commands below were retired on 2026-08-09. ✅ \"Background agents work on worktrees (local commits only)\"",
       "content_hash": "8784afe1f209"
     },
@@ -146,7 +146,7 @@
       "name": "naming-conventions.md",
       "type": "documentation",
       "size_lines": 77,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-12",
       "description": "This document defines naming standards for files, modules, and symbols in this repository.",
       "content_hash": "a12ec3641964"
     },
@@ -154,7 +154,7 @@
       "name": "quickstart-checklist.md",
       "type": "documentation",
       "size_lines": 509,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "Quick reference for common development tasks with step-by-step checklists. - [ ] **1. Create page file:** streamlit_app/pages/NN_📋_page_name.py",
       "content_hash": "fc45765618da"
     },
@@ -162,7 +162,7 @@
       "name": "repo-professionalism.md",
       "type": "documentation",
       "size_lines": 216,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-12",
       "description": "This doc does not replace existing rules. It links to the canonical sources and adds a practical \"what to do next\" map. bash",
       "content_hash": "9bfeb1c84183"
     },
@@ -170,7 +170,7 @@
       "name": "session-issues.md",
       "type": "documentation",
       "size_lines": 69,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "Purpose: capture recurring friction points and the fixes so we do not repeat them. - Pre-commit failures (files changed by hooks after staging)",
       "content_hash": "22ac3fe3a061"
     },
@@ -178,7 +178,7 @@
       "name": "solo-maintainer-operating-system.md",
       "type": "documentation",
       "size_lines": 133,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-12",
       "description": "- Deterministic outputs, explicit units, stable contracts. - One active task at a time (WIP=1).",
       "content_hash": "f22665a84705"
     },
@@ -186,7 +186,7 @@
       "name": "testing-strategy.md",
       "type": "documentation",
       "size_lines": 283,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "- Location: Python/tests/ - Runner: pytest",
       "content_hash": "6f72025a7f7f"
     },
@@ -194,11 +194,11 @@
       "name": "workflow-professional-review.md",
       "type": "documentation",
       "size_lines": 460,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-12",
       "description": "> Historical review of the retired wrapper design. It is not current guidance. | Feature | Status | Notes |",
       "content_hash": "4871421bb24a"
     }
   ],
   "subfolders": [],
-  "content_hash": "37c6118169caacab"
+  "content_hash": "32aa6383993053ea"
 }

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -3,7 +3,7 @@
 Guides for developers and maintainers of the structural engineering library.
 
 **Type:** Documentation
-**Last Updated:** 2026-08-11
+**Last Updated:** 2026-08-12
 **Files:** 24
 
 ## Documentation Files
@@ -21,7 +21,7 @@ Guides for developers and maintainers of the structural engineering library.
 | [doc-template.md](doc-template.md) |  | Copy this header to new documentation files and fill in the  | 92 |
 | [docstring-style-guide.md](docstring-style-guide.md) |  | > **Purpose:** Standard docstring format for all Python modu | 377 |
 | [end-of-session-workflow.md](end-of-session-workflow.md) |  | > **Standard procedure for ALL agents when ending a session. | 498 |
-| [git-workflow-ai-agents.md](git-workflow-ai-agents.md) |  | The canonical workflow is git-workflow-single-source.md. | 24 |
+| [git-workflow-ai-agents.md](git-workflow-ai-agents.md) |  | The canonical workflow is git-workflow-single-source.md. | 29 |
 | [git-workflow-testing.md](git-workflow-testing.md) |  | > Historical test strategy for the retired wrapper layer. Do | 346 |
 | [github-workflow.md](github-workflow.md) |  | Codex owns the repository's Git and GitHub lifecycle. The ol | 55 |
 | [handoff.md](handoff.md) |  | Goal: enable the next agent to resume in under 2 minutes. 1. | 96 |

--- a/docs/git-automation/git-recovery-case-study-column-pmm.md
+++ b/docs/git-automation/git-recovery-case-study-column-pmm.md
@@ -1,0 +1,228 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-12
+doc_type: guide
+complexity: intermediate
+tags: [git, worktree, recovery, scripts, learning]
+---
+
+# Git recovery case study: Column PMM
+
+## Why this case matters
+
+COLUMN-PMM-001 began as valuable unpublished engineering work on a stale branch.
+It could not safely be treated as either disposable or ready to merge. The
+successful path separated five questions that are easy to confuse:
+
+1. Is the work unique and recoverable?
+2. Is its Git base current?
+3. Is its engineering evidence sufficient?
+4. Which files express the useful intent?
+5. When is local cleanup safe?
+
+This case is reusable for any old feature lane whose intent is valuable but
+whose history, tests, or public boundary no longer match current `main`.
+
+## Starting evidence and decision
+
+The historical branch `codex/column-pmm-experimental` pointed to `8a52ed0f`.
+Its single large commit touched 36 files and was based on stale repository
+history. The work was clean and unique, but its PMM tests compared primarily
+against another repository solver rather than an independent oblique benchmark.
+
+The disposition was therefore:
+
+| Question | Decision | Reason |
+|---|---|---|
+| Delete the lane? | No | Unique unpublished calculation work existed. |
+| Merge the old branch? | No | Its base and public/API assumptions were stale. |
+| Cherry-pick the large commit? | No | It mixed the useful kernel with unrelated and premature surfaces. |
+| Rebase it? | No | Rewriting did not solve evidence or scope problems. |
+| Preserve it remotely? | Yes | Exact commit identity remained recoverable. |
+| Recover onto current `main`? | Yes | A fresh lane gave current contracts and clean review scope. |
+
+## Branch and worktree are different tools
+
+A branch is a movable name for a commit. A worktree is a checked-out directory
+with its own files, index, `HEAD`, and in-progress-operation state.
+
+For this recovery, both were needed:
+
+- branch `codex/column-pmm-completion` recorded the candidate history;
+- worktree `structural_engineering_lib-column-pmm-completion` isolated its files
+  from clean `main` and the active GIT-001 research lane.
+
+Creating only a branch in the primary folder would have required switching
+`main` away from its integration role. Creating only a folder would not have
+provided an independent Git index or branch history.
+
+The creation order also matters. The process working directory must already
+exist, so run `git worktree add` from an existing checkout. Only afterward can a
+command use the new worktree as its current directory.
+
+## Recovery graph
+
+```text
+historical PMM 8a52ed0f  ── preserved on origin
+                               │ selective intent recovery
+current main b069428b ── completion lane ── a481d1ab
+                                               │ PR #738 squash
+main ───────────────────────────────────────── 402bf22c
+                                               │ post-merge receipt
+main ───────────────────────────────────────── d106ff59
+```
+
+Because PR #738 was squash-merged, `8a52ed0f` and `a481d1ab` are not ancestors
+of the final `main`. Their intended content is integrated under the new commit
+`402bf22c`. Cleanup therefore used PR, tree, tests, and remote-ref evidence—not
+ancestry alone.
+
+## The execution sequence
+
+### 1. Inspect before mutation
+
+```bash
+./run.sh task brief "recover and benchmark experimental column PMM"
+git status --short --branch
+git worktree list --porcelain
+git fetch origin main
+```
+
+`task brief` is read-only. It answers which lane is active, whether it is dirty,
+which upstream/base is visible, and which worktrees already exist. Fetch updates
+remote-tracking knowledge; it does not merge anything into the current branch.
+
+### 2. Preserve before interpreting
+
+The exact historical commit was pushed without rewriting it. Preservation made
+later selection safe: rejecting files from the candidate no longer risked
+destroying the only copy of the work.
+
+### 3. Start from current main
+
+The completion worktree was created at the verified `main` commit. The old
+36-file commit was used as evidence, not applied as a unit. Only the generalized
+reinforcement types, pure IS 456 PMM module, focused tests, and benchmark record
+were recovered.
+
+### 4. Prove runtime identity
+
+```bash
+./scripts/python_runtime.sh --diagnose
+```
+
+Linked worktrees may borrow the primary checkout's Python executable, but the
+launcher prepends the invoking worktree's `Python/` source. Accept evidence only
+when `source_bound` is `true` and the reported module path belongs to the lane.
+
+### 5. Close the evidence gap
+
+Passing comparisons against the existing uniaxial implementation were useful
+regressions but not an independent benchmark. A closed-form 45-degree concrete
+integral plus exact discrete-bar calculation supplied an independent expected
+`Pu`, signed `Mx`, and signed `My`.
+
+This is both a software and Git lesson: preserve first, but do not confuse a
+preserved commit with an accepted feature.
+
+### 6. Validate scripts as evidence producers
+
+The focused quality command initially scanned every IS 456 module because it
+matched `pmm` in the absolute worktree directory name. The fix compared against
+the path relative to the IS 456 source root and added a PMM-named-parent
+regression. A focused command is valid evidence only when it actually focuses.
+
+### 7. Publish at one immutable head
+
+Focused tests, the full Python suite, quick/full repository gates, and commit
+hooks passed before publication. PR #738 was merged only after its head remained
+`a481d1ab`, required checks passed, and GitHub reported CLEAN and MERGEABLE.
+
+### 8. Record post-merge truth separately
+
+The feature commit could truthfully say “candidate ready,” but could not contain
+its own future merge receipt. A small documentation-only PR recorded the exact
+merge commit and moved the task to completed state without changing engineering
+code after review.
+
+### 9. Clean up from exact evidence
+
+Before removal, each PMM worktree was proven clean and each exact head was
+verified on `origin`. The three local worktrees and local branch names were then
+removed. Remote refs were retained as audit and recovery evidence.
+
+## Script behavior learned in this session
+
+| Tool | Mode | Question or action | Important boundary |
+|---|---|---|---|
+| `./run.sh task brief` | Read-only | What lane, base, route, and worktrees exist? | Does not fetch, branch, or edit. |
+| `git worktree add -b` | Git mutation | Create an isolated branch and checkout. | Run from an existing directory; verify collisions first. |
+| `python_runtime.sh --diagnose` | Read-only | Which source tree will Python import? | Interpreter location alone is insufficient. |
+| `check_function_quality.py --module` | Read-only | Do selected IS 456 functions meet the static contract? | Selection must use repository-relative paths. It is not a numerical proof. |
+| `generate_enhanced_index.py` | Workspace write | Refresh folder context projections. | New index locations require `--allow-new-index`; use `--dry-run` first. |
+| `safe_file_delete.py` | Destructive workspace write | Delete one validated file after reference checks. | Generic names such as `index.json` create noisy basename matches; verify the exact target and use `--force` only with known generated files. |
+| `./run.sh check --quick` | Read-only validation | Is the candidate safe for a reviewed commit? | Does not replace focused engineering tests. |
+| `./run.sh check` | Read-only validation | Does the complete repository contract pass? | Run once after the candidate is stable. |
+| GitHub required checks | Remote validation | Did CI pass at the published head? | Recheck if the head or base changes. |
+
+## Index-generator recurrence control
+
+The original generator would create `index.json` and `index.md` in any requested
+folder. During PMM work, targeting nested test directories created six new files
+where the repository had no maintained index convention.
+
+The maintained behavior is now fail-closed:
+
+```bash
+# Safe preview; writes nothing
+./scripts/python_runtime.sh scripts/generate_enhanced_index.py path/to/folder --dry-run
+
+# Normal update; allowed when indexes already exist or the folder is canonical
+./scripts/python_runtime.sh scripts/generate_enhanced_index.py scripts
+
+# Intentional new index topology; requires explicit opt-in
+./scripts/python_runtime.sh scripts/generate_enhanced_index.py path/to/new-folder --allow-new-index
+```
+
+Recursive generation may discover previously unmaintained subfolders and will
+refuse live creation unless the opt-in is supplied. This turns an accidental
+side effect into an explicit repository-design decision.
+
+## Issues, root causes, and reusable solutions
+
+| Symptom | Root cause | Reusable solution |
+|---|---|---|
+| Command could not start in the future worktree | Its process directory did not exist yet | Create from an existing checkout, then enter the lane. |
+| Passing old tests did not justify integration | Comparator was another repository solver | Require an independently derived benchmark for new engineering math. |
+| Oblique benchmark moment symmetry drifted | Rectangular fiber mesh broke square x/y numerical symmetry | Match mesh topology to benchmark symmetry, then tighten by convergence. |
+| Focused checker scanned 69 functions | Absolute path included `pmm` in worktree name | Filter on source-root-relative module paths and regression-test named parents. |
+| Test command stopped before collection | Paths were guessed from memory | Discover maintained paths with `rg --files` before invoking tests. |
+| Six unwanted index files appeared | Writer was targeted at folders without index ownership | Preview, update only maintained folders, and require explicit new-index opt-in. |
+| Safe deletion reported many references | Generic basename search matched unrelated `index.json` text | Inspect exact paths and Git status; never interpret basename count as proof. |
+| Squash-integrated branch looked unmerged | Squash created a new commit identity | Use PR receipt, patch/tree equivalence, tests, and remote preservation—not ancestry alone. |
+
+## How this work could be even better next time
+
+1. Define the independent engineering benchmark before recovering code.
+2. List intended handwritten, generated, and forbidden public-surface paths in
+   the intake packet.
+3. Discover test paths before composing the first combined command.
+4. Run index generation only after handwritten content is stable and only at
+   maintained parent folders.
+5. Decide the post-merge receipt strategy in advance so candidate wording stays
+   precise without an avoidable broad follow-up.
+6. Retain one exact remote preservation ref until the replacement has passed
+   integrated-main verification.
+
+## Teach-back questions
+
+1. Why did we need both a branch and a worktree?
+2. Why was cherry-picking one clean commit still unsafe?
+3. What does `source_bound=true` prove that a Python executable path does not?
+4. Why can squash-integrated work fail an ancestry check?
+5. Which scripts are read-only, which write files, and which delete them?
+6. What evidence justified removing the local PMM worktrees?
+
+If an answer uses “Git knows” or “the tests passed” without naming the exact
+commit, checkout, source root, test boundary, and remote ref, inspect again.

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-09
+last_updated: 2026-08-12
 doc_type: guide
 complexity: intermediate
 tags: [git, github, codex, workflow]
@@ -55,6 +55,17 @@ automatic reset, clean, checkout, stash/drop, rebase, or force push.
 If resolution requires choosing which user changes or commits to keep, stop and
 ask the user. A normal implementation request does not authorize discarding
 work.
+
+When recovering useful work from a stale or mixed historical branch, preserve
+the exact commit first and treat it as evidence rather than applying it as a
+unit. Create a fresh worktree from current `main`, recover only the intended
+paths or hunks, verify runtime/source identity, and establish any missing domain
+evidence before publication. Squash integration changes commit identity, so
+cleanup must consider the PR receipt, content, tests, and retained remote refs;
+ancestry alone is insufficient.
+
+See the worked [Column PMM recovery case study](git-recovery-case-study-column-pmm.md)
+for the complete branch/worktree, script, benchmark, CI, and cleanup sequence.
 
 ## Owner-approved operations
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,10 +17,10 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 3005,
+      "size_lines": 3071,
       "last_updated": "2026-08-12",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "47a26a300cd4"
+      "content_hash": "d03541b840e3"
     },
     {
       "name": "TASKS.md",
@@ -129,7 +129,7 @@
     {
       "name": "git-automation",
       "path": "git-automation/",
-      "file_count": 2,
+      "file_count": 3,
       "description": "owner: Main Agent"
     },
     {
@@ -211,5 +211,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "e3da7f5617103568"
+  "content_hash": "63ef515bcfa41648"
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,7 @@
 
 ```bash
 ./run.sh session start
+./run.sh task brief "describe the task"
 ./run.sh check --quick
 ./run.sh check
 ./run.sh test
@@ -45,11 +46,14 @@ hook enforcement and scripts that automate the Git lifecycle are prohibited.
 | Docs | `check_docs.py` | Metadata and documentation checks |
 | Governance | `check_governance.py` | Folder and policy validation |
 | Git diagnosis | `validate_git_state.sh` | Read-only Git state report |
+| Task intake | `run.sh task brief` | Read-only lane, base, worktree, route, and safe-start summary |
+| Python runtime | `python_runtime.sh --diagnose` | Prove linked-worktree import identity with `source_bound=true` |
 | Discovery | `find_automation.py` | Find an existing project automation |
 | API discovery | `discover_api_signatures.py` | Exact Python API signatures |
 | Files | `safe_file_move.py` | Move files after a dry run and link scan |
 | Files | `safe_file_delete.py` | Delete files after a dry run and reference scan |
-| Indexes | `generate_enhanced_index.py` | Regenerate folder indexes |
+| Indexes | `generate_enhanced_index.py` | Update maintained folder indexes; new index locations require `--allow-new-index` |
+| IS 456 quality | `check_function_quality.py --module <name>` | Source-relative static function-contract scan; not a numerical benchmark |
 | Sessions | `session.py` | Bounded session lifecycle and usage checkpoints |
 | CI | `diagnose_ci.py` | Diagnose CI failures without managing Git |
 | Release | `release.py` | Authorized release preparation and validation |
@@ -60,6 +64,9 @@ hook enforcement and scripts that automate the Git lifecycle are prohibited.
 - Run from the repository root and use `./scripts/python_runtime.sh`, never bare `python`.
 - Inspect `--help` before invoking an unfamiliar tool.
 - Use `--dry-run` before supported destructive file operations.
+- Treat index generation as a write: preview new locations with `--dry-run` and
+  use `--allow-new-index` only when adding that folder to the maintained index
+  topology is intentional.
 - Prefer targeted checks while editing and one full gate at closeout.
 - Preserve unrelated changes in a dirty worktree.
 - Stop on unclear Git state; do not automate recovery or rewrite history.

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -537,14 +537,15 @@
     "generate folder index": {
       "group": "Generation",
       "script": "./scripts/python_runtime.sh scripts/generate_enhanced_index.py <folder>",
-      "description": "Generate index.json + index.md for any folder (AI context files)",
+      "description": "Update maintained index.json + index.md files; new index locations require explicit opt-in",
       "permission": "WorkspaceWrite",
       "permission_modes": {
         "--dry-run": "ReadOnly",
         "--check": "ReadOnly"
       },
       "options": {
-        "--all": "Regenerate all folder indexes"
+        "--all": "Regenerate all key-folder indexes",
+        "--allow-new-index": "Permit intentional creation in a previously unmaintained folder"
       }
     },
     "generate all indexes": {

--- a/scripts/check_function_quality.py
+++ b/scripts/check_function_quality.py
@@ -17,6 +17,9 @@ Performs AST-based static analysis on IS 456 code modules to check:
   12. Errors as tuple return (advisory)
 
 When to use: after changing IS 456 functions or before their quality-gate review.
+The ``--module`` filter matches paths relative to the IS 456 source root, so a
+word in an absolute worktree directory cannot broaden the scan. This checker is
+static contract evidence; it does not replace an independent numerical benchmark.
 
 Usage:
     ./scripts/python_runtime.sh scripts/check_function_quality.py

--- a/scripts/generate_enhanced_index.py
+++ b/scripts/generate_enhanced_index.py
@@ -5,6 +5,10 @@ When to use: After adding, removing, or restructuring files in key project folde
 Generates machine-readable (index.json) and human-readable (index.md) indexes
 that enable agents to load folder context quickly without reading every file.
 
+Live generation updates folders that already contain an index or are listed in
+``KEY_FOLDERS``. Creating indexes in any other folder requires the explicit
+``--allow-new-index`` option. Use ``--dry-run`` first when the target is new.
+
 Extends generate_folder_index.py to handle:
 - Python packages (.py files with class/function extraction)
 - React/TypeScript (.ts/.tsx with export detection)
@@ -26,6 +30,8 @@ Options:
     --md-only     Generate only index.md
     --all         Generate indexes for all key project folders
     --dry-run     Show what would be generated
+    --allow-new-index
+                  Permit live creation in a folder without maintained indexes
 """
 
 from __future__ import annotations
@@ -98,6 +104,22 @@ KEY_FOLDERS = [
     "agents",
     "agents/roles",
 ]
+
+
+def is_maintained_index_folder(folder: Path) -> bool:
+    """Return whether live generation may update ``folder`` by default.
+
+    A folder is maintained when it is in the canonical key-folder list or
+    already contains either generated index. This distinguishes updating an
+    existing projection from introducing new repository files.
+    """
+    resolved_folder = folder.resolve()
+    relative_folder = resolved_folder.relative_to(PROJECT_ROOT).as_posix()
+    return (
+        relative_folder in KEY_FOLDERS
+        or (resolved_folder / "index.json").is_file()
+        or (resolved_folder / "index.md").is_file()
+    )
 
 
 # ─── Python Analysis ────────────────────────────────────────────
@@ -703,6 +725,11 @@ def main():
         "--dry-run", action="store_true", help="Show what would be generated"
     )
     parser.add_argument(
+        "--allow-new-index",
+        action="store_true",
+        help="Permit live index creation in a previously unmaintained folder",
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help="Check if existing indexes are stale (exit 1 if any are)",
@@ -789,6 +816,18 @@ def main():
         else:
             print(f"✓ All {checked} index(es) with hashes are current")
             sys.exit(0)
+
+    if not args.dry_run and not args.allow_new_index:
+        unmaintained = [
+            folder for folder in folders if not is_maintained_index_folder(folder)
+        ]
+        if unmaintained:
+            print("❌ Refusing to create indexes in unmaintained folder(s):")
+            for folder in unmaintained:
+                print(f"  - {folder.relative_to(PROJECT_ROOT)}")
+            print("Run with --dry-run to inspect the targets.")
+            print("Use --allow-new-index only when new index files are intentional.")
+            sys.exit(2)
 
     print(f"Folders to process: {len(folders)}")
     print(f"Mode: {'DRY RUN' if args.dry_run else 'LIVE'}")

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -8,11 +8,11 @@
     {
       "name": "README.md",
       "type": "documentation",
-      "size_lines": 72,
+      "size_lines": 79,
       "last_updated": "2026-08-12",
       "title": "Scripts",
       "description": "> Development, validation, discovery, release-preparation, and maintenance tools. > Git/GitHub lifecycle wrappers were retired on 2026-08-09; Codex owns that",
-      "content_hash": "f038a0884d21"
+      "content_hash": "812e467b64a5"
     },
     {
       "name": "agent_brief.sh",
@@ -912,7 +912,7 @@
         "_coverage",
         "tasks"
       ],
-      "content_hash": "5c3fe48192ca"
+      "content_hash": "186f2a2c15ec"
     },
     {
       "name": "batch_migrate_runner.py",
@@ -1678,7 +1678,7 @@
     {
       "name": "check_function_quality.py",
       "type": "python",
-      "size_lines": 674,
+      "size_lines": 677,
       "last_updated": "2026-08-12",
       "description": "12-point quality checklist for IS 456 functions.",
       "classes": [
@@ -1759,7 +1759,7 @@
         "UNIT_SUFFIXES",
         "ADVISORY_CHECKS"
       ],
-      "content_hash": "cda5924f482f"
+      "content_hash": "a6b22dde821d"
     },
     {
       "name": "check_governance.py",
@@ -3266,10 +3266,17 @@
     {
       "name": "generate_enhanced_index.py",
       "type": "python",
-      "size_lines": 827,
+      "size_lines": 866,
       "last_updated": "2026-08-12",
       "description": "Generate enhanced index.json + index.md for ANY folder type.",
       "functions": [
+        {
+          "name": "is_maintained_index_folder",
+          "description": "Return whether live generation may update ``folder`` by default.",
+          "params": [
+            "folder"
+          ]
+        },
         {
           "name": "analyze_python_file",
           "description": "Extract metadata from a Python file.",
@@ -3344,7 +3351,7 @@
         "SKIP_DIRS",
         "KEY_FOLDERS"
       ],
-      "content_hash": "102cdd8402b4"
+      "content_hash": "333f720a61be"
     },
     {
       "name": "generate_error_docs.py",
@@ -4059,10 +4066,10 @@
     {
       "name": "python_runtime.sh",
       "type": "shell-script",
-      "size_lines": 72,
+      "size_lines": 75,
       "last_updated": "2026-08-12",
       "description": "Resolve the repository Python interpreter across primary and linked worktrees.",
-      "content_hash": "3d184251b5e6"
+      "content_hash": "a1668746c936"
     },
     {
       "name": "release.py",
@@ -4154,7 +4161,7 @@
     {
       "name": "safe_file_delete.py",
       "type": "python",
-      "size_lines": 350,
+      "size_lines": 355,
       "last_updated": "2026-08-12",
       "description": "Safe file delete script with reference checking.",
       "functions": [
@@ -4193,7 +4200,7 @@
           "name": "main"
         }
       ],
-      "content_hash": "c2dea6869d7b"
+      "content_hash": "1c59c8d925fa"
     },
     {
       "name": "safe_file_move.py",
@@ -5370,5 +5377,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "6ed4e1cf64d433a3"
+  "content_hash": "eefbdc480ded19b3"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -14,7 +14,7 @@
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [README.md](README.md) | Scripts | > Development, validation, discovery, release-preparation, a | 72 |
+| [README.md](README.md) | Scripts | > Development, validation, discovery, release-preparation, a | 79 |
 
 ## Python Files
 
@@ -48,7 +48,7 @@
 | [check_docker_config.py](check_docker_config.py) | Docker Configuration Validator. | 0 | 6 | 295 |
 | [check_docs.py](check_docs.py) | Unified documentation checker — consolidates 4 doc validatio | 0 | 6 | 675 |
 | [check_fastapi_issues.py](check_fastapi_issues.py) | FastAPI Issues AST Scanner. | 3 | 4 | 468 |
-| [check_function_quality.py](check_function_quality.py) | 12-point quality checklist for IS 456 functions. | 3 | 6 | 674 |
+| [check_function_quality.py](check_function_quality.py) | 12-point quality checklist for IS 456 functions. | 3 | 6 | 677 |
 | [check_governance.py](check_governance.py) | Unified governance checker — folder structure + compliance v | 2 | 19 | 1042 |
 | [check_instruction_drift.py](check_instruction_drift.py) | Check for content drift between .github/instructions/ and .c | 0 | 2 | 219 |
 | [check_links.py](check_links.py) | Check and fix broken internal links in markdown files. | 0 | 2 | 351 |
@@ -79,7 +79,7 @@
 | [generate_beam_tool_manifest.py](generate_beam_tool_manifest.py) | Generate and byte-check the catalogue-derived beam tool mani | 0 | 4 | 64 |
 | [generate_client_sdks.py](generate_client_sdks.py) | Generate client SDKs from FastAPI OpenAPI specification. | 0 | 6 | 560 |
 | [generate_docs_index.py](generate_docs_index.py) | Generate machine-readable JSON index of documentation. | 0 | 7 | 246 |
-| [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 10 | 827 |
+| [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |
@@ -92,7 +92,7 @@
 | [project_health.py](project_health.py) | Unified project health scanner with auto-fix capability. | 3 | 9 | 908 |
 | [prompt_router.py](prompt_router.py) | Prompt router — routes natural language queries to the best  | 1 | 5 | 658 |
 | [release.py](release.py) | Unified release management CLI. | 0 | 10 | 1776 |
-| [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 350 |
+| [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
 | [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2300 |
 | [session_store.py](session_store.py) | JSON-based session state persistence for AI agent sessions. | 1 | 14 | 374 |

--- a/scripts/python_runtime.sh
+++ b/scripts/python_runtime.sh
@@ -2,7 +2,10 @@
 # Resolve the repository Python interpreter across primary and linked worktrees.
 #
 # When to use: internal launcher for run.sh, pre-commit, and Python subprocess
-# orchestration. Callers pass normal Python arguments after this script.
+# orchestration. Callers pass normal Python arguments after this script. In a
+# linked worktree, use --diagnose before evidence-producing tests and require
+# source_bound=true; the selected interpreter may live in the primary checkout
+# while imports must come from the invoking worktree.
 
 set -euo pipefail
 

--- a/scripts/safe_file_delete.py
+++ b/scripts/safe_file_delete.py
@@ -10,6 +10,11 @@ This script safely deletes files by:
 3. Optionally creating backup
 4. Running link validation after delete
 
+Reference discovery is deliberately conservative and searches by basename.
+Generic generated names such as ``index.json`` and ``index.md`` can therefore
+produce broad matches. Treat those matches as prompts to inspect the exact path,
+Git status, and ownership; ``--force`` is not proof that deletion is safe.
+
 Usage:
     python scripts/safe_file_delete.py <file> [--force] [--dry-run]
 


### PR DESCRIPTION
## What changed

- added a complete Column PMM Git recovery case study covering preservation, selective recovery, branch/worktree choice, runtime identity, independent evidence, squash integration, and cleanup
- updated the canonical Git workflow and compact AI-agent guide with the reusable recovery rule
- documented task intake, worktree-bound Python, function-quality, index generation, and safe deletion by evidence/mutation type
- made index generation fail closed for previously unmaintained folders unless `--allow-new-index` is explicit
- added a regression proving refusal before writing and explicit opt-in behavior
- regenerated only maintained repository indexes and recorded issues/root causes in the session log

## Why

The PMM recovery exposed reusable Git and automation lessons that should not remain only in a chat transcript. The main recurring script defect was that a targeted index command silently created six new files in folders that did not own maintained indexes. The new guard turns that side effect into an explicit topology decision.

## User and developer impact

- future stale feature lanes have a repository-specific worked recovery model
- linked-worktree tests explicitly distinguish interpreter location from imported source identity
- `generate_enhanced_index.py` continues updating existing/canonical indexes normally
- new index locations require `--dry-run` review and `--allow-new-index` intent
- `generate_all_indexes.sh` remains compatible with all 16 existing targets

## Validation

- focused session automation and function-quality tests: 41 passed
- live unmaintained-folder probe: exit 2, no index files written
- all 16 `generate_all_indexes.sh` targets recognized as maintained
- script-reference validation: zero runtime breaks, zero misleading output
- Codex-native Git workflow check: pass
- `./run.sh check --quick`: 10/10
- `./run.sh check`: 30/30
- commit hooks: pass, including 341-document link validation and script registry coverage
