### PR TITLE
docs(git): reconcile GIT-7D cleanup evidence

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,185 @@
 
 ---
 
+## 2026-08-15 — Session: GIT-7D Cleanup and Retrospective Reconciliation
+
+**Agent:** Codex (`ops`, with two bounded read-only reviewers)
+
+**Branch:** `codex/git-cleanup-reconciliation`, created from freshly verified
+`origin/main = bf4065f071f1245461df6d3c42f1cc070efbae70`
+
+**Focus:** Complete the non-destructive preservation/disposition receipt,
+reconcile GIT-7D2 status, capture the material retrospective, and leave GIT-7E
+as the next separate packet
+
+### Summary
+
+- Read the current repository instructions and canonical Git workflow, then
+  ran the mandated session brief/start, runtime diagnosis, and worktree-aware
+  Git-state authority before mutation.
+- Refreshed `origin/main`, confirmed the delegated expected SHA `bf4065f0`, and
+  created one fresh isolated packet branch/worktree with `source_bound=true`.
+- Re-audited all local `codex/*` refs, worktrees, live remote heads, Git config,
+  repository/ruleset settings, PRs #744-#748, open PRs/issues, and the exact
+  detached `e54a` dirty evidence without cleanup or deletion.
+- Verified PRs #744-#748 were merged at their exact reviewed heads, required
+  checks passed, each squash-result tree equals its reviewed tree, and both
+  post-merge push workflows passed at every result SHA.
+- Preserved the unique semantic boundary from `e54a` on current main while
+  leaving its path, head, dirty file, blobs, patch, and diff bytes unchanged.
+- Reconciled the task board, handoff, phase ledger, GIT-7D2 receipt, disposition
+  plan, generated projections, and learning material so GIT-7D is complete and
+  GIT-7E is next.
+- Added a readable and machine-readable non-mutation receipt, a repository case
+  study, and a separately verifiable external learning addendum. No timing,
+  productivity, usage, or learning-rate trend is claimed.
+
+### Key deliverables
+
+- `docs/research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.md`
+- `docs/research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.json`
+- `docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md`
+- Reconciled `docs/TASKS.md`, `docs/planning/next-session-brief.md`, GIT-001
+  ledger/disposition records, and affected generated projections
+- External `git-study-addendum-git-7d2-cleanup-audit.md` in the existing
+  personal Git learning package
+
+### Issues encountered
+
+- The delegated audit reported 18 local `codex/*` branches and 12 worktrees,
+  while live intake before packet-lane creation found 18 and 13. Without
+  attribution, the extra worktree could look like cleanup drift.
+- Detached worktree `e54a` still carried one unique dirty session-log record at
+  pre-merge head `0fdb48ed`. Removing, attaching, copying, or normalizing it
+  would change the evidence and could lose its unique detached-session fact.
+- Same-day task/handoff/phase surfaces still said GIT-7D2 was validating after
+  PRs #747-#748 were integrated. The current date could make completed work look
+  live and cause repetition.
+- The earlier disposition plan described attached Alpha lanes and eight
+  unattached branches as retirement-ready from pre-classifier evidence. That
+  wording could turn reachability/PR facts into deletion authority without the
+  new owner, dependency, retention, freshness, and classifier gates.
+- A read-only reviewer first used an unsupported `git show-ref --remotes`
+  option and omitted the `structural_engineering_lib` subdirectory from the
+  `e54a` path; both probes stopped without mutation.
+- One parent audit command asked for primary-main status while still using the
+  packet worktree as its implicit current directory. The first output therefore
+  described the packet lane rather than primary `main`.
+- The first session-document closeout check rejected the rebuilt handoff because
+  its semantically correct `Required reading` heading did not match the exact
+  maintained `Required Reading` schema. Its rerun then exposed the separate
+  literal `| **Current** |` row contract, which the semantically equivalent
+  `Reconciled` row did not satisfy.
+- Orchestrator review found that the receipt's top-level `mutation_policy` could
+  be read as claiming the whole packet was write-free even though task-owned
+  documentation and its normal Git/PR lifecycle are authorized. The same
+  review required an explicit reporting boundary for evidence available only
+  after the packet merges.
+
+### Root causes and resolutions
+
+- Root cause: the earlier count predated the clean detached `b94c` desktop task
+  worktree. Resolution: record delegated, live-before-packet, and live-after-
+  packet counts separately; the packet itself accounts for exactly one new
+  branch and one new worktree. Evidence: canonical `git_state.py --worktrees`
+  and `git worktree list --porcelain` inventories.
+- Root cause: the GIT-7C1/GIT-7C2 evidence-producing task deliberately remained
+  detached at a prohibited-to-mutate pre-merge base, so its task-owned session
+  entry had no truthful local commit route. Most semantic content later entered
+  current main through the Phase 7C2 and session receipts, but the detached dirty
+  identity itself remained unique. Resolution: compare first, preserve only
+  that non-duplicated semantic boundary plus exact path/head/diff/blob/patch
+  identities in the current packet, and leave `e54a` byte-for-byte unchanged.
+  Evidence: 119/7 diff, working blob `2c3d7ac8`, HEAD blob `bcdd9eda`, patch ID
+  `be157118`, and binary-diff SHA-256 `cf70f18f...b4930394` remained stable.
+- Root cause: PR #748 intentionally expanded the GIT-7D2 session issue ledger
+  but did not own the task board, handoff, phase ledger, or cleanup audit. A date
+  alone was used as a freshness cue. Resolution: reconcile every current status
+  surface in one single-writer packet and bind claims to exact PR/head/merge/
+  tree/check identities. Evidence: status searches and strict docs/projection
+  checks are part of closeout.
+- Root cause: the old plan predated the inspection-only supplied-evidence
+  schema and treated attachment/reachability/merged-PR tables as sufficient to
+  request deletion approval. Resolution: downgrade every row to a hold or
+  future disposition candidate until exact owner, ref/head/time/freshness,
+  dependent-PR, retention, classifier pending-approval, and separate action
+  authorization are complete. Evidence: the no-evidence classifier receipt
+  truthfully reports `NOT_CHECKED` and `UNKNOWN`.
+- Root cause: the review packet used one Git option unavailable in the installed
+  version and shortened the actual nested worktree root. Resolution: use
+  `git for-each-ref` and the exact `/e54a/structural_engineering_lib` path.
+  Evidence: corrected read-only probes produced the independently verified
+  heads and hashes without changing state.
+- Root cause: the combined parent command relied on implicit cwd for a fact
+  that belonged to another checkout. Resolution: rerun with explicit
+  `git -C /Users/pravinsurawase/VS_code_project/structural_engineering_lib`.
+  Evidence: primary `main` is clean and `0 4` behind refreshed `origin/main`.
+- Root cause: the handoff rewrite preserved the intended meaning but did not
+  inspect the session parser's literal heading and row-label contracts.
+  Resolution: inspect the maintained parser, restore canonical
+  `## Required Reading`, and use its exact `| **Current** |` and
+  `| **Next** |` row labels before rerunning `scripts/session.py check`.
+  Evidence: the corrected session-document check passes at closeout.
+- Root cause: one packet-level key compressed the narrower cleanup/disposition
+  safety policy and the authorized publication lifecycle into a single
+  ambiguous label; a post-merge result also cannot be versioned in the
+  unchanged reviewed head that it verifies. Resolution: scope
+  `INSPECTION_ONLY` to pre-existing disposition surfaces, record normal packet
+  writes separately, mark the replay pending rather than predicting it, and
+  name the final task handoff plus GitHub PR/workflow receipts as its reporting
+  surface. Evidence: receipt schema/topic checks pass before publication, and
+  the final preservation snapshot is replayed and compared only after merge.
+
+### Verification
+
+- Worktree-bound runtime diagnosis: `source_bound=true`.
+- Local/remote/tree/PR/settings/e54a preservation facts were independently
+  reviewed and then reproduced by the parent with corrected commands.
+- Focused classifier regression: `12 passed`; semantic Git workflow: passed;
+  task, handoff, and session schemas: passed.
+- Strict documentation: all five checks passed with zero invalid frontmatters;
+  link validation checked 342 Markdown files and 1,107 internal links with zero
+  broken links. Affected projections were dry-run first, then regenerated.
+- Repository gates: quick `10/10` and full `30/30`; token-efficiency policy,
+  machine-readable receipt parsing, and `git diff --check` also passed.
+- Existing refs, worktrees, shared Git config, GitHub settings/ruleset, open
+  dependency PRs/issues, and the exact `e54a` identities matched their recorded
+  pre-write fingerprints after document writes.
+- The external learning addendum is verified separately by exact path, required
+  topic/teach-back/review markers, no trailing whitespace, and SHA-256
+  `af3d47e5263adf6406a1b0d28171932414926862d0040699e14498744a8588f1`.
+- Normal PR publication, exact diff/comment/review/thread/check/mergeability
+  inspection, unchanged-green squash merge, tree comparison, and post-merge
+  workflow receipts complete the remote verification.
+
+### Preservation and next boundary
+
+- No branch, remote ref, worktree, issue, dependency PR, setting, release, or
+  primary-main synchronization was changed by cleanup; no cleanup action ran.
+- `e54a`, `codex/git-governance-research`, Excel, Alpha policy, every attached
+  GIT lane, every existing local/remote ref, and every existing worktree remain
+  held exactly as recorded in the machine-readable receipt.
+- GIT-7E may implement indexed semantic live-guidance coherence and a durable
+  read-only task-to-Git receipt. It does not refresh remotes, mutate GitHub,
+  reclassify or execute cleanup, synchronize preserved lanes, or alter GIT-7D1/
+  GIT-7D2 behavior.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: `git show-ref --remotes` was unsupported and the first
+  reviewer probe used the parent `e54a` directory instead of its repository
+  subdirectory -> reran with `git for-each-ref` and the exact nested worktree;
+  all required read-only evidence was obtained.
+- ⚠️ TERMINAL ISSUE: the first primary-main status probe inherited the packet
+  cwd -> reran with explicit `git -C` against the validated primary path and
+  confirmed a clean worktree four commits behind `origin/main`.
+- ⚠️ TERMINAL ISSUE: `scripts/session.py check` rejected the handoff's
+  noncanonical heading capitalization, then its semantically equivalent
+  `Reconciled` row -> inspected the maintained parser, restored exact
+  `## Required Reading`, `| **Current** |`, and `| **Next** |` literals, and
+  reran the maintained session checker.
+
+
 ## 2026-08-15 — Session: GIT-7D2 Inspection-Only Branch Disposition
 
 **Agent:** Codex (`ops`)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-15 — GIT-7D1 merged through PR #746 and GIT-7D2 inspection-only branch disposition is in validation
+**Updated:** 2026-08-15 — GIT-7D complete; GIT-7D2 integrated through PRs #747-#748 and the non-destructive reconciliation leaves GIT-7E next
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7D2 IN VALIDATION — GIT-7D1 merged through PR #746; inspection-only classifier regressions pass locally; deletion and GIT-7E remain separate |
+| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | ✅ GIT-7D COMPLETE — GIT-7D2 integrated through PRs #747-#748; preservation/disposition reconciliation is non-destructive; GIT-7E is next and separate |
 
 ## Up Next
 

--- a/docs/git-automation/README.md
+++ b/docs/git-automation/README.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-09
+last_updated: 2026-08-15
 doc_type: hub
 complexity: beginner
 tags: [git, github, codex]
@@ -16,5 +16,14 @@ preserving unrelated work and respecting approval gates.
 Read [Codex-Native Git and GitHub Workflow](git-workflow-single-source.md) for
 the authoritative process, recovery boundary, verification ladder, and
 owner-approved operations.
+
+Worked learning records:
+
+- [Column PMM recovery](git-recovery-case-study-column-pmm.md) — preserve stale
+  unique work, selectively recover current-compatible intent, and verify
+  source/engineering/integration evidence separately.
+- [GIT-7D2 and cleanup audit](git-governance-case-study-git-7d2-cleanup-audit.md)
+  — bind disposition evidence to exact identities, preserve `NOT_CHECKED`, and
+  distinguish holds, future candidates, and separate deletion approvals.
 
 Historical Git-automation documents under `docs/_archive/` remain evidence only.

--- a/docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md
+++ b/docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md
@@ -1,0 +1,160 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: guide
+complexity: intermediate
+tags: [git, github, worktree, cleanup, learning]
+---
+
+# Git governance case study: GIT-7D2 and the cleanup audit
+
+## Why this case matters
+
+GIT-7D2 replaced a deletion-capable stale-branch script with an inspection-only
+classifier. The implementation was correct only after several reviews exposed
+a deeper pattern: a list of passing examples is not the same as a complete
+invariant, and fresh-looking prose is not fresh evidence.
+
+The follow-on cleanup audit deliberately deleted nothing. It tested whether the
+new evidence model could describe real retained lanes without converting
+manually gathered facts into authority. The result was a useful mix of exact
+integration receipts, preserved unknowns, owner decisions, and future
+candidates that are still not deletion-ready.
+
+## The observed state
+
+- `origin/main` was refreshed at `bf4065f0`.
+- PRs #744-#748 were merged at their exact reviewed heads, required checks were
+  green, their squash-result trees equal the reviewed trees, and both push
+  workflows passed at each merge SHA.
+- The desktop task added one clean detached worktree to the earlier audit
+  count; the packet then added one explicitly owned branch/worktree.
+- `e54a` remained detached at `0fdb48ed` with one unique dirty session-log
+  patch. Its exact blobs, patch ID, diff hash, path, and hold were recorded
+  without touching it.
+- The GIT research, Excel planning, and Alpha policy lanes remained preserved
+  for three different reasons: unique divergence, owner decision, and dual-head
+  evidence.
+- Eight other branches were unattached, remote-matching, main-reachable, and
+  linked to merged PRs. They remained future disposition candidates because
+  complete owner/PR-dependency/retention evidence and exact approval were not
+  supplied to the classifier.
+
+## Examples, invariants, and the misses
+
+| Symptom and impact | Confirmed root cause or boundary | Resolution and proof |
+|---|---|---|
+| Scenario examples passed while a configured nonstandard default branch could enter the candidate path. The default integration anchor could have been nominated. | The implementation encoded familiar examples (`main`/`master`) instead of the invariant “the branch named by `default_ref` is retained.” | Derive the branch from the supplied configured default ref. A focused regression proves both `main` and custom `develop` receive `DEFAULT_BRANCH_INTEGRATION_ANCHOR`. |
+| An `ABSENT` remote observation and “no retention” assertion looked complete without proving which target/head/time they described. A receipt could authorize the wrong identity. | Evidence presence was checked, but ref/head/time/freshness binding was incomplete. | Require exact target ref for present or absent remote evidence and fresh, target-head-bound PR/retention evidence. Mismatch, stale, future, missing, or failed evidence becomes `UNKNOWN`. |
+| The semantic check passed after executable names changed, but a live agent guide still promised deletion. A later agent could restore the retired behavior. | The static checker used a hand-maintained surface/token list; replacement searched command strings but not headings and prose. | Search the full maintained guidance surface for semantic deletion claims. GIT-7E must own indexed live-surface selection; GIT-7D2 does not broaden that checker here. |
+| A same-day handoff still said “in validation” after PR #748 was on `main`. Intake could repeat completed work despite a current date. | Calendar freshness and lifecycle freshness were conflated; the handoff was not bound to exact branch/head/PR/check/merge identities. | Reconcile the board, handoff, phase ledger, projections, and session record together. GIT-7E must make identity-bound handoff data durable. |
+| Detached `e54a` carried a unique dirty session record that current indexed guidance did not name. Removing the worktree could destroy the only copy. | The evidence-producing session stayed on a deliberately non-mutated detached pre-merge lane, and no durable task-to-Git receipt existed. | Record exact path, head, diff stats, working/HEAD blobs, patch ID, diff hash, and preservation hold on current `main`; do not attach, checkout, stage, copy, reset, stash, or remove `e54a`. |
+| Closeout commands guessed two test filenames, one index-checker filename, and a positional classifier selector. Required evidence stopped before collection. | Descriptive labels and remembered signatures were treated as maintained paths/CLI schema. | Discover with `rg --files`, repository find commands, and `--help`. Correct paths and `--branch` selector passed the intended gates. |
+| A malformed GraphQL query failed, but a later semicolon-separated command made the composite shell command look successful. Review-thread evidence could have been falsely reported. | Semicolon sequencing returned the final command's status; the query was manually composed with unbalanced braces. | Run required hosted-evidence queries standalone or in a fail-fast chain and validate their output shape before using it. The corrected query reported zero threads at the unchanged PR head. |
+| Independent review found the configured-default and evidence-binding defects late in closeout. Rework occurred after the first “done” narrative. | Review was scheduled after implementation examples rather than before the stable invariant was declared complete. | Use a bounded read-only reviewer before the full gate for outcome-changing evidence contracts; the parent still verifies and writes the final surfaces. |
+| After squash merge, feature branches were `HOLD_DIVERGED` even though their content was integrated. An ancestry-only cleanup would either repeat work or erase evidence. | Squash creates a new commit identity. Reachability, patch identity, and tree identity answer different questions. | Bind PR reviewed head and merge SHA, compare trees/patches, verify integrated workflows, and retain attached or evidence-bearing lanes until separate disposition. |
+| The personal learning package explained detached state and squash, but not the GIT-7D2 receipt schema. The implementation lesson lagged behind the repository control. | Learning-artifact update was not part of the earlier closeout definition. No timing trend can be inferred from one lag event. | Add one separately verifiable study addendum with evidence identity, `NOT_CHECKED`, default refs, schema discovery, teach-back, and 1/3/7-day prompts. |
+| A zsh probe lost command lookup after assigning to `path`. Later evidence commands became unavailable. | In zsh, lowercase `path` is tied to `PATH`; it is not an ordinary scratch variable. | Use names such as `target_path` or `marker_target`. Run each evidence command from an explicit worktree root. |
+| A review script queried `.branches` in classifier output and could silently see an empty set. | The same noun appears in two different schemas: caller evidence uses `.branches`; classifier receipts return `.targets`. | Inspect `--help` and one real JSON sample. Use `.targets[]` for receipt output and reserve `.branches` for the supplied evidence input. |
+
+## Example tests versus invariants
+
+An example asks whether a named case works:
+
+```text
+main is held
+dirty branch is held
+open-PR branch is held
+```
+
+An invariant asks what must remain true for every configuration:
+
+```text
+branch(default_ref) is always held
+failed_or_unbound_evidence always becomes UNKNOWN
+age never changes authority
+classifier execution never mutates Git, GitHub, config, refs, or worktrees
+```
+
+Both are necessary. Examples make failures understandable; invariants prevent a
+new name, configured default, or evidence variant from bypassing the rule.
+
+## Evidence identity and freshness
+
+Treat remote or hosted evidence as a tuple, not a sentence:
+
+```text
+(target ref, target head, observed_at_utc, freshness status, query outcome)
+```
+
+`NOT_CHECKED` is truthful evidence about what did not happen. It is never a
+synonym for absent, current, merged, clean, or safe. A locally cached
+`origin/*` ref can support local graph comparison, but it cannot be represented
+as a fresh remote observation unless the caller actually refreshed it.
+
+## Schema and shell discovery card
+
+```bash
+# Discover the maintained script and CLI contract.
+rg --files scripts Python/tests | rg 'branch_disposition|git_state'
+./scripts/python_runtime.sh scripts/classify_branch_disposition.py --help
+
+# Receipt output uses .targets.
+./scripts/python_runtime.sh scripts/classify_branch_disposition.py \
+  --branch codex/example --json | jq '.targets[]'
+
+# The caller-supplied evidence file uses .branches.
+jq '.branches["codex/example"]' refreshed-evidence.json
+```
+
+For required external queries, prefer standalone commands or `&&`/explicit
+exit checking. Do not use a later success to mask an earlier failure. In zsh,
+never use `path` as a scratch variable because it changes `PATH`.
+
+## Cleanup disposition ladder
+
+```text
+observed fact
+  -> identity-bound evidence
+  -> classifier disposition
+  -> RETIREMENT_READY_PENDING_APPROVAL (only if complete)
+  -> separate exact local / remote / worktree approvals
+  -> same-session reinspection
+  -> one approved action
+  -> post-action receipt
+```
+
+At any unknown, dirty, attached, operation, divergence, open/dependent PR,
+unique-work, or retention state, stop. A candidate table is a work queue, not
+deletion authority.
+
+## Teach-back
+
+1. Why does `NOT_CHECKED` prevent a retirement-ready result even if `git
+   status` is clean?
+2. How would you prove the configured default branch is protected without
+   naming `main` or `master` in the rule?
+3. Which identities must an absent-remote observation carry?
+4. Why can a squash-integrated branch be both `HOLD_DIVERGED` and fully
+   integrated?
+5. Why was `e54a` summarized on current `main` instead of copied, attached, or
+   committed in place?
+6. Which JSON path is input (`.branches`) and which is output (`.targets`)?
+7. How can a semicolon-separated shell sequence produce a false green story?
+8. What belongs to GIT-7E, and what would accidentally reimplement cleanup?
+
+## 1/3/7-day review
+
+- **Day 1:** From memory, write the evidence tuple and explain `NOT_CHECKED`.
+  Run `--help`, then identify `.branches` and `.targets` in their correct roles.
+- **Day 3:** Draw the squash graph for PR #747 and explain why equal trees do
+  not authorize deletion of an attached worktree. Add the configured-default
+  invariant using `develop`.
+- **Day 7:** Given `e54a`, Excel, the Alpha policy lane, and one unattached
+  merged branch, classify which facts are known, unknown, owner-gated, or
+  approval-gated. Teach the full disposition ladder without using age or
+  cleanliness as authority.
+
+This review schedule is a learning aid. It makes no claim about elapsed task
+time, token use, productivity trend, or improvement rate.

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 3974,
+      "size_lines": 4153,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "80ac9af8d8e1"
+      "content_hash": "087e19d4bf0c"
     },
     {
       "name": "TASKS.md",
@@ -30,7 +30,7 @@
       "last_updated": "2026-08-15",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "ac20133de083"
+      "content_hash": "27d1451f78d4"
     },
     {
       "name": "WORKLOG.md",
@@ -130,7 +130,7 @@
     {
       "name": "git-automation",
       "path": "git-automation/",
-      "file_count": 3,
+      "file_count": 4,
       "description": "owner: Main Agent"
     },
     {
@@ -197,7 +197,7 @@
     {
       "name": "research",
       "path": "research/",
-      "file_count": 26
+      "file_count": 28
     },
     {
       "name": "specs",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "ab72b4c1b4af571c"
+  "content_hash": "444516192dd8a896"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 3974 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4153 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
@@ -34,7 +34,7 @@ Guides, references, evidence, and contributor material for the
 | [cookbook/](cookbook/) | 5 | Task-focused recipes and code snippets for common structural engineering workflo |
 | [developers/](developers/) | 6 | > **For developers building on top of the structural_engineering_lib platform** |
 | [getting-started/](getting-started/) | 21 | Quick onboarding guides for new users of the structural engineering library. |
-| [git-automation/](git-automation/) | 3 | owner: Main Agent |
+| [git-automation/](git-automation/) | 4 | owner: Main Agent |
 | [governance/](governance/) | 1 |  |
 | [guidelines/](guidelines/) | 18 |  |
 | [guides/](guides/) | 11 | End-user and developer guides for specific workflows. |
@@ -46,6 +46,6 @@ Guides, references, evidence, and contributor material for the
 | [planning/](planning/) | 19 |  |
 | [publications/](publications/) | 11 | This directory contains blog posts, technical articles, and academic papers docu |
 | [reference/](reference/) | 1792 |  |
-| [research/](research/) | 26 |  |
+| [research/](research/) | 28 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
 | [verification/](verification/) | 17 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -2,14 +2,14 @@
   "folder": "docs/planning",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-13",
+  "last_updated": "2026-08-15",
   "file_count": 17,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 154,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "title": "Planning",
       "description": "Internal planning documents and research notes. | Document | Purpose |",
       "content_hash": "56281c1a3fd2"
@@ -18,7 +18,7 @@
       "name": "adoption-trust-surface-plan.md",
       "type": "documentation",
       "size_lines": 380,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Make the released Alpha straightforward to evaluate from four perspectives: - a user can copy every public quick start and receive the documented result;",
       "content_hash": "ce4b11ed46d5"
     },
@@ -26,7 +26,7 @@
       "name": "compact-modernization-plan.md",
       "type": "documentation",
       "size_lines": 794,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Modernize the repository's CI, maintenance controls, and agent-facing workflow without changing the structural-engineering product outcome. The finished repository must have:",
       "content_hash": "b0efe5bf80fd"
     },
@@ -34,7 +34,7 @@
       "name": "democratization-vision.md",
       "type": "documentation",
       "size_lines": 273,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "> **\"What was not possible few years back, or only possible for big firms — now everyone can use them free.\"** This project is not just about building a structural engineering library. It's about **de",
       "content_hash": "248d22c61e51"
     },
@@ -42,7 +42,7 @@
       "name": "dependency-security-baseline.md",
       "type": "documentation",
       "size_lines": 69,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "This record makes MAINT-003 reproducible. It separates confirmed vulnerabilities from transferred-environment residue and records every temporary exception.",
       "content_hash": "7870e2a5028a"
     },
@@ -50,7 +50,7 @@
       "name": "etabs-killer-masterplan.md",
       "type": "documentation",
       "size_lines": 2855,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "title": "Project BHEEM: Open-Source Structural Design Software Masterplan",
       "description": "> **BHEEM** — **B**uilding **H**olistic **E**ngineering **E**nvironment with **M**achine-intelligence > An open-source, AI-native structural design platform that aims to surpass ETABS in usability, tr",
       "content_hash": "88e3dfd24f78"
@@ -59,7 +59,7 @@
       "name": "gpt-5-3-codex-spark-work-program.md",
       "type": "documentation",
       "size_lines": 614,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Use GPT-5.3-Codex-Spark as a high-throughput implementation lane for small, explicit, rapidly verifiable tasks. The program targets truthful documentation,",
       "content_hash": "4160ef25ca5e"
     },
@@ -67,7 +67,7 @@
       "name": "is456-library-first-master-plan.md",
       "type": "documentation",
       "size_lines": 1497,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "The Python package is the product. FastAPI, React, command-line workflows, reports, ETABS adapters, and future integrations are consumers of that product.",
       "content_hash": "3c22c1017a09"
     },
@@ -75,7 +75,7 @@
       "name": "is456-solid-slabs-master-plan.md",
       "type": "documentation",
       "size_lines": 1123,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "The next element program will complete a useful, evidence-backed solid-slab workflow under IS 456 without pretending to solve every slab system.",
       "content_hash": "bcd3ec19ce4d"
     },
@@ -83,7 +83,7 @@
       "name": "library-expansion-blueprint-v5.md",
       "type": "documentation",
       "size_lines": 1139,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "title": "Library Expansion Blueprint v5.0 — Multi-Code, Multi-Element",
       "description": "> Master plan for expanding structural_engineering_lib from single-code beam-only (IS 456) to multi-code (IS 456, ACI 318-19, EC2), multi-element (beam, column, slab, footing, wall, stair) with comple",
       "content_hash": "ead8ebc9e2eb"
@@ -92,7 +92,7 @@
       "name": "memory.md",
       "type": "documentation",
       "size_lines": 411,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "- Development resumed after a four-month pause and a Mac laptop → Mac Mini transfer. - Git history, reachable objects, sample data, package source, and ARM64 Python environment transferred intact.",
       "content_hash": "78a539f85b53"
     },
@@ -100,24 +100,24 @@
       "name": "next-phase-improvements-plan.md",
       "type": "documentation",
       "size_lines": 1445,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "> This document is a result of a full audit of the beam library, FastAPI layer, and React app. > Nothing here assumes — it traces every suggestion back to what already exists and what is missing.",
       "content_hash": "9be9935445ee"
     },
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 120,
-      "last_updated": "2026-08-13",
+      "size_lines": 127,
+      "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
-      "description": "<!-- HANDOFF:START --> - Date: 2026-08-13",
-      "content_hash": "a7c78a4306ea"
+      "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
+      "content_hash": "db1ff9e73568"
     },
     {
       "name": "pre-release-checklist.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "title": "Pre-Release Checklist",
       "description": "Release-ready source metadata: 0.23.1a1 Current public release: v0.23.1a1 Alpha",
       "content_hash": "aa14481f9a4b"
@@ -126,7 +126,7 @@
       "name": "professional-library-remediation-plan.md",
       "type": "documentation",
       "size_lines": 562,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "title": "Professional Library Remediation Plan",
       "description": "This document is no longer the active implementation plan. T0 and R1-R8 are complete, and their findings, packet definitions, and verification remain here",
       "content_hash": "31095ffcf998"
@@ -135,7 +135,7 @@
       "name": "react-ux-improvement-plan.md",
       "type": "documentation",
       "size_lines": 709,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "> **Historical implementation record.** Execution status in this document is > superseded by",
       "content_hash": "706c92bd3f7a"
     },
@@ -143,11 +143,11 @@
       "name": "ui-experience-foundation-master-plan.md",
       "type": "documentation",
       "size_lines": 2408,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "The product will move from a collection of equally weighted pages to one compact, professional structural workbench.",
       "content_hash": "fc8042fee46a"
     }
   ],
   "subfolders": [],
-  "content_hash": "ede530059fb55595"
+  "content_hash": "e1e1a15512855ef6"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -1,7 +1,7 @@
 # Planning
 
 **Type:** Documentation
-**Last Updated:** 2026-08-13
+**Last Updated:** 2026-08-15
 **Files:** 17
 
 ## Documentation Files
@@ -20,7 +20,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-13 | 120 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 127 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,139 +4,123 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: GIT-7D1 integrated; GIT-7D2 inspection-only branch disposition in exact-head validation
+- Focus: GIT-7D complete and non-destructively reconciled; GIT-7E semantic guidance and durable handoff is next
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha
 
-**Integrated GIT-7C1 receipt:** PR #745 merged as `729cc41b`; refresh `main` before work
-
-**Integrated GIT-7D1 receipt:** PR #746 merged as `ff6c919c`; refresh `main` before work
+**Refreshed GIT-7D anchor:** `origin/main = bf4065f071f1245461df6d3c42f1cc070efbae70`
 
 **Task board:** [TASKS.md](../TASKS.md)
 
 | State | Target | Decision |
 |---|---|---|
-| **Complete** | GIT-7C1 and GIT-7C2 | Required CI merged; main now requires PR plus strict `PR Gate`, has no bypass actor, retains deletion/non-fast-forward protection, permits merge/squash, and disables rebase |
-| **Current** | GIT-7D2 branch disposition | Deletion-oriented cleanup is replaced by a fail-closed, inspection-only classifier; focused scenarios pass |
-| **Next** | GIT-7D2 exact-head integration | Require Control Plane, Documentation, Repository, and aggregate `PR Gate` outcomes at the unchanged head |
-| **Held** | Cleanup/deletion and GIT-7E | Deletion remains a separate exact-target approval/action; durable handoff is a separate packet |
-| **Parallel owner decision** | Excel planning lane | Confirm a named active owner/next action or approve retirement |
-| **Approval-gated** | Alpha worktrees and merged branches | Exact evidence is ready; deletion still requires explicit target approval |
-| **Separate maintenance** | Seven dependency PRs | Replace one-by-one merging with four current-base compatibility packets |
+| **Complete** | GIT-7B, GIT-7C, and GIT-7D | State kernel, exact-head CI/server enforcement, targeted generation, and inspection-only disposition are integrated |
+| **Complete** | GIT-7D2 | PR #747 merged as `0a784de5`; closeout lessons PR #748 merged as `bf4065f0`; both reviewed/merge trees were equal |
+| **Current** | Preservation/disposition audit | GIT-7D is reconciled without deletion or cleanup; every attached, dirty, diverged, dual-head, owner-unresolved, and incomplete-evidence lane remains held |
+| **Next** | GIT-7E | Semantic live-guidance coherence and durable read-only task-to-Git handoff receipt only |
+| **Owner decision** | Excel planning lane | Name an active owner/next action or separately authorize a complete retirement assessment |
+| **Separate maintenance** | Seven dependency PRs | Do not close or merge the existing Dependabot PRs in GIT-001 |
 
 ## Required Reading
 
-1. [Reconciled future-work and disposition plan](../research/git-governance/GIT-001-next-agent-disposition-plan.md)
-2. [GIT-001 research index](../research/git-governance/GIT-001-README.md)
-3. [Official evidence register](../research/git-governance/GIT-001-official-evidence-register.md)
-4. [Lifecycle research](../research/git-governance/GIT-001-lifecycle-research.md)
-5. [Phase 2 incident register](../research/git-governance/GIT-001-phase-2-incident-register.md)
-6. [Phase 3 gap/risk matrix](../research/git-governance/GIT-001-phase-3-gap-risk-matrix.md)
-7. [Phase 4 operating-model proposal](../research/git-governance/GIT-001-phase-4-operating-model.md)
-8. [Phase 5 scenario validation](../research/git-governance/GIT-001-phase-5-scenario-validation.md)
-9. [Phase 6 canonical-policy proposal](../research/git-governance/GIT-001-phase-6-canonical-policy-proposal.md)
-10. [Phase 7B implementation receipt](../research/git-governance/GIT-001-phase-7B-state-intake-kernel.md)
-11. [Phase 7C1 required CI topology](../research/git-governance/GIT-001-phase-7C1-required-ci-topology.md)
-12. [Phase 7C2 server enforcement](../research/git-governance/GIT-001-phase-7C2-server-enforcement.md)
-13. [Phase 7D1 targeted index generation](../research/git-governance/GIT-001-phase-7D1-targeted-index-generation.md)
-14. [Phase 7D2 branch disposition](../research/git-governance/GIT-001-phase-7D2-branch-disposition.md)
-15. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
-16. [AI token-efficiency policy](../guidelines/ai-token-efficiency.md)
+1. [Phase 7D cleanup reconciliation](../research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.md)
+2. [Machine-readable preservation receipt](../research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.json)
+3. [GIT-001 research and phase ledger](../research/git-governance/GIT-001-README.md)
+4. [Phase 7D2 branch disposition](../research/git-governance/GIT-001-phase-7D2-branch-disposition.md)
+5. [Reconciled future disposition plan](../research/git-governance/GIT-001-next-agent-disposition-plan.md)
+6. [GIT-7D2 cleanup-audit case study](../git-automation/git-governance-case-study-git-7d2-cleanup-audit.md)
+7. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
+8. [Phase 5 GIT-7E acceptance](../research/git-governance/GIT-001-phase-5-scenario-validation.md)
 
-## Start command
+## Start commands
 
 ```bash
-./run.sh task brief "validate GIT-7D2 inspection-only branch disposition at the exact PR head"
 ./run.sh session brief --agent ops
 ./run.sh session start
+./scripts/python_runtime.sh --diagnose
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
 
-Then refresh and inspect the branch, upstream, worktree, diff, current PR, and
-all linked worktrees before mutation. The dated handoff is evidence, not a
-replacement for live inspection.
+Refresh and verify `origin/main` before relying on this handoff. Create a fresh
+`codex/<task-slug>` branch/worktree from verified current main for separately
+authorized GIT-7E work. Do not extend, reset, rebase, merge into, or reconcile a
+preserved squash-diverged lane.
 
-## Current Git facts
+## Verified current Git facts
 
-- GIT-7C1 PR #745 was independently reviewed at `c3edd247`, squash-merged as
-  `729cc41b`, tree-equivalent to the reviewed head, and both post-merge main
-  workflows passed.
-- Active ruleset `11390214` now requires PRs and strict `PR Gate`, retains
-  deletion/non-fast-forward protection, and has no bypass actor. Merge and
-  squash remain enabled; rebase is disabled; branch deletion remains disabled.
-- GIT-7D1 reproduced the preferred-generator defect, reversed only 31
-  generator-created paths, and routes folder/`--dry-run` arguments to the
-  worktree-bound maintained generator. PR #746 integrated it as `ff6c919c`.
-- GIT-7D2 replaces the former fetch/prune/age/deletion path with a local
-  inspection-only classifier. Ref/PR freshness is caller-supplied and SHA-bound;
-  errors and `NOT_CHECKED` hold as `UNKNOWN`; age is metadata only.
-- The dedicated GIT-001 branch was synchronized without history rewriting at
-  `54a03557`; its tree exactly matched `origin/main = 69d9f68c`, its quick gate
-  passed 10/10, and the merge was fast-forward pushed to its existing remote.
-- Phase 1 covers the required Git, GitHub, release/dependency/contributor, and
-  Codex lifecycle facts. Product guarantees for task snapshots, managed-
-  worktree cleanup, and task-to-task Git handoff remain explicitly unresolved.
-- Column PMM preservation, selective recovery, independent benchmark,
-  integration, closeout, and learning update are complete through PRs #738-#740.
-  Historical remote refs remain evidence; PMM remains experimental.
-- PR #723 is closed without merge. Its useful behavior was selectively rebuilt
-  through PRs #736-#737. Use #723 as incident evidence, not a merge target.
-- Excel planning has no unique commit, remote feature branch, or PR. Git supports
-  retirement, but task ownership still needs an owner decision.
-- Three merged Alpha worktrees are clean and retirement-ready after explicit
-  approval. They occupy roughly 651 MB, mainly old `node_modules`.
-- Eight unattached merged local branches, not seven, now have exact PR and main
-  reachability receipts. Local and remote deletion require separate approval.
-- All seven remaining Dependabot PRs are behind current `main`; their old green
-  checks are stale for integration.
+- PRs #744-#748 are merged at their exact reviewed heads with successful
+  `PR Gate`. Each reviewed-head tree equals its squash-result tree, and both
+  `PR Validation` and `Validate Documentation` passed after every merge.
+- GIT-7D1 is integrated through PR #746. GIT-7D2 is integrated through PRs
+  #747-#748. The old deletion-oriented route is absent; the classifier remains
+  local, inspection-only, fail-closed, and non-authorizing.
+- The clean primary `main` worktree remains at `0fdb48ed`, four commits behind
+  refreshed `origin/main = bf4065f0`. Synchronizing it was outside the packet.
+- The delegated prior audit counted 18 local `codex/*` branches and 12
+  worktrees. Live intake found 18 and 13 because the clean detached `b94c`
+  desktop task worktree existed; the authorized reconciliation lane alone made
+  the task totals 19 and 14.
+- Active ruleset `11390214` still requires a PR and strict `PR Gate`, protects
+  deletion/non-fast-forward, has no bypass actor, allows merge/squash, and
+  excludes rebase. Repository branch deletion after merge remains disabled.
+- The only pre-existing open PRs are Dependabot #683, #684, and #713-#717.
+  There are no open issues. None was changed by the audit.
 
-## Phase 1 through Phase 3 result
+## Preservation and disposition holds
 
-The evidence register dispositions are complete and the factual lifecycle map
-covers normal, parallel, integration, release, cleanup, and recovery paths.
-Two independent read-only reviews passed after local claims were explicitly
-labeled and bound to dated observation evidence. Phase 1 changed no canonical
-policy, GitHub setting, hook, cleanup behavior, or release state. Phase 2 now
-adds ten evidence-backed incident families with main-process impact, confirmed
-or explicit unconfirmed root causes, unsafe reactions, recovery, and proof.
-Phase 3 adds thirteen outcome-changing gaps. Phase 4 maps them into
-state/intake, publication/server enforcement, generated-data/cleanup, and
-guidance/handoff control planes, with the read-only state kernel first. Phase 5
-reproduces the current abnormal-state defects and defines falsifiable packet
-gates. The owner accepted Phase 6 and authorized GIT-7B on 2026-08-13. The
-read-only kernel integrated through PR #744 as `0fdb48ed`. GIT-7C1 then
-integrated through PR #745 as `729cc41b`; the owner authorized and the agent
-applied the exact GIT-7C2 server delta with guarded rollback and postcondition
-checks. GIT-7D1 integrated through PR #746. GIT-7D2 is the current
-inspection-only disposition packet; GIT-7E remains separate. No cleanup,
-deletion, recovery, or release mutation is authorized.
+- Detached `e54a` at `0fdb48ed` still has exactly one dirty path,
+  `docs/SESSION_LOG.md` (119 insertions, 7 deletions; patch ID `be157118`;
+  binary-diff SHA-256 begins `cf70f18f`). Preserve it byte-for-byte. Do not
+  attach, checkout, stage, copy, reset, stash, clean, or remove it.
+- `codex/git-governance-research` remains attached at local `65703736`, differs
+  from remote `51a8a57a`, and contains three locally unique patches. Preserve.
+- `codex/excel-product-planning` remains attached at `a0e115e1`, has no feature
+  remote or PR, and needs an owner decision. Git evidence cannot make it
+  deletion-ready.
+- `codex/release-preflight-alpha-policy` remains attached at local `5da9c66a`
+  while its remote is `20180a40`. Both are integrated, but the dual-head lane is
+  separate preserved evidence.
+- GIT-7B, GIT-7C1, GIT-7D1, GIT-7D2, GIT-7D2 lessons, Alpha closeout, and Alpha
+  integration branches remain attached worktree holds even where integration
+  evidence is complete.
+- Eight other local branches are unattached, remote-matching, main-reachable,
+  and linked to merged PRs. They are future disposition candidates only; owner,
+  dependent-PR, retention, classifier, and separate exact-approval gates remain.
+- Running the classifier without a supplied evidence receipt truthfully reports
+  `remote_freshness=NOT_CHECKED` and `UNKNOWN`. Never translate manually
+  gathered facts into deletion authority.
+
+## GIT-7E exact boundary
+
+GIT-7E must prove:
+
+1. every live indexed instruction rejects retired command and flag fixtures;
+2. archive/historical exclusions are explicit rather than accidental;
+3. branch, head, upstream, default base, tree, and operation identity survives
+   session handoff;
+4. remote, PR, reviewed-head, and required-check fields are exact or explicitly
+   unknown;
+5. task/transcript archive state is never represented as Git retention proof;
+6. aliases resolve maintained commands without permitting obsolete mutations.
+
+GIT-7E does not refresh remote state, mutate GitHub, change disposition logic,
+authorize cleanup/deletion, synchronize preserved lanes, modify GIT-7D1/7D2
+behavior, publish a release, or change product code. It requires separate owner
+authorization before implementation.
 
 ## Destructive-action holds
 
-- Do not remove Excel until the owner decides whether the planning task is active.
-- Do not remove Alpha worktrees until the owner approves the three exact paths.
-- Do not delete local or remote branches without an exact refreshed table and
-  explicit approval for that deletion scope.
-- Stop if a lane becomes dirty, attached unexpectedly, diverged, conflicted, or
-  gains new commits/PR activity. Never reset, clean, stash, rebase, or force-push
-  as a shortcut around uncertain ownership.
-
-## Dependency grouping
-
-- Python typing: PRs #715 and #717 together.
-- ESLint 10: PRs #713 and #683 together.
-- React build: hold #684 for coordinated Vite/toolchain compatibility.
-- Node types: hold #714 while repository runtime remains Node 24.
-- Motion: #716 can be an independent current-base frontend task.
-
-Each group gets a fresh worktree, a compatibility hypothesis, targeted checks,
-the complete relevant gate, and exact-head CI. Do not merge the seven old PRs
-as unrelated updates.
+- No branch, remote ref, or worktree deletion is authorized.
+- No prune, reset, rebase, stash/drop, clean, force push, or primary-main sync.
+- A future action needs a same-session refresh, complete identity-bound evidence,
+  `RETIREMENT_READY_PENDING_APPROVAL`, separate exact local/remote/worktree
+  authorization, immediate drift recheck, and post-action receipt.
 
 ## Session closeout
 
-Run the quick gate and the full relevant gate once at closeout. Record every
-material issue as symptom, impact, confirmed root cause, solution, and evidence
-in the newest `docs/SESSION_LOG.md` entry. Preserve shared-surface ownership:
-session/task records, generated indexes, registries, routes, manifests, and
-lockfiles have one writer at a time.
+Discover maintained tests/scripts with `rg --files`. Run focused checks, the
+semantic Git check, strict docs, quick gate, full gate once stable, session end,
+and `git diff --check`. Record every material issue with symptom/impact, root
+cause or explicit unconfirmed boundary, resolution, and proving evidence in the
+newest task-owned `docs/SESSION_LOG.md` entry.

--- a/docs/research/git-governance/GIT-001-README.md
+++ b/docs/research/git-governance/GIT-001-README.md
@@ -18,9 +18,10 @@ policy.
 The current normative policy is
 [`docs/git-automation/git-workflow-single-source.md`](../../git-automation/git-workflow-single-source.md)
 and now includes the owner-accepted GIT-7B read-only state/intake contract.
-GIT-7C1 is integrated, GIT-7C2 server enforcement is applied, and GIT-7D1 is
-integrated through PR #746. GIT-7D2 owns inspection-only branch disposition;
-GIT-7E remains separate.
+GIT-7C1 is integrated, GIT-7C2 server enforcement is applied, and GIT-7D is
+complete: GIT-7D1 integrated through PR #746, while GIT-7D2 integrated through
+PRs #747-#748 and has a non-destructive preservation/disposition reconciliation.
+GIT-7E semantic guidance and durable handoff remain the next separate packet.
 
 ## Objective
 
@@ -49,7 +50,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 | 4 | Operating-model design | Complete as proposal | Four control planes, one typed state model, lane lifecycle, permissions, CI/server policy, recovery, and four packets defined |
 | 5 | Scenario validation | Complete for proposal | Disposable Git and live read-only checks reproduce current defects, validate primitives, and define falsifiable GIT-7B–7E gates |
 | 6 | Canonical policy proposal | Accepted 2026-08-13 | Owner accepted the operating model and authorized GIT-7B only |
-| 7 | Controlled implementation | 7A–7D1 complete; GIT-7D2 implementation in validation | GIT-7D1 merged through PR #746; the deletion-oriented cleanup path is replaced by an inspection-only, fail-closed classifier |
+| 7 | Controlled implementation | 7A-7D complete; GIT-7E next | GIT-7D2 merged through PRs #747-#748; non-destructive cleanup reconciliation preserves every held lane and makes no deletion-ready claim without complete evidence |
 | 8 | Adoption and closeout | Not started | Integrated workflow verified; supersession and maintenance established |
 
 ## Artifact map
@@ -69,6 +70,8 @@ work, make recovery deterministic, and remain efficient during normal work.
 - [Phase 7C2 server enforcement](GIT-001-phase-7C2-server-enforcement.md)
 - [Phase 7D1 targeted index generation](GIT-001-phase-7D1-targeted-index-generation.md)
 - [Phase 7D2 inspection-only branch disposition](GIT-001-phase-7D2-branch-disposition.md)
+- [Phase 7D cleanup reconciliation](GIT-001-phase-7D-cleanup-reconciliation.md)
+- [Phase 7D machine-readable preservation receipt](GIT-001-phase-7D-cleanup-reconciliation.json)
 - Phase 7E durable handoff — planned
 - Phase 8 adoption/closeout report — planned
 

--- a/docs/research/git-governance/GIT-001-next-agent-disposition-plan.md
+++ b/docs/research/git-governance/GIT-001-next-agent-disposition-plan.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-12
+last_updated: 2026-08-15
 doc_type: reference
 task: GIT-001
 ---
@@ -21,31 +21,35 @@ workflow remains
 
 ## Snapshot and reading rule
 
-- Live refresh and inspection date: `2026-08-12`.
-- Refreshed integration anchor: `main = origin/main = 951f5e1d`.
-- The primary worktree was clean when inspected.
-- All five linked worktrees were clean when inspected.
+- Original plan inspection date: `2026-08-12`; current disposition claims are
+  superseded by the 2026-08-15 Phase 7D cleanup reconciliation.
+- Refreshed 2026-08-15 integration anchor: `origin/main = bf4065f0`; the clean
+  primary `main` worktree remains intentionally four commits behind at
+  `0fdb48ed`.
+- The current worktree inventory includes preserved dirty detached evidence;
+  never reuse the older “all linked worktrees clean” observation as live proof.
 - Ahead/behind counts below are commit-graph facts only. Squash integration is
   checked separately with patch equivalence, PR receipts, and main reachability.
-- “Ready to retire” means the evidence packet is complete enough to request the
-  owner's destructive-action approval. It does not itself authorize removal.
+- Older “ready to retire” wording in this plan is not a current classifier
+  result. The current gate is complete identity-bound evidence followed by
+  `RETIREMENT_READY_PENDING_APPROVAL` and separate exact-target approval.
 
 ## Outcome first: the revised order
 
 The old list mixed completed recovery with future work. The current order is:
 
-1. **Synchronize and continue GIT-001 Phase 1 research.** The active research
-   lane is clean but behind current `main`; bring current receipts into view,
-   finish official-source coverage, then write the factual lifecycle map.
+1. **Preserve the diverged GIT-001 research lane.** Phases 1-7D are integrated;
+   the local research head now carries unique evidence relative to its remote,
+   so a future continuation must use a fresh current-main lane.
 2. **Decide Excel planning ownership.** It has no unique commits and no PR, so
-   one owner decision determines whether it remains active or becomes a safe
-   retirement candidate.
-3. **Retire the three merged Alpha worktrees after explicit approval.** Their
-   exact heads are preserved and reachable; this is the largest immediate disk
-   recovery, roughly 650 MB.
-4. **Prepare and execute a separately approved branch-cleanup packet.** The old
-   count of seven is stale; eight unattached merged local branches are now
-   verified candidates. Local and remote deletion are separate decisions.
+   one owner decision determines whether it remains active or may enter a
+   separately evidenced retirement assessment.
+3. **Preserve the three attached Alpha worktrees pending a complete refreshed
+   disposition and exact approval.** Treat the dual-head Alpha policy lane
+   separately; no current deletion-ready claim is made.
+4. **Keep eight unattached merged branches as future disposition candidates.**
+   Their merge/reachability facts are refreshed, but owner, dependent-PR,
+   retention, classifier, and exact-approval gates remain incomplete.
 5. **Handle the seven remaining dependency PRs as four coordinated tasks.** Do
    not merge old, behind Dependabot branches one by one.
 
@@ -57,10 +61,10 @@ They stay in the completed ledger below so a future agent does not repeat them.
 | Original priority | Current result | Updated disposition |
 |---|---|---|
 | 1 — protect unique PMM work | Complete and superseded by safe integration | Keep remote forensic refs; no Git recovery action remains |
-| 2 — complete Phase 1 and study PR #723 | PR #723 study/recovery complete; Phase 1 incomplete | Continue only the remaining official research and lifecycle map |
-| 3 — decide Excel ownership | Still open | Make this the first ownership decision after research-lane synchronization |
-| 4 — retire merged Alpha worktrees | Evidence now complete; no deletion performed | Request exact approval, then retire in a controlled sequence |
-| 5 — branch cleanup packet for seven branches | Count changed from seven to eight | Publish the refreshed table and obtain separate local/remote approval |
+| 2 — complete Phase 1 and study PR #723 | Complete; lifecycle research and selective recovery are integrated | Preserve the diverged research lane; do not synchronize or rewrite it |
+| 3 — decide Excel ownership | Still open | Ask for a named owner/next action before any retirement assessment |
+| 4 — retire merged Alpha worktrees | Historical integration evidence exists; all remain attached and the policy lane is dual-head | Preserve; rerun complete disposition before requesting any exact action |
+| 5 — branch cleanup packet for seven branches | Count changed from seven to eight | Keep as future candidates until the classifier receives complete evidence and returns pending approval |
 | 6 — dependency maintenance | Still open; all seven PRs are behind `main` | Replace one-by-one merging with four tested compatibility packets |
 
 ## Completed ledger — do not repeat
@@ -111,78 +115,37 @@ silently import obsolete architecture.
 
 | Worktree / branch | Head | Relation to current `main` | Disposition |
 |---|---:|---|---|
-| Primary / `main` | `951f5e1d` | Exact `origin/main` | Clean integration anchor |
-| GIT-001 / `codex/git-governance-research` | `3be4790d` | 1 commit ahead, 6 behind by ancestry; patch already squash-integrated | Active; synchronize before continuing |
-| Excel / `codex/excel-product-planning` | `a0e115e1` | 0 ahead, 59 behind; head is ancestor of main | Ownership decision required |
-| Alpha closeout / `codex/alpha-0231-release-closeout` | `127afb64` | 0 ahead, 12 behind; ancestor of main | Retirement-ready after approval |
-| Alpha integration / `codex/alpha-0231-integration` | `e3b9a6cb` | 0 ahead, 30 behind; ancestor of main | Retirement-ready after approval |
-| Alpha policy / `codex/release-preflight-alpha-policy` | `5da9c66a` | Local head is ancestor of main | Retirement-ready after dual-head receipt |
+| Primary / `main` | `0fdb48ed` | Clean; four commits behind refreshed `origin/main = bf4065f0` | Preserve integration anchor; no synchronization in this packet |
+| GIT-001 / `codex/git-governance-research` | `65703736` | Local differs from remote `51a8a57a`; three locally unique patches | Preserve diverged evidence unchanged |
+| Excel / `codex/excel-product-planning` | `a0e115e1` | 67 behind; no feature remote or PR | Attached; ownership decision required |
+| Alpha closeout / `codex/alpha-0231-release-closeout` | `127afb64` | Matching remote; ancestor of main | Attached hold; complete evidence and approval required |
+| Alpha integration / `codex/alpha-0231-integration` | `e3b9a6cb` | Matching remote; ancestor of main | Attached hold; complete evidence and approval required |
+| Alpha policy / `codex/release-preflight-alpha-policy` | `5da9c66a` | Local differs from remote `20180a40`; both integrated | Preserve attached dual-head evidence separately |
 
 The GIT-001 branch looks “ahead” only because its research commit was
 squash-merged. `git cherry origin/main codex/git-governance-research` reports
 `- 3be4790d`, which means an equivalent patch already exists on `main`. This is
 why ahead/behind alone cannot decide integration or cleanup.
 
-## Priority 1 — synchronize and complete GIT-001 Phase 1
+## Priority 1 — preserve completed GIT-001 evidence and start fresh
 
-### Why this is first
+### Current state
 
-GIT-001 is the active governance program. Its research lane predates the PMM
-and PR #723 closeouts, so continuing without synchronization would cause the
-agent to repeat old facts or contradict current receipts. The lane is clean,
-published, and shared; preserving its history is preferable to silently
-replacing it.
+GIT-001 Phases 1-7D are complete through the integrated research, state,
+enforcement, generator, classifier, and reconciliation receipts. The local
+`codex/git-governance-research` head is now `65703736`, differs from remote
+`51a8a57a`, and has three locally unique patches relative to refreshed `main`.
+That exact lane is historical evidence, not the next write lane.
 
-### Recommended lane action
+### Required continuation rule
 
-1. Refresh `origin` and prove the GIT-001 worktree is clean, attached to
-   `codex/git-governance-research`, and exactly at its upstream head.
-2. Verify again that `3be4790d` is patch-equivalent to work already on `main`.
-3. Merge refreshed `origin/main` into the research branch. Do not rebase or
-   force-push the shared research branch.
-4. If the merge conflicts, stop and classify each conflict against the current
-   Phase 7A and PMM receipts. Do not choose “ours” or “theirs” across the tree.
-5. Run the documentation and quick gates, commit only deliberate reconciliation
-   edits if required, and push without history rewriting.
-
-If the existing lane has become unavailable or externally owned, create a
-fresh `codex/git-governance-phase1-continuation` worktree from current `main`
-and record the old branch as predecessor. Do not have two writers in the same
-research directory.
-
-### Research scope after synchronization
-
-Complete the open coverage listed in
-[`GIT-001-official-evidence-register.md`](GIT-001-official-evidence-register.md):
-
-- commits, branches, upstreams, fetch, pull, and push;
-- merge, rebase, cherry-pick, revert, reset, restore, stash, and clean;
-- hooks, configuration scope, pruning, garbage collection, and worktree repair;
-- tags, signatures, release ancestry, submodules, shallow and partial clones;
-- GitHub merge methods, merge queue/auto-merge, rulesets and branch protection,
-  environments, releases, Dependabot, forks, and external contributors;
-- verified Codex task/worktree lifecycle, archival, snapshot, and handoff facts.
-
-Then write one source-backed factual map for normal work, parallel work,
-integration, release, cleanup, and recovery. Label every statement as external
-fact, project observation, unresolved choice, or not applicable.
-
-### Non-goals
-
-- Do not change canonical Git policy, GitHub settings, hooks, or cleanup rules.
-- Do not delete historical branches or worktrees during research.
-- Do not advance to Phase 2 merely because a source list is long; each open
-  area must be covered, declared not applicable, or explicitly unresolved.
-- Treat PR #723 and the PMM incident as Phase 2 inputs, not as permission to
-  rewrite policy during Phase 1.
-
-### Acceptance evidence
-
-- Research worktree clean and current with its remote before mutation.
-- Current `origin/main` integrated without history rewriting.
-- Evidence register has no silent coverage gaps.
-- Factual lifecycle map exists and separates facts from decisions.
-- Phase 1 coverage review explicitly passes before Phase 2 begins.
+1. Preserve the existing research branch/worktree and remote ref unchanged.
+2. Refresh and verify `origin/main` in an existing checkout.
+3. Create a fresh `codex/<task-slug>` worktree from the verified current main.
+4. Recover only explicitly scoped current-compatible facts when needed; do not
+   extend, merge into, reset, rebase, or reconcile the preserved research lane.
+5. Keep GIT-7E limited to semantic live-guidance and durable read-only handoff
+   acceptance. Cleanup/deletion remains a separate exact-target workflow.
 
 ## Priority 2 — decide Excel planning ownership
 
@@ -221,13 +184,13 @@ Stop if the worktree becomes dirty, an operation marker exists, a new remote or
 PR appears, the task owner says it is active, or branch-only commits appear.
 Never stash, reset, clean, or copy files out as an implicit retirement method.
 
-## Priority 3 — retire merged Alpha worktrees after approval
+## Priority 3 — preserve and reassess merged Alpha worktrees
 
-### Why they are now retirement-ready
+### Historical integration evidence and current hold
 
-All three Alpha worktrees are clean. Their meaningful heads have exact PR and
-main-reachability receipts. Together they occupy about 651 MB; approximately
-418 MB is the old Alpha candidate's `react_app/node_modules`.
+All three Alpha worktrees were clean when refreshed and their meaningful heads
+retain PR/main-reachability evidence. They remain attached, so none is a branch-
+deletion candidate. Disk size is context only and cannot change disposition.
 
 | Worktree | Local head | Remote/PR evidence | Main evidence | Approx. size |
 |---|---:|---|---|---:|
@@ -240,53 +203,56 @@ to its own remote branch, but it is not lost or unintegrated because that exact
 commit is reachable from current `main`. Record both heads; do not “fix” the
 old remote by rewriting it.
 
-### Approved execution sequence
+### Prerequisites before any future execution proposal
 
-After the owner explicitly approves these exact three paths:
+Before asking the owner about any exact path:
 
 1. Refresh and repeat the clean/head/attachment/reachability checks.
-2. Retire Alpha closeout first because it reclaims the most space.
-3. Retire Alpha integration second.
-4. Retire Alpha policy last, preserving the dual-head receipt in the handoff.
-5. For each lane, remove the worktree before deleting its local branch.
-6. Verify the remaining worktree inventory and primary clean state after every
-   removal. Stop on the first unexpected result.
-7. Leave remote branches untouched until the separate branch-cleanup approval.
+2. Supply exact owner, remote-ref, PR/dependency, retention, and freshness
+   evidence to the inspection-only classifier.
+3. Require `RETIREMENT_READY_PENDING_APPROVAL`; every other result remains a
+   hold.
+4. Keep Alpha policy separate and retain both local and remote heads.
+5. Obtain separate exact approval for worktree, local branch, and remote branch
+   actions. No approval is granted by this plan.
 
 Use Git's worktree removal for the validated exact worktree, not a recursive
 filesystem deletion. Do not prune first, because pruning is not a substitute
 for proving or removing the actual worktree.
 
-## Priority 4 — branch-cleanup approval packet
+## Priority 4 — future branch-disposition packet
 
 ### Updated candidate count
 
-The original count of seven is obsolete. Eight unattached local branches are
-exact ancestors of current `origin/main`, have matching remote heads, and have
-merged PR receipts:
+The original count of seven is obsolete. Eight unattached local branches were
+refreshed on 2026-08-15 as exact ancestors of `origin/main`, with matching
+remote heads and merged PR receipts. Those facts make them future disposition
+candidates, not deletion-ready targets:
 
 | Local branch | Head | Merged PR | Local decision | Remote decision |
 |---|---:|---:|---|---|
-| `codex/alpha-0231-candidate-evidence` | `adb161b8` | #732 | Awaiting approval | Awaiting approval |
-| `codex/ci-fastapi-load-lane-fix` | `21b9df1f` | #729 | Awaiting approval | Awaiting approval |
-| `codex/column-rectangular-e2e` | `007dfa0c` | #725 | Awaiting approval | Awaiting approval |
-| `codex/footing-isolated-v1` | `886871ae` | #727 | Awaiting approval | Awaiting approval |
-| `codex/gpt-5-3-spark-work-program` | `6cd22dcb` | #734 | Awaiting approval | Awaiting approval |
-| `codex/is456-beam-primary-route` | `aa4fe606` | #726 | Awaiting approval | Awaiting approval |
-| `codex/is456-slabs-closeout` | `d79a1558` | #724 | Awaiting approval | Awaiting approval |
-| `codex/is456-slabs-plan` | `7e623984` | #728 | Awaiting approval | Awaiting approval |
+| `codex/alpha-0231-candidate-evidence` | `adb161b8` | #732 | Evidence incomplete | Evidence incomplete |
+| `codex/ci-fastapi-load-lane-fix` | `21b9df1f` | #729 | Evidence incomplete | Evidence incomplete |
+| `codex/column-rectangular-e2e` | `007dfa0c` | #725 | Evidence incomplete | Evidence incomplete |
+| `codex/footing-isolated-v1` | `886871ae` | #727 | Evidence incomplete | Evidence incomplete |
+| `codex/gpt-5-3-spark-work-program` | `6cd22dcb` | #734 | Evidence incomplete | Evidence incomplete |
+| `codex/is456-beam-primary-route` | `aa4fe606` | #726 | Evidence incomplete | Evidence incomplete |
+| `codex/is456-slabs-closeout` | `d79a1558` | #724 | Evidence incomplete | Evidence incomplete |
+| `codex/is456-slabs-plan` | `7e623984` | #728 | Evidence incomplete | Evidence incomplete |
 
 Before seeking approval, refresh every row for worktree attachment, local/remote
-head identity, main reachability, PR state, and new activity. A branch becoming
-attached, advancing, diverging, or gaining an open PR removes it from the batch.
+head identity, main reachability, PR state/dependencies, owner, retention, and
+new activity, then run the maintained classifier with that exact evidence. A
+branch becoming attached, advancing, diverging, gaining an open/dependent PR,
+or carrying a retention hold remains outside any action batch.
 
 ### Why the cleanup script did not list them
 
-The dry-run `cleanup_stale_branches.py` reported no stale branches because its
-current selection is age-oriented and remote-oriented with a minimum-age rule.
-That output does not prove that recently merged, unattached local branches do
-not exist. For this packet, the authoritative evidence is the explicit
-worktree/ref/reachability/PR table above.
+The historical `cleanup_stale_branches.py` result is superseded. The maintained
+`classify_branch_disposition.py` performs local inspection only and preserves
+`NOT_CHECKED`/missing supplied evidence as `UNKNOWN`. The explicit table above
+is an audit queue, not authorization and not a substitute for its complete
+identity-bound receipt.
 
 ### Approval and execution rules
 
@@ -294,8 +260,9 @@ worktree/ref/reachability/PR table above.
   other.
 - Delete only the exact approved rows and only after a same-session refresh.
 - Local deletion follows worktree-detachment proof.
-- Remote deletion uses the maintained cleanup workflow and a reviewed dry run;
-  do not issue an ad hoc remote-delete command.
+- No repository cleanup workflow performs deletion. After a pending-approval
+  receipt and explicit exact authorization, Codex performs only the approved
+  native Git action and records it.
 - Preserve a receipt containing branch name, local head, remote head, PR,
   reachability result, approval scope, action result, and post-action inventory.
 - Do not include GIT-001, Excel, Alpha attached branches, PMM forensic refs, or
@@ -341,18 +308,20 @@ session/task records are single-writer surfaces.
 
 1. Read `AGENTS.md`, this packet, the GIT-001 index, evidence register, and
    lifecycle research.
-2. Run `./run.sh task brief "continue GIT-001 Phase 1 official research"`.
+2. Run `./run.sh session brief --agent ops`, `./run.sh session start`, and the
+   worktree-bound runtime/state diagnostics.
 3. Refresh refs, inspect all worktrees read-only, and compare the result with
    this dated snapshot. Record drift; do not normalize it away.
-4. Take ownership of exactly one write lane. The preferred first lane is the
-   existing GIT-001 research worktree after clean/upstream verification.
-5. Synchronize the research lane with current `main` using a normal merge; stop
-   and classify if conflicts appear.
-6. Complete the official-source register and factual lifecycle map.
-7. Ask the owner the single Excel ownership question while research proceeds:
+4. For authorized GIT-7E work, create exactly one fresh current-main write lane;
+   do not reuse the preserved GIT research lane.
+5. Keep GIT-7E to semantic live-guidance coverage and the durable read-only
+   handoff receipt. It does not refresh remotes or authorize cleanup.
+6. Ask the owner the single Excel ownership question when disposition work is
+   separately resumed:
    “Is the Excel planning task still active with a named next action?”
-8. Do not delete Alpha lanes or branches until exact-target approval is given.
-9. At handoff, record issues, confirmed root causes, solutions, and command/test
+7. Do not delete Alpha lanes or branches until a complete pending-approval
+   receipt and separate exact-target approval exist.
+8. At handoff, record issues, confirmed root causes, solutions, and command/test
    evidence in the newest `docs/SESSION_LOG.md` entry.
 
 ## Maintained script guide
@@ -399,7 +368,8 @@ disposition. No single script answers the ownership and recoverability question.
 
 This plan is fulfilled when:
 
-- Phase 1 coverage and the factual lifecycle map pass review;
+- Phases 1-7D remain integrated and their preserved evidence is not reopened or
+  reconciled without new authorization;
 - Excel has a named active owner/next action or an approved retirement receipt;
 - the three Alpha worktrees are either explicitly retained or safely retired
   under exact approval;

--- a/docs/research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.json
+++ b/docs/research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.json
@@ -1,0 +1,205 @@
+{
+  "schema_version": 1,
+  "receipt_id": "GIT-001-7D-CLEANUP-RECONCILIATION-2026-08-15",
+  "task": "GIT-001",
+  "phase": "7D-closeout",
+  "cleanup_disposition_mutation_policy": "INSPECTION_ONLY",
+  "cleanup_disposition_mutation_policy_scope": "PRE_EXISTING_BRANCH_REF_WORKTREE_AND_GITHUB_DISPOSITION_ACTIONS_ONLY",
+  "packet_documentation_and_git_lifecycle": "NORMAL_AUTHORIZED_WRITES",
+  "cleanup_actions_performed": [],
+  "authorization": {
+    "normal_packet_git_lifecycle": "AUTHORIZED",
+    "branch_deletion": "NOT_AUTHORIZED",
+    "remote_ref_deletion": "NOT_AUTHORIZED",
+    "worktree_removal": "NOT_AUTHORIZED",
+    "settings_change": "NOT_AUTHORIZED",
+    "git_7e_implementation": "NOT_IN_SCOPE"
+  },
+  "observation": {
+    "started_at_utc": "2026-08-15T06:52:07Z",
+    "audit_completed_at_utc": "2026-08-15T07:00:18Z",
+    "default_ref": "refs/remotes/origin/main",
+    "default_sha": "bf4065f071f1245461df6d3c42f1cc070efbae70",
+    "remote_freshness": "REFRESHED_BY_CALLER",
+    "classifier_without_supplied_evidence": {
+      "remote_freshness": "NOT_CHECKED",
+      "status": "UNKNOWN",
+      "mutation_policy": "INSPECTION_ONLY",
+      "authorization": "SEPARATE_EXACT_TARGET_APPROVAL_REQUIRED"
+    }
+  },
+  "packet_lane": {
+    "branch": "codex/git-cleanup-reconciliation",
+    "start_sha": "bf4065f071f1245461df6d3c42f1cc070efbae70",
+    "worktree": "/Users/pravinsurawase/.codex/worktrees/git-cleanup-reconciliation",
+    "source_bound": true
+  },
+  "count_reconciliation": {
+    "delegated_prior_audit": {
+      "local_codex_branches": 18,
+      "worktrees": 12
+    },
+    "live_before_packet_lane": {
+      "local_codex_branches": 18,
+      "worktrees": 13,
+      "difference": "clean detached b94c desktop task worktree"
+    },
+    "live_after_packet_lane": {
+      "local_codex_branches": 19,
+      "worktrees": 14,
+      "difference": "authorized packet branch and worktree only"
+    }
+  },
+  "preservation_blockers": [
+    {
+      "target": "/Users/pravinsurawase/.codex/worktrees/e54a/structural_engineering_lib",
+      "branch": "DETACHED",
+      "head_sha": "0fdb48edbb73114288feb8a246d6f30b80ac4d95",
+      "dirty_paths": ["docs/SESSION_LOG.md"],
+      "insertions": 119,
+      "deletions": 7,
+      "working_blob_sha1": "2c3d7ac8277953256c7c46d12b923180a99f9c14",
+      "head_blob_sha1": "bcdd9edaba84e920bb01f140d9a7301ae6f40a8d",
+      "stable_patch_id": "be157118f0267af328051ffbacc18d79c49ffd8c",
+      "binary_diff_sha256": "cf70f18f57ea3c7e14c85fe06cdd00d0171ac65da42dce08eef6a286b4930394",
+      "decision": "PRESERVE_BYTE_FOR_BYTE"
+    },
+    {
+      "target": "codex/git-governance-research",
+      "local_head": "657037364bbb49f2ef834c70f3a3c704bac83c7b",
+      "remote_head": "51a8a57a7e4eaba5841f2fee86c83ae6287182bf",
+      "unique_patch_count": 3,
+      "attached": true,
+      "decision": "PRESERVE_DIVERGED_EVIDENCE"
+    },
+    {
+      "target": "codex/excel-product-planning",
+      "local_head": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
+      "remote_head": null,
+      "pull_requests": [],
+      "attached": true,
+      "decision": "OWNER_DECISION_REQUIRED"
+    },
+    {
+      "target": "codex/release-preflight-alpha-policy",
+      "local_head": "5da9c66a0f962fc08a6431fe95e39ec664a353f6",
+      "remote_head": "20180a40137cb43f8a4d8f51093c6337ac94ced1",
+      "attached": true,
+      "decision": "PRESERVE_DUAL_HEAD_EVIDENCE"
+    }
+  ],
+  "attached_integrated_worktrees": [
+    {"branch": "codex/git-7b-state-kernel", "head": "5c22cc05f1ed42139a54ff3a4072b8dc62a1e1ae", "pr": 744, "merge": "0fdb48edbb73114288feb8a246d6f30b80ac4d95", "tree": "30036fe6df7dbc9f034220b524624b1e2dc5e6c4"},
+    {"branch": "codex/git-7c-ci-enforcement", "head": "c3edd24783df0f14efe1854f411dbc6735b44f40", "pr": 745, "merge": "729cc41bfb68e1381ddf3125d6365f40d9ff8738", "tree": "33d94f67834ea8cc669f73678022e89a927c0b02"},
+    {"branch": "codex/git-7d1-index-routing", "head": "f156f9341a195a76da3f95b82b0340f7d2ff532f", "pr": 746, "merge": "ff6c919cca92964c11711b3f2b8648baaded80df", "tree": "7403239db5ae397eb5d26cfdddc8ac935ef2d9e5"},
+    {"branch": "codex/git-7d2-disposition-classifier", "head": "8742061604f75ad0807cb012a1192ebf997143bf", "pr": 747, "merge": "0a784de5cd519b661105846c4dfb2cf5bac51928", "tree": "c6f4a6f7f65eaf3561ab226a2e9b28dfd6436eae"},
+    {"branch": "codex/git-7d2-session-lessons", "head": "cb2750b9f2c0eaf2cbecff33f3ed09db1b82585e", "pr": 748, "merge": "bf4065f071f1245461df6d3c42f1cc070efbae70", "tree": "2b8e3cdb32e342c43a41af98e868c717feaca646"},
+    {"branch": "codex/alpha-0231-release-closeout", "head": "127afb64c52c0cac6cb3a90d0fe68fef3883b49c", "pr": 733, "decision": "ATTACHED_HOLD"},
+    {"branch": "codex/alpha-0231-integration", "head": "e3b9a6cbc35c3d4da9fbbdff975f92b88eec0c61", "pr": 730, "decision": "ATTACHED_HOLD"}
+  ],
+  "unattached_merged_branches": [
+    {"branch": "codex/alpha-0231-candidate-evidence", "head": "adb161b85489f530b42e78abd7039e59160c83d6", "pr": 732},
+    {"branch": "codex/ci-fastapi-load-lane-fix", "head": "21b9df1fd0d655d5976f73b8672502da4a6fbc60", "pr": 729},
+    {"branch": "codex/column-rectangular-e2e", "head": "007dfa0c012404515907779f396ed94cf7a6694d", "pr": 725},
+    {"branch": "codex/footing-isolated-v1", "head": "886871aef93d9a955a3cc2fa613fe49bad589ce7", "pr": 727},
+    {"branch": "codex/gpt-5-3-spark-work-program", "head": "6cd22dcbd073b599e4a2faef80352b294295f32e", "pr": 734},
+    {"branch": "codex/is456-beam-primary-route", "head": "aa4fe606ee685240648c88db75e0d1052350fcb4", "pr": 726},
+    {"branch": "codex/is456-slabs-closeout", "head": "d79a1558a0cfa5078f6ddea91c4166100bdc4d04", "pr": 724},
+    {"branch": "codex/is456-slabs-plan", "head": "7e623984e027141fff62e5129c23fdc16264f8e0", "pr": 728}
+  ],
+  "unattached_branch_common_facts": {
+    "attached": false,
+    "local_matches_live_remote": true,
+    "reachable_from_refreshed_main": true,
+    "merged_pr_head_matches": true,
+    "decision": "FUTURE_DISPOSITION_CANDIDATE_NOT_DELETION_READY",
+    "missing_authority": ["fresh owner evidence", "fresh dependent PR evidence", "fresh retention evidence", "classifier pending-approval receipt", "separate exact-target approval"]
+  },
+  "github": {
+    "repository_settings": {
+      "default_branch": "main",
+      "allow_squash_merge": true,
+      "allow_merge_commit": true,
+      "allow_rebase_merge": false,
+      "delete_branch_on_merge": false,
+      "allow_auto_merge": false,
+      "allow_update_branch": false
+    },
+    "ruleset": {
+      "id": 11390214,
+      "enforcement": "active",
+      "bypass_actors": [],
+      "required_check": "PR Gate",
+      "strict": true,
+      "pull_request_required": true,
+      "allowed_merge_methods": ["merge", "squash"],
+      "deletion_protected": true,
+      "non_fast_forward_protected": true
+    },
+    "open_pull_requests": [
+      {"number": 683, "author": "app/dependabot", "head": "dependabot/npm_and_yarn/react_app/eslint/js-10.0.1"},
+      {"number": 684, "author": "app/dependabot", "head": "dependabot/npm_and_yarn/react_app/vitejs/plugin-react-6.0.5"},
+      {"number": 713, "author": "app/dependabot", "head": "dependabot/npm_and_yarn/react_app/eslint-10.8.0"},
+      {"number": 714, "author": "app/dependabot", "head": "dependabot/npm_and_yarn/react_app/types/node-26.1.2"},
+      {"number": 715, "author": "app/dependabot", "head": "dependabot/pip/Python/mypy-gte-1.19-and-lt-3"},
+      {"number": 716, "author": "app/dependabot", "head": "dependabot/npm_and_yarn/react_app/framer-motion-13.0.0"},
+      {"number": 717, "author": "app/dependabot", "head": "dependabot/pip/mypy-2.3.0"}
+    ],
+    "open_issues": []
+  },
+  "immutability_fingerprints": {
+    "scope_note": "Packet branch/worktree excluded. The post-merge comparison will also exclude remote main and the packet branch because those refs belong to the authorized packet lifecycle.",
+    "before": {
+      "existing_local_codex_refs_sha256": "6dcfd5853293a33a2211d5a23fbf3004269a0435f88787cd70ec4701f3263f15",
+      "existing_remote_heads_sha256": "97d6dbb0c6c7d0950929ff43510a4370ddef42f7c4079b9ca189d27a23129524",
+      "existing_worktrees_sha256": "ae52e05f1a3c773367c292c348bd2fc12547ebda229a16a97e4801c9e971ff79",
+      "shared_local_config_sha256": "d03fbabe033dd7b2b5cf51ecc387a082bcf581db3c2009160d368b57f8710c0f",
+      "repository_settings_sha256": "47dd5a3a2a59ca1625b3d4dc38375ae003cd3dd5b77a06013e0b9ef69dfbca49",
+      "ruleset_sha256": "6e87df64b40e392eeff554a8cc158dd2e48da97fe8bd515b23464985c9a01a45",
+      "open_pr_identities_sha256": "db573efcc17e3f18559ba21f85cac28ebe59b16a9be52cac41b228b54877ac3a",
+      "open_issue_identities_sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+    },
+    "after_document_writes": {
+      "existing_local_codex_refs_sha256": "6dcfd5853293a33a2211d5a23fbf3004269a0435f88787cd70ec4701f3263f15",
+      "existing_remote_heads_sha256": "97d6dbb0c6c7d0950929ff43510a4370ddef42f7c4079b9ca189d27a23129524",
+      "existing_worktrees_sha256": "ae52e05f1a3c773367c292c348bd2fc12547ebda229a16a97e4801c9e971ff79",
+      "shared_local_config_sha256": "d03fbabe033dd7b2b5cf51ecc387a082bcf581db3c2009160d368b57f8710c0f",
+      "repository_settings_sha256": "47dd5a3a2a59ca1625b3d4dc38375ae003cd3dd5b77a06013e0b9ef69dfbca49",
+      "ruleset_sha256": "6e87df64b40e392eeff554a8cc158dd2e48da97fe8bd515b23464985c9a01a45",
+      "open_pr_identities_sha256": "db573efcc17e3f18559ba21f85cac28ebe59b16a9be52cac41b228b54877ac3a",
+      "open_issue_identities_sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
+      "e54a_working_blob_sha1": "2c3d7ac8277953256c7c46d12b923180a99f9c14",
+      "e54a_stable_patch_id": "be157118f0267af328051ffbacc18d79c49ffd8c",
+      "e54a_binary_diff_sha256": "cf70f18f57ea3c7e14c85fe06cdd00d0171ac65da42dce08eef6a286b4930394"
+    }
+  },
+  "post_merge_replay": {
+    "status": "PENDING_UNTIL_PACKET_INTEGRATION",
+    "versioning_boundary": "A result produced after merge cannot be committed into the unchanged reviewed head that it verifies.",
+    "reporting_surface": "Final Codex task handoff plus the GitHub pull request merge and post-merge workflow receipt.",
+    "required_comparison": [
+      "pre-existing local codex refs excluding the packet branch",
+      "live remote heads excluding main and the packet branch",
+      "pre-existing worktrees excluding the packet worktree",
+      "shared local Git config excluding packet-branch tracking",
+      "e54a exact dirty evidence identities",
+      "repository settings and ruleset",
+      "seven pre-existing Dependabot PR identities and open issues"
+    ]
+  },
+  "deletion_approval_prerequisites": [
+    "same-session remote and target refresh",
+    "worktree-aware local reinspection",
+    "exact owner, ref, head, time, freshness, PR dependency, and retention evidence",
+    "reviewed-head and merge patch or tree comparison for squash histories",
+    "RETIREMENT_READY_PENDING_APPROVAL classifier result",
+    "separate exact approval for local branch, remote branch, and worktree",
+    "immediate pre-action drift check",
+    "exact post-action inventory"
+  ],
+  "next_boundary": {
+    "packet": "GIT-7E",
+    "scope": "semantic live-guidance coherence and durable read-only task-to-Git handoff receipt",
+    "not_authorized_here": ["remote refresh implementation", "GitHub mutation", "cleanup classification changes", "cleanup or deletion", "preserved lane synchronization"]
+  }
+}

--- a/docs/research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.md
+++ b/docs/research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.md
@@ -1,0 +1,205 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: reference
+task: GIT-001
+phase: 7D-closeout
+---
+
+# GIT-001 Phase 7D — Non-Destructive Cleanup Reconciliation
+
+## Outcome and authority boundary
+
+GIT-7D is complete as an inspection and control packet. GIT-7D1 targeted index
+generation is integrated through PR #746. GIT-7D2 inspection-only branch
+disposition is integrated through PR #747, with its closeout lessons integrated
+through PR #748.
+
+This reconciliation performed no cleanup or disposition mutation. Its
+`INSPECTION_ONLY` policy is scoped to pre-existing branches, refs, worktrees,
+and GitHub disposition actions; it does not describe the whole packet as
+write-free. The packet intentionally writes only task-owned documentation and
+uses its authorized normal branch, commit, push, PR, and unchanged-green merge
+lifecycle. It did not delete, remove, attach, checkout, stage, commit, reset,
+stash, rebase, prune, or rewrite any pre-existing branch, ref, or worktree. It
+did not close or merge a dependency PR, close an issue, change GitHub settings,
+publish a release, synchronize the primary `main` worktree, or implement
+GIT-7E.
+
+The companion machine-readable receipt is
+[`GIT-001-phase-7D-cleanup-reconciliation.json`](GIT-001-phase-7D-cleanup-reconciliation.json).
+The normalized fingerprint comparison in that receipt excludes the packet's
+authorized branch/worktree. Its post-merge replay will also exclude remote
+`main` and the packet branch because those ref changes belong to the normal
+packet lifecycle; it does not claim that replay or merge has already occurred.
+
+## Evidence identity
+
+| Field | Observed value |
+|---|---|
+| Live observation started | `2026-08-15T06:52:07Z` |
+| Refreshed default ref | `refs/remotes/origin/main` |
+| Refreshed default SHA | `bf4065f071f1245461df6d3c42f1cc070efbae70` |
+| Fresh packet branch | `codex/git-cleanup-reconciliation` |
+| Fresh packet start SHA | `bf4065f071f1245461df6d3c42f1cc070efbae70` |
+| Packet worktree | `/Users/pravinsurawase/.codex/worktrees/git-cleanup-reconciliation` |
+| Runtime identity | `source_bound=true` |
+| Classifier without supplied evidence | `remote_freshness=NOT_CHECKED`; all inspected targets held as `UNKNOWN` |
+| Mutation policy | `INSPECTION_ONLY` |
+| Retirement authorization | `SEPARATE_EXACT_TARGET_APPROVAL_REQUIRED` |
+
+The delegated audit described 18 local `codex/*` branches and 12 worktrees.
+Live inspection before creating the packet lane found the same 18 branches but
+13 worktrees because the desktop task's clean detached `b94c` worktree already
+existed. Creating this authorized fresh lane raised only the task-owned totals
+to 19 branches and 14 worktrees. No pre-existing branch or worktree explains
+that attributable increase.
+
+## Preservation blockers
+
+### Detached `e54a` session evidence
+
+The worktree at
+`/Users/pravinsurawase/.codex/worktrees/e54a/structural_engineering_lib` remains
+detached at `0fdb48edbb73114288feb8a246d6f30b80ac4d95` with exactly one dirty
+path, `docs/SESSION_LOG.md`.
+
+| Identity | Exact value |
+|---|---|
+| Diff size | 119 insertions, 7 deletions |
+| Working-file blob | `2c3d7ac8277953256c7c46d12b923180a99f9c14` |
+| HEAD blob | `bcdd9edaba84e920bb01f140d9a7301ae6f40a8d` |
+| Stable patch ID | `be157118f0267af328051ffbacc18d79c49ffd8c` |
+| Binary-diff SHA-256 | `cf70f18f57ea3c7e14c85fe06cdd00d0171ac65da42dce08eef6a286b4930394` |
+| Disposition | Preserve byte-for-byte; detached, dirty, and owner-unresolved hold |
+
+Current `main` already contains the PR #745 reviewed-head, merge/tree,
+post-merge workflow, ruleset normalization, guarded rollback, and applied
+GIT-7C2 facts in the Phase 7C2 receipt and current session log. The unique
+semantic fact retained here without copying the whole dirty narrative is that
+the evidence-producing session remained on a prohibited-to-mutate detached
+pre-merge lane; its task-owned log could not be truthfully committed there, so
+the quick/session closeout held instead of discarding or relocating it. This
+exact identity and preservation hold is now durable without touching `e54a`.
+
+### Other exact preservation holds
+
+| Target | Live identity | Why it remains held |
+|---|---|---|
+| `codex/git-governance-research` | local `657037364bbb49f2ef834c70f3a3c704bac83c7b`; remote `51a8a57a7e4eaba5841f2fee86c83ae6287182bf` | Attached and diverged; classifier reports three locally unique patches and no complete supplied disposition evidence |
+| `codex/excel-product-planning` | local `a0e115e17009cc14b3d883e3c291d47c32f7ca4e`; no remote feature ref; no PR | Attached; Git cannot decide whether the external planning task is active; owner decision required |
+| `codex/release-preflight-alpha-policy` | local `5da9c66a0f962fc08a6431fe95e39ec664a353f6`; remote `20180a40137cb43f8a4d8f51093c6337ac94ced1` | Attached and dual-head; local commit is integrated into `main` but remains different from its feature remote; preserve separately |
+| Primary `main` worktree | clean at `0fdb48edbb73114288feb8a246d6f30b80ac4d95`, four commits behind refreshed `origin/main` | Integration anchor hold; primary-main synchronization was not authorized or needed |
+
+## Attached integrated worktrees
+
+An attached worktree is not a branch-deletion candidate. These exact lanes are
+integrated but remain attached and retained:
+
+| Branch | Head | Integration evidence | Current disposition |
+|---|---:|---|---|
+| `codex/git-7b-state-kernel` | `5c22cc05` | PR #744 -> `0fdb48ed`; equal tree `30036fe6` | Attached hold |
+| `codex/git-7c-ci-enforcement` | `c3edd247` | PR #745 -> `729cc41b`; equal tree `33d94f67` | Attached hold |
+| `codex/git-7d1-index-routing` | `f156f934` | PR #746 -> `ff6c919c`; equal tree `7403239d` | Attached hold |
+| `codex/git-7d2-disposition-classifier` | `87420616` | PR #747 -> `0a784de5`; equal tree `c6f4a6f7` | Attached hold |
+| `codex/git-7d2-session-lessons` | `cb2750b9` | PR #748 -> `bf4065f0`; equal tree `2b8e3cdb` | Attached hold |
+| `codex/alpha-0231-release-closeout` | `127afb64` | matching remote; PR #733 merged; ancestor of current `main` | Attached hold; complete evidence and exact approval still required |
+| `codex/alpha-0231-integration` | `e3b9a6cb` | matching remote; PR #730 merged; ancestor of current `main` | Attached hold; complete evidence and exact approval still required |
+
+All applicable checks for PRs #744-#748, including `PR Gate`, passed at their
+unchanged reviewed heads. Each merge result has an equal tree to its reviewed
+head. Both push workflows, `PR Validation` and `Validate Documentation`, passed
+at each resulting `main` SHA. Squash tree equivalence proves integration; it
+does not override attachment or authorize retirement.
+
+## Unattached merged branches
+
+Eight pre-existing local branches are unattached, match their live remote
+heads, are ancestors of refreshed `origin/main`, and retain merged PR receipts.
+They are **future disposition candidates**, not deletion-ready claims: this
+packet did not supply the classifier with fresh owner, PR-dependency, and
+retention evidence for an exact pending-approval receipt.
+
+| Branch | Exact head | Merged PR | Current decision |
+|---|---:|---:|---|
+| `codex/alpha-0231-candidate-evidence` | `adb161b85489f530b42e78abd7039e59160c83d6` | #732 | Hold for complete same-session evidence and exact approval |
+| `codex/ci-fastapi-load-lane-fix` | `21b9df1fd0d655d5976f73b8672502da4a6fbc60` | #729 | Hold for complete same-session evidence and exact approval |
+| `codex/column-rectangular-e2e` | `007dfa0c012404515907779f396ed94cf7a6694d` | #725 | Hold for complete same-session evidence and exact approval |
+| `codex/footing-isolated-v1` | `886871aef93d9a955a3cc2fa613fe49bad589ce7` | #727 | Hold for complete same-session evidence and exact approval |
+| `codex/gpt-5-3-spark-work-program` | `6cd22dcbd073b599e4a2faef80352b294295f32e` | #734 | Hold for complete same-session evidence and exact approval |
+| `codex/is456-beam-primary-route` | `aa4fe606ee685240648c88db75e0d1052350fcb4` | #726 | Hold for complete same-session evidence and exact approval |
+| `codex/is456-slabs-closeout` | `d79a1558a0cfa5078f6ddea91c4166100bdc4d04` | #724 | Hold for complete same-session evidence and exact approval |
+| `codex/is456-slabs-plan` | `7e623984e027141fff62e5129c23fdc16264f8e0` | #728 | Hold for complete same-session evidence and exact approval |
+
+## Owner decisions and exact deletion prerequisites
+
+The only named ownership decision in this packet is Excel: identify a current
+owner and next action, or separately authorize an exact retirement assessment.
+No inference is made from its lack of branch-only commits, remote feature ref,
+or PR.
+
+Before any future local-branch, remote-branch, or worktree action:
+
+1. refresh `origin/main` and exact target remote refs in the same session;
+2. re-run the worktree-aware state authority and stop on attachment, dirt,
+   operation markers, locks, divergence, or query failure;
+3. bind owner, remote-ref, open/dependent-PR, retention, default-ref, head SHA,
+   observation time, and freshness evidence to the exact target;
+4. for squash histories, verify reviewed-head/merge PR receipt plus patch or
+   tree/content equivalence; ancestry alone is insufficient;
+5. require the classifier result `RETIREMENT_READY_PENDING_APPROVAL` rather
+   than interpreting `UNKNOWN`, age, cleanliness, or a hand-built table as
+   authority;
+6. obtain separate explicit owner authorization for each exact local branch,
+   remote branch, and worktree action;
+7. re-inspect immediately before the action and stop on any drift;
+8. record the exact post-action inventory. Deleting one surface never implies
+   permission to delete another.
+
+## GitHub and non-mutation receipt
+
+At the audit observation, the only open PRs were Dependabot PRs #683, #684, and
+#713-#717; there were no open issues. None was changed. Repository settings
+remained: default `main`; squash and merge-commit enabled; rebase, auto-merge,
+update-branch, and delete-branch-on-merge disabled. Active ruleset `11390214`
+retained PR enforcement, strict `PR Gate`, deletion/non-fast-forward
+protection, no bypass actor, and merge/squash as the allowed methods.
+
+The pre-existing-state fingerprints below are recorded before and after the
+document write/validation interval. They intentionally exclude the packet's
+own branch/worktree and, for remote refs, `main` and the packet branch.
+
+| Surface | Before SHA-256 | After document writes |
+|---|---|---|
+| Existing local `codex/*` refs | `6dcfd5853293a33a2211d5a23fbf3004269a0435f88787cd70ec4701f3263f15` | same |
+| Existing remote heads except `main` | `97d6dbb0c6c7d0950929ff43510a4370ddef42f7c4079b9ca189d27a23129524` | same |
+| Existing worktree topology | `ae52e05f1a3c773367c292c348bd2fc12547ebda229a16a97e4801c9e971ff79` | same |
+| Shared local Git config excluding packet branch | `d03fbabe033dd7b2b5cf51ecc387a082bcf581db3c2009160d368b57f8710c0f` | same |
+| Repository settings | `47dd5a3a2a59ca1625b3d4dc38375ae003cd3dd5b77a06013e0b9ef69dfbca49` | same |
+| Ruleset `11390214` | `6e87df64b40e392eeff554a8cc158dd2e48da97fe8bd515b23464985c9a01a45` | same |
+| Seven pre-existing open PR identities | `db573efcc17e3f18559ba21f85cac28ebe59b16a9be52cac41b228b54877ac3a` | same |
+| Open issue identities | `37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570` | same |
+
+The final post-publication replay is necessarily produced after the unchanged
+reviewed head has merged, so it cannot truthfully be committed into the PR it
+verifies. Its exact comparison result, reviewed-head/merge tree equivalence,
+remote-main SHA, preservation replay, and post-merge workflow outcomes will be
+reported in the final Codex task handoff and remain visible in the GitHub PR and
+workflow receipts. The machine-readable companion marks that replay
+`PENDING_UNTIL_PACKET_INTEGRATION`; this document makes no future result claim.
+
+## Next boundary: GIT-7E
+
+GIT-7E is the next separate packet. It may implement semantic live-guidance
+coverage and a durable read-only task-to-Git handoff receipt. It must prove the
+six Phase 5 requirements: indexed live instructions reject retired commands;
+historical exclusions are explicit; branch/head/upstream/base/tree/operation
+identity survives handoff; remote/PR/check fields are exact or unknown; task
+archive state is never Git-retention proof; and aliases resolve only maintained
+non-obsolete commands.
+
+GIT-7E does not refresh remote state, mutate GitHub, classify retirement anew,
+authorize cleanup/deletion, synchronize preserved lanes, or change GIT-7D1/
+GIT-7D2 behavior. It starts only from a separately authorized, fresh current-
+`main` lane.

--- a/docs/research/git-governance/GIT-001-phase-7D2-branch-disposition.md
+++ b/docs/research/git-governance/GIT-001-phase-7D2-branch-disposition.md
@@ -115,6 +115,26 @@ The Control Plane Validation job runs this regression family at the exact PR
 head. Strict documentation, semantic Git workflow, quick, and full repository
 gates remain required before integration.
 
+## Integration completion
+
+GIT-7D2 completed through two unchanged-head squash integrations:
+
+| Evidence | Exact result |
+|---|---|
+| Implementation PR | #747, reviewed head `8742061604f75ad0807cb012a1192ebf997143bf` |
+| Implementation merge | `0a784de5cd519b661105846c4dfb2cf5bac51928` |
+| Implementation tree | reviewed and merged tree `c6f4a6f7f65eaf3561ab226a2e9b28dfd6436eae` |
+| Closeout-lessons PR | #748, reviewed head `cb2750b9f2c0eaf2cbecff33f3ed09db1b82585e` |
+| Closeout-lessons merge | `bf4065f071f1245461df6d3c42f1cc070efbae70` |
+| Closeout-lessons tree | reviewed and merged tree `2b8e3cdb32e342c43a41af98e868c717feaca646` |
+| Required checks | `PR Gate` passed at both unchanged reviewed heads |
+| Post-merge workflows | `PR Validation` and `Validate Documentation` passed at both merge SHAs |
+
+The original feature and lessons branches/worktrees remain retained. Squash
+tree equivalence proves integrated content but does not make either attached
+lane a deletion candidate. The Phase 7D cleanup reconciliation records the
+current preservation and disposition boundary without performing deletion.
+
 ## Non-goals and retained state
 
 No local/remote branch or worktree is deleted, detached, pruned, cleaned, or

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -3,15 +3,15 @@
   "type": "documentation",
   "description": "",
   "last_updated": "2026-08-15",
-  "file_count": 16,
+  "file_count": 18,
   "files": [
     {
       "name": "GIT-001-README.md",
       "type": "documentation",
-      "size_lines": 99,
+      "size_lines": 102,
       "last_updated": "2026-08-15",
       "description": "This directory is the task-owned, non-normative research record for GIT-001. Its contents may describe official Git/GitHub/Codex facts, observed project",
-      "content_hash": "2654f5b084a6"
+      "content_hash": "1cc6819f6b0b"
     },
     {
       "name": "GIT-001-lifecycle-research.md",
@@ -24,10 +24,10 @@
     {
       "name": "GIT-001-next-agent-disposition-plan.md",
       "type": "documentation",
-      "size_lines": 411,
+      "size_lines": 381,
       "last_updated": "2026-08-15",
       "description": "This packet converts the original six-priority cleanup and recovery list into a current, evidence-backed handoff. It tells the next agent what is already done,",
-      "content_hash": "9e8d050f8766"
+      "content_hash": "c9555c6ad9bd"
     },
     {
       "name": "GIT-001-official-evidence-register.md",
@@ -118,6 +118,32 @@
       "content_hash": "494e0c9d67de"
     },
     {
+      "name": "GIT-001-phase-7D-cleanup-reconciliation.json",
+      "type": "config",
+      "last_updated": "2026-08-15",
+      "top_level_keys": [
+        "schema_version",
+        "receipt_id",
+        "task",
+        "phase",
+        "cleanup_disposition_mutation_policy",
+        "cleanup_disposition_mutation_policy_scope",
+        "packet_documentation_and_git_lifecycle",
+        "cleanup_actions_performed",
+        "authorization",
+        "observation"
+      ],
+      "content_hash": "cccf64989d0b"
+    },
+    {
+      "name": "GIT-001-phase-7D-cleanup-reconciliation.md",
+      "type": "documentation",
+      "size_lines": 206,
+      "last_updated": "2026-08-15",
+      "description": "GIT-7D is complete as an inspection and control packet. GIT-7D1 targeted index generation is integrated through PR #746. GIT-7D2 inspection-only branch",
+      "content_hash": "2644ecdaae12"
+    },
+    {
       "name": "GIT-001-phase-7D1-targeted-index-generation.md",
       "type": "documentation",
       "size_lines": 93,
@@ -128,12 +154,12 @@
     {
       "name": "GIT-001-phase-7D2-branch-disposition.md",
       "type": "documentation",
-      "size_lines": 124,
+      "size_lines": 144,
       "last_updated": "2026-08-15",
       "description": "GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale_branches.py path with",
-      "content_hash": "5a34e7a396cc"
+      "content_hash": "a51ad88ca239"
     }
   ],
   "subfolders": [],
-  "content_hash": "e9ffc88f6bff2c65"
+  "content_hash": "425d9e77fd81e375"
 }

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -2,15 +2,19 @@
 
 **Type:** Documentation
 **Last Updated:** 2026-08-15
-**Files:** 16
+**Files:** 18
+
+## Config Files
+
+- [GIT-001-phase-7D-cleanup-reconciliation.json](GIT-001-phase-7D-cleanup-reconciliation.json)
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 99 |
+| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 102 |
 | [GIT-001-lifecycle-research.md](GIT-001-lifecycle-research.md) |  | This is a source-backed, non-normative map. It does not repl | 192 |
-| [GIT-001-next-agent-disposition-plan.md](GIT-001-next-agent-disposition-plan.md) |  | This packet converts the original six-priority cleanup and r | 411 |
+| [GIT-001-next-agent-disposition-plan.md](GIT-001-next-agent-disposition-plan.md) |  | This packet converts the original six-priority cleanup and r | 381 |
 | [GIT-001-official-evidence-register.md](GIT-001-official-evidence-register.md) |  | Only primary, official sources belong in the source tables.  | 147 |
 | [GIT-001-phase-0-preservation-baseline.md](GIT-001-phase-0-preservation-baseline.md) |  | - Observation time: 2026-08-12T21:17:05+05:30 - Repository:  | 165 |
 | [GIT-001-phase-2-incident-register.md](GIT-001-phase-2-incident-register.md) |  | This register traces confirmed Git, worktree, automation, CI | 350 |
@@ -22,5 +26,6 @@
 | [GIT-001-phase-7B-state-intake-kernel.md](GIT-001-phase-7B-state-intake-kernel.md) |  | The repository owner accepted Phase 6 and authorized GIT-7B  | 149 |
 | [GIT-001-phase-7C1-required-ci-topology.md](GIT-001-phase-7C1-required-ci-topology.md) |  | After GIT-7B merged through PR #744, the repository owner au | 148 |
 | [GIT-001-phase-7C2-server-enforcement.md](GIT-001-phase-7C2-server-enforcement.md) |  | The owner explicitly authorized the documented GIT-7C2 setti | 93 |
+| [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
-| [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 124 |
+| [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |

--- a/docs/research/index.json
+++ b/docs/research/index.json
@@ -60,8 +60,8 @@
     {
       "name": "git-governance",
       "path": "git-governance/",
-      "file_count": 18
+      "file_count": 20
     }
   ],
-  "content_hash": "763aee82aa7b162c"
+  "content_hash": "f8f55a8bd6560eec"
 }

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -19,4 +19,4 @@
 
 | Folder | Files | Description |
 |--------|-------|-------------|
-| [git-governance/](git-governance/) | 18 |  |
+| [git-governance/](git-governance/) | 20 |  |


### PR DESCRIPTION
## What changed

- add readable and machine-readable GIT-7D preservation/disposition receipts
- preserve the unique detached e54a semantic fact without touching its dirty worktree
- reconcile GIT-7D2 across the task board, handoff, phase ledger, disposition plan, projections, and session record
- add the GIT-7D2 cleanup-audit retrospective and repository learning case study
- keep GIT-7E as the next separate semantic-guidance and durable-handoff packet

## Safety boundary

The cleanup/disposition policy is inspection-only. This PR performs no branch, ref, worktree, issue, dependency PR, setting, release, or primary-main cleanup action. It retains NOT_CHECKED/UNKNOWN truth and makes no deletion-ready claim without complete evidence and separate exact approval.

The normal documentation/commit/push/PR lifecycle is explicitly authorized and separately named in the receipt. Post-merge preservation replay is marked pending and will be reported in the final task handoff and GitHub workflow receipts rather than predicted inside this reviewed head.

## Root causes captured

The retrospective covers example tests versus invariants, configured default branches, evidence identity/freshness, static semantic surface lists, stale same-day handoff, detached evidence, guessed paths/CLI/schema, masked shell/GraphQL failures, late independent review, squash equivalence, learning lag, zsh path/PATH, and jq .branches input versus .targets output.

## Validation

- focused branch-disposition regression: 12 passed
- semantic Codex-native Git workflow: passed
- task, handoff, session, JSON, and whitespace checks: passed
- strict docs: 5/5; 342 Markdown files and 1,107 links; 0 broken
- quick gate: 10/10
- full gate: 30/30
- session end: passed
- external learning addendum SHA-256: af3d47e5263adf6406a1b0d28171932414926862d0040699e14498744a8588f1