### PR TITLE
docs(git): record future plan merge receipt

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,3 +1,45 @@
+## 2026-08-12 — Session: GIT-001 Future-Work Plan Closeout
+
+**Agent:** Codex
+
+**Branch:** `codex/git-future-work-plan-closeout`
+
+**Focus:** Record the exact publication receipt for the reconciled GIT-001
+future-work and next-agent handoff
+
+### Summary
+
+- PR #741 passed required checks at unchanged head `0f324db9` and was
+  squash-merged to `main` as `52ac5f58`.
+- Fast-forwarded the clean primary worktree to the exact merge and reran the
+  quick repository gate from integrated `main`.
+- Replaced the pre-merge base label in the next-session briefing with the exact
+  published-plan receipt so it cannot be mistaken for current remote state.
+
+### Issues encountered
+
+- The plan candidate necessarily recorded its pre-merge base before the future
+  squash-merge commit existed.
+
+### Root causes and resolutions
+
+- A commit cannot truthfully record its own future GitHub checks and squash
+  identity. This bounded closeout records PR #741, its unchanged reviewed head,
+  and merge commit, while the briefing still instructs the next agent to refresh
+  live state rather than treating any dated SHA as permanent current truth.
+
+### Verification
+
+- PR #741: `MERGED`, reviewed head `0f324db9`, merge `52ac5f58`.
+- Detect Changes, Repository Validation, Build MkDocs, and PR Gate passed;
+  unaffected Python, FastAPI, and React jobs were skipped by design.
+- Integrated primary worktree: `HEAD = origin/main = 52ac5f58`, clean.
+- Integrated `./run.sh check --quick`: 10/10 passed.
+
+### Terminal issues
+
+- None encountered.
+
 ## 2026-08-12 — Session: GIT-001 Future-Work Reconciliation
 
 **Agent:** Codex

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -111,7 +111,7 @@
       "last_updated": "2026-08-12",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-12",
-      "content_hash": "aaa04ca6a626"
+      "content_hash": "d3cdb4dffce0"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "be162b8c7d232fd2"
+  "content_hash": "24dde689556de40c"
 }

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -9,7 +9,7 @@
 
 **Current release:** `v0.23.1a1` Alpha
 
-**Integration anchor at handoff:** `main = origin/main = 951f5e1d`
+**Published plan receipt:** PR #741 merged as `52ac5f58`; refresh `main` before work
 
 **Task board:** [TASKS.md](../TASKS.md)
 


### PR DESCRIPTION
## What changed

- Recorded the exact PR 741 reviewed head and squash merge receipt.
- Replaced the pre-merge base label in the next-session briefing with the published-plan receipt.
- Preserved the rule that future agents must refresh live main before work.

## Why

The planning candidate could not know its own future GitHub merge commit. This bounded closeout prevents the pre-merge base from being mistaken for current integrated state.

## Validation

- Integrated main quick gate: 10/10
- Closeout quick gate: 10/10
- Session handoff contract: passed
- Pre-commit hooks: passed
