### PR TITLE
ci(git): require control-plane and docs validation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,12 +1,6 @@
 name: Validate Documentation
 
 on:
-  pull_request:
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'Python/pyproject.toml'
-      - 'Python/structural_lib/**'
   push:
     branches: [main]
     paths:
@@ -20,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-docs
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -22,6 +22,7 @@ jobs:
       fastapi: ${{ steps.filter.outputs.fastapi }}
       react: ${{ steps.filter.outputs.react }}
       control_plane: ${{ steps.filter.outputs.control_plane }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -43,18 +44,33 @@ jobs:
               - 'react_app/**'
               - '**/package-lock.json'
             control_plane:
-              - 'scripts/git_state.py'
-              - 'scripts/prompt_router.py'
-              - 'scripts/session.py'
-              - 'scripts/check_all.py'
-              - 'scripts/automation-map.json'
-              - 'scripts/validate_git_state.sh'
-              - 'scripts/check_unfinished_merge.sh'
-              - 'scripts/check_not_main.sh'
-              - 'scripts/check_codex_git_workflow.py'
+              - 'scripts/**'
+              - 'run.sh'
+              - 'agents/**'
+              - '.codex/**'
+              - '.github/agents/**'
+              - '.github/instructions/**'
+              - '.github/prompts/**'
+              - '.github/skills/**'
+              - '.github/workflows/**'
+              - '.github/copilot-instructions.md'
+              - '.pre-commit-config.yaml'
+              - 'AGENTS.md'
+              - 'CLAUDE.md'
+              - 'docs/git-automation/**'
+              - 'docs/guidelines/ai-token-efficiency.md'
+              - 'docs/research/git-governance/**'
+              - 'Python/tests/test_agent_governance_automation.py'
+              - 'Python/tests/test_ci_workflow_contract.py'
               - 'Python/tests/test_git_state.py'
+              - 'Python/tests/test_pipeline_state.py'
               - 'Python/tests/test_session_automation.py'
-              - '.github/workflows/fast-checks.yml'
+              - 'Python/tests/test_session_store.py'
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+              - 'Python/pyproject.toml'
+              - 'Python/structural_lib/**'
 
   python-validation:
     name: Python Validation
@@ -170,6 +186,63 @@ jobs:
           npm run build
           npx vitest run
 
+  control-plane-validation:
+    name: Control Plane Validation
+    needs: changes
+    if: needs.changes.outputs.control_plane == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: Python/pyproject.toml
+
+      - name: Install control-plane test dependencies
+        run: python -m pip install -e 'Python/[dev]' PyYAML
+
+      - name: Validate Git, intake, session, and governance controls
+        run: |
+          STRUCTURAL_LIB_PYTHON="$(command -v python)" python scripts/check_codex_git_workflow.py
+          STRUCTURAL_LIB_PYTHON="$(command -v python)" python -m pytest \
+            Python/tests/test_git_state.py \
+            Python/tests/test_session_automation.py \
+            Python/tests/test_session_store.py \
+            Python/tests/test_pipeline_state.py \
+            Python/tests/test_agent_governance_automation.py \
+            Python/tests/test_ci_workflow_contract.py \
+            -q
+
+  documentation-validation:
+    name: Documentation Validation
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Install documentation dependencies
+        run: |
+          python -m pip install "mkdocs-material>=9.5,<10" "mkdocstrings[python]>=0.25,<1"
+          python -m pip install -e Python/
+
+      - name: Build documentation strictly
+        run: mkdocs build --strict
+
   repository-validation:
     name: Repository Validation
     needs: changes
@@ -219,15 +292,6 @@ jobs:
           python scripts/check_architecture_boundaries.py
           python scripts/skill_tiers.py validate
 
-      - name: Validate Git state and intake control plane
-        if: needs.changes.outputs.control_plane == 'true'
-        run: >-
-          STRUCTURAL_LIB_PYTHON="$(command -v python)"
-          python -m pytest
-          Python/tests/test_git_state.py
-          Python/tests/test_session_automation.py
-          -q
-
       - name: Validate maintenance scripts
         run: |
           bash -n scripts/validate_git_state.sh
@@ -235,7 +299,6 @@ jobs:
           bash -n scripts/check_not_main.sh
           bash -n scripts/agent_start.sh
           python scripts/git_state.py --json > /dev/null
-          python scripts/check_codex_git_workflow.py
           python -m pytest tests/integration/test_migration_scripts.py -q
 
   pr-gate:
@@ -246,6 +309,8 @@ jobs:
       - python-validation
       - fastapi-validation
       - react-validation
+      - control-plane-validation
+      - documentation-validation
       - repository-validation
     runs-on: ubuntu-latest
     steps:
@@ -258,6 +323,10 @@ jobs:
           FASTAPI_RESULT: ${{ needs.fastapi-validation.result }}
           REACT_CHANGED: ${{ needs.changes.outputs.react }}
           REACT_RESULT: ${{ needs.react-validation.result }}
+          CONTROL_PLANE_CHANGED: ${{ needs.changes.outputs.control_plane }}
+          CONTROL_PLANE_RESULT: ${{ needs.control-plane-validation.result }}
+          DOCS_CHANGED: ${{ needs.changes.outputs.docs }}
+          DOCS_RESULT: ${{ needs.documentation-validation.result }}
           REPOSITORY_RESULT: ${{ needs.repository-validation.result }}
         run: |
           failed=0
@@ -288,6 +357,8 @@ jobs:
           require_component 'Python Validation' "$PYTHON_CHANGED" "$PYTHON_RESULT"
           require_component 'FastAPI Validation' "$FASTAPI_CHANGED" "$FASTAPI_RESULT"
           require_component 'React Validation' "$REACT_CHANGED" "$REACT_RESULT"
+          require_component 'Control Plane Validation' "$CONTROL_PLANE_CHANGED" "$CONTROL_PLANE_RESULT"
+          require_component 'Documentation Validation' "$DOCS_CHANGED" "$DOCS_RESULT"
 
           if [[ "$failed" -ne 0 ]]; then
             exit 1

--- a/Python/tests/test_agent_governance_automation.py
+++ b/Python/tests/test_agent_governance_automation.py
@@ -142,8 +142,13 @@ def test_control_paths_use_python_runtime_launcher():
     workflow = (REPO_ROOT / ".github" / "workflows" / "fast-checks.yml").read_text(
         encoding="utf-8"
     )
-    install_offset = workflow.index("python -m pip install -e Python pytest PyYAML")
-    smoke_offset = workflow.index("python scripts/test_cli_smoke.py")
+    repository_validation = workflow.partition("  repository-validation:\n")[
+        2
+    ].partition("  pr-gate:\n")[0]
+    install_offset = repository_validation.index(
+        "python -m pip install -e 'Python/[dev]' PyYAML"
+    )
+    smoke_offset = repository_validation.index("python scripts/test_cli_smoke.py")
     assert install_offset < smoke_offset
 
 

--- a/Python/tests/test_ci_workflow_contract.py
+++ b/Python/tests/test_ci_workflow_contract.py
@@ -1,0 +1,181 @@
+"""Regression tests for fail-closed PR workflow routing."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.repo_only
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FAST_CHECKS = REPO_ROOT / ".github" / "workflows" / "fast-checks.yml"
+DEPLOY_DOCS = REPO_ROOT / ".github" / "workflows" / "deploy-docs.yml"
+
+BASE_GATE_ENV = {
+    "CHANGES_RESULT": "success",
+    "PYTHON_CHANGED": "false",
+    "PYTHON_RESULT": "skipped",
+    "FASTAPI_CHANGED": "false",
+    "FASTAPI_RESULT": "skipped",
+    "REACT_CHANGED": "false",
+    "REACT_RESULT": "skipped",
+    "CONTROL_PLANE_CHANGED": "false",
+    "CONTROL_PLANE_RESULT": "skipped",
+    "DOCS_CHANGED": "false",
+    "DOCS_RESULT": "skipped",
+    "REPOSITORY_RESULT": "success",
+}
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(FAST_CHECKS.read_text(encoding="utf-8"))
+
+
+def _pr_gate_script() -> str:
+    steps = _workflow()["jobs"]["pr-gate"]["steps"]
+    return next(
+        step["run"]
+        for step in steps
+        if step["name"] == "Verify every applicable validation"
+    )
+
+
+def _run_pr_gate(**overrides: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-eu", "-o", "pipefail", "-c", _pr_gate_script()],
+        cwd=REPO_ROOT,
+        env={**os.environ, **BASE_GATE_ENV, **overrides},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_changed_path_routes_cover_controls_docs_and_their_tests():
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+    filters_text = next(
+        step["with"]["filters"]
+        for step in jobs["changes"]["steps"]
+        if step["name"] == "Classify changed paths"
+    )
+    filters = yaml.safe_load(filters_text)
+    control_paths = set(filters["control_plane"])
+    docs_paths = set(filters["docs"])
+    control_command = next(
+        step["run"]
+        for step in jobs["control-plane-validation"]["steps"]
+        if step["name"] == "Validate Git, intake, session, and governance controls"
+    )
+
+    assert {
+        "scripts/**",
+        "run.sh",
+        "agents/**",
+        ".github/agents/**",
+        ".github/workflows/**",
+        "docs/git-automation/**",
+        "docs/research/git-governance/**",
+    } <= control_paths
+    assert {
+        "docs/**",
+        "mkdocs.yml",
+        "Python/pyproject.toml",
+        "Python/structural_lib/**",
+    } == docs_paths
+
+    exact_tests = {
+        "Python/tests/test_git_state.py",
+        "Python/tests/test_session_automation.py",
+        "Python/tests/test_session_store.py",
+        "Python/tests/test_pipeline_state.py",
+        "Python/tests/test_agent_governance_automation.py",
+        "Python/tests/test_ci_workflow_contract.py",
+    }
+    assert exact_tests <= control_paths
+    assert all(test_path in control_command for test_path in exact_tests)
+
+
+def test_pr_gate_topology_and_cancellation_are_scoped_per_pr():
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+    pr_gate = jobs["pr-gate"]
+
+    assert workflow["concurrency"] == {
+        "group": "${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}",
+        "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
+    }
+    assert {
+        "control-plane-validation",
+        "documentation-validation",
+    } <= set(pr_gate["needs"])
+    assert jobs["documentation-validation"]["if"] == (
+        "needs.changes.outputs.docs == 'true'"
+    )
+    docs_python = next(
+        step["with"]["python-version"]
+        for step in jobs["documentation-validation"]["steps"]
+        if step["name"] == "Set up Python 3.11"
+    )
+    assert docs_python == "3.11"
+    docs_run = next(
+        step["run"]
+        for step in jobs["documentation-validation"]["steps"]
+        if step["name"] == "Build documentation strictly"
+    )
+    assert docs_run == "mkdocs build --strict"
+
+    deploy_docs = DEPLOY_DOCS.read_text(encoding="utf-8")
+    trigger_block = deploy_docs.partition("\non:\n")[2].partition("\npermissions:")[0]
+    assert "pull_request:" not in trigger_block
+    assert "group: ${{ github.workflow }}-${{ github.ref }}" in deploy_docs
+    assert "group: deploy-docs" not in deploy_docs
+
+
+def test_pr_gate_accepts_successful_applicable_routes():
+    result = _run_pr_gate(
+        CONTROL_PLANE_CHANGED="true",
+        CONTROL_PLANE_RESULT="success",
+        DOCS_CHANGED="true",
+        DOCS_RESULT="success",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "All required and applicable validation jobs passed." in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("changed_key", "result_key"),
+    [
+        ("CONTROL_PLANE_CHANGED", "CONTROL_PLANE_RESULT"),
+        ("DOCS_CHANGED", "DOCS_RESULT"),
+    ],
+)
+@pytest.mark.parametrize("bad_result", ["failure", "cancelled", "skipped", "timed_out"])
+def test_pr_gate_rejects_non_successful_applicable_route(
+    changed_key: str, result_key: str, bad_result: str
+):
+    result = _run_pr_gate(**{changed_key: "true", result_key: bad_result})
+
+    assert result.returncode == 1
+    assert f"concluded '{bad_result}'" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("changed_key", "result_key"),
+    [
+        ("CONTROL_PLANE_CHANGED", "CONTROL_PLANE_RESULT"),
+        ("DOCS_CHANGED", "DOCS_RESULT"),
+    ],
+)
+def test_pr_gate_rejects_unexpected_non_applicable_execution(
+    changed_key: str, result_key: str
+):
+    result = _run_pr_gate(**{changed_key: "false", result_key: "success"})
+
+    assert result.returncode == 1
+    assert "should be skipped" in result.stdout

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,3 +1,115 @@
+# Session Log
+
+> Append-only decision log for AI agent sessions.
+> Earlier sessions (1-100): [SESSION_LOG_through_session_100.md](_archive/SESSION_LOG_through_session_100.md)
+
+---
+
+## 2026-08-14 — Session: GIT-001 Phase 7C1 Required CI Topology
+
+**Agent:** Codex (`ops`)
+
+**Branch:** `codex/git-7c-ci-enforcement`
+
+**Focus:** Make control-plane and strict documentation validation required,
+fail-closed dependencies of the existing `PR Gate` without changing GitHub
+server settings
+
+### Summary
+
+- Verified clean exact `main = origin/main = 0fdb48ed`, created a fresh
+  isolated GIT-7C1 lane, and proved `source_bound=true` before editing.
+- Added broad but explicit routing for scripts, `run.sh`, agent/session controls,
+  registries, Git workflow policy, workflow definitions, and maintained tests.
+- Added a dedicated Control Plane Validation job that runs the exact existing
+  Git, intake, session, persistence, pipeline, governance, and CI-contract
+  regression families.
+- Moved strict MkDocs PR evidence into Documentation Validation and made both
+  new routes direct, fail-closed dependencies of `PR Gate`.
+- Removed the duplicate docs pull-request trigger and replaced its global
+  cancellation group with ref-scoped post-merge/manual evidence.
+- Added executable result-matrix tests for success, failure, cancellation,
+  timeout-like, unexpected-skip, and unexpected-execution outcomes.
+- Restored the session log's canonical header and newest-first placement after
+  the required session-end check exposed an inherited structural break.
+
+### PRs Merged
+
+| PR | Summary |
+|----|---------|
+| #744 | GIT-7B read-only worktree-aware state and intake kernel |
+
+### Key Deliverables
+
+- `.github/workflows/fast-checks.yml`
+- `.github/workflows/deploy-docs.yml`
+- `Python/tests/test_ci_workflow_contract.py`
+- `scripts/check_codex_git_workflow.py`
+- `docs/research/git-governance/GIT-001-phase-7C1-required-ci-topology.md`
+
+### Issues encountered
+
+- The agent-governance family selected for the new required control-plane route
+  failed its existing workflow dependency assertion before the new behavior was
+  exercised. If left unchanged, every control-plane PR would fail despite using
+  the supported dependency installation.
+- The required session-end check reported that no current entry existed and
+  that the newest entry was not for today, even though the completed 2026-08-14
+  block was present. This blocked a truthful handoff.
+- The first commit attempt was blocked by the Python-version consistency hook
+  because the new integrated documentation job selected Python 3.12.
+
+### Root causes and resolutions
+
+- Root cause: GIT-7B changed Repository Validation from a base-package plus
+  hand-picked test dependency install to `Python/[dev]` so shared pytest
+  configuration could import Hypothesis, but an older assertion from
+  `0d01fa1f` still matched the retired command and was outside GIT-7B's focused
+  test route. Resolution: scope the assertion to the Repository Validation job,
+  match its supported `Python/[dev]` install, and make that regression family a
+  required control-plane input and command. Evidence: the previously failing
+  file passes, the combined maintained control-plane route passes 173 tests,
+  and the semantic workflow checker passes.
+- Root cause: the canonical `# Session Log` header and separator were embedded
+  after older entries, so session start inserted today's skeleton at that
+  mid-file separator while session end inspected the file's first dated block
+  and a bounded prefix. Resolution: move only the canonical header and today's
+  task-owned block to the top, preserving every historical entry and its text.
+  Evidence: the date headings now begin with 2026-08-14 and the required
+  session-end check passes.
+- Root cause: the documentation job was moved from the standalone workflow,
+  which used Python 3.12, into `fast-checks.yml`, whose repository contract pins
+  every job to the project minimum Python 3.11. Resolution: align the integrated
+  docs job to 3.11 and assert that version in the CI topology regression test.
+  Evidence: the Python-version consistency check and normal commit hooks pass.
+
+### Verification
+
+- Worktree Python diagnosis: `source_bound=true`.
+- New fail-closed workflow contract: 13 tests passed.
+- Existing maintained control-plane families: 160 tests passed.
+- Combined control-plane route: 173 tests passed.
+- Black, Ruff, workflow YAML parsing, semantic workflow check, and
+  `git diff --check`: passed.
+- Strict MkDocs passed in 8.1 seconds; the quick repository gate passed 10/10
+  in 3.0 seconds; the full repository gate passed 30/30 in 9.7 seconds.
+- Live exact-head draft-PR checks remain the final publication evidence.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: `./run.sh session end --agent ops` initially reported no
+  current/newest session entry -> restored the canonical header and today's
+  block to newest-first position, then reran the required session-end check.
+- ⚠️ TERMINAL ISSUE: the first normal commit stopped at the Python-version
+  consistency hook because the new docs job used 3.12 -> aligned it with the
+  repository's 3.11 workflow contract and retried without bypassing hooks.
+
+### Notes
+
+- No ruleset, bypass actor, merge method, branch-deletion setting, cleanup,
+  recovery, release, or product-runtime change is included. GIT-7C2 remains a
+  separate owner gate after GIT-7C1 is green on `main`.
+
 ## 2026-08-13 — Session: GIT-001 Phase 7B State and Intake Kernel
 
 **Agent:** Codex (`ops`)
@@ -1199,13 +1311,6 @@ history, and close the picker acceptance gap found in Phase 1
   repository gate passed 10/10 and the source-bound full gate passed 30/30.
 
 ## 2026-08-10 — Session: Fresh-Start Maintenance Closeout
-# Session Log
-
-> Append-only decision log for AI agent sessions.
-> Earlier sessions (1-100): [SESSION_LOG_through_session_100.md](_archive/SESSION_LOG_through_session_100.md)
-
----
-
 ## 2026-08-11 — Session: GPT-5.3-Codex-Spark Work Program
 
 **Agent:** Codex

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-13 — GIT-001 Phase 6 accepted; GIT-7B implementation and all local closeout gates complete, publication pending
+**Updated:** 2026-08-14 — GIT-7B merged through PR #744; GIT-7C1 required CI topology is locally complete and authorized for draft-PR validation
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | ✅ GIT-7B LOCALLY COMPLETE — read-only state/intake kernel; 64 focused, quick 10/10, full 30/30; push/PR pending explicit request; GIT-7C–7E remain held |
+| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7C1 READY FOR DRAFT PR — required control-plane/docs routing and fail-closed PR Gate contract pass locally; GIT-7C2 settings and GIT-7D–7E remain held |
 
 ## Up Next
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -3,20 +3,21 @@
 ## Latest Handoff
 
 <!-- HANDOFF:START -->
-- Date: 2026-08-13
-- Focus: GIT-001 Phase 6 accepted; GIT-7B locally complete and awaiting publication decision
+- Date: 2026-08-14
+- Focus: GIT-7B merged; GIT-7C1 required CI topology locally complete and authorized for draft validation
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha
 
-**Published plan receipt:** PR #741 merged as `52ac5f58`; refresh `main` before work
+**Integrated GIT-7B receipt:** PR #744 merged as `0fdb48ed`; refresh `main` before work
 
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | GIT-7B locally complete | Kernel, consumers, compatibility delegates, 64 focused tests, quick 10/10, full 30/30, and narrow CI routing pass |
-| **Next** | Owner publication decision | Push/open a draft PR only when explicitly requested; GIT-7C–7E remain separately approval-gated |
+| **Current** | GIT-7C1 locally complete | Required control-plane/docs routes, fail-closed PR Gate aggregation, scoped cancellation, and 173 control-plane tests pass |
+| **Next** | Draft PR exact-head validation | Require Control Plane, Documentation, Repository, and aggregate PR Gate outcomes at the unchanged head |
+| **Held** | GIT-7C2 server settings | No ruleset, bypass, merge-method, or branch-deletion change without a fresh exact-delta owner decision after GIT-7C1 is green on `main` |
 | **Parallel owner decision** | Excel planning lane | Confirm a named active owner/next action or approve retirement |
 | **Approval-gated** | Alpha worktrees and merged branches | Exact evidence is ready; deletion still requires explicit target approval |
 | **Separate maintenance** | Seven dependency PRs | Replace one-by-one merging with four current-base compatibility packets |
@@ -33,13 +34,14 @@
 8. [Phase 5 scenario validation](../research/git-governance/GIT-001-phase-5-scenario-validation.md)
 9. [Phase 6 canonical-policy proposal](../research/git-governance/GIT-001-phase-6-canonical-policy-proposal.md)
 10. [Phase 7B implementation receipt](../research/git-governance/GIT-001-phase-7B-state-intake-kernel.md)
-11. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
-12. [AI token-efficiency policy](../guidelines/ai-token-efficiency.md)
+11. [Phase 7C1 required CI topology](../research/git-governance/GIT-001-phase-7C1-required-ci-topology.md)
+12. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
+13. [AI token-efficiency policy](../guidelines/ai-token-efficiency.md)
 
 ## Start command
 
 ```bash
-./run.sh task brief "close out accepted GIT-7B read-only state and intake kernel"
+./run.sh task brief "validate GIT-7C1 required CI topology at the exact draft PR head"
 ./run.sh session brief --agent ops
 ./run.sh session start
 ```
@@ -84,9 +86,12 @@ state/intake, publication/server enforcement, generated-data/cleanup, and
 guidance/handoff control planes, with the read-only state kernel first. Phase 5
 reproduces the current abnormal-state defects and defines falsifiable packet
 gates. The owner accepted Phase 6 and authorized GIT-7B on 2026-08-13. The
-read-only kernel, task brief, live session trust, quick Git checks, compatibility
-delegates, and focused CI routing are implemented; GIT-7C through GIT-7E remain
-held and no GitHub setting, cleanup, deletion, or recovery mutation is authorized.
+read-only kernel integrated through PR #744 as `0fdb48ed`. On 2026-08-14 the
+owner authorized publication of the planned GIT-7C1 workflow packet as a draft
+PR. Required control-plane and strict-documentation routes, fail-closed
+aggregation, and scoped cancellation are implemented locally. GIT-7C2 GitHub
+settings and GIT-7D–7E remain held; no cleanup, deletion, recovery, or release
+mutation is authorized.
 
 ## Destructive-action holds
 

--- a/docs/research/git-governance/GIT-001-README.md
+++ b/docs/research/git-governance/GIT-001-README.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-13
+last_updated: 2026-08-14
 doc_type: index
 task: GIT-001
 ---
@@ -18,8 +18,8 @@ policy.
 The current normative policy is
 [`docs/git-automation/git-workflow-single-source.md`](../../git-automation/git-workflow-single-source.md)
 and now includes the owner-accepted GIT-7B read-only state/intake contract.
-Learning material and held GIT-7C–7E proposals remain inputs, never silent
-operational authority.
+GIT-7C1 changes required CI topology only; GIT-7C2 server settings and GIT-7D–7E
+remain held inputs, never silent operational authority.
 
 ## Objective
 
@@ -48,7 +48,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 | 4 | Operating-model design | Complete as proposal | Four control planes, one typed state model, lane lifecycle, permissions, CI/server policy, recovery, and four packets defined |
 | 5 | Scenario validation | Complete for proposal | Disposable Git and live read-only checks reproduce current defects, validate primitives, and define falsifiable GIT-7B–7E gates |
 | 6 | Canonical policy proposal | Accepted 2026-08-13 | Owner accepted the operating model and authorized GIT-7B only |
-| 7 | Controlled implementation | Packets 7A and GIT-7B complete locally | GIT-7B focused, quick, and full evidence pass; publication remains explicit; GIT-7C–7E require separate authorization |
+| 7 | Controlled implementation | 7A complete; GIT-7B merged; GIT-7C1 ready for draft validation | GIT-7C1 exact workflow tests and repository gates pass; GIT-7C2 settings and GIT-7D–7E remain separately gated |
 | 8 | Adoption and closeout | Not started | Integrated workflow verified; supersession and maintenance established |
 
 ## Artifact map
@@ -64,7 +64,8 @@ work, make recovery deterministic, and remain efficient during normal work.
 - [Phase 5 simulation and verification report](GIT-001-phase-5-scenario-validation.md)
 - [Phase 6 canonical-policy proposal](GIT-001-phase-6-canonical-policy-proposal.md)
 - [Phase 7B read-only state/intake kernel](GIT-001-phase-7B-state-intake-kernel.md)
-- Phase 7 implementation packets — owner-approval gated
+- [Phase 7C1 required CI topology](GIT-001-phase-7C1-required-ci-topology.md)
+- Phase 7C2 server enforcement and Phases 7D–7E — owner-approval gated
 - Phase 8 adoption/closeout report — planned
 
 ## Ownership and non-goals

--- a/docs/research/git-governance/GIT-001-phase-7C1-required-ci-topology.md
+++ b/docs/research/git-governance/GIT-001-phase-7C1-required-ci-topology.md
@@ -1,0 +1,147 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-14
+doc_type: reference
+task: GIT-001
+phase: 7C1
+owner_decision: authorized-draft-publication-2026-08-14
+implementation_authorized: GIT-7C1-workflow-only
+---
+
+# GIT-001 Phase 7C1 — Required CI Topology
+
+## Authorization and boundary
+
+After GIT-7B merged through PR #744, the repository owner authorized the next
+planned workflow packet for publication as a draft PR on 2026-08-14. This
+packet changes repository workflow code and its regression evidence only.
+
+No GitHub ruleset, bypass actor, merge method, branch-deletion setting, release,
+cleanup, recovery, product runtime, or professional-approval boundary is
+changed. Those GitHub server settings remain the separately gated GIT-7C2
+packet and may be considered only after this workflow code is green on `main`.
+
+## Lane and preservation receipt
+
+- Primary `main` and `origin/main` were clean and exact at `0fdb48ed`, the
+  GIT-7B squash result, before the implementation lane was created.
+- The fresh lane is `codex/git-7c-ci-enforcement` at
+  `/Users/pravinsurawase/VS_code_project/structural_engineering_lib-git-7c-ci-enforcement`.
+- Worktree-bound Python diagnosis returned `source_bound=true`.
+- The retained GIT-7B worktree and every other existing lane were left
+  untouched. No branch, worktree, stash, ref, GitHub object, or unknown change
+  was deleted, rewritten, reset, cleaned, or stashed.
+
+## Implemented topology
+
+| Route | Applies when | Required outcome |
+|---|---|---|
+| `control-plane-validation` | Scripts, `run.sh`, agent/session controls, registries, Git workflow policy, workflow definitions, or their maintained tests change | Semantic workflow checker and the exact Git, intake, session, persistence, pipeline, governance, and CI-contract regression families pass |
+| `documentation-validation` | `docs/**`, `mkdocs.yml`, package metadata, or package source used by generated API docs changes | `mkdocs build --strict` passes at the same PR head |
+| `repository-validation` | Every PR | Existing repository policy and maintenance checks pass |
+| `PR Gate` | Every PR | Change detection, repository validation, and every applicable component, control-plane, and documentation route conclude `success` |
+
+`PR Gate` rejects failed, cancelled, timed-out or otherwise non-successful
+applicable jobs. It also rejects an applicable job that is unexpectedly skipped
+and a non-applicable job that unexpectedly runs, so routing cannot silently
+degrade into false-green evidence.
+
+## Cancellation and duplicate-work control
+
+- PR Validation remains grouped by workflow and pull-request number. A newer
+  head cancels only the older run for that same PR; unrelated PRs have distinct
+  groups.
+- The separate documentation workflow no longer runs on pull requests. It is
+  retained for `main` pushes and manual build evidence only, grouped by ref
+  instead of the former repository-wide `deploy-docs` group.
+- Strict documentation validation therefore runs once in the required PR
+  topology instead of once as required evidence and again as a non-required,
+  globally cancelling signal.
+
+## Regression contract
+
+`Python/tests/test_ci_workflow_contract.py` parses the maintained workflow and
+executes the real inline `PR Gate` shell program against a result matrix. It
+proves:
+
+1. scripts, agent/session controls, Git workflow policy, documentation inputs,
+   and every selected regression file route to the intended jobs;
+2. control-plane and documentation jobs are direct `PR Gate` dependencies;
+3. strict MkDocs is the documentation job's outcome;
+4. successful applicable control-plane and documentation routes pass;
+5. `failure`, `cancelled`, `skipped`, and an unexpected timeout-like result all
+   fail when the route is applicable;
+6. unexpected execution fails when a route is non-applicable; and
+7. PR and post-merge documentation concurrency groups are scoped to their PR
+   or ref rather than shared globally.
+
+The existing semantic checker independently enforces the same required routes,
+runtime binding, test files, and removal of the globally cancelling docs PR
+workflow.
+
+## Issue and root-cause evidence
+
+The newly required agent-governance family initially failed before this packet
+changed its behavior. Its workflow assertion still searched for
+`python -m pip install -e Python pytest PyYAML`, while GIT-7B had correctly
+changed Repository Validation to install `Python/[dev]` so the shared test
+configuration could import Hypothesis.
+
+Git history confirmed the assertion originated in `0d01fa1f` and the install
+contract changed in the GIT-7B squash result `0fdb48ed`. The test had not been
+part of the prior focused workflow route, so the stale assertion did not block
+that PR. This packet updates the assertion to inspect the Repository Validation
+job's actual supported dependency contract and includes the entire maintained
+family in the required control-plane route.
+
+The first required session-end check also reported that today's completed entry
+was absent and not newest. The canonical session-log header had been embedded
+after older entries, so session start inserted the new skeleton in the middle
+while session end inspected the file's leading dated block and bounded prefix.
+This packet restores only the canonical header and today's task-owned entry to
+newest-first position, preserving the text and order of all historical entries.
+The handoff and session-completeness checks then pass; the overall session-end
+command remains intentionally nonzero until the intended worktree changes are
+committed.
+
+The first commit attempt then stopped at the Python-version consistency hook.
+The documentation job had carried Python 3.12 from the standalone workflow into
+`fast-checks.yml`, where the repository contract requires its project-minimum
+Python 3.11. The integrated job now uses 3.11, and the CI topology regression
+test enforces that version so later edits cannot reintroduce the mismatch.
+
+## Scenario status
+
+| GIT-7C scenario | Status in this packet |
+|---|---|
+| Control-plane change runs exact maintained regressions | Implemented and locally proved; draft PR is the live route proof |
+| Changed control-plane test file runs its family | Implemented; the new CI-contract test is itself an explicit route input |
+| Docs change runs strict MkDocs as a `PR Gate` dependency | Implemented and locally proved; this receipt is a docs change |
+| Failure, cancellation, timeout, or unexpected skip fails `PR Gate` | Proved by executable result-matrix tests |
+| Same-PR supersession cancels only the old run | Static contract proved; live draft-PR evidence to be recorded after publication |
+| Direct main update is rejected | Held for GIT-7C2 server settings |
+| Merge cannot bypass failed or pending checks | Held for GIT-7C2 server settings |
+| Merge-method exact-SHA receipts | Held for GIT-7C2 integration receipt |
+| Before/after ruleset JSON matches approved delta | Held for GIT-7C2 owner authorization |
+
+## Local verification
+
+- New fail-closed CI contract: 13 tests passed.
+- Maintained Git/intake/session/persistence/pipeline/governance family: 160
+  tests passed.
+- Combined control-plane route: 173 tests passed.
+- Semantic Codex-native workflow checker: passed.
+- Black, Ruff, YAML parsing, and `git diff --check`: passed.
+- `mkdocs build --strict`: passed in 8.1 seconds.
+- `./run.sh check --quick`: 10/10 passed in 2.7 seconds.
+- `./run.sh check`: 30/30 passed in 9.7 seconds.
+- Exact-head draft-PR checks remain the live publication gate.
+
+## Next gate
+
+Publish this unchanged implementation to its draft PR and require the live
+control-plane, documentation, repository, and aggregate jobs to pass at the
+exact head. After this workflow packet merges and is green on `main`, prepare a
+read-only current-settings refresh and an exact GIT-7C2 delta for a separate
+owner decision. Do not mutate settings from this packet.

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -2,22 +2,22 @@
   "folder": "docs/research/git-governance",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-13",
-  "file_count": 12,
+  "last_updated": "2026-08-14",
+  "file_count": 13,
   "files": [
     {
       "name": "GIT-001-README.md",
       "type": "documentation",
-      "size_lines": 94,
-      "last_updated": "2026-08-13",
+      "size_lines": 95,
+      "last_updated": "2026-08-14",
       "description": "This directory is the task-owned, non-normative research record for GIT-001. Its contents may describe official Git/GitHub/Codex facts, observed project",
-      "content_hash": "a33e68ad4118"
+      "content_hash": "234824c3c75f"
     },
     {
       "name": "GIT-001-lifecycle-research.md",
       "type": "documentation",
       "size_lines": 192,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "This is a source-backed, non-normative map. It does not replace the canonical workflow and does not authorize policy, settings, cleanup, or release changes.",
       "content_hash": "8a2c9f510b77"
     },
@@ -25,7 +25,7 @@
       "name": "GIT-001-next-agent-disposition-plan.md",
       "type": "documentation",
       "size_lines": 411,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "This packet converts the original six-priority cleanup and recovery list into a current, evidence-backed handoff. It tells the next agent what is already done,",
       "content_hash": "eb05a95fb3ae"
     },
@@ -33,7 +33,7 @@
       "name": "GIT-001-official-evidence-register.md",
       "type": "documentation",
       "size_lines": 147,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "Only primary, official sources belong in the source tables. A source supports a bounded external fact; it does not create project policy. Project observations,",
       "content_hash": "2fb0b91dbc96"
     },
@@ -41,7 +41,7 @@
       "name": "GIT-001-phase-0-preservation-baseline.md",
       "type": "documentation",
       "size_lines": 165,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "- Observation time: 2026-08-12T21:17:05+05:30 - Repository: Pravin-surawase/structural_engineering_lib",
       "content_hash": "6d737c63cb6d"
     },
@@ -49,7 +49,7 @@
       "name": "GIT-001-phase-2-incident-register.md",
       "type": "documentation",
       "size_lines": 350,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "This register traces confirmed Git, worktree, automation, CI, release, and recovery failures from this repository. It is forensic evidence for the later",
       "content_hash": "e94fe169b0f7"
     },
@@ -57,7 +57,7 @@
       "name": "GIT-001-phase-3-gap-risk-matrix.md",
       "type": "documentation",
       "size_lines": 234,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "This matrix compares five evidence layers: 1. official Git/GitHub/Codex facts from Phase 1;",
       "content_hash": "c4c66d7f8b7e"
     },
@@ -65,7 +65,7 @@
       "name": "GIT-001-phase-4-operating-model.md",
       "type": "documentation",
       "size_lines": 429,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "Use a **preservation-first, evidence-separated, Codex-native** operating model: - one task, one attached worktree, one branch, and one named integration owner;",
       "content_hash": "2648d526bef2"
     },
@@ -73,7 +73,7 @@
       "name": "GIT-001-phase-5-scenario-validation.md",
       "type": "documentation",
       "size_lines": 227,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "Phase 5 tests whether the proposed operating model is grounded in observable Git/GitHub behavior and whether every implementation packet has a falsifiable",
       "content_hash": "c58cdf2724e1"
     },
@@ -81,7 +81,7 @@
       "name": "GIT-001-phase-6-canonical-policy-proposal.md",
       "type": "documentation",
       "size_lines": 264,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "state and intake kernel, as the first implementation packet.** Do not yet authorize GitHub ruleset changes, CI topology changes, generated-data",
       "content_hash": "8bb49d830e7b"
     },
@@ -89,19 +89,27 @@
       "name": "GIT-001-phase-7A-preservation-workflow-recovery.md",
       "type": "documentation",
       "size_lines": 82,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-14",
       "description": "The repository owner authorized Git operations, merge/deletion when proven safe, parallel subagents, preservation of Column PMM, and selective recovery of",
       "content_hash": "3a5222567115"
     },
     {
       "name": "GIT-001-phase-7B-state-intake-kernel.md",
       "type": "documentation",
-      "size_lines": 133,
-      "last_updated": "2026-08-13",
+      "size_lines": 149,
+      "last_updated": "2026-08-14",
       "description": "The repository owner accepted Phase 6 and authorized GIT-7B on 2026-08-13. This packet implements only the read-only Git state authority, task intake,",
-      "content_hash": "658e05dc0d46"
+      "content_hash": "66c215280a81"
+    },
+    {
+      "name": "GIT-001-phase-7C1-required-ci-topology.md",
+      "type": "documentation",
+      "size_lines": 148,
+      "last_updated": "2026-08-14",
+      "description": "After GIT-7B merged through PR #744, the repository owner authorized the next planned workflow packet for publication as a draft PR on 2026-08-14. This",
+      "content_hash": "ff780318f964"
     }
   ],
   "subfolders": [],
-  "content_hash": "94942503c47c59b7"
+  "content_hash": "ccc27f23f29d19b2"
 }

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -1,14 +1,14 @@
 # Git Governance
 
 **Type:** Documentation
-**Last Updated:** 2026-08-13
-**Files:** 12
+**Last Updated:** 2026-08-14
+**Files:** 13
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 94 |
+| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 95 |
 | [GIT-001-lifecycle-research.md](GIT-001-lifecycle-research.md) |  | This is a source-backed, non-normative map. It does not repl | 192 |
 | [GIT-001-next-agent-disposition-plan.md](GIT-001-next-agent-disposition-plan.md) |  | This packet converts the original six-priority cleanup and r | 411 |
 | [GIT-001-official-evidence-register.md](GIT-001-official-evidence-register.md) |  | Only primary, official sources belong in the source tables.  | 147 |
@@ -19,4 +19,5 @@
 | [GIT-001-phase-5-scenario-validation.md](GIT-001-phase-5-scenario-validation.md) |  | Phase 5 tests whether the proposed operating model is ground | 227 |
 | [GIT-001-phase-6-canonical-policy-proposal.md](GIT-001-phase-6-canonical-policy-proposal.md) |  | state and intake kernel, as the first implementation packet. | 264 |
 | [GIT-001-phase-7A-preservation-workflow-recovery.md](GIT-001-phase-7A-preservation-workflow-recovery.md) |  | The repository owner authorized Git operations, merge/deleti | 82 |
-| [GIT-001-phase-7B-state-intake-kernel.md](GIT-001-phase-7B-state-intake-kernel.md) |  | The repository owner accepted Phase 6 and authorized GIT-7B  | 133 |
+| [GIT-001-phase-7B-state-intake-kernel.md](GIT-001-phase-7B-state-intake-kernel.md) |  | The repository owner accepted Phase 6 and authorized GIT-7B  | 149 |
+| [GIT-001-phase-7C1-required-ci-topology.md](GIT-001-phase-7C1-required-ci-topology.md) |  | After GIT-7B merged through PR #744, the repository owner au | 148 |

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -24,6 +24,7 @@ GIT_STATE_COMPATIBILITY = (
     "scripts/check_not_main.sh",
 )
 FAST_CHECKS = REPO_ROOT / ".github/workflows/fast-checks.yml"
+DEPLOY_DOCS = REPO_ROOT / ".github/workflows/deploy-docs.yml"
 
 RETIRED_PATHS = (
     "scripts/ai_commit.sh",
@@ -149,14 +150,35 @@ def main() -> int:
         workflow = FAST_CHECKS.read_text(encoding="utf-8")
         for token in (
             "control_plane:",
-            "'scripts/git_state.py'",
+            "docs:",
+            "'scripts/**'",
+            "'docs/**'",
+            "control-plane-validation:",
+            "documentation-validation:",
             "needs.changes.outputs.control_plane == 'true'",
+            "needs.changes.outputs.docs == 'true'",
             "Python/tests/test_git_state.py",
             "Python/tests/test_session_automation.py",
+            "Python/tests/test_session_store.py",
+            "Python/tests/test_pipeline_state.py",
+            "Python/tests/test_agent_governance_automation.py",
+            "Python/tests/test_ci_workflow_contract.py",
+            "CONTROL_PLANE_RESULT:",
+            "DOCS_RESULT:",
+            "require_component 'Control Plane Validation'",
+            "require_component 'Documentation Validation'",
         ):
             if token not in workflow:
-                errors.append(f"control-plane CI routing is missing: {token}")
-        focused_marker = "- name: Validate Git state and intake control plane"
+                errors.append(f"required PR Gate routing is missing: {token}")
+        expected_concurrency = (
+            "group: ${{ github.workflow }}-"
+            "${{ github.event.pull_request.number || github.run_id }}"
+        )
+        if expected_concurrency not in workflow:
+            errors.append("PR validation concurrency is not scoped per pull request")
+        focused_marker = (
+            "- name: Validate Git, intake, session, and governance controls"
+        )
         if focused_marker in workflow:
             focused_step = workflow.partition(focused_marker)[2].partition(
                 "\n      - name:"
@@ -166,6 +188,22 @@ def main() -> int:
                 errors.append(
                     "control-plane CI tests do not bind the setup-python interpreter"
                 )
+
+    if not DEPLOY_DOCS.exists():
+        errors.append("post-merge documentation workflow is missing")
+    else:
+        deploy_docs = DEPLOY_DOCS.read_text(encoding="utf-8")
+        trigger_block = deploy_docs.partition("\non:\n")[2].partition("\npermissions:")[
+            0
+        ]
+        if "pull_request:" in trigger_block:
+            errors.append(
+                "documentation PR validation must run inside required PR Gate"
+            )
+        if "group: ${{ github.workflow }}-${{ github.ref }}" not in deploy_docs:
+            errors.append("post-merge documentation concurrency is not scoped per ref")
+        if "group: deploy-docs" in deploy_docs:
+            errors.append("global documentation concurrency group is still active")
 
     retired_names = tuple(Path(path).name for path in RETIRED_PATHS[:7])
     for relative in LIVE_FILES_WITHOUT_WRAPPER_CALLS:


### PR DESCRIPTION
## What

- add a dedicated Control Plane Validation route for scripts, agent/session controls, registries, Git workflow policy, workflow definitions, and their maintained tests
- add strict MkDocs validation at the same PR head and make it a direct PR Gate dependency
- make both new routes fail closed for failure, cancellation, timeout-like, unexpected-skip, and unexpected-execution outcomes
- scope PR cancellation by pull request and retain the separate docs workflow only for ref-scoped main/manual evidence
- add executable workflow-contract regressions and extend the semantic Codex-native workflow checker
- record the GIT-7C1 receipt and restore the session log header/newest-first structure without changing historical entry text

## Why

Strict documentation validation previously ran as a separate non-required workflow with one global cancellation group. PR Gate could therefore pass without the docs outcome, and unrelated docs runs could cancel each other.

Control-plane routing also covered only a narrow hand-picked path list and omitted maintained session, persistence, pipeline, governance, and routing-contract regressions.

## Impact

PR Gate now requires every applicable component, control-plane, documentation, and repository outcome to conclude success at the current PR head. A newer head cancels only the older run for that PR.

This is GIT-7C1 workflow code only. It does not change the main ruleset, bypass actors, merge methods, branch deletion, release, cleanup, recovery, or product runtime. GIT-7C2 server settings remain separately owner-gated after this workflow is green on main.

## Root causes fixed

- required docs evidence was outside the required aggregate and globally cancelled
- control-plane path routing did not select all maintained outcome tests
- an agent-governance assertion still matched a retired pre-GIT-7B dependency command because that family was not in the focused route
- the session log header was embedded below older entries, causing session start and session end to disagree about the newest entry
- the first commit attempt correctly exposed a Python 3.12 mismatch in the integrated docs job; it now follows the repository Python 3.11 workflow contract

## Verification

- 173 combined control-plane tests passed
- fail-closed CI result matrix: 13 tests passed
- strict MkDocs build passed
- quick repository gate: 10/10
- full repository gate: 30/30
- Black, Ruff, YAML parsing, Python-version consistency, semantic workflow check, link checks, generated-index freshness, and normal commit hooks passed
- worktree-bound Python diagnosis reported source_bound=true
