### PR TITLE
docs(git): reconcile future work plan

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,3 +1,95 @@
+## 2026-08-12 — Session: GIT-001 Future-Work Reconciliation
+
+**Agent:** Codex
+
+**Branch:** `codex/git-future-work-plan`
+
+**Focus:** Reconcile the six-priority Git recovery/cleanup list against live
+repository and GitHub state, then provide an executable next-agent handoff
+
+### Summary
+
+- Reconciled every original priority against refreshed refs, worktree state,
+  patch equivalence, merged-PR receipts, branch attachment, and dependency PRs.
+- Moved completed PMM and PR #723 recovery into a completed ledger so future
+  agents do not repeat them.
+- Defined the current execution order: synchronize and complete GIT-001 Phase
+  1, decide Excel ownership, seek Alpha retirement approval, seek separate
+  local/remote branch-cleanup approval, then process dependencies in coherent
+  compatibility packets.
+- Updated the global next-session briefing and generated the two maintained
+  documentation indexes through the lane-bound runtime.
+
+### Issues encountered
+
+- The first combined document-read command stopped after requesting a Phase 0
+  filename that does not exist.
+- The initial runtime-pin inspection used `react_app/.nvmrc`, but this repository
+  stores the maintained Node pin at the root `.nvmrc`.
+- The stale-branch cleanup dry run returned no candidates even though eight
+  unattached merged local branches were identified by direct Git/PR evidence.
+- The GIT-001 research branch appeared one commit ahead of `main` even though
+  its work has already been integrated.
+- The index generator rejected two folder paths in one invocation.
+- The first documentation gate rejected `doc_type: plan` on the new packet.
+- The commit hook rejected the handoff heading `Read first` and then the custom
+  `Decision needed` state even though the quick and full gates had passed.
+
+### Root causes and resolutions
+
+- The actual Phase 0 file is
+  `GIT-001-phase-0-preservation-baseline.md`; `rg --files` established the exact
+  name, and subsequent reads used that path.
+- The Node runtime pin is repository-wide rather than React-folder-local.
+  Reading root `.nvmrc` proved Node 24, which makes the proposed Node 26 type
+  update a policy decision rather than a routine independent bump.
+- `cleanup_stale_branches.py` selects age-oriented remote cleanup candidates;
+  it is not a complete classifier for recent unattached local branches. The
+  plan therefore uses an explicit worktree/ref/reachability/PR receipt table
+  and preserves the maintained script only for an approved remote cleanup run.
+- The research commit was squash-integrated, so graph ancestry retained an
+  apparent branch-only commit. `git cherry origin/main
+  codex/git-governance-research` returned `- 3be4790d`, proving patch
+  equivalence; the next action is to synchronize the shared lane without
+  rebasing or rewriting it.
+- `generate_enhanced_index.py` accepts one optional folder per invocation. The
+  two already-maintained folders were regenerated in separate lane-bound calls;
+  both completed successfully and the generated entries include the new plan.
+- The documentation schema allows `guide`, `reference`, `tutorial`, `index`,
+  `spec`, and `log`, but not `plan`. The packet is an active non-normative
+  research reference, so its front matter now uses `doc_type: reference`; the
+  documentation gate then validates the new file.
+- `check_session_docs.py` requires the exact heading `Required Reading` and
+  literal `Current` and `Next` table rows; semantic equivalents are not
+  accepted. The briefing now uses those contract phrases, and the focused
+  session-doc check plus the next commit hook verify it.
+
+### Verification
+
+- Refreshed `main` and `origin/main` were exact at `951f5e1d`; primary and all
+  five pre-existing linked worktrees were clean at inspection.
+- PMM and workflow recovery receipts were matched to PRs #736-#740.
+- Three Alpha lanes have clean, main-reachable heads; the policy lane's local
+  and remote heads were both separately proven reachable from main.
+- Eight unattached merged local branches have matching remote heads and merged
+  PR receipts; no deletion was performed.
+- Documentation indexes regenerated only in their already-maintained folders.
+- Documentation validation passed 5/5 with zero invalid front-matter files;
+  internal-link validation found zero broken links across 1,103 links.
+- `./run.sh check --quick` passed 10/10 and `./run.sh check` passed 30/30.
+
+### Terminal issues
+
+- `sed` failed on the guessed Phase 0 filename; `rg --files` supplied the exact
+  maintained path.
+- `react_app/.nvmrc` was absent; root `.nvmrc` is the correct runtime pin.
+- The index generator does not accept multiple positional folders; run one
+  invocation per maintained folder or use the documented all/recursive modes.
+- `check_docs.py` rejected the unsupported `plan` value; use the repository's
+  controlled front-matter values rather than inferring a type from the title.
+- The pre-commit session-doc validator rejected semantic variants; use the exact
+  maintained `Required Reading`, `Current`, and `Next` labels in global handoffs.
+
 ## 2026-08-12 — Session: COLUMN-PMM-001 Git Learning Update
 
 **Agent:** Codex

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -107,11 +107,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 148,
+      "size_lines": 105,
       "last_updated": "2026-08-12",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-12",
-      "content_hash": "66f0b90ce258"
+      "content_hash": "aaa04ca6a626"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "bf9c2655bed83479"
+  "content_hash": "be162b8c7d232fd2"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -20,7 +20,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-12 | 148 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-12 | 105 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,144 +4,101 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-12
-- Focus: COLUMN-PMM-001 integrated; GIT-001 Phase 1 continues
+- Focus: GIT-001 Phase 1 continuation and evidence-gated repository disposition
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha
-**Branch:** `codex/column-pmm-closeout`
-**Integration base:** `origin/main` at `402bf22c`; immutable Alpha tag `v0.23.1a1` remains unchanged
+
+**Integration anchor at handoff:** `main = origin/main = 951f5e1d`
+
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | GIT-001 Phase 1 | Complete primary-source coverage and factual lifecycle research without changing canonical policy |
-| **Next** | GIT-001 Phase 2 | Forensic incident study only after the Phase 1 coverage review passes |
-| **Held** | Broad policy implementation and remote cleanup | Historical refs stay preserved; PMM production/public support remains a separately approved contract |
-
-## Integrated footing scope
-
-- The maintained scope is one concentric square/rectangular isolated-footing
-  workflow with explicit service and factored actions, external allowable-soil-
-  pressure approval, and approved A1 load-transfer evidence.
-- Overall thickness and effective depth remain distinct; flexure, directional
-  one-way shear, punching shear, bearing, and uniform-depth selection are
-  fail-closed.
-- Optional two-layer bottom-reinforcement detailing returns physical directional
-  depths, bar schedules, rectangular central/outer-band zones, anchorage evidence
-  and linked dowels. Missing or unsupported inputs remain visible HOLDs.
-- The release inclusion receipt binds 15 footing-owned file hashes and six
-  cross-layer markers; verify it after the complete merge before any PR action.
-
-## Public-distribution permission
-
-- The repository owner confirmed source/licensing permission on 2026-08-11 for
-  approved-scope normalized IS 456 data. The canonical record is
-  [`is456-public-distribution-permission.json`](../verification/is456-public-distribution-permission.json);
-  release preflight, candidate checks, and publish CI validate it fail closed.
-- The private corpus remains private, protected prose/images remain excluded,
-  and each release still needs separate owner authorization. Do not report this
-  gate as pending unless the owner explicitly changes the recorded decision.
+| **Current** | GIT-001 Phase 1 | Synchronize the research lane, finish official-source coverage, and write the factual lifecycle map |
+| **Next** | Excel planning lane | Confirm a named active owner/next action or approve retirement |
+| **Approval-gated** | Alpha worktrees and merged branches | Exact evidence is ready; deletion still requires explicit target approval |
+| **Separate maintenance** | Seven dependency PRs | Replace one-by-one merging with four current-base compatibility packets |
 
 ## Required Reading
 
-- [GIT-001 research index](../research/git-governance/GIT-001-README.md)
-- [AI token-efficiency policy](../guidelines/ai-token-efficiency.md)
-- [IS 456 solid slabs master plan](is456-solid-slabs-master-plan.md)
-- [IS 456 library-first evidence](../verification/is456-library-first-evidence.md)
-- [UI experience foundation master plan](ui-experience-foundation-master-plan.md)
-- [Session 2 acceptance](../verification/ui-experience-session-2-acceptance.md)
-- [Current task board](../TASKS.md)
-- [Release policy](../getting-started/releases.md)
+1. [Reconciled future-work and disposition plan](../research/git-governance/GIT-001-next-agent-disposition-plan.md)
+2. [GIT-001 research index](../research/git-governance/GIT-001-README.md)
+3. [Official evidence register](../research/git-governance/GIT-001-official-evidence-register.md)
+4. [Lifecycle research](../research/git-governance/GIT-001-lifecycle-research.md)
+5. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
+6. [AI token-efficiency policy](../guidelines/ai-token-efficiency.md)
 
-## GIT-001 research state
+## Start command
 
-- Dedicated `codex/git-governance-research` worktree was created from refreshed
-  `origin/main` at `6bc356c3`; primary `main` remains clean and synchronized.
-- Phase 0 records eight clean worktrees, sixteen local branches, eight open PRs,
-  the active main ruleset, no stashes, protected unique work, and explicit unknowns.
-- Column PMM is remotely preserved, recovered onto current `main`, and checked
-  against an independent closed-form oblique benchmark. It remains experimental.
-  PR #723 is closed after its bounded replacement merged via #736.
-- Phase 1 has begun with official Git, GitHub, and OpenAI sources. Research facts,
-  project observations, proposed decisions, and normative policy stay separate.
-- Existing conflicting Git guides and retired-wrapper learning text are Phase 2
-  evidence candidates, not early rewrite targets.
-- Integrated packet 7A restores lane-safe intake and index-runtime behavior;
-  canonical policy, GitHub settings, broad cleanup, and release remain held.
-- SPARK-001 remains integrated at PR #734, but Wave 0 stays behind owner gate G0.
+```bash
+./run.sh task brief "continue GIT-001 Phase 1 official research"
+./run.sh session brief --agent ops
+./run.sh session start
+```
 
-## IS456-SLAB-001 implementation outcome
+Then refresh and inspect the branch, upstream, worktree, diff, current PR, and
+all linked worktrees before mutation. The dated handoff is evidence, not a
+replacement for live inspection.
 
-- Existing compatibility slab functions remain available; the implementation
-  extends the maintained slab package rather than creating another engine.
-- Built-in Tables 12/13 and Tables 26/27 resolution is implemented with exact
-  provenance, bounded adjacent interpolation and explicit extrapolation errors.
-  External coefficient providers remain available with distinct trust status.
-- Oriented physical edges drive common two-way cases, strip widths and full/
-  half/none/free corner-torsion dispositions without silent span rotation.
-- Complete bounded routes cover provided bars, minimum/maximum detailing,
-  reviewed span/depth serviceability and ordinary one-way shear. Direct
-  deflection, automatic shear reinforcement and irregular/concentrated-load
-  panels remain held.
-- Five new FastAPI routes and the `/workbench/slabs` React flow are live-verified.
-  Results preserve revision identity and stale results cannot be exported.
-- Flat slabs, drops, column strips, slab-column transfer and column-supported
-  punching remain under a separately approved FS0 extension.
+## Current Git facts
 
-### Verification at handoff
+- The dedicated GIT-001 worktree is clean at `3be4790d`, one commit ahead and
+  six behind current `main` by ancestry. `git cherry` shows its patch is already
+  squash-integrated. Merge current `origin/main` into this shared branch after
+  exact clean/upstream checks; do not rebase or force-push it.
+- Column PMM preservation, selective recovery, independent benchmark,
+  integration, closeout, and learning update are complete through PRs #738-#740.
+  Historical remote refs remain evidence; PMM remains experimental.
+- PR #723 is closed without merge. Its useful behavior was selectively rebuilt
+  through PRs #736-#737. Use #723 as incident evidence, not a merge target.
+- Excel planning has no unique commit, remote feature branch, or PR. Git supports
+  retirement, but task ownership still needs an owner decision.
+- Three merged Alpha worktrees are clean and retirement-ready after explicit
+  approval. They occupy roughly 651 MB, mainly old `node_modules`.
+- Eight unattached merged local branches, not seven, now have exact PR and main
+  reachability receipts. Local and remote deletion require separate approval.
+- All seven remaining Dependabot PRs are behind current `main`; their old green
+  checks are stale for integration.
 
-- 5,532 Python tests passed, 3 skipped and 6 deselected.
-- 388 FastAPI tests and 241 React tests passed.
-- Frontend lint/test/TypeScript/production build passed.
-- Quick gate 10/10 and integrated gate 30/30 passed.
-- Live continuous and B04 two-way flows passed without browser console errors;
-  stale passport export was blocked as designed.
+## Phase 1 boundary
 
-## Accepted UIX outcome
+Finish official coverage for core Git operations and recovery, GitHub merging
+and governance, dependency automation, releases/contributors, and verified
+Codex task/worktree behavior. Then produce the source-backed lifecycle map for
+normal, parallel, integration, release, cleanup, and recovery paths.
 
-Session 1 delivered revision-safe quick/project results, durable project identity,
-revision-bound exports, and authoritative 3D inspection. Session 2 delivered one
-immutable beam catalogue, thin discovery API, curated schema renderer, one
-default-disabled bounded workflow, one generated provider-neutral beam manifest,
-canonical workbench routes, and integrated live acceptance.
+Every statement must be labeled as an external fact, project observation,
+unresolved choice, or not applicable. Do not change canonical policy, GitHub
+settings, hooks, or cleanup behavior during Phase 1. Do not advance to Phase 2
+until the coverage review explicitly passes.
 
-The final live pass fixed three main-process causes:
+## Destructive-action holds
 
-- React Strict Mode cancelled the initial quick-design effect while a one-shot
-  ref prevented its replacement; the hook now retains the current runner.
-- Catalogue inputs were rendered beside the legacy input surface; catalogue and
-  manual modes now have mutually exclusive ownership.
-- Project route guards redirected before IndexedDB hydration began; idle/loading
-  are now explicit restore states.
+- Do not remove Excel until the owner decides whether the planning task is active.
+- Do not remove Alpha worktrees until the owner approves the three exact paths.
+- Do not delete local or remote branches without an exact refreshed table and
+  explicit approval for that deletion scope.
+- Stop if a lane becomes dirty, attached unexpectedly, diverged, conflicted, or
+  gains new commits/PR activity. Never reset, clean, stash, rebase, or force-push
+  as a shortcut around uncertain ownership.
 
-The bundled sample settles 153/153 PASS and restores canonical results directly.
-Safe, unsafe, stale/recalculate, export, bounded workflow, legacy redirects,
-390/1024/1440 px, and WebGL interruption flows pass in maintained Chromium.
+## Dependency grouping
 
-## Verification
+- Python typing: PRs #715 and #717 together.
+- ESLint 10: PRs #713 and #683 together.
+- React build: hold #684 for coordinated Vite/toolchain compatibility.
+- Node types: hold #714 while repository runtime remains Node 24.
+- Motion: #716 can be an independent current-base frontend task.
 
-- 91 focused Python/FastAPI tests, 87 focused React tests, and 76 focused
-  geometry/streaming tests pass.
-- React/API signature scan matches 29 maintained call sites.
-- `./run.sh frontend check` passes lint, 239 tests, and production build.
-- `./run.sh check --quick` passes 10/10 and the final integrated gate passes
-  30/30; pull-request checks remain the merge authority.
+Each group gets a fresh worktree, a compatibility hypothesis, targeted checks,
+the complete relevant gate, and exact-head CI. Do not merge the seven old PRs
+as unrelated updates.
 
-## Holds
+## Session closeout
 
-- Workflow execution remains unavailable by default and is enabled only through
-  explicit development/test flags.
-- Firefox, exact Safari responsive automation, GitHub Pages, public workflow
-  activation, release/tag/package publication, and professional-use claims are
-  not part of UIX acceptance.
-- Production JWT secret provisioning remains an owner operation.
-- PR #711 remains superseded; PR #683 belongs to a coordinated ESLint 10
-  migration; PR #684 remains blocked on a coordinated Vite 8 migration.
-
-## Repeat-prevention record
-
-Every session must record observed issue, confirmed root cause, resolution, and
-verification in the newest `docs/SESSION_LOG.md` block. Shared `AGENTS.md` and
-agent templates enforce that schema, and session closeout validates the newest
-entry only. Log terminal/tool failures with the maintained command or evidence
-path that succeeded; do not treat an observer limitation as a product failure.
+Run the quick gate and the full relevant gate once at closeout. Record every
+material issue as symptom, impact, confirmed root cause, solution, and evidence
+in the newest `docs/SESSION_LOG.md` entry. Preserve shared-surface ownership:
+session/task records, generated indexes, registries, routes, manifests, and
+lockfiles have one writer at a time.

--- a/docs/research/git-governance/GIT-001-README.md
+++ b/docs/research/git-governance/GIT-001-README.md
@@ -31,10 +31,10 @@ work, make recovery deterministic, and remain efficient during normal work.
 
 | Role | Path / branch | Start state |
 |---|---|---|
-| Integration anchor | primary checkout / `main` | Clean at `6bc356c3`; no implementation work |
-| GIT-001 research lane | `structural_engineering_lib-git-governance-research` / `codex/git-governance-research` | Created from refreshed `origin/main` at `6bc356c3` |
-| Preserved engineering lane | `structural_engineering_lib-column-pmm` / `codex/column-pmm-experimental` | Exact commit published; integration held for independent benchmark |
-| Preserved workflow lane | remote `codex/parallel-task-policy` | PR #723 closed after replacement; remote retained for audit |
+| Integration anchor | primary checkout / `main` | Refreshed and clean at `951f5e1d` on 2026-08-12 |
+| GIT-001 research lane | `structural_engineering_lib-git-governance-research` / `codex/git-governance-research` | Active at `3be4790d`; patch integrated, branch behind current `main` and must be synchronized before more research |
+| Preserved engineering evidence | remote PMM forensic/recovery refs | Selective recovery and independent benchmark integrated through PRs #738-#740; PMM remains experimental |
+| Preserved workflow evidence | remote `codex/parallel-task-policy` | PR #723 closed after bounded replacement through PRs #736-#737; remote retained for audit |
 
 ## Phase ledger
 
@@ -56,6 +56,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 - [Official evidence register](GIT-001-official-evidence-register.md)
 - [Lifecycle research](GIT-001-lifecycle-research.md)
 - [Phase 7A preservation and workflow recovery](GIT-001-phase-7A-preservation-workflow-recovery.md)
+- [Reconciled future-work and disposition plan](GIT-001-next-agent-disposition-plan.md)
 - Phase 2 incident register — planned
 - Phase 3 gap/risk matrix — planned
 - Phase 4 operating-model proposal — planned

--- a/docs/research/git-governance/GIT-001-next-agent-disposition-plan.md
+++ b/docs/research/git-governance/GIT-001-next-agent-disposition-plan.md
@@ -1,0 +1,410 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-12
+doc_type: reference
+task: GIT-001
+---
+
+# GIT-001 — Reconciled Future-Work and Disposition Plan
+
+## Purpose
+
+This packet converts the original six-priority cleanup and recovery list into a
+current, evidence-backed handoff. It tells the next agent what is already done,
+what remains, why the order changed, which actions need owner approval, and what
+evidence must exist before any destructive Git operation.
+
+This is a planning and forensic record, not new Git policy. The canonical
+workflow remains
+[`git-workflow-single-source.md`](../../git-automation/git-workflow-single-source.md).
+
+## Snapshot and reading rule
+
+- Live refresh and inspection date: `2026-08-12`.
+- Refreshed integration anchor: `main = origin/main = 951f5e1d`.
+- The primary worktree was clean when inspected.
+- All five linked worktrees were clean when inspected.
+- Ahead/behind counts below are commit-graph facts only. Squash integration is
+  checked separately with patch equivalence, PR receipts, and main reachability.
+- “Ready to retire” means the evidence packet is complete enough to request the
+  owner's destructive-action approval. It does not itself authorize removal.
+
+## Outcome first: the revised order
+
+The old list mixed completed recovery with future work. The current order is:
+
+1. **Synchronize and continue GIT-001 Phase 1 research.** The active research
+   lane is clean but behind current `main`; bring current receipts into view,
+   finish official-source coverage, then write the factual lifecycle map.
+2. **Decide Excel planning ownership.** It has no unique commits and no PR, so
+   one owner decision determines whether it remains active or becomes a safe
+   retirement candidate.
+3. **Retire the three merged Alpha worktrees after explicit approval.** Their
+   exact heads are preserved and reachable; this is the largest immediate disk
+   recovery, roughly 650 MB.
+4. **Prepare and execute a separately approved branch-cleanup packet.** The old
+   count of seven is stale; eight unattached merged local branches are now
+   verified candidates. Local and remote deletion are separate decisions.
+5. **Handle the seven remaining dependency PRs as four coordinated tasks.** Do
+   not merge old, behind Dependabot branches one by one.
+
+Column PMM preservation/recovery and the useful portion of PR #723 are complete.
+They stay in the completed ledger below so a future agent does not repeat them.
+
+## What changed from the original priorities
+
+| Original priority | Current result | Updated disposition |
+|---|---|---|
+| 1 — protect unique PMM work | Complete and superseded by safe integration | Keep remote forensic refs; no Git recovery action remains |
+| 2 — complete Phase 1 and study PR #723 | PR #723 study/recovery complete; Phase 1 incomplete | Continue only the remaining official research and lifecycle map |
+| 3 — decide Excel ownership | Still open | Make this the first ownership decision after research-lane synchronization |
+| 4 — retire merged Alpha worktrees | Evidence now complete; no deletion performed | Request exact approval, then retire in a controlled sequence |
+| 5 — branch cleanup packet for seven branches | Count changed from seven to eight | Publish the refreshed table and obtain separate local/remote approval |
+| 6 — dependency maintenance | Still open; all seven PRs are behind `main` | Replace one-by-one merging with four tested compatibility packets |
+
+## Completed ledger — do not repeat
+
+### A. Column PMM preservation and recovery
+
+The historical branch `codex/column-pmm-experimental` was published unchanged
+at `8a52ed0f` before integration work. Its single large stale-base commit was not
+blindly merged or cherry-picked. The engineering surface was selectively
+recovered on current code, checked against an independent closed-form oblique
+benchmark, reviewed, and integrated through:
+
+- feature PR #738, reviewed head `a481d1ab`, squash merge `402bf22c`;
+- closeout PR #739, reviewed head `04f789de`, squash merge `d106ff59`;
+- Git-learning closeout PR #740, now included in `main` at `951f5e1d`.
+
+The old PMM local worktree and local branch were removed only after exact merge
+and integrated-main receipts. The remote historical and recovery refs remain
+available as forensic evidence. PMM is still experimental and not part of the
+stable root, services, FastAPI, or React contract. Promoting it is a separate
+engineering decision, not unfinished Git recovery.
+
+**Lesson:** publish irreplaceable history first; then recover the intended
+outcome onto a fresh base and prove it independently. A clean old branch is not
+automatically safe to merge, and a merged replacement does not make the
+historical evidence useless.
+
+### B. PR #723 selective workflow recovery
+
+PR #723 (`codex/parallel-task-policy`, head `75d66681`) was closed without merge.
+It was used as incident and design evidence, not as a conflict-resolution task.
+The useful current-compatible behavior was selectively reimplemented:
+
+- `./run.sh task brief <description>` for read-only lane intake;
+- worktree-bound Python runtime use during index generation;
+- a read-only `generate indexes --help` path.
+
+These changes merged through PR #736 at reviewed head `aec9fbb2` and merge
+`30ec598d`; PR #737 added the closeout record at merge `b069428b`. Broad parallel
+policy text, unrelated generated surfaces, registry churn, and stale session
+automation were deliberately not copied.
+
+**Lesson:** a conflicted PR can still be valuable as a requirements source.
+Recover the behavior that remains correct; do not use conflict resolution to
+silently import obsolete architecture.
+
+## Current worktree topology
+
+| Worktree / branch | Head | Relation to current `main` | Disposition |
+|---|---:|---|---|
+| Primary / `main` | `951f5e1d` | Exact `origin/main` | Clean integration anchor |
+| GIT-001 / `codex/git-governance-research` | `3be4790d` | 1 commit ahead, 6 behind by ancestry; patch already squash-integrated | Active; synchronize before continuing |
+| Excel / `codex/excel-product-planning` | `a0e115e1` | 0 ahead, 59 behind; head is ancestor of main | Ownership decision required |
+| Alpha closeout / `codex/alpha-0231-release-closeout` | `127afb64` | 0 ahead, 12 behind; ancestor of main | Retirement-ready after approval |
+| Alpha integration / `codex/alpha-0231-integration` | `e3b9a6cb` | 0 ahead, 30 behind; ancestor of main | Retirement-ready after approval |
+| Alpha policy / `codex/release-preflight-alpha-policy` | `5da9c66a` | Local head is ancestor of main | Retirement-ready after dual-head receipt |
+
+The GIT-001 branch looks “ahead” only because its research commit was
+squash-merged. `git cherry origin/main codex/git-governance-research` reports
+`- 3be4790d`, which means an equivalent patch already exists on `main`. This is
+why ahead/behind alone cannot decide integration or cleanup.
+
+## Priority 1 — synchronize and complete GIT-001 Phase 1
+
+### Why this is first
+
+GIT-001 is the active governance program. Its research lane predates the PMM
+and PR #723 closeouts, so continuing without synchronization would cause the
+agent to repeat old facts or contradict current receipts. The lane is clean,
+published, and shared; preserving its history is preferable to silently
+replacing it.
+
+### Recommended lane action
+
+1. Refresh `origin` and prove the GIT-001 worktree is clean, attached to
+   `codex/git-governance-research`, and exactly at its upstream head.
+2. Verify again that `3be4790d` is patch-equivalent to work already on `main`.
+3. Merge refreshed `origin/main` into the research branch. Do not rebase or
+   force-push the shared research branch.
+4. If the merge conflicts, stop and classify each conflict against the current
+   Phase 7A and PMM receipts. Do not choose “ours” or “theirs” across the tree.
+5. Run the documentation and quick gates, commit only deliberate reconciliation
+   edits if required, and push without history rewriting.
+
+If the existing lane has become unavailable or externally owned, create a
+fresh `codex/git-governance-phase1-continuation` worktree from current `main`
+and record the old branch as predecessor. Do not have two writers in the same
+research directory.
+
+### Research scope after synchronization
+
+Complete the open coverage listed in
+[`GIT-001-official-evidence-register.md`](GIT-001-official-evidence-register.md):
+
+- commits, branches, upstreams, fetch, pull, and push;
+- merge, rebase, cherry-pick, revert, reset, restore, stash, and clean;
+- hooks, configuration scope, pruning, garbage collection, and worktree repair;
+- tags, signatures, release ancestry, submodules, shallow and partial clones;
+- GitHub merge methods, merge queue/auto-merge, rulesets and branch protection,
+  environments, releases, Dependabot, forks, and external contributors;
+- verified Codex task/worktree lifecycle, archival, snapshot, and handoff facts.
+
+Then write one source-backed factual map for normal work, parallel work,
+integration, release, cleanup, and recovery. Label every statement as external
+fact, project observation, unresolved choice, or not applicable.
+
+### Non-goals
+
+- Do not change canonical Git policy, GitHub settings, hooks, or cleanup rules.
+- Do not delete historical branches or worktrees during research.
+- Do not advance to Phase 2 merely because a source list is long; each open
+  area must be covered, declared not applicable, or explicitly unresolved.
+- Treat PR #723 and the PMM incident as Phase 2 inputs, not as permission to
+  rewrite policy during Phase 1.
+
+### Acceptance evidence
+
+- Research worktree clean and current with its remote before mutation.
+- Current `origin/main` integrated without history rewriting.
+- Evidence register has no silent coverage gaps.
+- Factual lifecycle map exists and separates facts from decisions.
+- Phase 1 coverage review explicitly passes before Phase 2 begins.
+
+## Priority 2 — decide Excel planning ownership
+
+### Live finding
+
+`codex/excel-product-planning` is clean at `a0e115e1`, has no branch-only commit,
+is 59 commits behind current `main`, has no matching remote branch, and has no
+PR. It is configured against `origin/main`, which does not make it a published
+feature branch. Git evidence says there is no unique committed work at its tip;
+Git cannot tell whether an external planning task still intends to use the
+folder.
+
+### Decision routes
+
+**If the planning task remains active:**
+
+1. Name the current owner and expected next action.
+2. Prefer a fresh current-main worktree if new implementation is about to
+   begin; the old lane provides no unique commit to preserve.
+3. If the old branch is deliberately retained, give it a matching dedicated
+   remote upstream only when there is real branch-owned work to publish.
+4. Record an expiry or review date so “active” does not mean indefinite.
+
+**If the planning task is inactive:**
+
+1. Recheck clean state, branch attachment, `0` branch-only commits, absence of
+   an open PR, and absence of a remote feature branch.
+2. Ask the owner for explicit approval to remove the worktree and local branch.
+3. Remove the worktree first; delete the local branch only after Git no longer
+   reports it as attached.
+4. Verify the planning path is gone and the primary repository remains clean.
+
+### Stop conditions
+
+Stop if the worktree becomes dirty, an operation marker exists, a new remote or
+PR appears, the task owner says it is active, or branch-only commits appear.
+Never stash, reset, clean, or copy files out as an implicit retirement method.
+
+## Priority 3 — retire merged Alpha worktrees after approval
+
+### Why they are now retirement-ready
+
+All three Alpha worktrees are clean. Their meaningful heads have exact PR and
+main-reachability receipts. Together they occupy about 651 MB; approximately
+418 MB is the old Alpha candidate's `react_app/node_modules`.
+
+| Worktree | Local head | Remote/PR evidence | Main evidence | Approx. size |
+|---|---:|---|---|---:|
+| Alpha closeout | `127afb64` | Matching remote; PR #733 merged | Head is ancestor of `origin/main` | 508 MB |
+| Alpha integration | `e3b9a6cb` | Matching remote; PR #730 merged | Head is ancestor of `origin/main` | 65 MB |
+| Alpha policy | `5da9c66a` | Remote/PR #731 head is `20180a40`; local is one commit ahead of that remote | Both `20180a40` and local `5da9c66a` are ancestors of `origin/main` | 78 MB |
+
+The Alpha policy explanation is resolved: `5da9c66a` is unpublished relative
+to its own remote branch, but it is not lost or unintegrated because that exact
+commit is reachable from current `main`. Record both heads; do not “fix” the
+old remote by rewriting it.
+
+### Approved execution sequence
+
+After the owner explicitly approves these exact three paths:
+
+1. Refresh and repeat the clean/head/attachment/reachability checks.
+2. Retire Alpha closeout first because it reclaims the most space.
+3. Retire Alpha integration second.
+4. Retire Alpha policy last, preserving the dual-head receipt in the handoff.
+5. For each lane, remove the worktree before deleting its local branch.
+6. Verify the remaining worktree inventory and primary clean state after every
+   removal. Stop on the first unexpected result.
+7. Leave remote branches untouched until the separate branch-cleanup approval.
+
+Use Git's worktree removal for the validated exact worktree, not a recursive
+filesystem deletion. Do not prune first, because pruning is not a substitute
+for proving or removing the actual worktree.
+
+## Priority 4 — branch-cleanup approval packet
+
+### Updated candidate count
+
+The original count of seven is obsolete. Eight unattached local branches are
+exact ancestors of current `origin/main`, have matching remote heads, and have
+merged PR receipts:
+
+| Local branch | Head | Merged PR | Local decision | Remote decision |
+|---|---:|---:|---|---|
+| `codex/alpha-0231-candidate-evidence` | `adb161b8` | #732 | Awaiting approval | Awaiting approval |
+| `codex/ci-fastapi-load-lane-fix` | `21b9df1f` | #729 | Awaiting approval | Awaiting approval |
+| `codex/column-rectangular-e2e` | `007dfa0c` | #725 | Awaiting approval | Awaiting approval |
+| `codex/footing-isolated-v1` | `886871ae` | #727 | Awaiting approval | Awaiting approval |
+| `codex/gpt-5-3-spark-work-program` | `6cd22dcb` | #734 | Awaiting approval | Awaiting approval |
+| `codex/is456-beam-primary-route` | `aa4fe606` | #726 | Awaiting approval | Awaiting approval |
+| `codex/is456-slabs-closeout` | `d79a1558` | #724 | Awaiting approval | Awaiting approval |
+| `codex/is456-slabs-plan` | `7e623984` | #728 | Awaiting approval | Awaiting approval |
+
+Before seeking approval, refresh every row for worktree attachment, local/remote
+head identity, main reachability, PR state, and new activity. A branch becoming
+attached, advancing, diverging, or gaining an open PR removes it from the batch.
+
+### Why the cleanup script did not list them
+
+The dry-run `cleanup_stale_branches.py` reported no stale branches because its
+current selection is age-oriented and remote-oriented with a minimum-age rule.
+That output does not prove that recently merged, unattached local branches do
+not exist. For this packet, the authoritative evidence is the explicit
+worktree/ref/reachability/PR table above.
+
+### Approval and execution rules
+
+- Ask separately for local deletion and remote deletion; one does not imply the
+  other.
+- Delete only the exact approved rows and only after a same-session refresh.
+- Local deletion follows worktree-detachment proof.
+- Remote deletion uses the maintained cleanup workflow and a reviewed dry run;
+  do not issue an ad hoc remote-delete command.
+- Preserve a receipt containing branch name, local head, remote head, PR,
+  reachability result, approval scope, action result, and post-action inventory.
+- Do not include GIT-001, Excel, Alpha attached branches, PMM forensic refs, or
+  PR #723 evidence refs in this eight-branch batch.
+
+## Priority 5 — coordinated dependency maintenance
+
+### Current open set
+
+All seven remaining Dependabot PRs are behind current `main`. Their older green
+checks are not merge authority for today's base. Treat the PRs as update notices
+and patch inputs, then construct fresh tested lanes from current `main`.
+
+| Packet | Existing PRs | Decision and reason |
+|---|---|---|
+| Python typing major | #715 constraint `<3`; #717 mypy 2.3.0 | One coherent task: these overlap semantically and must not both merge independently |
+| ESLint 10 toolchain | #713 ESLint 10; #683 `@eslint/js` 10 | One coordinated compatibility task with TypeScript-ESLint and React lint plugins |
+| React build major | #684 Vite plugin React 6 | Hold until a compatible Vite/toolchain plan; its prior React Validation and PR Gate failed |
+| Node type/runtime policy | #714 `@types/node` 26 | Hold while runtime pin is Node 24; decide runtime major before accepting type-major mismatch |
+| Motion library major | #716 Framer Motion 13 | Independent frontend packet after current-main refresh and live motion verification |
+
+### Required workflow for each packet
+
+1. Create a dedicated branch and worktree from refreshed `main`.
+2. State the compatibility hypothesis, affected lock/config files, and explicit
+   non-goals before changing versions.
+3. Apply one coherent dependency group, regenerate only its owned lockfiles,
+   and inspect the actual transitive change.
+4. Run targeted tests while iterating and the appropriate complete gate before
+   publication. Frontend majors require lint, tests, TypeScript, production
+   build, and a focused live user-path check. Mypy majors require current
+   package typing and repository validation.
+5. Publish a fresh PR or update only a still-correct candidate. Required checks
+   must pass at the exact reviewed head on the current base.
+6. Close or supersede old overlapping PRs only with explicit owner authority
+   where closure is required.
+
+Dependency work can run independently from the research program, but each
+packet needs its own writer. Lockfiles, workflow files, generated indexes, and
+session/task records are single-writer surfaces.
+
+## Next-agent first-hour checklist
+
+1. Read `AGENTS.md`, this packet, the GIT-001 index, evidence register, and
+   lifecycle research.
+2. Run `./run.sh task brief "continue GIT-001 Phase 1 official research"`.
+3. Refresh refs, inspect all worktrees read-only, and compare the result with
+   this dated snapshot. Record drift; do not normalize it away.
+4. Take ownership of exactly one write lane. The preferred first lane is the
+   existing GIT-001 research worktree after clean/upstream verification.
+5. Synchronize the research lane with current `main` using a normal merge; stop
+   and classify if conflicts appear.
+6. Complete the official-source register and factual lifecycle map.
+7. Ask the owner the single Excel ownership question while research proceeds:
+   “Is the Excel planning task still active with a named next action?”
+8. Do not delete Alpha lanes or branches until exact-target approval is given.
+9. At handoff, record issues, confirmed root causes, solutions, and command/test
+   evidence in the newest `docs/SESSION_LOG.md` entry.
+
+## Maintained script guide
+
+These repository scripts reduce repeated mistakes, but they do not replace Git
+judgment or Codex's native branch/commit/PR lifecycle.
+
+| Command | What it helps prove | What it does not prove |
+|---|---|---|
+| `./run.sh task brief "task"` | Read-only branch/head/dirty/base/upstream/worktree context, task route, and matching automation before work starts | That the suggested route owns the task, or that an old lane is safe to reuse/delete |
+| `./run.sh session brief --agent ops` | Bounded role context, recent commits, task focus, and expected validation | Live remote freshness or merge readiness |
+| `./run.sh session start` | Environment, clean-state trust, lane-bound runtime, and current session setup | Permission for destructive cleanup or publication |
+| `./scripts/python_runtime.sh --diagnose` | Which Python is selected and whether imports resolve to the invoking worktree | That the code is correct or fully tested |
+| `./run.sh check --quick` | Fast 10-check repository validation before commit | Full product, release, or exact-head GitHub CI acceptance |
+| `./run.sh check` | Full local repository gate at closeout | GitHub ruleset state or unchanged-head remote checks after a push |
+| `scripts/cleanup_stale_branches.py` | Maintained, dry-run-first remote stale-branch cleanup path | Recently merged local candidates outside its age/remote selection rules |
+| `scripts/safe_file_delete.py` | Validated in-repository file deletion with reference checks | Git worktree or branch retirement; use Git's own worktree/ref operations |
+| `./run.sh generate indexes --help` | Read-only usage information | Index freshness; actual generation is intentionally write-capable |
+| `./run.sh generate indexes` | Regenerates maintained documentation indexes through the invoking lane's Python runtime | Authority to create new index topology or overwrite another lane's shared output |
+
+Use `git status`, `git worktree list --porcelain`, `git for-each-ref`,
+`git rev-list`, `git cherry`, exact object IDs, and PR metadata together for
+disposition. No single script answers the ownership and recoverability question.
+
+## Common mistakes this plan prevents
+
+- **Mistaking clean for safe.** Clean says no visible file change; it says
+  nothing about unpublished commits, wrong upstreams, or task ownership.
+- **Mistaking ahead/behind for content identity.** Squash merges change the
+  graph; use patch equivalence and PR receipts as well as reachability.
+- **Treating an upstream as publication.** Excel tracks `origin/main`, not a
+  matching feature ref. That configuration does not publish Excel work.
+- **Fixing a historical remote unnecessarily.** Alpha policy's local extra
+  commit is already on main; rewriting the remote would add risk without
+  protecting work.
+- **Using age as the only cleanup test.** A new merged branch may be safe to
+  retire, while an old branch may contain irreplaceable work.
+- **Merging stale dependency bots individually.** Major updates interact through
+  runtimes, peer constraints, configs, and lockfiles; group by compatibility.
+- **Editing shared surfaces from parallel lanes.** Generated indexes, task and
+  session records, registries, routes, manifests, and lockfiles need one owner.
+
+## Completion definition for this plan
+
+This plan is fulfilled when:
+
+- Phase 1 coverage and the factual lifecycle map pass review;
+- Excel has a named active owner/next action or an approved retirement receipt;
+- the three Alpha worktrees are either explicitly retained or safely retired
+  under exact approval;
+- the eight-branch table has an owner decision and any approved actions have
+  post-action receipts;
+- each dependency group is completed, held with a named reason, or deliberately
+  superseded on a current base;
+- completed PMM and PR #723 recovery is not reopened without new evidence.

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -3,15 +3,15 @@
   "type": "documentation",
   "description": "",
   "last_updated": "2026-08-12",
-  "file_count": 5,
+  "file_count": 6,
   "files": [
     {
       "name": "GIT-001-README.md",
       "type": "documentation",
-      "size_lines": 91,
+      "size_lines": 92,
       "last_updated": "2026-08-12",
       "description": "This directory is the task-owned, non-normative research record for GIT-001. Its contents may describe official Git/GitHub/Codex facts, observed project",
-      "content_hash": "c6c9777e4f0f"
+      "content_hash": "09c6c6b7ec58"
     },
     {
       "name": "GIT-001-lifecycle-research.md",
@@ -20,6 +20,14 @@
       "last_updated": "2026-08-12",
       "description": "This is a factual, non-normative lifecycle model under research. It does not replace the canonical project workflow. Proposed transitions and permissions",
       "content_hash": "351814e5c940"
+    },
+    {
+      "name": "GIT-001-next-agent-disposition-plan.md",
+      "type": "documentation",
+      "size_lines": 411,
+      "last_updated": "2026-08-12",
+      "description": "This packet converts the original six-priority cleanup and recovery list into a current, evidence-backed handoff. It tells the next agent what is already done,",
+      "content_hash": "eb05a95fb3ae"
     },
     {
       "name": "GIT-001-official-evidence-register.md",
@@ -47,5 +55,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "32c2f9c0475d6d4f"
+  "content_hash": "2f3aeb29cde330ce"
 }

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -2,14 +2,15 @@
 
 **Type:** Documentation
 **Last Updated:** 2026-08-12
-**Files:** 5
+**Files:** 6
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 91 |
+| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 92 |
 | [GIT-001-lifecycle-research.md](GIT-001-lifecycle-research.md) |  | This is a factual, non-normative lifecycle model under resea | 114 |
+| [GIT-001-next-agent-disposition-plan.md](GIT-001-next-agent-disposition-plan.md) |  | This packet converts the original six-priority cleanup and r | 411 |
 | [GIT-001-official-evidence-register.md](GIT-001-official-evidence-register.md) |  | Only primary, official sources belong in this register. A ve | 47 |
 | [GIT-001-phase-0-preservation-baseline.md](GIT-001-phase-0-preservation-baseline.md) |  | - Observation time: 2026-08-12T21:17:05+05:30 - Repository:  | 165 |
 | [GIT-001-phase-7A-preservation-workflow-recovery.md](GIT-001-phase-7A-preservation-workflow-recovery.md) |  | The repository owner authorized Git operations, merge/deleti | 82 |


### PR DESCRIPTION
## What changed

- Added an in-depth, evidence-backed GIT-001 future-work and disposition packet.
- Reconciled the original six priorities against current PMM, PR 723, Excel, Alpha, merged-branch, and dependency state.
- Replaced the stale next-session briefing with a concise current handoff.
- Documented maintained scripts, their proof boundaries, session issues, and root-cause resolutions.

## Why

The original priority list mixed completed recovery with still-open work. A future agent could repeat PMM or PR 723 recovery, work from a stale branch identity, or treat age/ahead-behind status as cleanup proof. This packet separates completed receipts from active decisions and provides explicit approval gates.

## Validation

- Documentation validation: 5/5
- Internal links: 1,103 checked, zero broken
- Quick gate: 10/10
- Full repository gate: 30/30
- Pre-commit hooks: passed
