### PR TITLE
fix(git): route targeted index generation

### DIFF
--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -85,6 +85,13 @@ def test_run_task_brief_and_index_help_are_read_only():
         text=True,
         timeout=20,
     )
+    no_args_result = subprocess.run(
+        [str(REPO_ROOT / "run.sh"), "generate", "indexes"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
     task_help = subprocess.run(
         [str(REPO_ROOT / "run.sh"), "task", "brief", "--help"],
         cwd=REPO_ROOT,
@@ -105,9 +112,56 @@ def test_run_task_brief_and_index_help_are_read_only():
     assert "Route:" in brief.stdout
     assert "Safe start:" in brief.stdout
     assert help_result.returncode == 0, help_result.stderr
-    assert "Usage: ./run.sh generate indexes" in help_result.stdout
+    assert "./run.sh generate indexes <owned-folder> [options]" in help_result.stdout
+    assert no_args_result.returncode == 0, no_args_result.stderr
+    assert "No arguments or --help shows this non-writing help" in no_args_result.stdout
     assert task_help.returncode == 0, task_help.stderr
     assert "Usage: ./run.sh task brief" in task_help.stdout
+    assert before == after
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        (
+            ["docs/research/git-governance", "--dry-run"],
+            "Would generate: docs/research/git-governance/index.json + "
+            "docs/research/git-governance/index.md",
+        ),
+        (["--all", "--dry-run"], "Folders to process:"),
+    ],
+)
+def test_run_index_generator_dry_run_routes_scope_without_writes(
+    arguments: list[str], expected: str
+):
+    before = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "run.sh"), "generate", "indexes", *arguments],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    after = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    assert result.returncode == 0, result.stderr
+    assert "Mode: DRY RUN" in result.stdout
+    assert expected in result.stdout
+    if arguments[0] != "--all":
+        assert "Folders to process: 1" in result.stdout
     assert before == after
 
 
@@ -524,6 +578,26 @@ def test_index_generator_requires_opt_in_for_new_index_folder(
 
     assert (unmaintained / "index.json").is_file()
     assert (unmaintained / "index.md").is_file()
+
+
+def test_index_generator_owned_folder_write_changes_only_expected_indexes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    generator = importlib.import_module("scripts.generate_enhanced_index")
+    owned = tmp_path / "owned"
+    owned.mkdir()
+    (owned / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setattr(generator, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(generator, "KEY_FOLDERS", ["owned"])
+    monkeypatch.setattr(sys, "argv", ["generate_enhanced_index.py", "owned"])
+
+    generator.main()
+
+    generated = {
+        path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("index.*")
+    }
+    assert generated == {"owned/index.json", "owned/index.md"}
 
 
 def test_session_end_preserves_current_same_day_handoff(

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,119 @@
 
 ---
 
+## 2026-08-15 — Session: GIT-7C2 Receipt and GIT-7D1 Targeted Generation
+
+**Agent:** Codex (`ops`)
+
+**Branch:** `codex/git-7d1-index-routing`
+
+**Focus:** Preserve the completed GIT-7C1/GIT-7C2 integration receipt, then
+implement the bounded preferred index-generator route as GIT-7D1
+
+### Summary
+
+- Independently reviewed and squash-merged GIT-7C1 PR #745 as `729cc41b`,
+  proved tree equivalence with reviewed head `c3edd247`, and verified both
+  post-merge main workflows passed.
+- Applied the explicitly authorized GIT-7C2 ruleset and merge-method delta with
+  guarded rollback, exact readback, and effective-branch verification.
+- Reproduced the GIT-7D generator-scope defect from a fresh current-main lane,
+  reversed only its 31 generated paths, and preserved the task-owned log.
+- Changed the preferred route so no arguments show non-writing help, folder
+  scope is retained, and all-folder generation requires explicit `--all`.
+- Added executable acceptance coverage and refreshed only the task-owned child
+  and parent generated projections after exact dry-run previews.
+
+### PRs Merged
+
+| PR | Summary |
+|----|---------|
+| #745 | GIT-7C1 required CI topology, squash result `729cc41b` |
+
+### Key Deliverables
+
+- `run.sh`
+- `Python/tests/test_session_automation.py`
+- `docs/research/git-governance/GIT-001-phase-7C2-server-enforcement.md`
+- `docs/research/git-governance/GIT-001-phase-7D1-targeted-index-generation.md`
+- Current task board, next-session brief, research map, and owned indexes
+
+### Issues encountered
+
+- `./run.sh generate indexes docs/research/git-governance --dry-run` ignored
+  both the folder and dry-run arguments, ran live, and changed 31 unrelated
+  index files.
+- The first focused test run failed one help-text assertion after the help
+  contract intentionally changed.
+- The first live-evidence refresh used a repository slug without the account
+  name's hyphen, so GitHub rejected the query before later chained API reads.
+- The first authorized GIT-7C2 update failed its exact response assertion even
+  though GitHub accepted the ruleset payload; the transaction rolled back.
+- The first full repository gate failed documentation front-matter validation
+  for the three updated GIT phase receipts.
+
+### Root causes and resolutions
+
+- Root cause: `run.sh` routed every index request to
+  `generate_all_indexes.sh`, whose hard-coded global loop consumes no caller
+  arguments. Resolution: route non-help requests through the worktree-bound
+  maintained Python generator; retain no-argument/help as read-only usage.
+  Evidence: the reproduced command now reports one dry-run target, explicit
+  `--all --dry-run` reports 32 targets, 45 focused tests pass, and Git status is
+  unchanged by both previews.
+- Root cause: the existing test asserted the former single-line usage prefix,
+  while the safer help now has two explicit forms. Resolution: assert the
+  folder-scoped form and rerun the maintained test file. Evidence: 45 tests
+  pass.
+- Root cause: the remote URL is `Pravin-surawase`, but the first command used
+  `pravinsurawase`. Resolution: derive and use the exact remote owner/repository
+  slug. Evidence: PR, ruleset, effective rules, repository settings, and
+  workflow API reads all succeeded on retry.
+- Root cause: GitHub normalizes a pull-request rule by adding
+  `required_reviewers: []`; the first verifier compared against the unnormalized
+  request. Resolution: confirm automatic rollback, run a controlled
+  apply/read/rollback probe, include the normalized field, and rerun the guarded
+  transaction. Evidence: ruleset `11390214` now has PR enforcement, strict
+  `PR Gate`, no bypass actor, and retained deletion/non-fast-forward rules;
+  repository settings retain merge/squash and disable rebase.
+- Root cause: the receipts used descriptive lifecycle values (`complete` and
+  `implementation`) instead of the front-matter schema's allowed `status`
+  vocabulary. Resolution: use `active` for maintained live references and keep
+  completion/implementation detail in phase prose and the task ledger.
+  Evidence: direct all-document validation and the rerun full gate pass.
+
+### Verification
+
+- Worktree-bound Python diagnosis: `source_bound=true`.
+- Focused session/generator plus CI-topology contracts: 58 tests passed.
+- No-argument help, one-folder dry-run, and explicit all-folder dry-run are
+  non-writing; isolated one-folder live generation creates only two indexes;
+  unexpected new topology fails without opt-in.
+- Remote `main` and post-merge workflows remain green at `729cc41b`.
+- Current and effective ruleset plus repository merge settings match GIT-7C2.
+- Black, Ruff, Bash syntax, diff whitespace, semantic Git workflow, token
+  efficiency, strict MkDocs, and direct all-document validation passed.
+- Quick repository gate: 10/10; full repository gate: 30/30 after correcting
+  the receipt front-matter vocabulary.
+- Exact-head required PR checks remain the publication gate.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: the canonical folder-scoped `--dry-run` ran the legacy
+  live all-folder generator -> reversed only the enumerated generated drift and
+  corrected the dispatcher before any owned live generation.
+- ⚠️ TERMINAL ISSUE: the first GitHub refresh used `pravinsurawase` instead of
+  the exact remote account `Pravin-surawase` -> reran with the derived slug and
+  completed all live reads.
+
+### Notes
+
+- GIT-7D2 classification, cleanup/deletion, GIT-7E, releases, product code, and
+  adjacent hardening remain out of scope.
+- Git-process timing starts only at the first publication action after local
+  verification; implementation/debugging time is reported separately.
+
+
 ## 2026-08-14 — Session: GIT-001 Phase 7C1 Required CI Topology
 
 **Agent:** Codex (`ops`)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-14 — GIT-7B merged through PR #744; GIT-7C1 required CI topology is locally complete and authorized for draft-PR validation
+**Updated:** 2026-08-15 — GIT-7C1 merged through PR #745, GIT-7C2 server enforcement is applied, and GIT-7D1 targeted index routing is in validation
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7C1 READY FOR DRAFT PR — required control-plane/docs routing and fail-closed PR Gate contract pass locally; GIT-7C2 settings and GIT-7D–7E remain held |
+| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7D1 IN VALIDATION — GIT-7C1 merged and green, GIT-7C2 server settings applied and verified, targeted non-writing index routing passes locally; GIT-7D2/GIT-7E remain separate |
 
 ## Up Next
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -3,21 +3,22 @@
 ## Latest Handoff
 
 <!-- HANDOFF:START -->
-- Date: 2026-08-14
-- Focus: GIT-7B merged; GIT-7C1 required CI topology locally complete and authorized for draft validation
+- Date: 2026-08-15
+- Focus: GIT-7C1 and GIT-7C2 complete; GIT-7D1 targeted index routing in exact-head validation
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha
 
-**Integrated GIT-7B receipt:** PR #744 merged as `0fdb48ed`; refresh `main` before work
+**Integrated GIT-7C1 receipt:** PR #745 merged as `729cc41b`; refresh `main` before work
 
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Current** | GIT-7C1 locally complete | Required control-plane/docs routes, fail-closed PR Gate aggregation, scoped cancellation, and 173 control-plane tests pass |
-| **Next** | Draft PR exact-head validation | Require Control Plane, Documentation, Repository, and aggregate PR Gate outcomes at the unchanged head |
-| **Held** | GIT-7C2 server settings | No ruleset, bypass, merge-method, or branch-deletion change without a fresh exact-delta owner decision after GIT-7C1 is green on `main` |
+| **Complete** | GIT-7C1 and GIT-7C2 | Required CI merged; main now requires PR plus strict `PR Gate`, has no bypass actor, retains deletion/non-fast-forward protection, permits merge/squash, and disables rebase |
+| **Current** | GIT-7D1 targeted generation | Preferred no-arg route is help; one-folder and explicit all-folder dry-runs are non-writing; focused tests pass |
+| **Next** | GIT-7D1 exact-head integration | Require Control Plane, Documentation, Repository, and aggregate `PR Gate` outcomes at the unchanged head |
+| **Held** | GIT-7D2 and GIT-7E | Inspection-only disposition and durable handoff remain separate packets; cleanup/deletion remains prohibited |
 | **Parallel owner decision** | Excel planning lane | Confirm a named active owner/next action or approve retirement |
 | **Approval-gated** | Alpha worktrees and merged branches | Exact evidence is ready; deletion still requires explicit target approval |
 | **Separate maintenance** | Seven dependency PRs | Replace one-by-one merging with four current-base compatibility packets |
@@ -35,13 +36,15 @@
 9. [Phase 6 canonical-policy proposal](../research/git-governance/GIT-001-phase-6-canonical-policy-proposal.md)
 10. [Phase 7B implementation receipt](../research/git-governance/GIT-001-phase-7B-state-intake-kernel.md)
 11. [Phase 7C1 required CI topology](../research/git-governance/GIT-001-phase-7C1-required-ci-topology.md)
-12. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
-13. [AI token-efficiency policy](../guidelines/ai-token-efficiency.md)
+12. [Phase 7C2 server enforcement](../research/git-governance/GIT-001-phase-7C2-server-enforcement.md)
+13. [Phase 7D1 targeted index generation](../research/git-governance/GIT-001-phase-7D1-targeted-index-generation.md)
+14. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
+15. [AI token-efficiency policy](../guidelines/ai-token-efficiency.md)
 
 ## Start command
 
 ```bash
-./run.sh task brief "validate GIT-7C1 required CI topology at the exact draft PR head"
+./run.sh task brief "validate GIT-7D1 targeted index generation at the exact PR head"
 ./run.sh session brief --agent ops
 ./run.sh session start
 ```
@@ -52,6 +55,15 @@ replacement for live inspection.
 
 ## Current Git facts
 
+- GIT-7C1 PR #745 was independently reviewed at `c3edd247`, squash-merged as
+  `729cc41b`, tree-equivalent to the reviewed head, and both post-merge main
+  workflows passed.
+- Active ruleset `11390214` now requires PRs and strict `PR Gate`, retains
+  deletion/non-fast-forward protection, and has no bypass actor. Merge and
+  squash remain enabled; rebase is disabled; branch deletion remains disabled.
+- GIT-7D1 reproduced the preferred-generator defect, reversed only 31
+  generator-created paths, and routes folder/`--dry-run` arguments to the
+  worktree-bound maintained generator. The focused contract passes 45 tests.
 - The dedicated GIT-001 branch was synchronized without history rewriting at
   `54a03557`; its tree exactly matched `origin/main = 69d9f68c`, its quick gate
   passed 10/10, and the merge was fast-forward pushed to its existing remote.
@@ -86,12 +98,12 @@ state/intake, publication/server enforcement, generated-data/cleanup, and
 guidance/handoff control planes, with the read-only state kernel first. Phase 5
 reproduces the current abnormal-state defects and defines falsifiable packet
 gates. The owner accepted Phase 6 and authorized GIT-7B on 2026-08-13. The
-read-only kernel integrated through PR #744 as `0fdb48ed`. On 2026-08-14 the
-owner authorized publication of the planned GIT-7C1 workflow packet as a draft
-PR. Required control-plane and strict-documentation routes, fail-closed
-aggregation, and scoped cancellation are implemented locally. GIT-7C2 GitHub
-settings and GIT-7D–7E remain held; no cleanup, deletion, recovery, or release
-mutation is authorized.
+read-only kernel integrated through PR #744 as `0fdb48ed`. GIT-7C1 then
+integrated through PR #745 as `729cc41b`; the owner authorized and the agent
+applied the exact GIT-7C2 server delta with guarded rollback and postcondition
+checks. GIT-7D1 is the current targeted-generator packet. GIT-7D2 and GIT-7E
+remain separate; no cleanup, deletion, recovery, or release mutation is
+authorized.
 
 ## Destructive-action holds
 

--- a/docs/research/git-governance/GIT-001-README.md
+++ b/docs/research/git-governance/GIT-001-README.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-14
+last_updated: 2026-08-15
 doc_type: index
 task: GIT-001
 ---
@@ -18,8 +18,8 @@ policy.
 The current normative policy is
 [`docs/git-automation/git-workflow-single-source.md`](../../git-automation/git-workflow-single-source.md)
 and now includes the owner-accepted GIT-7B read-only state/intake contract.
-GIT-7C1 changes required CI topology only; GIT-7C2 server settings and GIT-7D–7E
-remain held inputs, never silent operational authority.
+GIT-7C1 is integrated and GIT-7C2 server enforcement is applied. GIT-7D1 owns
+only targeted index generation; GIT-7D2 and GIT-7E remain separate packets.
 
 ## Objective
 
@@ -48,7 +48,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 | 4 | Operating-model design | Complete as proposal | Four control planes, one typed state model, lane lifecycle, permissions, CI/server policy, recovery, and four packets defined |
 | 5 | Scenario validation | Complete for proposal | Disposable Git and live read-only checks reproduce current defects, validate primitives, and define falsifiable GIT-7B–7E gates |
 | 6 | Canonical policy proposal | Accepted 2026-08-13 | Owner accepted the operating model and authorized GIT-7B only |
-| 7 | Controlled implementation | 7A complete; GIT-7B merged; GIT-7C1 ready for draft validation | GIT-7C1 exact workflow tests and repository gates pass; GIT-7C2 settings and GIT-7D–7E remain separately gated |
+| 7 | Controlled implementation | 7A–7C complete; GIT-7D1 implementation in validation | GIT-7C1 merged through PR #745; GIT-7C2 exact server delta is applied and verified; GIT-7D1 routes targeted non-writing previews |
 | 8 | Adoption and closeout | Not started | Integrated workflow verified; supersession and maintenance established |
 
 ## Artifact map
@@ -65,7 +65,9 @@ work, make recovery deterministic, and remain efficient during normal work.
 - [Phase 6 canonical-policy proposal](GIT-001-phase-6-canonical-policy-proposal.md)
 - [Phase 7B read-only state/intake kernel](GIT-001-phase-7B-state-intake-kernel.md)
 - [Phase 7C1 required CI topology](GIT-001-phase-7C1-required-ci-topology.md)
-- Phase 7C2 server enforcement and Phases 7D–7E — owner-approval gated
+- [Phase 7C2 server enforcement](GIT-001-phase-7C2-server-enforcement.md)
+- [Phase 7D1 targeted index generation](GIT-001-phase-7D1-targeted-index-generation.md)
+- Phase 7D2 inspection-only disposition and Phase 7E durable handoff — planned
 - Phase 8 adoption/closeout report — planned
 
 ## Ownership and non-goals

--- a/docs/research/git-governance/GIT-001-phase-7C1-required-ci-topology.md
+++ b/docs/research/git-governance/GIT-001-phase-7C1-required-ci-topology.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-14
+last_updated: 2026-08-15
 doc_type: reference
 task: GIT-001
 phase: 7C1
@@ -140,8 +140,8 @@ test enforces that version so later edits cannot reintroduce the mismatch.
 
 ## Next gate
 
-Publish this unchanged implementation to its draft PR and require the live
-control-plane, documentation, repository, and aggregate jobs to pass at the
-exact head. After this workflow packet merges and is green on `main`, prepare a
-read-only current-settings refresh and an exact GIT-7C2 delta for a separate
-owner decision. Do not mutate settings from this packet.
+Completed 2026-08-15: PR #745 passed every applicable job and `PR Gate` at
+reviewed head `c3edd247`, then squash-merged as `729cc41b` with an identical
+tree. Both post-merge main workflows passed. The separately authorized GIT-7C2
+delta is recorded in
+[`GIT-001-phase-7C2-server-enforcement.md`](GIT-001-phase-7C2-server-enforcement.md).

--- a/docs/research/git-governance/GIT-001-phase-7C2-server-enforcement.md
+++ b/docs/research/git-governance/GIT-001-phase-7C2-server-enforcement.md
@@ -1,0 +1,92 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: reference
+task: GIT-001
+phase: 7C2
+owner_decision: authorized-and-applied-2026-08-15
+---
+
+# GIT-001 Phase 7C2 — Server Enforcement
+
+## Authorization and prerequisite
+
+The owner explicitly authorized the documented GIT-7C2 settings delta and
+autonomous verification/rollback on 2026-08-15. The change was applied only
+after PR [#745](https://github.com/Pravin-surawase/structural_engineering_lib/pull/745)
+integrated GIT-7C1 and both post-merge workflows passed on `main`.
+
+## GIT-7C1 integration receipt
+
+| Evidence | Exact result |
+|---|---|
+| Reviewed base | `0fdb48edbb73114288feb8a246d6f30b80ac4d95` |
+| Reviewed head | `c3edd24783df0f14efe1854f411dbc6735b44f40` |
+| Review state | no comments, reviews, unresolved threads, conflicts, or essential blocker; required `PR Gate` passed |
+| Merge method | squash |
+| Resulting `main` | `729cc41bfb68e1381ddf3125d6365f40d9ff8738` |
+| Content equivalence | reviewed-head and squash-result trees both `33d94f67834ea8cc669f73678022e89a927c0b02` |
+| Post-merge workflows | [PR Validation 31864615708](https://github.com/Pravin-surawase/structural_engineering_lib/actions/runs/31864615708) and [Validate Documentation 31864615731](https://github.com/Pravin-surawase/structural_engineering_lib/actions/runs/31864615731), both successful at the resulting `main` SHA |
+
+## Applied current-to-target delta
+
+Ruleset [`11390214`](https://github.com/Pravin-surawase/structural_engineering_lib/rules/11390214)
+remains active and scoped to `refs/heads/main`.
+
+| Surface | Before | Applied/current |
+|---|---|---|
+| Pull requests | no pull-request rule | required; zero approving reviews; no code-owner, last-push, stale-review, or thread-resolution requirement |
+| Required check | strict `PR Gate`, integration `15368` | retained unchanged |
+| History/deletion | deletion and non-fast-forward blocked | retained unchanged |
+| Standing bypass | repository role `actor_id=5`, mode `always`; current owner could always bypass | `bypass_actors=[]`; `current_user_can_bypass=never` |
+| Ruleset merge methods | not applicable without a PR rule | `merge` and `squash` only |
+| Repository merge methods | merge, squash, and rebase enabled | merge and squash retained; rebase disabled |
+| Delete branch on merge | disabled | preserved disabled |
+| Auto-merge/update branch | disabled/disabled | preserved disabled/disabled |
+
+The effective branch-rule API independently reports deletion,
+non-fast-forward, strict `PR Gate`, and pull-request enforcement from this
+ruleset. The repository API reports squash and merge-commit enabled, rebase
+disabled, and branch deletion after merge disabled.
+
+## Transaction, rollback, and risk receipt
+
+The first guarded update was rejected by the exact postcondition because
+GitHub added the normalized empty field `required_reviewers: []`. The
+transaction automatically restored the original three rules and standing
+bypass before repository merge settings changed. A controlled
+apply/read/rollback probe confirmed the normalization, then the final guarded
+transaction included that field and passed every postcondition.
+
+The preserved rollback is the exact inverse: restore the three original rules,
+restore `{actor_id: 5, actor_type: RepositoryRole, bypass_mode: always}`, and
+set `allow_rebase_merge=true`; keep the other repository settings unchanged.
+Rollback is appropriate only if PR creation or required-check integration is
+proven unusable, and must use the same read-before/write/exact-readback guard.
+
+Primary risks are a misnamed required context blocking integration, loss of a
+routine direct-main escape path, and server normalization causing false
+postcondition failures. GIT-7C1 proved the exact `PR Gate` context; the owner
+accepted deliberate ruleset edit plus dated rollback as the emergency path;
+and the normalized response is now part of the verifier.
+
+## Phase 5 acceptance status
+
+| Scenario | Evidence/status |
+|---|---|
+| Control-plane and docs routes gate the exact PR head | passed on PR #745 |
+| Failed, cancelled, skipped, or timeout-like applicable work fails `PR Gate` | executable GIT-7C1 result-matrix tests passed |
+| Same-PR cancellation is scoped | GIT-7C1 workflow contract passed |
+| Main requires a PR with strict `PR Gate` | current ruleset and effective branch rules confirm |
+| Standing bypass is absent | current ruleset reports empty actors and `never` |
+| Deletion/non-fast-forward protections remain | current effective rules confirm |
+| Merge methods and branch deletion match target | current repository and ruleset APIs confirm |
+| Before/after settings match the authorized delta | guarded postcondition passed; remote `main` and both workflows remained unchanged/green |
+
+The owner phrase that authorized the mutation was: “Adopt the standing Git
+authorization model and apply the documented GIT-7C2 settings delta now.
+Proceed autonomously through verification and rollback if needed.”
+
+No branch, worktree, release, cleanup target, or product code was changed by
+the settings transaction.

--- a/docs/research/git-governance/GIT-001-phase-7D1-targeted-index-generation.md
+++ b/docs/research/git-governance/GIT-001-phase-7D1-targeted-index-generation.md
@@ -1,0 +1,92 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: reference
+task: GIT-001
+phase: 7D1
+---
+
+# GIT-001 Phase 7D1 — Targeted Index Generation
+
+## Scope and confirmed defect
+
+GIT-7D is split so the incident-producing generator route can be corrected
+without combining it with branch/worktree disposition logic. This packet owns
+only the preferred index-generator contract. GIT-7D2 remains an
+inspection-only classifier packet; deletion and cleanup remain outside both.
+
+From a fresh current-main lane, this command was expected to preview one owned
+folder:
+
+```text
+./run.sh generate indexes docs/research/git-governance --dry-run
+```
+
+Instead it reported `Mode: LIVE`, processed the legacy global list, and changed
+31 unrelated maintained index files. The exact generator-created drift was
+enumerated and reversed with an inspected reverse patch; the task-owned
+`docs/SESSION_LOG.md` change was preserved. Verification reported all 31
+generated paths restored and only the session record remaining dirty.
+
+The confirmed root cause was the `run.sh` dispatcher: every `indexes` call
+invoked `scripts/generate_all_indexes.sh`, whose hard-coded loop consumes no
+arguments. The already-maintained Python generator supports a positional
+folder, `--dry-run`, explicit `--all`, checks, output selection, recursion, and
+new-topology opt-in, but the preferred command discarded that contract.
+
+## Implemented contract
+
+The canonical entrypoint now routes non-help arguments directly through the
+invoking worktree's `scripts/python_runtime.sh` to
+`generate_enhanced_index.py`:
+
+```text
+./run.sh generate indexes <owned-folder> --dry-run
+./run.sh generate indexes <owned-folder>
+./run.sh generate indexes --all --dry-run
+./run.sh generate indexes --all
+```
+
+No arguments and `--help` show non-writing help. Folder scope is the default;
+all-folder generation requires explicit `--all`. Existing index ownership and
+the separate `--allow-new-index` opt-in continue to prevent accidental new
+topology during live generation.
+
+The legacy all-folder shell launcher remains available to its existing direct
+callers in this bounded packet, but it is no longer the canonical `run.sh`
+route. Migrating or retiring those direct callers is separate work if live
+evidence shows a main-process need.
+
+## Acceptance evidence
+
+| GIT-7D scenario | Result in GIT-7D1 |
+|---|---|
+| No-argument preferred generator is non-writing help | passed; status byte-for-byte unchanged |
+| One-folder dry-run affects only expected maintained paths | passed; one folder and its two index paths reported, no write |
+| One-folder live write changes only expected indexes | passed in an isolated temporary project |
+| `--all` is explicit and previews the full target set | passed; 32 canonical existing folders previewed, no write |
+| Unexpected new topology fails without opt-in | passed; existing regression exits 2 and creates no index |
+| Branch classifier is mutation-free and fail-closed | held for GIT-7D2 |
+| Cleanup or deletion | prohibited and not performed |
+
+Focused `Python/tests/test_session_automation.py` verification passes 45 tests.
+The exact previously failing preferred command now reports one dry-run target
+and leaves Git status unchanged.
+
+## Timing experiment
+
+This packet is measurement run 1 for the owner's Git-process efficiency
+question. The clock starts only after implementation and local verification,
+at the first commit/publication action, and ends after exact-head checks,
+integration, and post-merge verification. The receipt separates local Git,
+GitHub/PR operations, CI wait, retry/rollback time, and total wall time so
+additional safeguards can be judged against prevented rework rather than raw
+step count alone.
+
+## Non-goals and next gate
+
+No classifier, branch/worktree disposition, deletion, cleanup, release,
+product code, GitHub setting, bypass, or adjacent hardening is included. The
+next gate is exact-head required CI and normal PR integration of this packet;
+GIT-7D2 remains separate.

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -2,22 +2,22 @@
   "folder": "docs/research/git-governance",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-14",
-  "file_count": 13,
+  "last_updated": "2026-08-15",
+  "file_count": 15,
   "files": [
     {
       "name": "GIT-001-README.md",
       "type": "documentation",
-      "size_lines": 95,
-      "last_updated": "2026-08-14",
+      "size_lines": 97,
+      "last_updated": "2026-08-15",
       "description": "This directory is the task-owned, non-normative research record for GIT-001. Its contents may describe official Git/GitHub/Codex facts, observed project",
-      "content_hash": "234824c3c75f"
+      "content_hash": "529af567b0bd"
     },
     {
       "name": "GIT-001-lifecycle-research.md",
       "type": "documentation",
       "size_lines": 192,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "This is a source-backed, non-normative map. It does not replace the canonical workflow and does not authorize policy, settings, cleanup, or release changes.",
       "content_hash": "8a2c9f510b77"
     },
@@ -25,7 +25,7 @@
       "name": "GIT-001-next-agent-disposition-plan.md",
       "type": "documentation",
       "size_lines": 411,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "This packet converts the original six-priority cleanup and recovery list into a current, evidence-backed handoff. It tells the next agent what is already done,",
       "content_hash": "eb05a95fb3ae"
     },
@@ -33,7 +33,7 @@
       "name": "GIT-001-official-evidence-register.md",
       "type": "documentation",
       "size_lines": 147,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "Only primary, official sources belong in the source tables. A source supports a bounded external fact; it does not create project policy. Project observations,",
       "content_hash": "2fb0b91dbc96"
     },
@@ -41,7 +41,7 @@
       "name": "GIT-001-phase-0-preservation-baseline.md",
       "type": "documentation",
       "size_lines": 165,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "- Observation time: 2026-08-12T21:17:05+05:30 - Repository: Pravin-surawase/structural_engineering_lib",
       "content_hash": "6d737c63cb6d"
     },
@@ -49,7 +49,7 @@
       "name": "GIT-001-phase-2-incident-register.md",
       "type": "documentation",
       "size_lines": 350,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "This register traces confirmed Git, worktree, automation, CI, release, and recovery failures from this repository. It is forensic evidence for the later",
       "content_hash": "e94fe169b0f7"
     },
@@ -57,7 +57,7 @@
       "name": "GIT-001-phase-3-gap-risk-matrix.md",
       "type": "documentation",
       "size_lines": 234,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "This matrix compares five evidence layers: 1. official Git/GitHub/Codex facts from Phase 1;",
       "content_hash": "c4c66d7f8b7e"
     },
@@ -65,7 +65,7 @@
       "name": "GIT-001-phase-4-operating-model.md",
       "type": "documentation",
       "size_lines": 429,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "Use a **preservation-first, evidence-separated, Codex-native** operating model: - one task, one attached worktree, one branch, and one named integration owner;",
       "content_hash": "2648d526bef2"
     },
@@ -73,7 +73,7 @@
       "name": "GIT-001-phase-5-scenario-validation.md",
       "type": "documentation",
       "size_lines": 227,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "Phase 5 tests whether the proposed operating model is grounded in observable Git/GitHub behavior and whether every implementation packet has a falsifiable",
       "content_hash": "c58cdf2724e1"
     },
@@ -81,7 +81,7 @@
       "name": "GIT-001-phase-6-canonical-policy-proposal.md",
       "type": "documentation",
       "size_lines": 264,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "state and intake kernel, as the first implementation packet.** Do not yet authorize GitHub ruleset changes, CI topology changes, generated-data",
       "content_hash": "8bb49d830e7b"
     },
@@ -89,7 +89,7 @@
       "name": "GIT-001-phase-7A-preservation-workflow-recovery.md",
       "type": "documentation",
       "size_lines": 82,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "The repository owner authorized Git operations, merge/deletion when proven safe, parallel subagents, preservation of Column PMM, and selective recovery of",
       "content_hash": "3a5222567115"
     },
@@ -97,7 +97,7 @@
       "name": "GIT-001-phase-7B-state-intake-kernel.md",
       "type": "documentation",
       "size_lines": 149,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "The repository owner accepted Phase 6 and authorized GIT-7B on 2026-08-13. This packet implements only the read-only Git state authority, task intake,",
       "content_hash": "66c215280a81"
     },
@@ -105,11 +105,27 @@
       "name": "GIT-001-phase-7C1-required-ci-topology.md",
       "type": "documentation",
       "size_lines": 148,
-      "last_updated": "2026-08-14",
+      "last_updated": "2026-08-15",
       "description": "After GIT-7B merged through PR #744, the repository owner authorized the next planned workflow packet for publication as a draft PR on 2026-08-14. This",
-      "content_hash": "ff780318f964"
+      "content_hash": "bb370fb77675"
+    },
+    {
+      "name": "GIT-001-phase-7C2-server-enforcement.md",
+      "type": "documentation",
+      "size_lines": 93,
+      "last_updated": "2026-08-15",
+      "description": "The owner explicitly authorized the documented GIT-7C2 settings delta and autonomous verification/rollback on 2026-08-15. The change was applied only",
+      "content_hash": "494e0c9d67de"
+    },
+    {
+      "name": "GIT-001-phase-7D1-targeted-index-generation.md",
+      "type": "documentation",
+      "size_lines": 93,
+      "last_updated": "2026-08-15",
+      "description": "GIT-7D is split so the incident-producing generator route can be corrected without combining it with branch/worktree disposition logic. This packet owns",
+      "content_hash": "612cc39c216d"
     }
   ],
   "subfolders": [],
-  "content_hash": "ccc27f23f29d19b2"
+  "content_hash": "5d2bd7e75171e8d4"
 }

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -1,14 +1,14 @@
 # Git Governance
 
 **Type:** Documentation
-**Last Updated:** 2026-08-14
-**Files:** 13
+**Last Updated:** 2026-08-15
+**Files:** 15
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 95 |
+| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 97 |
 | [GIT-001-lifecycle-research.md](GIT-001-lifecycle-research.md) |  | This is a source-backed, non-normative map. It does not repl | 192 |
 | [GIT-001-next-agent-disposition-plan.md](GIT-001-next-agent-disposition-plan.md) |  | This packet converts the original six-priority cleanup and r | 411 |
 | [GIT-001-official-evidence-register.md](GIT-001-official-evidence-register.md) |  | Only primary, official sources belong in the source tables.  | 147 |
@@ -21,3 +21,5 @@
 | [GIT-001-phase-7A-preservation-workflow-recovery.md](GIT-001-phase-7A-preservation-workflow-recovery.md) |  | The repository owner authorized Git operations, merge/deleti | 82 |
 | [GIT-001-phase-7B-state-intake-kernel.md](GIT-001-phase-7B-state-intake-kernel.md) |  | The repository owner accepted Phase 6 and authorized GIT-7B  | 149 |
 | [GIT-001-phase-7C1-required-ci-topology.md](GIT-001-phase-7C1-required-ci-topology.md) |  | After GIT-7B merged through PR #744, the repository owner au | 148 |
+| [GIT-001-phase-7C2-server-enforcement.md](GIT-001-phase-7C2-server-enforcement.md) |  | The owner explicitly authorized the documented GIT-7C2 setti | 93 |
+| [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |

--- a/docs/research/index.json
+++ b/docs/research/index.json
@@ -2,14 +2,14 @@
   "folder": "docs/research",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-13",
+  "last_updated": "2026-08-15",
   "file_count": 6,
   "files": [
     {
       "name": "2026-python-toolchain-report.md",
       "type": "documentation",
       "size_lines": 625,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "| Attribute | Value | |-----------|-------|",
       "content_hash": "7edf43b81123"
     },
@@ -17,7 +17,7 @@
       "name": "2026-state-of-the-art-report.md",
       "type": "documentation",
       "size_lines": 585,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "> **See also:** 2026 Python Toolchain Report for the definitive tools/versions guide. - **Learning mode**: Show formulas alongside results. \"Why is Ast = 1256 mm²?\" not just \"Ast = 1256 mm²\"",
       "content_hash": "4b3c1240fe05"
     },
@@ -25,7 +25,7 @@
       "name": "claw-code-harness-ideas.md",
       "type": "documentation",
       "size_lines": 1770,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "The claw-code repo reveals how production-grade AI agent systems wire tools, manage sessions, enforce permissions, and orchestrate multi-turn workflows. After analyzing ~40 source files, 200+ tool def",
       "content_hash": "82f22386de56"
     },
@@ -33,7 +33,7 @@
       "name": "innovation-generative-design-intelligence.md",
       "type": "documentation",
       "size_lines": 141,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "title": "Innovation: Generative Design Intelligence — Pareto-Optimal Beam Explorer with Engineering Narratives",
       "description": "Every structural engineering tool in existence today — ETABS, SAP2000, STAAD Pro, SAFE — works the same way: the engineer inputs dimensions and loads, and the software returns **one answer**. If the e",
       "content_hash": "1bb3a412bf8f"
@@ -42,7 +42,7 @@
       "name": "innovation-structural-design-companion.md",
       "type": "documentation",
       "size_lines": 176,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "title": "Innovation: The Structural Design Companion",
       "description": "Every structural engineering tool in the world — ETABS, STAAD, SAP2000, SAFE, OpenSees, SkyCiv, RFEM, PROKON — is a **calculator**. Input → output. No explanation. No reasoning. No context. Engineers ",
       "content_hash": "05a6e95b8e6d"
@@ -51,7 +51,7 @@
       "name": "innovation-sustainability-scoring.md",
       "type": "documentation",
       "size_lines": 182,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Every beam design in our library produces structural results (area of steel, utilization, safety checks) and cost estimates — but **zero information about environmental impact**. Engineers designing R",
       "content_hash": "aea35db632ce"
     }
@@ -60,8 +60,8 @@
     {
       "name": "git-governance",
       "path": "git-governance/",
-      "file_count": 14
+      "file_count": 17
     }
   ],
-  "content_hash": "b7ead3da7b195627"
+  "content_hash": "ad5b0bf189c78090"
 }

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,7 +1,7 @@
 # Research
 
 **Type:** Documentation
-**Last Updated:** 2026-08-13
+**Last Updated:** 2026-08-15
 **Files:** 6
 
 ## Documentation Files
@@ -19,4 +19,4 @@
 
 | Folder | Files | Description |
 |--------|-------|-------------|
-| [git-governance/](git-governance/) | 14 |  |
+| [git-governance/](git-governance/) | 17 |  |

--- a/run.sh
+++ b/run.sh
@@ -500,10 +500,10 @@ _cmd_generate() {
 
     case "$subcmd" in
         indexes)
-            if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+            if [[ $# -eq 0 || "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
                 _help_generate_indexes
             else
-                "$SCRIPTS/generate_all_indexes.sh" "$@"
+                "$VENV" "$SCRIPTS/generate_enhanced_index.py" "$@"
             fi
             ;;
         sdk)
@@ -538,14 +538,15 @@ Usage: ./run.sh generate <subcommand> [args]
 Generate indexes, SDKs, manifests, and scaffolds.
 
 Subcommands:
-  indexes              Regenerate all folder index.json + index.md
+  indexes              Preview or regenerate owned folder indexes
   sdk                  Generate TypeScript/Python client SDKs
   manifest             Generate/validate api-manifest.json
   docs-index           Generate docs-index.json from markdown
   scaffold <module>    Generate pytest test template for a module
 
 Examples:
-  ./run.sh generate indexes                     # Regenerate all indexes
+  ./run.sh generate indexes docs/reference --dry-run
+  ./run.sh generate indexes --all --dry-run
   ./run.sh generate sdk                         # Generate client SDKs
   ./run.sh generate scaffold structural_lib.core  # Test template
 EOF
@@ -553,10 +554,30 @@ EOF
 
 _help_generate_indexes() {
     cat <<'EOF'
-Usage: ./run.sh generate indexes
+Usage:
+  ./run.sh generate indexes <owned-folder> [options]
+  ./run.sh generate indexes --all [options]
 
-Regenerate folder index.json and index.md files using the Python runtime bound
-to the invoking worktree. This command writes generated index files.
+Preview or regenerate folder index.json and index.md files using the Python
+runtime bound to the invoking worktree.
+
+No arguments or --help shows this non-writing help. Target one owned folder by
+default; use --all explicitly for every canonical key folder.
+
+Options:
+  --dry-run            Show exact targets without writing
+  --all                Select every canonical key folder
+  --check              Check existing index hashes without writing
+  --allow-new-index    Permit intentional new index topology
+  --json-only          Generate only index.json
+  --md-only            Generate only index.md
+  --recursive          Include subfolders up to --depth (default: 3)
+
+Examples:
+  ./run.sh generate indexes docs/research/git-governance --dry-run
+  ./run.sh generate indexes docs/research/git-governance
+  ./run.sh generate indexes --all --dry-run
+  ./run.sh generate indexes --all
 EOF
 }
 


### PR DESCRIPTION
## Summary
- make no-argument index generation non-writing help
- preserve one-folder and dry-run arguments through the worktree-bound generator
- require explicit --all and add maintained acceptance coverage
- record GIT-7C2 enforcement and GIT-7D1 evidence

## Verification
- 58 focused session/generator and CI-contract tests
- strict MkDocs build
- quick gate 10/10
- full gate 30/30
- semantic Git workflow and token-efficiency checks

## Scope
GIT-7D1 only. No classifier, cleanup, deletion, release, product code, or settings mutation.