### PR TITLE
feat(git): add semantic handoff receipts

### DIFF
--- a/.github/agents/governance.agent.md
+++ b/.github/agents/governance.agent.md
@@ -83,18 +83,19 @@ ls docs/planning/*.md | wc -l               # Target: <10
 .venv/bin/python scripts/check_links.py
 ```
 
-### Phase 2: Branch & Worktree Cleanup (30 min)
+### Phase 2: Branch & Worktree Disposition Review (30 min)
 
 ```bash
-# List worktrees (target: ≤2)
-git worktree list
+# Inspect local lanes through the sole state authority
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 
-# List merged remote branches
-git branch -r --merged main | grep -v "HEAD\|main"
-
-# Prune stale references
-git remote prune origin && git fetch --prune
+# Classify exact branches without fetch, prune, removal, or deletion
+./scripts/python_runtime.sh scripts/classify_branch_disposition.py --all-local --json
 ```
+
+`NOT_CHECKED`, missing, stale, contradictory, or failed evidence is an
+`UNKNOWN` hold. Cleanup is never inferred from worktree count, age, reachability,
+or merge state; later exact-target actions require separate authorization.
 
 ### Phase 3: Version Consistency (30 min)
 

--- a/.github/skills/session-management/SKILL.md
+++ b/.github/skills/session-management/SKILL.md
@@ -47,7 +47,9 @@ archive path. Resolve the maintained command with `./run.sh find "task"`.
    as `**Git handoff receipt:** <path>`. Session handoff validates the
    `local_state_receipt_hash`, exact identities, independently derived
    fail-closed holds, `receipt_grants_authority: false`, and externally sourced
-   exact-target authorization evidence.
+   exact-target authorization evidence, including fresh/query-successful
+   provenance and a next action bound to that authority or the closed safe-hold
+   set.
 3. Run the pre-commit gate once:
 
    ```bash

--- a/.github/skills/session-management/SKILL.md
+++ b/.github/skills/session-management/SKILL.md
@@ -42,6 +42,10 @@ archive path. Resolve the maintained command with `./run.sh find "task"`.
 
 1. Run the narrow checks for changed behavior while iterating.
 2. Update `docs/TASKS.md` and `docs/planning/next-session-brief.md` only when their project state actually changed or another agent needs a durable handoff. Update other logs only when the task explicitly owns them.
+   Create or update the task's versioned receipt with
+   `scripts/git_handoff_receipt.py`; include its path in the newest session entry
+   as `**Git handoff receipt:** <path>`. Session handoff validates the
+   `local_state_receipt_hash`, exact identities, and fail-closed holds.
 3. Run the pre-commit gate once:
 
    ```bash
@@ -79,11 +83,16 @@ Verifies:
 | `docs/WORKLOG.md` | Compact completed-work history when the task changes it |
 | `docs/planning/next-session-brief.md` | Handoff to next session |
 | `docs/TASKS.md` | Active task board |
-| `scripts/session.py` | Session management CLI |
+| `scripts/session.py` | Session management CLI and receipt round-trip validation |
+| `scripts/git_handoff_receipt.py` | Read-only task-to-Git receipt contract |
 
 ## Context Checkpoint (save before context overflow)
 
-When a task must transfer to another session, update the handoff with: completed outcome, current branch/commit, exact remaining work, verification already run, and blockers. Keep it task-specific; do not copy the conversation.
+When a task must transfer to another session, update the handoff with: completed
+outcome, the versioned receipt path and `local_state_receipt_hash`, exact
+remaining work, verification already run, and blockers. Remote/PR/check facts
+are exact or `UNKNOWN`/`NOT_CHECKED`; `NOT_APPLICABLE` always has a reason. Keep
+it task-specific; do not copy the conversation.
 
 ## Context Recovery (new chat after overflow)
 

--- a/.github/skills/session-management/SKILL.md
+++ b/.github/skills/session-management/SKILL.md
@@ -45,7 +45,9 @@ archive path. Resolve the maintained command with `./run.sh find "task"`.
    Create or update the task's versioned receipt with
    `scripts/git_handoff_receipt.py`; include its path in the newest session entry
    as `**Git handoff receipt:** <path>`. Session handoff validates the
-   `local_state_receipt_hash`, exact identities, and fail-closed holds.
+   `local_state_receipt_hash`, exact identities, independently derived
+   fail-closed holds, `receipt_grants_authority: false`, and externally sourced
+   exact-target authorization evidence.
 3. Run the pre-commit gate once:
 
    ```bash

--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -63,6 +63,8 @@ jobs:
               - 'Python/tests/test_agent_governance_automation.py'
               - 'Python/tests/test_ci_workflow_contract.py'
               - 'Python/tests/test_git_state.py'
+              - 'Python/tests/test_git_handoff_receipt.py'
+              - 'Python/tests/test_git_guidance_semantics.py'
               - 'Python/tests/test_pipeline_state.py'
               - 'Python/tests/test_session_automation.py'
               - 'Python/tests/test_session_store.py'
@@ -211,6 +213,8 @@ jobs:
           STRUCTURAL_LIB_PYTHON="$(command -v python)" python scripts/check_codex_git_workflow.py
           STRUCTURAL_LIB_PYTHON="$(command -v python)" python -m pytest \
             Python/tests/test_git_state.py \
+            Python/tests/test_git_handoff_receipt.py \
+            Python/tests/test_git_guidance_semantics.py \
             Python/tests/test_branch_disposition.py \
             Python/tests/test_session_automation.py \
             Python/tests/test_session_store.py \

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 321,
+      "size_lines": 362,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2274,6 +2274,9 @@
           ]
         },
         {
+          "name": "test_clause_local_pull_rule_matches_from_the_governed_action"
+        },
+        {
           "name": "test_omitted_git_pull_pattern_respects_prohibition_and_history",
           "params": [
             "safe_context",
@@ -2291,7 +2294,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "2d4f3045c23a"
+      "content_hash": "c005b465b8e6"
     },
     {
       "name": "test_git_handoff_receipt.py",
@@ -2395,7 +2398,7 @@
     {
       "name": "test_git_state.py",
       "type": "python",
-      "size_lines": 448,
+      "size_lines": 538,
       "last_updated": "2026-08-15",
       "description": "Outcome tests for the read-only, worktree-aware Git state authority.",
       "functions": [
@@ -2416,6 +2419,21 @@
           "params": [
             "tmp_path",
             "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_state_consistency_rejects_malformed_schema_and_enums_without_git_io",
+          "params": [
+            "tmp_path",
+            "monkeypatch",
+            "case",
+            "expected"
+          ]
+        },
+        {
+          "name": "test_state_consistency_accepts_canonical_unknown_only_with_query_failure",
+          "params": [
+            "tmp_path"
           ]
         },
         {
@@ -2500,7 +2518,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "c1445882b756"
+      "content_hash": "1022c84432fe"
     },
     {
       "name": "test_inputs.py",
@@ -3737,7 +3755,7 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 1158,
+      "size_lines": 1236,
       "last_updated": "2026-08-15",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
@@ -3761,6 +3779,14 @@
           "name": "test_session_closeout_reports_canonical_dirty_paths",
           "params": [
             "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_session_closeout_holds_malformed_canonical_contract_without_subprocess",
+          "params": [
+            "case",
+            "monkeypatch",
+            "capsys"
           ]
         },
         {
@@ -3820,6 +3846,14 @@
           ]
         },
         {
+          "name": "test_session_end_malformed_canonical_contract_fails_closed",
+          "params": [
+            "case",
+            "monkeypatch",
+            "capsys"
+          ]
+        },
+        {
           "name": "test_session_heading_marker_accepts_descriptive_titles",
           "params": [
             "heading"
@@ -3847,22 +3881,12 @@
           "params": [
             "tmp_path"
           ]
-        },
-        {
-          "name": "test_latest_session_block_does_not_rewind_descriptive_heading"
-        },
-        {
-          "name": "test_last_session_date_reads_multiline_log",
-          "params": [
-            "tmp_path",
-            "monkeypatch"
-          ]
         }
       ],
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "c4c7b166c1fe"
+      "content_hash": "f6db956817fe"
     },
     {
       "name": "test_session_store.py",
@@ -4620,5 +4644,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "395e81a86fdd3fca"
+  "content_hash": "060e799620533ee0"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2,14 +2,14 @@
   "folder": "Python/tests",
   "type": "python-package",
   "description": "This document describes the test taxonomy and structure for the structural_engineering_lib test suite.",
-  "last_updated": "2026-08-13",
-  "file_count": 63,
+  "last_updated": "2026-08-15",
+  "file_count": 67,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 394,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "title": "Test Suite Organization",
       "description": "This document describes the test taxonomy and structure for the structural_engineering_lib test suite. - test_detailing.py - Reinforcement detailing calculations",
       "content_hash": "706b48faeda0"
@@ -18,14 +18,14 @@
       "name": "__init__.py",
       "type": "python",
       "size_lines": 1,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "content_hash": "e3b0c44298fc"
     },
     {
       "name": "conftest.py",
       "type": "python",
       "size_lines": 131,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Pytest configuration and Hypothesis profiles for the test suite.",
       "functions": [
         {
@@ -64,8 +64,8 @@
     {
       "name": "test_agent_governance_automation.py",
       "type": "python",
-      "size_lines": 536,
-      "last_updated": "2026-08-13",
+      "size_lines": 541,
+      "last_updated": "2026-08-15",
       "description": "Regression tests for agent-governance automation controls.",
       "functions": [
         {
@@ -160,13 +160,13 @@
         "REPO_ROOT",
         "SCRIPTS_DIR"
       ],
-      "content_hash": "9cb6f613dcfd"
+      "content_hash": "138c02929959"
     },
     {
       "name": "test_api_manifest_tools.py",
       "type": "python",
       "size_lines": 134,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Regression tests for the single canonical public API manifest.",
       "functions": [
         {
@@ -214,7 +214,7 @@
       "name": "test_api_results.py",
       "type": "python",
       "size_lines": 394,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for API result dataclasses.",
       "classes": [
         {
@@ -254,7 +254,7 @@
       "name": "test_api_stability.py",
       "type": "python",
       "size_lines": 233,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "EA-9: Wheel API stability tests.",
       "classes": [
         {
@@ -308,7 +308,7 @@
       "name": "test_api_surface_snapshot.py",
       "type": "python",
       "size_lines": 122,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Snapshot regression tests — assert minimum API surface counts.",
       "classes": [
         {
@@ -361,7 +361,7 @@
       "name": "test_assertion_helpers.py",
       "type": "python",
       "size_lines": 82,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the IS 456 test assertion helpers.",
       "classes": [
         {
@@ -403,7 +403,7 @@
       "name": "test_audit.py",
       "type": "python",
       "size_lines": 468,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for audit module (TASK-278).",
       "classes": [
         {
@@ -477,7 +477,7 @@
       "name": "test_boq.py",
       "type": "python",
       "size_lines": 190,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the BOQ (Bill of Quantities) aggregation module.",
       "classes": [
         {
@@ -500,10 +500,97 @@
       "content_hash": "5b94d7b3d0bd"
     },
     {
+      "name": "test_branch_disposition.py",
+      "type": "python",
+      "size_lines": 437,
+      "last_updated": "2026-08-15",
+      "description": "Outcome tests for the inspection-only branch disposition classifier.",
+      "functions": [
+        {
+          "name": "test_attached_and_dirty_worktrees_have_distinct_reasoned_holds",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_open_pr_unique_work_retention_and_ready_candidate_are_distinct",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_squash_patch_equivalence_requires_review",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_git_query_failure_is_unknown_not_integrated_or_ready",
+          "params": [
+            "tmp_path",
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_age_is_metadata_and_never_sufficient_authority",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_classifier_does_not_mutate_files_refs_index_or_config",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_not_checked_remote_freshness_is_explicit_unknown",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_stale_caller_evidence_is_unknown",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_remote_absence_and_retention_evidence_are_exact_and_fresh",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_default_branch_is_never_a_retirement_candidate",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_git_commands_are_local_read_only_and_cli_has_no_action_flag",
+          "params": [
+            "tmp_path",
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_cli_emits_machine_readable_receipt",
+          "params": [
+            "tmp_path"
+          ]
+        }
+      ],
+      "constants": [
+        "REPO_ROOT"
+      ],
+      "content_hash": "8afc00caa932"
+    },
+    {
       "name": "test_bump_version_semantics.py",
       "type": "python",
       "size_lines": 66,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Regression coverage for candidate-version documentation semantics.",
       "functions": [
         {
@@ -524,7 +611,7 @@
       "name": "test_calculation_report.py",
       "type": "python",
       "size_lines": 745,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the calculation_report module (TASK-277).",
       "classes": [
         {
@@ -649,10 +736,50 @@
       "content_hash": "0c5032818d28"
     },
     {
+      "name": "test_ci_workflow_contract.py",
+      "type": "python",
+      "size_lines": 182,
+      "last_updated": "2026-08-15",
+      "description": "Regression tests for fail-closed PR workflow routing.",
+      "functions": [
+        {
+          "name": "test_changed_path_routes_cover_controls_docs_and_their_tests"
+        },
+        {
+          "name": "test_pr_gate_topology_and_cancellation_are_scoped_per_pr"
+        },
+        {
+          "name": "test_pr_gate_accepts_successful_applicable_routes"
+        },
+        {
+          "name": "test_pr_gate_rejects_non_successful_applicable_route",
+          "params": [
+            "changed_key",
+            "result_key",
+            "bad_result"
+          ]
+        },
+        {
+          "name": "test_pr_gate_rejects_unexpected_non_applicable_execution",
+          "params": [
+            "changed_key",
+            "result_key"
+          ]
+        }
+      ],
+      "constants": [
+        "REPO_ROOT",
+        "FAST_CHECKS",
+        "DEPLOY_DOCS",
+        "BASE_GATE_ENV"
+      ],
+      "content_hash": "41b5fe48a58b"
+    },
+    {
       "name": "test_clause_traceability.py",
       "type": "python",
       "size_lines": 489,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for IS 456 Traceability Module",
       "classes": [
         {
@@ -770,7 +897,7 @@
       "name": "test_column_axial.py",
       "type": "python",
       "size_lines": 273,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for column axial module — effective_length() per IS 456 Table 28.",
       "classes": [
         {
@@ -842,7 +969,7 @@
       "name": "test_column_biaxial.py",
       "type": "python",
       "size_lines": 958,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for IS 456 Cl 39.6 biaxial bending check — TASK-635.",
       "classes": [
         {
@@ -973,7 +1100,7 @@
       "name": "test_column_helical.py",
       "type": "python",
       "size_lines": 356,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for IS 456 Cl 39.4 helical reinforcement check.",
       "classes": [
         {
@@ -1040,7 +1167,7 @@
       "name": "test_column_long.py",
       "type": "python",
       "size_lines": 662,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for IS 456 Cl 39.7 long (slender) column design.",
       "classes": [
         {
@@ -1168,7 +1295,7 @@
       "name": "test_column_return_types.py",
       "type": "python",
       "size_lines": 281,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for UX-02: Column API return type unification.",
       "classes": [
         {
@@ -1258,7 +1385,7 @@
       "name": "test_core.py",
       "type": "python",
       "size_lines": 176,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for structural_lib.core module.",
       "classes": [
         {
@@ -1328,7 +1455,7 @@
       "name": "test_core_types.py",
       "type": "python",
       "size_lines": 391,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for core types and error dataclasses.",
       "classes": [
         {
@@ -1437,7 +1564,7 @@
       "name": "test_dashboard.py",
       "type": "python",
       "size_lines": 259,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the dashboard analytics module.",
       "classes": [
         {
@@ -1491,7 +1618,7 @@
       "name": "test_design_from_input.py",
       "type": "python",
       "size_lines": 142,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for design_from_input API function.",
       "classes": [
         {
@@ -1514,7 +1641,7 @@
       "name": "test_error_messages.py",
       "type": "python",
       "size_lines": 294,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for error message templates.",
       "classes": [
         {
@@ -1595,7 +1722,7 @@
       "name": "test_etabs_import_integration.py",
       "type": "python",
       "size_lines": 330,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Integration tests for etabs_import Pydantic conversion functions.",
       "classes": [
         {
@@ -1665,7 +1792,7 @@
       "name": "test_evidence.py",
       "type": "python",
       "size_lines": 169,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Focused tests for the supported IS 456 beam evidence envelope.",
       "functions": [
         {
@@ -1693,7 +1820,7 @@
       "name": "test_exception_hierarchy.py",
       "type": "python",
       "size_lines": 278,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for exception hierarchy in errors module.",
       "classes": [
         {
@@ -1746,7 +1873,7 @@
       "name": "test_footing.py",
       "type": "python",
       "size_lines": 1801,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for IS 456 footing design — TASK-650/651/652.",
       "classes": [
         {
@@ -1923,7 +2050,7 @@
       "name": "test_footing_api.py",
       "type": "python",
       "size_lines": 357,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Focused contract tests for Phase B1 isolated-footing orchestration.",
       "functions": [
         {
@@ -1976,7 +2103,7 @@
       "name": "test_footing_detailing.py",
       "type": "python",
       "size_lines": 238,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Outcome-focused tests for the bounded footing detailing slice.",
       "functions": [
         {
@@ -2026,7 +2153,7 @@
       "name": "test_footing_load_transfer.py",
       "type": "python",
       "size_lines": 165,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Focused independent arithmetic checks for IS 456 Cl. 34.4 load transfer.",
       "functions": [
         {
@@ -2061,7 +2188,7 @@
       "name": "test_function_quality_checker.py",
       "type": "python",
       "size_lines": 55,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Focused regressions for the IS 456 function-quality checker.",
       "functions": [
         {
@@ -2081,7 +2208,7 @@
       "name": "test_generated_clients.py",
       "type": "python",
       "size_lines": 71,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Contract checks for the checked-in basic generated clients.",
       "functions": [
         {
@@ -2098,10 +2225,98 @@
       "content_hash": "5f72938f65a1"
     },
     {
+      "name": "test_git_guidance_semantics.py",
+      "type": "python",
+      "size_lines": 139,
+      "last_updated": "2026-08-15",
+      "description": "Semantic live-guidance discovery and coherence regressions.",
+      "functions": [
+        {
+          "name": "test_live_semantic_contradiction_fails_and_coherent_guidance_passes",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_indexed_deprecated_history_is_excluded_only_with_explicit_boundary",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_archive_path_is_explicitly_excluded_from_live_authority",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_live_aliases_route_to_receipt_and_not_retired_mutation"
+        }
+      ],
+      "constants": [
+        "REPO_ROOT"
+      ],
+      "content_hash": "fdc8af919041"
+    },
+    {
+      "name": "test_git_handoff_receipt.py",
+      "type": "python",
+      "size_lines": 257,
+      "last_updated": "2026-08-15",
+      "description": "Regressions for the durable, fail-closed task-to-Git handoff receipt.",
+      "functions": [
+        {
+          "name": "test_valid_receipt_round_trips_with_exact_identity",
+          "params": [
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_missing_not_checked_stale_and_query_failed_evidence_hold",
+          "params": [
+            "evidence",
+            "reason"
+          ]
+        },
+        {
+          "name": "test_failed_git_state_is_unknown_even_when_hosted_evidence_is_green"
+        },
+        {
+          "name": "test_dirty_or_interrupted_local_state_holds_even_when_queries_succeed"
+        },
+        {
+          "name": "test_not_applicable_requires_a_reason_and_never_replaces_unknown"
+        },
+        {
+          "name": "test_exact_head_and_check_contradictions_fail_closed"
+        },
+        {
+          "name": "test_squash_merge_needs_tree_equivalence_and_does_not_grant_retirement"
+        },
+        {
+          "name": "test_stored_hash_or_identity_tampering_is_rejected"
+        },
+        {
+          "name": "test_stored_observed_evidence_expires_instead_of_remaining_authority"
+        },
+        {
+          "name": "test_receipt_module_has_no_independent_git_or_network_reader"
+        }
+      ],
+      "constants": [
+        "NOW",
+        "HEAD",
+        "BASE",
+        "TREE",
+        "MERGE"
+      ],
+      "content_hash": "dd629d194925"
+    },
+    {
       "name": "test_git_state.py",
       "type": "python",
       "size_lines": 425,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Outcome tests for the read-only, worktree-aware Git state authority.",
       "functions": [
         {
@@ -2204,7 +2419,7 @@
       "name": "test_inputs.py",
       "type": "python",
       "size_lines": 464,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the inputs module (TASK-276: Input Flexibility).",
       "classes": [
         {
@@ -2295,7 +2510,7 @@
       "name": "test_is456_common.py",
       "type": "python",
       "size_lines": 854,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for IS 456:2000 common modules - stress_blocks, reinforcement, validation.",
       "classes": [
         {
@@ -2471,7 +2686,7 @@
       "name": "test_is456_constants.py",
       "type": "python",
       "size_lines": 163,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for IS 456:2000 named design constants.",
       "classes": [
         {
@@ -2497,7 +2712,7 @@
       "name": "test_model_picker.py",
       "type": "python",
       "size_lines": 132,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the deterministic low-token model picker.",
       "functions": [
         {
@@ -2541,7 +2756,7 @@
       "name": "test_multi_objective_optimizer.py",
       "type": "python",
       "size_lines": 319,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the multi-objective optimizer module (NSGA-II).",
       "classes": [
         {
@@ -2594,7 +2809,7 @@
       "name": "test_numerics.py",
       "type": "python",
       "size_lines": 136,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for structural_lib.core.numerics - safe arithmetic utilities.",
       "classes": [
         {
@@ -2654,7 +2869,7 @@
       "name": "test_packaging.py",
       "type": "python",
       "size_lines": 452,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for package distribution correctness.",
       "classes": [
         {
@@ -2748,7 +2963,7 @@
       "name": "test_pipeline_state.py",
       "type": "python",
       "size_lines": 353,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for scripts/pipeline_state.py — Pipeline step tracking + resume.",
       "classes": [
         {
@@ -2825,7 +3040,7 @@
       "name": "test_private_source_boundary.py",
       "type": "python",
       "size_lines": 40,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Protected engineering-source material stays local and outside distributions.",
       "functions": [
         {
@@ -2844,7 +3059,7 @@
       "name": "test_release_environment.py",
       "type": "python",
       "size_lines": 263,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Regression tests for local release preflight environment selection.",
       "functions": [
         {
@@ -2936,7 +3151,7 @@
       "name": "test_release_scripts.py",
       "type": "python",
       "size_lines": 693,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for release scripts (bump_version.py, release.py).",
       "classes": [
         {
@@ -3093,7 +3308,7 @@
       "name": "test_report_edge_cases.py",
       "type": "python",
       "size_lines": 303,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Edge case tests for report generation modules (TASK-520).",
       "classes": [
         {
@@ -3154,7 +3369,7 @@
       "name": "test_report_svg.py",
       "type": "python",
       "size_lines": 141,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the SVG report generation module.",
       "classes": [
         {
@@ -3206,7 +3421,7 @@
       "name": "test_reports.py",
       "type": "python",
       "size_lines": 447,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the reports module.",
       "classes": [
         {
@@ -3293,7 +3508,7 @@
       "name": "test_research_prototypes.py",
       "type": "python",
       "size_lines": 910,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for research prototypes: Sustainability, Generative Design, Design Companion.",
       "classes": [
         {
@@ -3367,7 +3582,7 @@
       "name": "test_result_base.py",
       "type": "python",
       "size_lines": 217,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for result_base module.",
       "classes": [
         {
@@ -3435,8 +3650,8 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 663,
-      "last_updated": "2026-08-13",
+      "size_lines": 858,
+      "last_updated": "2026-08-15",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
         {
@@ -3453,6 +3668,13 @@
         },
         {
           "name": "test_run_task_brief_and_index_help_are_read_only"
+        },
+        {
+          "name": "test_run_index_generator_dry_run_routes_scope_without_writes",
+          "params": [
+            "arguments",
+            "expected"
+          ]
         },
         {
           "name": "test_index_generator_uses_worktree_runtime_in_temp_project",
@@ -3535,25 +3757,18 @@
           "params": [
             "tmp_path"
           ]
-        },
-        {
-          "name": "test_usage_checkpoint_records_observable_fields_only",
-          "params": [
-            "tmp_path",
-            "monkeypatch"
-          ]
         }
       ],
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "aa5e008a7a20"
+      "content_hash": "76744a2f80de"
     },
     {
       "name": "test_session_store.py",
       "type": "python",
       "size_lines": 287,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for scripts/session_store.py — JSON session persistence.",
       "classes": [
         {
@@ -3625,7 +3840,7 @@
       "name": "test_slenderness.py",
       "type": "python",
       "size_lines": 360,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Unit tests for slenderness module.",
       "classes": [
         {
@@ -3696,7 +3911,7 @@
       "name": "test_testing_strategies.py",
       "type": "python",
       "size_lines": 681,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for the testing_strategies module (TASK-279).",
       "classes": [
         {
@@ -3830,7 +4045,7 @@
       "name": "test_timing_regression.py",
       "type": "python",
       "size_lines": 86,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Regression tests for Windows-compatible timing.",
       "functions": [
         {
@@ -3850,7 +4065,7 @@
       "name": "test_token_efficiency.py",
       "type": "python",
       "size_lines": 83,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Regression tests for repository-side token-efficiency controls.",
       "functions": [
         {
@@ -3878,7 +4093,7 @@
       "name": "test_tool_manifest.py",
       "type": "python",
       "size_lines": 101,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Focused gates for the catalogue-derived beam tool manifest.",
       "functions": [
         {
@@ -3910,7 +4125,7 @@
       "name": "test_visualization_edge_cases.py",
       "type": "python",
       "size_lines": 757,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Edge case tests for 3D visualization / geometry module (TASK-520).",
       "classes": [
         {
@@ -4034,7 +4249,7 @@
       "name": "test_visualization_geometry_3d.py",
       "type": "python",
       "size_lines": 765,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Tests for visualization.geometry_3d module.",
       "classes": [
         {
@@ -4156,7 +4371,7 @@
       "name": "test_visualization_integration.py",
       "type": "python",
       "size_lines": 246,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Integration tests for visualization.geometry_3d with detailing module.",
       "classes": [
         {
@@ -4190,7 +4405,7 @@
       "name": "test_workflow_catalog.py",
       "type": "python",
       "size_lines": 89,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Focused contract tests for the one-beam application workflow catalogue.",
       "functions": [
         {
@@ -4212,7 +4427,7 @@
       "name": "test_workflow_runner.py",
       "type": "python",
       "size_lines": 189,
-      "last_updated": "2026-08-13",
+      "last_updated": "2026-08-15",
       "description": "Bounded-runner tests for the approved beam workflow only.",
       "functions": [
         {
@@ -4305,5 +4520,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "bd436b89b756a7e3"
+  "content_hash": "e3f02f525d4be678"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 302,
+      "size_lines": 312,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2291,7 +2291,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "4b4b9a8560dc"
+      "content_hash": "b5f2bfd443ff"
     },
     {
       "name": "test_git_handoff_receipt.py",
@@ -3730,7 +3730,7 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 890,
+      "size_lines": 1019,
       "last_updated": "2026-08-15",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
@@ -3742,6 +3742,45 @@
           "params": [
             "monkeypatch",
             "tmp_path"
+          ]
+        },
+        {
+          "name": "test_session_closeout_uses_canonical_clean_evidence_without_subprocess",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_session_closeout_reports_canonical_dirty_paths",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_session_closeout_holds_nonzero_git_state_query",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_session_closeout_holds_git_state_exception",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_session_closeout_holds_malformed_or_unknown_evidence",
+          "params": [
+            "evidence",
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_session_closeout_never_prints_clean_for_hold",
+          "params": [
+            "status",
+            "monkeypatch",
+            "capsys"
           ]
         },
         {
@@ -3813,37 +3852,12 @@
         },
         {
           "name": "test_launcher_port_discovery_is_listener_only"
-        },
-        {
-          "name": "test_run_sh_does_not_own_git_or_github_lifecycle"
-        },
-        {
-          "name": "test_retired_git_lifecycle_paths_stay_absent"
-        },
-        {
-          "name": "test_p0_missing_script_control_paths_stay_removed"
-        },
-        {
-          "name": "test_script_reference_validator_fails_missing_control_target",
-          "params": [
-            "tmp_path",
-            "monkeypatch"
-          ]
-        },
-        {
-          "name": "test_api_endpoint_extraction_stops_before_query_template"
-        },
-        {
-          "name": "test_api_call_method_extraction_stops_at_each_fetch",
-          "params": [
-            "tmp_path"
-          ]
         }
       ],
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "1f75dfd1fc3b"
+      "content_hash": "f70081cd341f"
     },
     {
       "name": "test_session_store.py",
@@ -4601,5 +4615,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "ab6faf0ddf9132d5"
+  "content_hash": "29e2736cf53dbfa1"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 233,
+      "size_lines": 245,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2277,7 +2277,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "78e36bb84a23"
+      "content_hash": "459b84ef4a4f"
     },
     {
       "name": "test_git_handoff_receipt.py",
@@ -4587,5 +4587,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "1464440469a8b468"
+  "content_hash": "d84f605cac5ac6ca"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 312,
+      "size_lines": 321,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2291,7 +2291,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "b5f2bfd443ff"
+      "content_hash": "2d4f3045c23a"
     },
     {
       "name": "test_git_handoff_receipt.py",
@@ -2395,7 +2395,7 @@
     {
       "name": "test_git_state.py",
       "type": "python",
-      "size_lines": 425,
+      "size_lines": 448,
       "last_updated": "2026-08-15",
       "description": "Outcome tests for the read-only, worktree-aware Git state authority.",
       "functions": [
@@ -2409,6 +2409,13 @@
           "name": "test_porcelain_v2_classifies_each_dirty_surface",
           "params": [
             "tmp_path"
+          ]
+        },
+        {
+          "name": "test_state_consistency_recomputes_action_and_holds_without_git_io",
+          "params": [
+            "tmp_path",
+            "monkeypatch"
           ]
         },
         {
@@ -2493,7 +2500,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "d9c97021b08a"
+      "content_hash": "c1445882b756"
     },
     {
       "name": "test_inputs.py",
@@ -3730,7 +3737,7 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 1019,
+      "size_lines": 1158,
       "last_updated": "2026-08-15",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
@@ -3757,6 +3764,21 @@
           ]
         },
         {
+          "name": "test_session_closeout_holds_clean_action_hold_contradiction",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_session_closeout_holds_dirty_ready_contradiction",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_changed_doc_folders_uses_only_canonical_dirty_paths"
+        },
+        {
           "name": "test_session_closeout_holds_nonzero_git_state_query",
           "params": [
             "monkeypatch"
@@ -3779,6 +3801,20 @@
           "name": "test_session_closeout_never_prints_clean_for_hold",
           "params": [
             "status",
+            "monkeypatch",
+            "capsys"
+          ]
+        },
+        {
+          "name": "test_session_end_reuses_one_clean_authority_query_and_skips_unknown_doc_set",
+          "params": [
+            "monkeypatch",
+            "capsys"
+          ]
+        },
+        {
+          "name": "test_session_end_query_failure_cannot_pass_or_print_clean",
+          "params": [
             "monkeypatch",
             "capsys"
           ]
@@ -3821,43 +3857,12 @@
             "tmp_path",
             "monkeypatch"
           ]
-        },
-        {
-          "name": "test_active_task_reader_accepts_current_and_legacy_headings",
-          "params": [
-            "tmp_path",
-            "monkeypatch",
-            "heading",
-            "task_id"
-          ]
-        },
-        {
-          "name": "test_commit_summary_uses_exclusive_previous_day_boundary",
-          "params": [
-            "monkeypatch"
-          ]
-        },
-        {
-          "name": "test_session_trust_accepts_only_kernel_ready_local",
-          "params": [
-            "action",
-            "trusted"
-          ]
-        },
-        {
-          "name": "test_git_identity_helpers_reject_failed_commands",
-          "params": [
-            "monkeypatch"
-          ]
-        },
-        {
-          "name": "test_launcher_port_discovery_is_listener_only"
         }
       ],
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "f70081cd341f"
+      "content_hash": "c4c7b166c1fe"
     },
     {
       "name": "test_session_store.py",
@@ -4615,5 +4620,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "29e2736cf53dbfa1"
+  "content_hash": "395e81a86fdd3fca"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 245,
+      "size_lines": 302,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2267,6 +2267,20 @@
           ]
         },
         {
+          "name": "test_data_driven_omitted_git_pull_before_push_instruction_fails",
+          "params": [
+            "instruction",
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_omitted_git_pull_pattern_respects_prohibition_and_history",
+          "params": [
+            "safe_context",
+            "tmp_path"
+          ]
+        },
+        {
           "name": "test_harmless_historical_prose_is_not_treated_as_live_instruction",
           "params": [
             "historical",
@@ -2277,7 +2291,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "459b84ef4a4f"
+      "content_hash": "4b4b9a8560dc"
     },
     {
       "name": "test_git_handoff_receipt.py",
@@ -4587,5 +4601,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "d84f605cac5ac6ca"
+  "content_hash": "ab6faf0ddf9132d5"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 139,
+      "size_lines": 176,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2251,17 +2251,30 @@
         },
         {
           "name": "test_live_aliases_route_to_receipt_and_not_retired_mutation"
+        },
+        {
+          "name": "test_live_indexed_unsafe_instruction_context_fails",
+          "params": [
+            "instruction",
+            "tmp_path"
+          ]
+        },
+        {
+          "name": "test_harmless_historical_prose_is_not_treated_as_live_instruction",
+          "params": [
+            "tmp_path"
+          ]
         }
       ],
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "fdc8af919041"
+      "content_hash": "dbac1809f4b3"
     },
     {
       "name": "test_git_handoff_receipt.py",
       "type": "python",
-      "size_lines": 333,
+      "size_lines": 384,
       "last_updated": "2026-08-15",
       "description": "Regressions for the durable, fail-closed task-to-Git handoff receipt.",
       "functions": [
@@ -2321,6 +2334,24 @@
           "name": "test_destructive_or_merge_actions_cannot_be_smuggled_into_ready_receipt"
         },
         {
+          "name": "test_injected_destructive_or_merge_next_action_is_not_authorized",
+          "params": [
+            "next_action"
+          ]
+        },
+        {
+          "name": "test_stale_authorization_source_provenance_fails_closed"
+        },
+        {
+          "name": "test_authorization_query_failure_fails_closed"
+        },
+        {
+          "name": "test_closed_safe_hold_next_actions_need_no_mutation_authority",
+          "params": [
+            "next_action"
+          ]
+        },
+        {
           "name": "test_receipt_cannot_claim_to_grant_authority"
         },
         {
@@ -2334,7 +2365,7 @@
         "TREE",
         "MERGE"
       ],
-      "content_hash": "5c9ea566105e"
+      "content_hash": "8fc3c8723ad3"
     },
     {
       "name": "test_git_state.py",
@@ -4545,5 +4576,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "36b2f66f02e43f35"
+  "content_hash": "4ed46b2bb74bd507"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2398,7 +2398,7 @@
     {
       "name": "test_git_state.py",
       "type": "python",
-      "size_lines": 538,
+      "size_lines": 635,
       "last_updated": "2026-08-15",
       "description": "Outcome tests for the read-only, worktree-aware Git state authority.",
       "functions": [
@@ -2434,6 +2434,24 @@
           "name": "test_state_consistency_accepts_canonical_unknown_only_with_query_failure",
           "params": [
             "tmp_path"
+          ]
+        },
+        {
+          "name": "test_state_consistency_rejects_ref_identity_and_freshness_tampering_without_io",
+          "params": [
+            "tmp_path",
+            "monkeypatch",
+            "case",
+            "expected"
+          ]
+        },
+        {
+          "name": "test_state_consistency_accepts_valid_linked_ref_time_and_duration_contract",
+          "params": [
+            "tmp_path",
+            "monkeypatch",
+            "observed_at",
+            "duration_ms"
           ]
         },
         {
@@ -2516,9 +2534,10 @@
         }
       ],
       "constants": [
-        "REPO_ROOT"
+        "REPO_ROOT",
+        "VALIDATION_NOW"
       ],
-      "content_hash": "1022c84432fe"
+      "content_hash": "aa2be65be1b6"
     },
     {
       "name": "test_inputs.py",
@@ -3755,7 +3774,7 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 1236,
+      "size_lines": 1276,
       "last_updated": "2026-08-15",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
@@ -3886,7 +3905,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "f6db956817fe"
+      "content_hash": "f629a968f1b6"
     },
     {
       "name": "test_session_store.py",
@@ -4644,5 +4663,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "060e799620533ee0"
+  "content_hash": "24170f169f67e4fc"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2261,7 +2261,7 @@
     {
       "name": "test_git_handoff_receipt.py",
       "type": "python",
-      "size_lines": 257,
+      "size_lines": 333,
       "last_updated": "2026-08-15",
       "description": "Regressions for the durable, fail-closed task-to-Git handoff receipt.",
       "functions": [
@@ -2300,6 +2300,30 @@
           "name": "test_stored_observed_evidence_expires_instead_of_remaining_authority"
         },
         {
+          "name": "test_clearing_required_holds_cannot_upgrade_unknown_evidence_to_ready"
+        },
+        {
+          "name": "test_removing_one_required_hold_is_detected_independently"
+        },
+        {
+          "name": "test_receipt_status_enum_is_closed",
+          "params": [
+            "bad_status"
+          ]
+        },
+        {
+          "name": "test_missing_or_invalid_authorization_next_action_fails_closed",
+          "params": [
+            "next_action"
+          ]
+        },
+        {
+          "name": "test_destructive_or_merge_actions_cannot_be_smuggled_into_ready_receipt"
+        },
+        {
+          "name": "test_receipt_cannot_claim_to_grant_authority"
+        },
+        {
           "name": "test_receipt_module_has_no_independent_git_or_network_reader"
         }
       ],
@@ -2310,7 +2334,7 @@
         "TREE",
         "MERGE"
       ],
-      "content_hash": "dd629d194925"
+      "content_hash": "5c9ea566105e"
     },
     {
       "name": "test_git_state.py",
@@ -4521,5 +4545,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "be0a5560dc4e7f36"
+  "content_hash": "36b2f66f02e43f35"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2398,7 +2398,7 @@
     {
       "name": "test_git_state.py",
       "type": "python",
-      "size_lines": 635,
+      "size_lines": 682,
       "last_updated": "2026-08-15",
       "description": "Outcome tests for the read-only, worktree-aware Git state authority.",
       "functions": [
@@ -2419,6 +2419,12 @@
           "params": [
             "tmp_path",
             "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_pure_branch_validator_matches_read_only_git_check_ref_format",
+          "params": [
+            "name"
           ]
         },
         {
@@ -2537,7 +2543,7 @@
         "REPO_ROOT",
         "VALIDATION_NOW"
       ],
-      "content_hash": "aa2be65be1b6"
+      "content_hash": "40ceabc73929"
     },
     {
       "name": "test_inputs.py",
@@ -3774,7 +3780,7 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 1276,
+      "size_lines": 1357,
       "last_updated": "2026-08-15",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
@@ -3873,6 +3879,23 @@
           ]
         },
         {
+          "name": "test_session_context_uses_only_canonical_git_state_and_fails_closed",
+          "params": [
+            "case",
+            "expected_return",
+            "expected_text",
+            "monkeypatch",
+            "capsys"
+          ]
+        },
+        {
+          "name": "test_session_context_holds_authority_exception_without_subprocess_fallback",
+          "params": [
+            "monkeypatch",
+            "capsys"
+          ]
+        },
+        {
           "name": "test_session_heading_marker_accepts_descriptive_titles",
           "params": [
             "heading"
@@ -3886,26 +3909,12 @@
         },
         {
           "name": "test_run_task_brief_and_index_help_are_read_only"
-        },
-        {
-          "name": "test_run_index_generator_dry_run_routes_scope_without_writes",
-          "params": [
-            "arguments",
-            "expected"
-          ]
-        },
-        {
-          "name": "test_index_generator_uses_worktree_runtime_in_temp_project",
-          "description": "The index launcher must resolve its runtime from its own worktree.",
-          "params": [
-            "tmp_path"
-          ]
         }
       ],
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "f629a968f1b6"
+      "content_hash": "6d82a69832c8"
     },
     {
       "name": "test_session_store.py",
@@ -4663,5 +4672,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "24170f169f67e4fc"
+  "content_hash": "8dcb6b97fa2d632a"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -3650,10 +3650,20 @@
     {
       "name": "test_session_automation.py",
       "type": "python",
-      "size_lines": 858,
+      "size_lines": 890,
       "last_updated": "2026-08-15",
       "description": "Regression tests for maintenance session automation.",
       "functions": [
+        {
+          "name": "test_run_sh_routes_receipt_bound_handoff_help"
+        },
+        {
+          "name": "test_handoff_replaces_maintained_legacy_heading",
+          "params": [
+            "monkeypatch",
+            "tmp_path"
+          ]
+        },
         {
           "name": "test_session_heading_marker_accepts_descriptive_titles",
           "params": [
@@ -3748,21 +3758,12 @@
           "params": [
             "tmp_path"
           ]
-        },
-        {
-          "name": "test_api_route_shape_matches_dynamic_segments"
-        },
-        {
-          "name": "test_api_contract_scan_fails_closed_without_typescript",
-          "params": [
-            "tmp_path"
-          ]
         }
       ],
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "76744a2f80de"
+      "content_hash": "1f75dfd1fc3b"
     },
     {
       "name": "test_session_store.py",
@@ -4520,5 +4521,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "e3f02f525d4be678"
+  "content_hash": "be0a5560dc4e7f36"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 224,
+      "size_lines": 233,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2277,7 +2277,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "8cb1f978a95c"
+      "content_hash": "78e36bb84a23"
     },
     {
       "name": "test_git_handoff_receipt.py",
@@ -4587,5 +4587,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "d8578afefe46969c"
+  "content_hash": "1464440469a8b468"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 195,
+      "size_lines": 224,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2260,6 +2260,13 @@
           ]
         },
         {
+          "name": "test_genuine_governing_prohibition_is_safe",
+          "params": [
+            "prohibition",
+            "tmp_path"
+          ]
+        },
+        {
           "name": "test_harmless_historical_prose_is_not_treated_as_live_instruction",
           "params": [
             "historical",
@@ -2270,7 +2277,7 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "fc94cc81944a"
+      "content_hash": "8cb1f978a95c"
     },
     {
       "name": "test_git_handoff_receipt.py",
@@ -4580,5 +4587,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "03bf742b165a0924"
+  "content_hash": "d8578afefe46969c"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2227,7 +2227,7 @@
     {
       "name": "test_git_guidance_semantics.py",
       "type": "python",
-      "size_lines": 176,
+      "size_lines": 195,
       "last_updated": "2026-08-15",
       "description": "Semantic live-guidance discovery and coherence regressions.",
       "functions": [
@@ -2262,6 +2262,7 @@
         {
           "name": "test_harmless_historical_prose_is_not_treated_as_live_instruction",
           "params": [
+            "historical",
             "tmp_path"
           ]
         }
@@ -2269,12 +2270,12 @@
       "constants": [
         "REPO_ROOT"
       ],
-      "content_hash": "dbac1809f4b3"
+      "content_hash": "fc94cc81944a"
     },
     {
       "name": "test_git_handoff_receipt.py",
       "type": "python",
-      "size_lines": 384,
+      "size_lines": 429,
       "last_updated": "2026-08-15",
       "description": "Regressions for the durable, fail-closed task-to-Git handoff receipt.",
       "functions": [
@@ -2343,19 +2344,22 @@
           "name": "test_stale_authorization_source_provenance_fails_closed"
         },
         {
-          "name": "test_authorization_query_failure_fails_closed"
-        },
-        {
-          "name": "test_closed_safe_hold_next_actions_need_no_mutation_authority",
+          "name": "test_nested_authorization_source_query_failure_fails_closed",
           "params": [
-            "next_action"
+            "query_status"
           ]
         },
         {
-          "name": "test_receipt_cannot_claim_to_grant_authority"
+          "name": "test_future_authorization_source_provenance_fails_closed"
         },
         {
-          "name": "test_receipt_module_has_no_independent_git_or_network_reader"
+          "name": "test_missing_or_malformed_authorization_source_time_fails_closed",
+          "params": [
+            "timestamp"
+          ]
+        },
+        {
+          "name": "test_authorization_query_failure_fails_closed"
         }
       ],
       "constants": [
@@ -2365,7 +2369,7 @@
         "TREE",
         "MERGE"
       ],
-      "content_hash": "8fc3c8723ad3"
+      "content_hash": "07e27ee74292"
     },
     {
       "name": "test_git_state.py",
@@ -4576,5 +4580,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "4ed46b2bb74bd507"
+  "content_hash": "03bf742b165a0924"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,9 +50,9 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 9 | 312 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 9 | 321 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
-| [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
+| [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 15 | 448 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
 | [test_is456_constants.py](test_is456_constants.py) | Tests for IS 456:2000 named design constants. | 1 | 0 | 163 |
@@ -69,7 +69,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 910 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1019 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1158 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,8 +50,8 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 4 | 139 |
-| [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 16 | 333 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 6 | 176 |
+| [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 384 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -52,7 +52,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
 | [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 10 | 362 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
-| [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 19 | 635 |
+| [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 20 | 682 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
 | [test_is456_constants.py](test_is456_constants.py) | Tests for IS 456:2000 named design constants. | 1 | 0 | 163 |
@@ -69,7 +69,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 910 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1276 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1357 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -51,7 +51,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
 | [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 4 | 139 |
-| [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 10 | 257 |
+| [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 16 | 333 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,8 +50,8 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 6 | 176 |
-| [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 384 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 6 | 195 |
+| [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,7 +50,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 7 | 233 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 7 | 245 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,7 +50,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 9 | 302 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 9 | 312 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
@@ -69,7 +69,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 910 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 890 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1019 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,9 +50,9 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 9 | 321 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 10 | 362 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
-| [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 15 | 448 |
+| [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 17 | 538 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
 | [test_is456_constants.py](test_is456_constants.py) | Tests for IS 456:2000 named design constants. | 1 | 0 | 163 |
@@ -69,7 +69,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 910 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1158 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1236 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -52,7 +52,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
 | [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 10 | 362 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
-| [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 17 | 538 |
+| [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 19 | 635 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
 | [test_is456_constants.py](test_is456_constants.py) | Tests for IS 456:2000 named design constants. | 1 | 0 | 163 |
@@ -69,7 +69,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 910 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1236 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 1276 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -3,8 +3,8 @@
 This document describes the test taxonomy and structure for the structural_engineering_lib test suite.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-13
-**Files:** 63
+**Last Updated:** 2026-08-15
+**Files:** 67
 
 ## Documentation Files
 
@@ -18,7 +18,7 @@ This document describes the test taxonomy and structure for the structural_engin
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) |  | 0 | 0 | 1 |
 | [conftest.py](conftest.py) | Pytest configuration and Hypothesis profiles for the test su | 0 | 6 | 131 |
-| [test_agent_governance_automation.py](test_agent_governance_automation.py) | Regression tests for agent-governance automation controls. | 0 | 20 | 536 |
+| [test_agent_governance_automation.py](test_agent_governance_automation.py) | Regression tests for agent-governance automation controls. | 0 | 20 | 541 |
 | [test_api_manifest_tools.py](test_api_manifest_tools.py) | Regression tests for the single canonical public API manifes | 0 | 5 | 134 |
 | [test_api_results.py](test_api_results.py) | Tests for API result dataclasses. | 3 | 0 | 394 |
 | [test_api_stability.py](test_api_stability.py) | EA-9: Wheel API stability tests. | 6 | 0 | 233 |
@@ -26,8 +26,10 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_assertion_helpers.py](test_assertion_helpers.py) | Tests for the IS 456 test assertion helpers. | 3 | 0 | 82 |
 | [test_audit.py](test_audit.py) | Tests for audit module (TASK-278). | 6 | 0 | 468 |
 | [test_boq.py](test_boq.py) | Tests for the BOQ (Bill of Quantities) aggregation module. | 1 | 0 | 190 |
+| [test_branch_disposition.py](test_branch_disposition.py) | Outcome tests for the inspection-only branch disposition cla | 0 | 12 | 437 |
 | [test_bump_version_semantics.py](test_bump_version_semantics.py) | Regression coverage for candidate-version documentation sema | 0 | 1 | 66 |
 | [test_calculation_report.py](test_calculation_report.py) | Tests for the calculation_report module (TASK-277). | 9 | 4 | 745 |
+| [test_ci_workflow_contract.py](test_ci_workflow_contract.py) | Regression tests for fail-closed PR workflow routing. | 0 | 5 | 182 |
 | [test_clause_traceability.py](test_clause_traceability.py) | Tests for IS 456 Traceability Module | 10 | 2 | 489 |
 | [test_column_axial.py](test_column_axial.py) | Tests for column axial module — effective_length() per IS 45 | 6 | 0 | 273 |
 | [test_column_biaxial.py](test_column_biaxial.py) | Tests for IS 456 Cl 39.6 biaxial bending check — TASK-635. | 8 | 0 | 958 |
@@ -48,6 +50,8 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 4 | 139 |
+| [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 10 | 257 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
@@ -65,7 +69,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 910 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 663 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 858 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,7 +50,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 7 | 224 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 7 | 233 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -69,7 +69,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_reports.py](test_reports.py) | Tests for the reports module. | 8 | 0 | 447 |
 | [test_research_prototypes.py](test_research_prototypes.py) | Tests for research prototypes: Sustainability, Generative De | 4 | 0 | 910 |
 | [test_result_base.py](test_result_base.py) | Tests for result_base module. | 7 | 0 | 217 |
-| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 858 |
+| [test_session_automation.py](test_session_automation.py) | Regression tests for maintenance session automation. | 0 | 20 | 890 |
 | [test_session_store.py](test_session_store.py) | Tests for scripts/session_store.py — JSON session persistenc | 7 | 0 | 287 |
 | [test_slenderness.py](test_slenderness.py) | Unit tests for slenderness module. | 5 | 0 | 360 |
 | [test_testing_strategies.py](test_testing_strategies.py) | Tests for the testing_strategies module (TASK-279). | 12 | 0 | 681 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,7 +50,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 6 | 195 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 7 | 224 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -50,7 +50,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_footing_load_transfer.py](test_footing_load_transfer.py) | Focused independent arithmetic checks for IS 456 Cl. 34.4 lo | 0 | 7 | 165 |
 | [test_function_quality_checker.py](test_function_quality_checker.py) | Focused regressions for the IS 456 function-quality checker. | 0 | 2 | 55 |
 | [test_generated_clients.py](test_generated_clients.py) | Contract checks for the checked-in basic generated clients. | 0 | 2 | 71 |
-| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 7 | 245 |
+| [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 9 | 302 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 14 | 425 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -35,20 +36,28 @@ def _write_index(root: Path, **overrides) -> Path:
             r"(^|[` ])git\s+checkout\s+-b(?:\s|`|$)",
             r"(^|[` ])git\s+switch\s+-c\s+(?!codex/)",
             (
-                r"(?:(?<![A-Za-z0-9])(?:do not|don't|never)\s+push\b"
-                r"[^\n.;!?]*\bwithout\s+pull(?:ing)?\s+first\b|"
-                r"(?=[^\n]*(?:git|PR|branch|remote|repository|upstream|commit))"
-                r"[^\n.;!?]*\bpull(?:\s+(?:the\s+)?(?:PR\s+)?branch)?"
-                r"\s+before\s+(?:you\s+)?push(?:ing)?\b|"
-                r"(?=[^\n]*(?:git|PR|branch|remote|repository|upstream|commit))"
-                r"[^\n.;!?]*\bpull\s+first\b[^\n.;!?]{0,40}"
-                r"\b(?:then\s+)?push(?:ing)?\b|"
-                r"^\s*(?:always\s+)?pull\s+before\s+you\s+push"
-                r"(?:\s+to\s+(?:the\s+)?PR\s+branch)?[.!]?\s*$|"
-                r"^\s*pull\s+first\s*,?\s*then\s+push"
-                r"(?:\s+the\s+change)?[.!]?\s*$|"
-                r"^\s*before\s+you\s+push\s*,\s*pull\s+first[.!]?\s*$)"
+                r"(?<![A-Za-z0-9])(?:do not|don't|never)\s+push\b"
+                r"[^\n.;!?]*\bwithout\s+pull(?:ing)?\s+first\b"
             ),
+            {
+                "kind": "clause_action",
+                "action_pattern": (
+                    r"\bpull(?:\s+(?:the\s+)?(?:(?:pr|remote|upstream)\s+)?"
+                    r"branch)?\s+before\s+(?:you\s+)?push(?:ing)?\b|"
+                    r"\bpull\s+first\b[^\n.;!?]{0,40}\b(?:then\s+)?"
+                    r"push(?:ing)?\b|\bpull\s+first\b"
+                ),
+                "context_pattern": (
+                    r"\b(?:git|pr|branch|remote|repository|upstream|commit)\b"
+                ),
+                "standalone_clause_patterns": [
+                    r"(?:then\s+)?(?:always\s+)?pull\s+before\s+you\s+push"
+                    r"(?:\s+to\s+(?:the\s+)?pr\s+branch)?",
+                    r"(?:then\s+)?pull\s+first\s*,?\s*then\s+push"
+                    r"(?:\s+the\s+change)?",
+                    r"(?:then\s+)?before\s+you\s+push\s*,\s*pull\s+first",
+                ],
+            },
         ],
         "required_contracts": {},
     }
@@ -247,6 +256,8 @@ def test_genuine_governing_prohibition_is_safe(prohibition, tmp_path):
         "Before you push, pull first.",
         "For the PR branch, pull first, then push the change.",
         "Don't push to the PR branch without pulling first.",
+        "Pull the remote branch before pushing.",
+        "Do not delete the worktree; then pull before you push.",
     ],
 )
 def test_data_driven_omitted_git_pull_before_push_instruction_fails(
@@ -262,14 +273,41 @@ def test_data_driven_omitted_git_pull_before_push_instruction_fails(
     pull_patterns = [
         pattern
         for pattern in live_config["forbidden_instruction_patterns"]
-        if "pull" in pattern and "push" in pattern
+        if (isinstance(pattern, str) and "pull" in pattern and "push" in pattern)
+        or (isinstance(pattern, dict) and pattern.get("kind") == "clause_action")
     ]
-    assert len(pull_patterns) == 1
+    assert len(pull_patterns) == 2
     index = _write_index(tmp_path, forbidden_instruction_patterns=pull_patterns)
 
     errors = checker.check_semantic_guidance(tmp_path, index)
 
     assert any("unsafe Git instruction" in error for error in errors)
+
+
+def test_clause_local_pull_rule_matches_from_the_governed_action():
+    config = json.loads(
+        (REPO_ROOT / "docs/git-automation/live-git-guidance-index.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    rule = next(
+        item
+        for item in config["forbidden_instruction_patterns"]
+        if isinstance(item, dict) and item.get("kind") == "clause_action"
+    )
+    line = "Do not delete the worktree; then Pull the remote branch before pushing."
+    spans = checker._structured_instruction_errors(
+        line,
+        re.compile(rule["action_pattern"], re.IGNORECASE),
+        re.compile(rule["context_pattern"], re.IGNORECASE),
+        tuple(
+            re.compile(pattern, re.IGNORECASE)
+            for pattern in rule["standalone_clause_patterns"]
+        ),
+    )
+
+    assert len(spans) == 1
+    assert line[slice(*spans[0])] == "Pull the remote branch before pushing"
 
 
 @pytest.mark.parametrize(
@@ -283,6 +321,9 @@ def test_data_driven_omitted_git_pull_before_push_instruction_fails(
         "Pull first aid supplies from the cabinet.",
         "For the sled exercise, pull first, then push the load.",
         "The actuator will pull before you push the test lever.",
+        "For the sled exercise, pull first, then push the spring-loaded cart.",
+        "The actuator will pull before you push the appropriate test lever.",
+        "For the sled exercise, pull first, then push the load. The repository records the result.",
         "Do not pull before you push; inspect branch and upstream first.",
         "Historical guidance said pull before you push.",
     ],

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -38,7 +38,10 @@ def _write_index(root: Path, **overrides) -> Path:
                 r"(?:(?<![A-Za-z0-9])(?:do not|don't|never)\s+push\b"
                 r"[^\n.;!?]*\bwithout\s+pull(?:ing)?\s+first\b|"
                 r"\bpull(?:\s+(?:the\s+)?(?:PR\s+)?branch)?\s+before"
-                r"\s+push(?:ing)?\b|\bpull\s+first\b)"
+                r"\s+(?:you\s+)?push(?:ing)?\b|\bpull\s+first\b"
+                r"[^\n.;!?]{0,40}\b(?:then\s+)?push(?:ing)?\b|"
+                r"\bbefore\s+you\s+push\b[^\n.;!?]{0,40}"
+                r"\bpull\s+first\b)"
             ),
         ],
         "required_contracts": {},
@@ -232,7 +235,10 @@ def test_genuine_governing_prohibition_is_safe(prohibition, tmp_path):
     [
         "Pull before pushing to the PR branch.",
         "Pull the PR branch before pushing.",
+        "Pull before you push.",
+        "Always pull before you push to the PR branch.",
         "Pull first, then push the change.",
+        "Before you push, pull first.",
         "Don't push to the PR branch without pulling first.",
     ],
 )
@@ -266,6 +272,10 @@ def test_data_driven_omitted_git_pull_before_push_instruction_fails(
         "Never pull first; inspect with git_state.py.",
         "Historical incident evidence says the old guide required pull before pushing.",
         "Deprecated guidance says pull first, then push.",
+        "The lead horse should pull first in the team.",
+        "Pull first aid supplies from the cabinet.",
+        "Do not pull before you push; inspect branch and upstream first.",
+        "Historical guidance said pull before you push.",
     ],
 )
 def test_omitted_git_pull_pattern_respects_prohibition_and_history(

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -25,6 +25,12 @@ def _write_index(root: Path, **overrides) -> Path:
         "historical_exclusions": [],
         "forbidden_tokens": ["ai_commit.sh", "--finish"],
         "forbidden_command_patterns": [r"(^|[` ])git\s+reset\s+--hard(?:[` ]|$)"],
+        "forbidden_instruction_patterns": [
+            r"(^|[` ])git\s+add\s+(?:\.|-A|--all)(?:[` ]|$)",
+            r"(^|[` ])git\s+filter-branch(?:[` ]|$)",
+            r"(^|[` ])git\s+checkout\b[^\n]*(?:HEAD|--)\b",
+            r"(^|[` ])git\s+reset(?:\s|`|$)",
+        ],
         "required_contracts": {},
     }
     payload.update(overrides)
@@ -136,3 +142,34 @@ def test_live_aliases_route_to_receipt_and_not_retired_mutation():
     assert "git_handoff_receipt.py" in result.stdout
     assert "ai_commit.sh" not in result.stdout
     assert "cleanup_stale_branches.py" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    "instruction",
+    [
+        "| `git add .` | Stage everything |",
+        "```bash\ngit add -A\n```",
+        "Use `git filter-branch` to remove the secret.",
+        "`git checkout HEAD -- path/to/file`",
+        "```bash\ngit reset --soft HEAD~1\n```",
+    ],
+)
+def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
+    guide = tmp_path / "guide.md"
+    guide.write_text(instruction + "\n", encoding="utf-8")
+    index = _write_index(tmp_path)
+
+    errors = checker.check_semantic_guidance(tmp_path, index)
+
+    assert any("unsafe Git instruction" in error for error in errors)
+
+
+def test_harmless_historical_prose_is_not_treated_as_live_instruction(tmp_path):
+    guide = tmp_path / "guide.md"
+    guide.write_text(
+        "Historical incident evidence says git reset --soft was used in 2024.\n",
+        encoding="utf-8",
+    )
+    index = _write_index(tmp_path)
+
+    assert checker.check_semantic_guidance(tmp_path, index) == []

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -1,0 +1,138 @@
+"""Semantic live-guidance discovery and coherence regressions."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_only
+
+checker = importlib.import_module("scripts.check_codex_git_workflow")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_index(root: Path, **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "canonical": "guide.md",
+        "live_surfaces": ["guide.md"],
+        "live_globs": [],
+        "indexed_surface_sets": [],
+        "historical_exclusions": [],
+        "forbidden_tokens": ["ai_commit.sh", "--finish"],
+        "forbidden_command_patterns": [r"(^|[` ])git\s+reset\s+--hard(?:[` ]|$)"],
+        "required_contracts": {},
+    }
+    payload.update(overrides)
+    path = root / "live-index.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_live_semantic_contradiction_fails_and_coherent_guidance_passes(tmp_path):
+    guide = tmp_path / "guide.md"
+    guide.write_text("Use ./scripts/ai_commit.sh --finish.\n", encoding="utf-8")
+    index = _write_index(tmp_path)
+
+    errors = checker.check_semantic_guidance(tmp_path, index)
+
+    assert any("ai_commit.sh" in error for error in errors)
+    assert any("--finish" in error for error in errors)
+
+    guide.write_text(
+        "Use scripts/git_state.py; NOT_CHECKED and UNKNOWN are holds.\n",
+        encoding="utf-8",
+    )
+    assert checker.check_semantic_guidance(tmp_path, index) == []
+
+
+def test_indexed_deprecated_history_is_excluded_only_with_explicit_boundary(
+    tmp_path: Path,
+):
+    guides = tmp_path / "guides"
+    guides.mkdir()
+    current = guides / "current.md"
+    current.write_text("Current coherent guidance.\n", encoding="utf-8")
+    old = guides / "old.md"
+    old.write_text(
+        """---
+status: deprecated
+---
+> Historical only. Use ./scripts/ai_commit.sh --finish in the old workflow.
+""",
+        encoding="utf-8",
+    )
+    generated = guides / "index.json"
+    generated.write_text(
+        json.dumps({"files": [{"name": "current.md"}, {"name": "old.md"}]}),
+        encoding="utf-8",
+    )
+    index = _write_index(
+        tmp_path,
+        live_surfaces=[],
+        indexed_surface_sets=[
+            {
+                "index": "guides/index.json",
+                "root": "guides",
+                "historical_statuses": ["deprecated"],
+                "ignore_names": [],
+            }
+        ],
+    )
+
+    surfaces, errors, _config = checker.discover_guidance_surfaces(tmp_path, index)
+
+    assert errors == []
+    assert surfaces == [current]
+
+    old.write_text(
+        """---
+status: deprecated
+---
+Use ./scripts/ai_commit.sh --finish.
+""",
+        encoding="utf-8",
+    )
+    _surfaces, errors, _config = checker.discover_guidance_surfaces(tmp_path, index)
+    assert any("lacks an explicit boundary" in error for error in errors)
+
+
+def test_archive_path_is_explicitly_excluded_from_live_authority(tmp_path: Path):
+    guide = tmp_path / "guide.md"
+    guide.write_text("Current coherent guidance.\n", encoding="utf-8")
+    archive = tmp_path / "docs" / "_archive"
+    archive.mkdir(parents=True)
+    (archive / "old.md").write_text(
+        "Use ./scripts/ai_commit.sh --finish.\n", encoding="utf-8"
+    )
+    index = _write_index(
+        tmp_path,
+        historical_exclusions=[
+            {"glob": "docs/_archive/**", "boundary": "archive_path"}
+        ],
+    )
+
+    assert checker.check_semantic_guidance(tmp_path, index) == []
+
+
+def test_live_aliases_route_to_receipt_and_not_retired_mutation():
+    result = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts/python_runtime.sh"),
+            "scripts/find_automation.py",
+            "task git handoff receipt",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "git_handoff_receipt.py" in result.stdout
+    assert "ai_commit.sh" not in result.stdout
+    assert "cleanup_stale_branches.py" not in result.stdout

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -37,11 +37,17 @@ def _write_index(root: Path, **overrides) -> Path:
             (
                 r"(?:(?<![A-Za-z0-9])(?:do not|don't|never)\s+push\b"
                 r"[^\n.;!?]*\bwithout\s+pull(?:ing)?\s+first\b|"
-                r"\bpull(?:\s+(?:the\s+)?(?:PR\s+)?branch)?\s+before"
-                r"\s+(?:you\s+)?push(?:ing)?\b|\bpull\s+first\b"
-                r"[^\n.;!?]{0,40}\b(?:then\s+)?push(?:ing)?\b|"
-                r"\bbefore\s+you\s+push\b[^\n.;!?]{0,40}"
-                r"\bpull\s+first\b)"
+                r"(?=[^\n]*(?:git|PR|branch|remote|repository|upstream|commit))"
+                r"[^\n.;!?]*\bpull(?:\s+(?:the\s+)?(?:PR\s+)?branch)?"
+                r"\s+before\s+(?:you\s+)?push(?:ing)?\b|"
+                r"(?=[^\n]*(?:git|PR|branch|remote|repository|upstream|commit))"
+                r"[^\n.;!?]*\bpull\s+first\b[^\n.;!?]{0,40}"
+                r"\b(?:then\s+)?push(?:ing)?\b|"
+                r"^\s*(?:always\s+)?pull\s+before\s+you\s+push"
+                r"(?:\s+to\s+(?:the\s+)?PR\s+branch)?[.!]?\s*$|"
+                r"^\s*pull\s+first\s*,?\s*then\s+push"
+                r"(?:\s+the\s+change)?[.!]?\s*$|"
+                r"^\s*before\s+you\s+push\s*,\s*pull\s+first[.!]?\s*$)"
             ),
         ],
         "required_contracts": {},
@@ -239,6 +245,7 @@ def test_genuine_governing_prohibition_is_safe(prohibition, tmp_path):
         "Always pull before you push to the PR branch.",
         "Pull first, then push the change.",
         "Before you push, pull first.",
+        "For the PR branch, pull first, then push the change.",
         "Don't push to the PR branch without pulling first.",
     ],
 )
@@ -274,6 +281,8 @@ def test_data_driven_omitted_git_pull_before_push_instruction_fails(
         "Deprecated guidance says pull first, then push.",
         "The lead horse should pull first in the team.",
         "Pull first aid supplies from the cabinet.",
+        "For the sled exercise, pull first, then push the load.",
+        "The actuator will pull before you push the test lever.",
         "Do not pull before you push; inspect branch and upstream first.",
         "Historical guidance said pull before you push.",
     ],

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -160,6 +160,18 @@ def test_live_aliases_route_to_receipt_and_not_retired_mutation():
         "Recover the work with `git cherry-pick abc123`.",
         "```bash\ngit checkout -b recovery-branch abc123\n```",
         "Use `git switch -c recovery-branch` to preserve the commit.",
+        "Amend the commit with `git commit --amend --no-edit`.",
+        "Cherry-pick the recovery using `git cherry-pick abc123`.",
+        "Create a recovery branch with `git checkout -b recovery abc123`.",
+        "Replay the change via `git cherry-pick abc123`.",
+        (
+            "Do not delete the worktree; then amend the commit with "
+            "`git commit --amend --no-edit`."
+        ),
+        (
+            "Never ignore ownership. Create a recovery branch with "
+            "`git checkout -b recovery abc123`."
+        ),
     ],
 )
 def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
@@ -170,6 +182,23 @@ def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
     errors = checker.check_semantic_guidance(tmp_path, index)
 
     assert any("unsafe Git instruction" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "prohibition",
+    [
+        "Never use `git commit --amend --no-edit`.",
+        "Do not recover with `git cherry-pick abc123`.",
+        "`git checkout -b recovery abc123` is forbidden.",
+        "Using `git switch -c recovery` is prohibited.",
+    ],
+)
+def test_genuine_governing_prohibition_is_safe(prohibition, tmp_path):
+    guide = tmp_path / "guide.md"
+    guide.write_text(prohibition + "\n", encoding="utf-8")
+    index = _write_index(tmp_path)
+
+    assert checker.check_semantic_guidance(tmp_path, index) == []
 
 
 @pytest.mark.parametrize(

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -34,6 +34,12 @@ def _write_index(root: Path, **overrides) -> Path:
             r"(^|[` ])git\s+cherry-pick(?:\s|`|$)",
             r"(^|[` ])git\s+checkout\s+-b(?:\s|`|$)",
             r"(^|[` ])git\s+switch\s+-c\s+(?!codex/)",
+            (
+                r"(?:(?<![A-Za-z0-9])(?:do not|don't|never)\s+push\b"
+                r"[^\n.;!?]*\bwithout\s+pull(?:ing)?\s+first\b|"
+                r"\bpull(?:\s+(?:the\s+)?(?:PR\s+)?branch)?\s+before"
+                r"\s+push(?:ing)?\b|\bpull\s+first\b)"
+            ),
         ],
         "required_contracts": {},
     }
@@ -216,6 +222,57 @@ def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
 def test_genuine_governing_prohibition_is_safe(prohibition, tmp_path):
     guide = tmp_path / "guide.md"
     guide.write_text(prohibition + "\n", encoding="utf-8")
+    index = _write_index(tmp_path)
+
+    assert checker.check_semantic_guidance(tmp_path, index) == []
+
+
+@pytest.mark.parametrize(
+    "instruction",
+    [
+        "Pull before pushing to the PR branch.",
+        "Pull the PR branch before pushing.",
+        "Pull first, then push the change.",
+        "Don't push to the PR branch without pulling first.",
+    ],
+)
+def test_data_driven_omitted_git_pull_before_push_instruction_fails(
+    instruction, tmp_path
+):
+    guide = tmp_path / "guide.md"
+    guide.write_text(instruction + "\n", encoding="utf-8")
+    live_config = json.loads(
+        (REPO_ROOT / "docs/git-automation/live-git-guidance-index.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    pull_patterns = [
+        pattern
+        for pattern in live_config["forbidden_instruction_patterns"]
+        if "pull" in pattern and "push" in pattern
+    ]
+    assert len(pull_patterns) == 1
+    index = _write_index(tmp_path, forbidden_instruction_patterns=pull_patterns)
+
+    errors = checker.check_semantic_guidance(tmp_path, index)
+
+    assert any("unsafe Git instruction" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "safe_context",
+    [
+        "Do not pull before pushing; inspect branch and upstream first.",
+        "Never pull first; inspect with git_state.py.",
+        "Historical incident evidence says the old guide required pull before pushing.",
+        "Deprecated guidance says pull first, then push.",
+    ],
+)
+def test_omitted_git_pull_pattern_respects_prohibition_and_history(
+    safe_context, tmp_path
+):
+    guide = tmp_path / "guide.md"
+    guide.write_text(safe_context + "\n", encoding="utf-8")
     index = _write_index(tmp_path)
 
     assert checker.check_semantic_guidance(tmp_path, index) == []

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -30,6 +30,10 @@ def _write_index(root: Path, **overrides) -> Path:
             r"(^|[` ])git\s+filter-branch(?:[` ]|$)",
             r"(^|[` ])git\s+checkout\b[^\n]*(?:HEAD|--)\b",
             r"(^|[` ])git\s+reset(?:\s|`|$)",
+            r"(^|[` ])git\s+commit\b[^\n]*--amend(?:[` ]|$)",
+            r"(^|[` ])git\s+cherry-pick(?:\s|`|$)",
+            r"(^|[` ])git\s+checkout\s+-b(?:\s|`|$)",
+            r"(^|[` ])git\s+switch\s+-c\s+(?!codex/)",
         ],
         "required_contracts": {},
     }
@@ -152,6 +156,10 @@ def test_live_aliases_route_to_receipt_and_not_retired_mutation():
         "Use `git filter-branch` to remove the secret.",
         "`git checkout HEAD -- path/to/file`",
         "```bash\ngit reset --soft HEAD~1\n```",
+        "```bash\ngit commit --amend --no-edit\n```",
+        "Recover the work with `git cherry-pick abc123`.",
+        "```bash\ngit checkout -b recovery-branch abc123\n```",
+        "Use `git switch -c recovery-branch` to preserve the commit.",
     ],
 )
 def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
@@ -164,10 +172,21 @@ def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
     assert any("unsafe Git instruction" in error for error in errors)
 
 
-def test_harmless_historical_prose_is_not_treated_as_live_instruction(tmp_path):
+@pytest.mark.parametrize(
+    "historical",
+    [
+        "Historical incident evidence says git reset --soft was used in 2024.",
+        "The 2024 incident record says git commit --amend was used.",
+        "Historical evidence records git cherry-pick during the old recovery.",
+        "The archived incident narrative mentions git checkout -b recovery-old.",
+    ],
+)
+def test_harmless_historical_prose_is_not_treated_as_live_instruction(
+    historical, tmp_path
+):
     guide = tmp_path / "guide.md"
     guide.write_text(
-        "Historical incident evidence says git reset --soft was used in 2024.\n",
+        historical + "\n",
         encoding="utf-8",
     )
     index = _write_index(tmp_path)

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -178,6 +178,10 @@ def test_live_aliases_route_to_receipt_and_not_retired_mutation():
         "Do not fail to run git reset --soft HEAD~1.",
         "Never remember to recover with git cherry-pick abc123.",
         "Do not omit to create a branch with git checkout -b recovery.",
+        "`git reset --hard` — do not forget to run this command.",
+        "`git cherry-pick abc123` — never hesitate to use this form.",
+        "`git reset --hard`; do not run tests.",
+        "Do not avoid git reset --hard.",
     ],
 )
 def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
@@ -200,6 +204,13 @@ def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
         "Do not recover with `git cherry-pick abc123`.",
         "`git checkout -b recovery abc123` is forbidden.",
         "Using `git switch -c recovery` is prohibited.",
+        "`git reset --hard` — **do not run this command**.",
+        "`git cherry-pick abc123` — _never use this form_.",
+        "Never forget not to run git reset --hard.",
+        "Do not fail to avoid git cherry-pick abc123.",
+        "Do not fail to avoid running git reset --hard.",
+        "Avoid using git reset --hard.",
+        "Do not run git reset --hard; however, preserve the worktree.",
     ],
 )
 def test_genuine_governing_prohibition_is_safe(prohibition, tmp_path):
@@ -217,6 +228,7 @@ def test_genuine_governing_prohibition_is_safe(prohibition, tmp_path):
         "The 2024 incident record says git commit --amend was used.",
         "Historical evidence records git cherry-pick during the old recovery.",
         "The archived incident narrative mentions git checkout -b recovery-old.",
+        "Historical evidence records that operators were told not to run git reset.",
     ],
 )
 def test_harmless_historical_prose_is_not_treated_as_live_instruction(

--- a/Python/tests/test_git_guidance_semantics.py
+++ b/Python/tests/test_git_guidance_semantics.py
@@ -172,6 +172,12 @@ def test_live_aliases_route_to_receipt_and_not_retired_mutation():
             "Never ignore ownership. Create a recovery branch with "
             "`git checkout -b recovery abc123`."
         ),
+        "Do not forget to run git reset --hard.",
+        "Never hesitate to recover with git cherry-pick abc123.",
+        "Never fail to create a branch with git checkout -b recovery.",
+        "Do not fail to run git reset --soft HEAD~1.",
+        "Never remember to recover with git cherry-pick abc123.",
+        "Do not omit to create a branch with git checkout -b recovery.",
     ],
 )
 def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
@@ -188,6 +194,9 @@ def test_live_indexed_unsafe_instruction_context_fails(instruction, tmp_path):
     "prohibition",
     [
         "Never use `git commit --amend --no-edit`.",
+        "Never use git reset --hard.",
+        "Do not run git reset --soft HEAD~1.",
+        "NEVER: git push --force-with-lease.",
         "Do not recover with `git cherry-pick abc123`.",
         "`git checkout -b recovery abc123` is forbidden.",
         "Using `git switch -c recovery` is prohibited.",

--- a/Python/tests/test_git_handoff_receipt.py
+++ b/Python/tests/test_git_handoff_receipt.py
@@ -100,6 +100,8 @@ def _evidence() -> dict:
             "prohibited_actions": ["DELETE_BRANCH", "DELETE_WORKTREE"],
             "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
             "authority_source": {
+                "status": "OBSERVED",
+                "query_status": "OK",
                 "kind": "ORCHESTRATOR_DELEGATION",
                 "reference": "task:GIT-7E:test-fixture",
                 "observed_at_utc": NOW.isoformat(),
@@ -335,6 +337,49 @@ def test_stale_authorization_source_provenance_fails_closed():
     errors = receipt_module.validate_receipt(receipt, now=NOW)
 
     assert "MISSING_REQUIRED_HOLD:AUTHORIZATION_SOURCE_STALE_EVIDENCE" in errors
+    assert "FALSE_READY_CLAIM" in errors
+
+
+@pytest.mark.parametrize("query_status", ["FAILED", "UNKNOWN", None, 42])
+def test_nested_authorization_source_query_failure_fails_closed(query_status):
+    receipt = _receipt()
+    if query_status is None:
+        receipt["authorization"]["authority_source"].pop("query_status")
+    else:
+        receipt["authorization"]["authority_source"]["query_status"] = query_status
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "MISSING_REQUIRED_HOLD:AUTHORIZATION_SOURCE_QUERY_FAILED" in errors
+    assert "FALSE_READY_CLAIM" in errors
+
+
+def test_future_authorization_source_provenance_fails_closed():
+    receipt = _receipt()
+    receipt["authorization"]["authority_source"]["observed_at_utc"] = (
+        NOW + timedelta(minutes=1)
+    ).isoformat()
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "MISSING_REQUIRED_HOLD:AUTHORIZATION_SOURCE_FUTURE_EVIDENCE" in errors
+    assert "FALSE_READY_CLAIM" in errors
+
+
+@pytest.mark.parametrize("timestamp", [None, "not-a-time"])
+def test_missing_or_malformed_authorization_source_time_fails_closed(timestamp):
+    receipt = _receipt()
+    if timestamp is None:
+        receipt["authorization"]["authority_source"].pop("observed_at_utc")
+    else:
+        receipt["authorization"]["authority_source"]["observed_at_utc"] = timestamp
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert (
+        "MISSING_REQUIRED_HOLD:AUTHORIZATION_SOURCE_MALFORMED_OBSERVATION_TIME"
+        in errors
+    )
     assert "FALSE_READY_CLAIM" in errors
 
 

--- a/Python/tests/test_git_handoff_receipt.py
+++ b/Python/tests/test_git_handoff_receipt.py
@@ -94,6 +94,8 @@ def _evidence() -> dict:
         "task_archive": {"status": "NOT_CHECKED"},
         "authorization": {
             "status": "OBSERVED",
+            "query_status": "OK",
+            "observed_at_utc": NOW.isoformat(),
             "authorized_actions": ["OPEN_DRAFT_PR"],
             "prohibited_actions": ["DELETE_BRANCH", "DELETE_WORKTREE"],
             "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
@@ -311,6 +313,55 @@ def test_destructive_or_merge_actions_cannot_be_smuggled_into_ready_receipt():
 
     assert "MISSING_REQUIRED_HOLD:AUTHORIZATION_TARGET_ACTION_MISMATCH" in errors
     assert "FALSE_READY_CLAIM" in errors
+
+
+@pytest.mark.parametrize("next_action", ["DELETE_BRANCH", "MERGE"])
+def test_injected_destructive_or_merge_next_action_is_not_authorized(next_action):
+    receipt = _receipt()
+    receipt["authorization"]["next_action"] = next_action
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "MISSING_REQUIRED_HOLD:NEXT_ACTION_NOT_AUTHORIZED" in errors
+    assert "FALSE_READY_CLAIM" in errors
+
+
+def test_stale_authorization_source_provenance_fails_closed():
+    receipt = _receipt()
+    receipt["authorization"]["authority_source"]["observed_at_utc"] = (
+        NOW - timedelta(hours=1)
+    ).isoformat()
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "MISSING_REQUIRED_HOLD:AUTHORIZATION_SOURCE_STALE_EVIDENCE" in errors
+    assert "FALSE_READY_CLAIM" in errors
+
+
+def test_authorization_query_failure_fails_closed():
+    receipt = _receipt()
+    receipt["authorization"]["query_status"] = "FAILED"
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "MISSING_REQUIRED_HOLD:AUTHORIZATION_QUERY_FAILED" in errors
+    assert "FALSE_READY_CLAIM" in errors
+
+
+@pytest.mark.parametrize(
+    "next_action",
+    [
+        "HOLD_FOR_EXACT_EVIDENCE",
+        "WAIT_FOR_EXACT_HEAD_AUDIT",
+        "WAIT_FOR_OWNER_DECISION",
+        "STOP_AND_REINSPECT",
+    ],
+)
+def test_closed_safe_hold_next_actions_need_no_mutation_authority(next_action):
+    receipt = _receipt()
+    receipt["authorization"]["next_action"] = next_action
+
+    assert receipt_module.validate_receipt(receipt, now=NOW) == []
 
 
 def test_receipt_cannot_claim_to_grant_authority():

--- a/Python/tests/test_git_handoff_receipt.py
+++ b/Python/tests/test_git_handoff_receipt.py
@@ -1,0 +1,256 @@
+"""Regressions for the durable, fail-closed task-to-Git handoff receipt."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_only
+
+git_state = importlib.import_module("scripts.git_state")
+receipt_module = importlib.import_module("scripts.git_handoff_receipt")
+
+
+NOW = datetime(2026, 8, 15, 9, 30, tzinfo=UTC)
+HEAD = "a" * 40
+BASE = "b" * 40
+TREE = "c" * 40
+MERGE = "d" * 40
+
+
+def _state(*, failed: bool = False) -> git_state.RepositoryState:
+    return git_state.RepositoryState(
+        schema_version=1,
+        observed_at_utc=NOW.isoformat(),
+        repository_root="/tmp/repo",
+        worktree_root="/tmp/repo",
+        git_dir="/tmp/repo/.git",
+        git_common_dir="/tmp/repo/.git",
+        linked_worktree=False,
+        branch="codex/git-7e",
+        head_sha=HEAD,
+        default_base=git_state.Relation("origin/main", BASE, 1, 0, "ahead"),
+        upstream=git_state.Relation("origin/codex/git-7e", HEAD, 0, 0, "equal"),
+        tree=git_state.TreeState(clean=True),
+        operation="none",
+        operation_markers=[],
+        locks=[],
+        remote_freshness="NOT_CHECKED",
+        derived_action="HOLD_UNKNOWN" if failed else "READY_LOCAL",
+        hold_reasons=["query failed"] if failed else [],
+        query_failures=(
+            [git_state.QueryFailure("git status", "failed")] if failed else []
+        ),
+        duration_ms=1.0,
+    )
+
+
+def _observed(**values):
+    return {
+        "status": "OBSERVED",
+        "query_status": "OK",
+        "observed_at_utc": NOW.isoformat(),
+        **values,
+    }
+
+
+def _evidence() -> dict:
+    return {
+        "remote": _observed(
+            branch_state="PRESENT",
+            branch_ref="refs/heads/codex/git-7e",
+            head_sha=HEAD,
+            default_ref="refs/heads/main",
+            default_sha=BASE,
+        ),
+        "pull_request": _observed(
+            number=751,
+            state="OPEN",
+            base_ref="main",
+            base_sha=BASE,
+            head_ref="codex/git-7e",
+            head_sha=HEAD,
+            merge_state="CLEAN",
+            required_checks=[
+                {
+                    "name": "PR Gate",
+                    "head_sha": HEAD,
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                }
+            ],
+        ),
+        "review": _observed(base_sha=BASE, head_sha=HEAD, tree_sha=TREE),
+        "integration": {"status": "NOT_APPLICABLE", "reason_code": "PR_OPEN"},
+        "retention": _observed(
+            owner="Main Agent",
+            decision="RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+            holds=[],
+        ),
+        "task_archive": {"status": "NOT_CHECKED"},
+        "authorization": {
+            "status": "OBSERVED",
+            "authorized_actions": ["OPEN_DRAFT_PR"],
+            "prohibited_actions": ["DELETE_BRANCH", "DELETE_WORKTREE"],
+            "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+        },
+    }
+
+
+def _receipt(evidence: dict | None = None, *, state=None) -> dict:
+    return receipt_module.build_receipt(
+        task_id="GIT-7E",
+        integration_owner="Main Agent",
+        local_state=state or _state(),
+        evidence=_evidence() if evidence is None else evidence,
+        owned_paths=["scripts/git_handoff_receipt.py"],
+        shared_paths=["docs/SESSION_LOG.md"],
+        forbidden_paths=["refs/**"],
+        now=NOW,
+    )
+
+
+def test_valid_receipt_round_trips_with_exact_identity(tmp_path: Path):
+    receipt = _receipt()
+    path = tmp_path / "handoff.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    loaded = receipt_module.load_receipt(path)
+
+    assert receipt["receipt_status"] == "READY"
+    assert receipt["holds"] == []
+    assert loaded == receipt
+    assert receipt_module.validate_receipt(loaded, now=NOW) == []
+    assert loaded["local"]["state"]["head_sha"] == HEAD
+    assert loaded["review"]["tree_sha"] == TREE
+    assert loaded["task_archive"]["is_git_retention_evidence"] is False
+
+
+@pytest.mark.parametrize(
+    ("evidence", "reason"),
+    [
+        ({}, "REMOTE_NOT_CHECKED"),
+        (
+            {**_evidence(), "remote": {"status": "NOT_CHECKED"}},
+            "REMOTE_NOT_CHECKED",
+        ),
+        (
+            {
+                **_evidence(),
+                "remote": _observed(
+                    branch_state="PRESENT",
+                    head_sha=HEAD,
+                    observed_at_utc=(NOW - timedelta(hours=1)).isoformat(),
+                ),
+            },
+            "REMOTE_STALE_EVIDENCE",
+        ),
+        (
+            {
+                **_evidence(),
+                "remote": {
+                    **_observed(branch_state="PRESENT", head_sha=HEAD),
+                    "query_status": "FAILED",
+                },
+            },
+            "REMOTE_QUERY_FAILED",
+        ),
+    ],
+)
+def test_missing_not_checked_stale_and_query_failed_evidence_hold(evidence, reason):
+    receipt = _receipt(evidence)
+
+    assert receipt["receipt_status"] == "HOLD"
+    assert reason in receipt["holds"]
+
+
+def test_failed_git_state_is_unknown_even_when_hosted_evidence_is_green():
+    receipt = _receipt(state=_state(failed=True))
+
+    assert receipt["receipt_status"] == "HOLD"
+    assert "LOCAL_STATE_UNKNOWN" in receipt["holds"]
+
+
+def test_dirty_or_interrupted_local_state_holds_even_when_queries_succeed():
+    state = _state()
+    state.tree = git_state.TreeState(clean=False, modified_paths=["owned.py"])
+    state.derived_action = "HOLD_DIRTY"
+
+    receipt = _receipt(state=state)
+
+    assert receipt["receipt_status"] == "HOLD"
+    assert "LOCAL_HOLD_DIRTY" in receipt["holds"]
+
+
+def test_not_applicable_requires_a_reason_and_never_replaces_unknown():
+    evidence = _evidence()
+    evidence["review"] = {"status": "NOT_APPLICABLE"}
+
+    receipt = _receipt(evidence)
+
+    assert receipt["review"]["status"] == "UNKNOWN"
+    assert "REVIEW_NOT_APPLICABLE_WITHOUT_REASON" in receipt["holds"]
+
+
+def test_exact_head_and_check_contradictions_fail_closed():
+    evidence = _evidence()
+    evidence["pull_request"] = {
+        **evidence["pull_request"],
+        "head_sha": "e" * 40,
+    }
+
+    receipt = _receipt(evidence)
+
+    assert receipt["receipt_status"] == "HOLD"
+    assert "PULL_REQUEST_HEAD_MISMATCH" in receipt["holds"]
+    assert "REVIEWED_HEAD_MISMATCH" in receipt["holds"]
+    assert "REQUIRED_CHECK_HEAD_MISMATCH" in receipt["holds"]
+
+
+def test_squash_merge_needs_tree_equivalence_and_does_not_grant_retirement():
+    evidence = _evidence()
+    evidence["integration"] = _observed(
+        method="squash",
+        merge_sha=MERGE,
+        reviewed_tree_sha=TREE,
+        merged_tree_sha="e" * 40,
+    )
+    evidence["retention"] = {"status": "NOT_CHECKED"}
+
+    receipt = _receipt(evidence)
+
+    assert "SQUASH_TREE_EQUIVALENCE_UNKNOWN" in receipt["holds"]
+    assert "RETENTION_NOT_CHECKED" in receipt["holds"]
+    assert receipt["receipt_status"] == "HOLD"
+
+
+def test_stored_hash_or_identity_tampering_is_rejected():
+    receipt = _receipt()
+    receipt["local"]["state"]["head_sha"] = "f" * 40
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "LOCAL_STATE_HASH_MISMATCH" in errors
+    assert "REMOTE_HEAD_MISMATCH" in errors
+
+
+def test_stored_observed_evidence_expires_instead_of_remaining_authority():
+    receipt = _receipt()
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW + timedelta(hours=1))
+
+    assert "REMOTE_STALE_EVIDENCE" in errors
+    assert "PULL_REQUEST_STALE_EVIDENCE" in errors
+
+
+def test_receipt_module_has_no_independent_git_or_network_reader():
+    source = Path(receipt_module.__file__).read_text(encoding="utf-8")
+
+    assert "subprocess" not in source
+    assert "urlopen" not in source
+    assert "requests." not in source
+    assert "collect_repository_state" in source

--- a/Python/tests/test_git_handoff_receipt.py
+++ b/Python/tests/test_git_handoff_receipt.py
@@ -97,6 +97,17 @@ def _evidence() -> dict:
             "authorized_actions": ["OPEN_DRAFT_PR"],
             "prohibited_actions": ["DELETE_BRANCH", "DELETE_WORKTREE"],
             "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+            "authority_source": {
+                "kind": "ORCHESTRATOR_DELEGATION",
+                "reference": "task:GIT-7E:test-fixture",
+                "observed_at_utc": NOW.isoformat(),
+            },
+            "target_binding": {
+                "task_id": "GIT-7E",
+                "branch": "codex/git-7e",
+                "head_sha": HEAD,
+                "actions": ["OPEN_DRAFT_PR"],
+            },
         },
     }
 
@@ -123,6 +134,7 @@ def test_valid_receipt_round_trips_with_exact_identity(tmp_path: Path):
 
     assert receipt["receipt_status"] == "READY"
     assert receipt["holds"] == []
+    assert receipt["receipt_grants_authority"] is False
     assert loaded == receipt
     assert receipt_module.validate_receipt(loaded, now=NOW) == []
     assert loaded["local"]["state"]["head_sha"] == HEAD
@@ -166,6 +178,7 @@ def test_missing_not_checked_stale_and_query_failed_evidence_hold(evidence, reas
 
     assert receipt["receipt_status"] == "HOLD"
     assert reason in receipt["holds"]
+    assert receipt_module.validate_receipt(receipt, now=NOW) == []
 
 
 def test_failed_git_state_is_unknown_even_when_hosted_evidence_is_green():
@@ -235,7 +248,7 @@ def test_stored_hash_or_identity_tampering_is_rejected():
     errors = receipt_module.validate_receipt(receipt, now=NOW)
 
     assert "LOCAL_STATE_HASH_MISMATCH" in errors
-    assert "REMOTE_HEAD_MISMATCH" in errors
+    assert "MISSING_REQUIRED_HOLD:REMOTE_HEAD_MISMATCH" in errors
 
 
 def test_stored_observed_evidence_expires_instead_of_remaining_authority():
@@ -243,8 +256,71 @@ def test_stored_observed_evidence_expires_instead_of_remaining_authority():
 
     errors = receipt_module.validate_receipt(receipt, now=NOW + timedelta(hours=1))
 
-    assert "REMOTE_STALE_EVIDENCE" in errors
-    assert "PULL_REQUEST_STALE_EVIDENCE" in errors
+    assert "MISSING_REQUIRED_HOLD:REMOTE_STALE_EVIDENCE" in errors
+    assert "MISSING_REQUIRED_HOLD:PULL_REQUEST_STALE_EVIDENCE" in errors
+
+
+def test_clearing_required_holds_cannot_upgrade_unknown_evidence_to_ready():
+    receipt = _receipt({})
+    required_holds = set(receipt["holds"])
+    receipt["receipt_status"] = "READY"
+    receipt["holds"] = []
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "FALSE_READY_CLAIM" in errors
+    assert "RECEIPT_STATUS_CONTRADICTION" in errors
+    assert "HOLD_SET_MISMATCH" in errors
+    assert {f"MISSING_REQUIRED_HOLD:{hold}" for hold in required_holds}.issubset(errors)
+
+
+def test_removing_one_required_hold_is_detected_independently():
+    receipt = _receipt({})
+    removed = receipt["holds"].pop()
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "HOLD_SET_MISMATCH" in errors
+    assert f"MISSING_REQUIRED_HOLD:{removed}" in errors
+
+
+@pytest.mark.parametrize("bad_status", ["GREEN", "", None])
+def test_receipt_status_enum_is_closed(bad_status):
+    receipt = _receipt()
+    receipt["receipt_status"] = bad_status
+
+    assert "RECEIPT_STATUS_INVALID" in receipt_module.validate_receipt(receipt, now=NOW)
+
+
+@pytest.mark.parametrize("next_action", [None, "", 42])
+def test_missing_or_invalid_authorization_next_action_fails_closed(next_action):
+    receipt = _receipt()
+    receipt["authorization"]["next_action"] = next_action
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "HOLD_SET_MISMATCH" in errors
+    assert "MISSING_REQUIRED_HOLD:NEXT_ACTION_UNKNOWN" in errors
+
+
+def test_destructive_or_merge_actions_cannot_be_smuggled_into_ready_receipt():
+    receipt = _receipt()
+    receipt["authorization"]["authorized_actions"].extend(["DELETE_BRANCH", "MERGE"])
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "MISSING_REQUIRED_HOLD:AUTHORIZATION_TARGET_ACTION_MISMATCH" in errors
+    assert "FALSE_READY_CLAIM" in errors
+
+
+def test_receipt_cannot_claim_to_grant_authority():
+    receipt = _receipt()
+    receipt["receipt_grants_authority"] = True
+
+    errors = receipt_module.validate_receipt(receipt, now=NOW)
+
+    assert "RECEIPT_AUTHORITY_BOUNDARY_MISSING" in errors
+    assert "FALSE_READY_CLAIM" in errors
 
 
 def test_receipt_module_has_no_independent_git_or_network_reader():

--- a/Python/tests/test_git_state.py
+++ b/Python/tests/test_git_state.py
@@ -7,6 +7,7 @@ import importlib
 import json
 import subprocess
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -19,6 +20,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 git_state = importlib.import_module("scripts.git_state")
+VALIDATION_NOW = datetime(2026, 8, 15, 12, 30, tzinfo=UTC)
 
 
 def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
@@ -217,6 +219,101 @@ def test_state_consistency_accepts_canonical_unknown_only_with_query_failure(
     assert state.default_base.status == "unknown"
     assert state.query_failures
     assert git_state.validate_repository_state_consistency(state) == []
+
+
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    [
+        ("default_none_observed", "default_base relation ref is malformed"),
+        ("default_bad_ref", "default_base relation ref is malformed"),
+        ("upstream_none_observed", "upstream relation ref is malformed"),
+        ("double_slash_branch", "branch is malformed"),
+        ("leading_dash_branch", "branch is malformed"),
+        ("worktree_identity", "repository_root contradicts worktree_root"),
+        ("nan_duration", "duration_ms is malformed"),
+        ("infinite_duration", "duration_ms is malformed"),
+        ("future_timestamp", "observed_at_utc is in the future"),
+        ("stale_timestamp", "observed_at_utc is stale"),
+    ],
+)
+def test_state_consistency_rejects_ref_identity_and_freshness_tampering_without_io(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    expected: str,
+):
+    repo = _repo(tmp_path)
+    _feature(repo)
+    state = copy.deepcopy(git_state.collect_repository_state(repo, default_ref="main"))
+    state.observed_at_utc = VALIDATION_NOW.isoformat()
+    if case == "default_none_observed":
+        state.default_base.ref = "NONE"
+    elif case == "default_bad_ref":
+        state.default_base.ref = "bad ref"
+    elif case == "upstream_none_observed":
+        state.upstream = git_state.Relation("NONE", state.head_sha, 0, 0, "equal")
+    elif case == "double_slash_branch":
+        state.branch = "codex//x"
+    elif case == "leading_dash_branch":
+        state.branch = "-bad"
+    elif case == "worktree_identity":
+        state.worktree_root = str(repo / "other")
+    elif case == "nan_duration":
+        state.duration_ms = float("nan")
+    elif case == "infinite_duration":
+        state.duration_ms = float("inf")
+    elif case == "future_timestamp":
+        state.observed_at_utc = (VALIDATION_NOW + timedelta(minutes=1)).isoformat()
+    elif case == "stale_timestamp":
+        state.observed_at_utc = (VALIDATION_NOW - timedelta(minutes=6)).isoformat()
+
+    monkeypatch.setattr(
+        git_state.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("state validation must not query Git")
+        ),
+    )
+
+    errors = git_state.validate_repository_state_consistency(
+        state, now_utc=VALIDATION_NOW
+    )
+
+    assert any(expected in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("observed_at", "duration_ms"),
+    [
+        (VALIDATION_NOW, 0.0),
+        (VALIDATION_NOW - git_state.MAX_EVIDENCE_AGE, 1.25),
+        (VALIDATION_NOW + git_state.MAX_FUTURE_SKEW, 2),
+    ],
+)
+def test_state_consistency_accepts_valid_linked_ref_time_and_duration_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    observed_at: datetime,
+    duration_ms: float,
+):
+    repo = _repo(tmp_path)
+    linked = tmp_path / "linked"
+    _git(repo, "worktree", "add", "-b", "codex/linked-test", str(linked))
+    state = git_state.collect_repository_state(linked, default_ref="main")
+    state.observed_at_utc = observed_at.isoformat()
+    state.duration_ms = duration_ms
+    monkeypatch.setattr(
+        git_state.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("state validation must not query Git")
+        ),
+    )
+
+    assert (
+        git_state.validate_repository_state_consistency(state, now_utc=VALIDATION_NOW)
+        == []
+    )
 
 
 def test_conflicted_paths_never_return_ready(tmp_path: Path):

--- a/Python/tests/test_git_state.py
+++ b/Python/tests/test_git_state.py
@@ -135,10 +135,55 @@ def test_state_consistency_recomputes_action_and_holds_without_git_io(
 
 
 @pytest.mark.parametrize(
+    "name",
+    [
+        "HEAD",
+        "head",
+        "FETCH_HEAD",
+        "main",
+        "codex/git-7e",
+        "refs/heads/feature",
+        "@",
+        "feature.x",
+        "-bad",
+        "codex//x",
+        "feature.lock",
+        "foo/.bar",
+        "foo..bar",
+        "foo@{bar",
+        "foo\\bar",
+        "foo~bar",
+        "foo^bar",
+        "foo:bar",
+        "foo?bar",
+        "foo*bar",
+        "foo[bar",
+        "foo bar",
+        "foo/",
+        "/foo",
+        ".foo",
+        "foo.",
+    ],
+)
+def test_pure_branch_validator_matches_read_only_git_check_ref_format(name: str):
+    oracle = subprocess.run(
+        ["git", "check-ref-format", "--branch", name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert git_state._is_valid_git_refname(name, branch=True) is (
+        oracle.returncode == 0
+    )
+
+
+@pytest.mark.parametrize(
     ("case", "expected"),
     [
         ("head_sha", "head_sha is malformed"),
         ("empty_branch", "branch is malformed"),
+        ("head_branch", "branch is malformed"),
         ("banana_relation", "relation status is unsupported"),
         ("uppercase_unknown_relation", "relation status is unsupported"),
         ("schema", "schema is unsupported"),
@@ -165,6 +210,8 @@ def test_state_consistency_rejects_malformed_schema_and_enums_without_git_io(
         state.head_sha = "not-a-sha"
     elif case == "empty_branch":
         state.branch = ""
+    elif case == "head_branch":
+        state.branch = "HEAD"
     elif case == "banana_relation":
         state.default_base.status = "BANANA"
     elif case == "uppercase_unknown_relation":

--- a/Python/tests/test_git_state.py
+++ b/Python/tests/test_git_state.py
@@ -106,6 +106,29 @@ def test_porcelain_v2_classifies_each_dirty_surface(tmp_path: Path):
     assert state.tree.conflicted_paths == []
 
 
+def test_state_consistency_recomputes_action_and_holds_without_git_io(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    repo = _repo(tmp_path)
+    _feature(repo)
+    state = git_state.collect_repository_state(repo, default_ref="main")
+    assert git_state.validate_repository_state_consistency(state) == []
+
+    monkeypatch.setattr(
+        git_state.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("consistency validation must not query Git")
+        ),
+    )
+    state.operation = "merge"
+
+    errors = git_state.validate_repository_state_consistency(state)
+
+    assert any("derived_action contradicts" in error for error in errors)
+    assert any("hold_reasons contradict" in error for error in errors)
+
+
 def test_conflicted_paths_never_return_ready(tmp_path: Path):
     repo = _repo(tmp_path)
     _feature(repo, "left")

--- a/Python/tests/test_git_state.py
+++ b/Python/tests/test_git_state.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import copy
 import importlib
 import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -122,11 +124,99 @@ def test_state_consistency_recomputes_action_and_holds_without_git_io(
         ),
     )
     state.operation = "merge"
+    state.operation_markers = ["MERGE_HEAD:/tmp/repo/.git/MERGE_HEAD"]
 
     errors = git_state.validate_repository_state_consistency(state)
 
     assert any("derived_action contradicts" in error for error in errors)
     assert any("hold_reasons contradict" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    [
+        ("head_sha", "head_sha is malformed"),
+        ("empty_branch", "branch is malformed"),
+        ("banana_relation", "relation status is unsupported"),
+        ("uppercase_unknown_relation", "relation status is unsupported"),
+        ("schema", "schema is unsupported"),
+        ("remote_freshness", "remote_freshness is unsupported"),
+        ("relation_counts", "relation status contradicts counts"),
+        ("lowercase_unknown_without_failure", "lacks query failure evidence"),
+        ("operation_enum", "operation is unsupported"),
+        ("operation_markers", "operation contradicts operation markers"),
+        ("linked_worktree", "linked_worktree contradicts"),
+        ("query_failure", "query failure evidence is malformed"),
+        ("tree_count", "tree dirty_count contradicts paths"),
+    ],
+)
+def test_state_consistency_rejects_malformed_schema_and_enums_without_git_io(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    expected: str,
+):
+    repo = _repo(tmp_path)
+    _feature(repo)
+    state = copy.deepcopy(git_state.collect_repository_state(repo, default_ref="main"))
+    if case == "head_sha":
+        state.head_sha = "not-a-sha"
+    elif case == "empty_branch":
+        state.branch = ""
+    elif case == "banana_relation":
+        state.default_base.status = "BANANA"
+    elif case == "uppercase_unknown_relation":
+        state.default_base.status = "UNKNOWN"
+    elif case == "schema":
+        state.schema_version = 999
+    elif case == "remote_freshness":
+        state.remote_freshness = "CURRENT"
+    elif case == "relation_counts":
+        state.default_base.behind = 1
+    elif case == "lowercase_unknown_without_failure":
+        state.default_base.status = "unknown"
+        state.default_base.sha = None
+        state.default_base.ahead = None
+        state.default_base.behind = None
+    elif case == "operation_enum":
+        state.operation = "teleport"
+    elif case == "operation_markers":
+        state.operation_markers = ["MERGE_HEAD:/tmp/repo/.git/MERGE_HEAD"]
+    elif case == "linked_worktree":
+        state.linked_worktree = not state.linked_worktree
+    elif case == "query_failure":
+        state.query_failures = [SimpleNamespace(command="", reason="exit 128")]
+    elif case == "tree_count":
+        state.tree = SimpleNamespace(
+            staged_paths=[],
+            modified_paths=[],
+            untracked_paths=[],
+            conflicted_paths=[],
+            clean=True,
+            dirty_count=1,
+        )
+
+    monkeypatch.setattr(
+        git_state.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("state validation must not query Git")
+        ),
+    )
+
+    errors = git_state.validate_repository_state_consistency(state)
+
+    assert any(expected in error for error in errors)
+
+
+def test_state_consistency_accepts_canonical_unknown_only_with_query_failure(
+    tmp_path: Path,
+):
+    state = git_state.collect_repository_state(tmp_path / "missing")
+
+    assert state.default_base.status == "unknown"
+    assert state.query_failures
+    assert git_state.validate_repository_state_consistency(state) == []
 
 
 def test_conflicted_paths_never_return_ready(tmp_path: Path):

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -58,6 +58,135 @@ git_state = importlib.import_module("scripts.git_state")
 git_handoff_receipt = importlib.import_module("scripts.git_handoff_receipt")
 
 
+def _closeout_state(
+    *,
+    clean: bool,
+    paths: list[str] | None = None,
+    failures: list | None = None,
+    schema_version: int = 1,
+):
+    modified = list(paths or [])
+    return git_state.RepositoryState(
+        schema_version=schema_version,
+        observed_at_utc="2026-08-15T00:00:00+00:00",
+        repository_root="/tmp/repo",
+        worktree_root="/tmp/repo",
+        git_dir="/tmp/repo/.git",
+        git_common_dir="/tmp/repo/.git",
+        linked_worktree=False,
+        branch="codex/git-7e",
+        head_sha="a" * 40,
+        default_base=git_state.Relation("origin/main", "b" * 40, 1, 0, "ahead"),
+        upstream=git_state.Relation("origin/codex/git-7e", "a" * 40, 0, 0, "equal"),
+        tree=git_state.TreeState(modified_paths=modified, clean=clean),
+        operation="none",
+        operation_markers=[],
+        locks=[],
+        remote_freshness="NOT_CHECKED",
+        derived_action="READY_LOCAL" if clean else "HOLD_DIRTY",
+        hold_reasons=[] if clean else ["WORKTREE_DIRTY"],
+        query_failures=list(failures or []),
+        duration_ms=1.0,
+    )
+
+
+def test_session_closeout_uses_canonical_clean_evidence_without_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    state = _closeout_state(clean=True)
+    monkeypatch.setattr(session, "collect_repository_state", lambda _repo: state)
+    monkeypatch.setattr(
+        session.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("closeout evidence must not invoke a second subprocess")
+        ),
+    )
+
+    assert session.get_closeout_git_evidence() == (
+        "CLEAN",
+        [],
+        "Canonical Git-state tree is clean",
+    )
+
+
+def test_session_closeout_reports_canonical_dirty_paths(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    state = _closeout_state(clean=False, paths=["docs/SESSION_LOG.md"])
+    monkeypatch.setattr(session, "collect_repository_state", lambda _repo: state)
+
+    status, paths, _reason = session.get_closeout_git_evidence()
+
+    assert status == "DIRTY"
+    assert paths == ["docs/SESSION_LOG.md"]
+
+
+def test_session_closeout_holds_nonzero_git_state_query(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    state = _closeout_state(
+        clean=False,
+        failures=[git_state.QueryFailure("git status --porcelain=v2", "exit 128")],
+    )
+    monkeypatch.setattr(session, "collect_repository_state", lambda _repo: state)
+
+    status, paths, reason = session.get_closeout_git_evidence()
+
+    assert status == "UNKNOWN"
+    assert paths == []
+    assert "exit 128" in reason
+
+
+def test_session_closeout_holds_git_state_exception(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def raise_query(_repo):
+        raise OSError("authority unavailable")
+
+    monkeypatch.setattr(session, "collect_repository_state", raise_query)
+
+    status, paths, reason = session.get_closeout_git_evidence()
+
+    assert status == "UNKNOWN"
+    assert paths == []
+    assert "authority unavailable" in reason
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        {"tree": {"clean": True}},
+        _closeout_state(clean=True, schema_version=999),
+        _closeout_state(clean=True, paths=["contradiction.md"]),
+        _closeout_state(clean=False),
+    ],
+)
+def test_session_closeout_holds_malformed_or_unknown_evidence(
+    evidence, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(session, "collect_repository_state", lambda _repo: evidence)
+
+    status, paths, _reason = session.get_closeout_git_evidence()
+
+    assert status == "UNKNOWN"
+    assert paths == []
+
+
+@pytest.mark.parametrize("status", ["DIRTY", "UNKNOWN"])
+def test_session_closeout_never_prints_clean_for_hold(
+    status: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    monkeypatch.setattr(
+        session,
+        "get_closeout_git_evidence",
+        lambda: (status, ["dirty.md"] if status == "DIRTY" else [], "held"),
+    )
+
+    assert session.report_closeout_git_evidence() is False
+    assert "Working tree clean" not in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
     "heading",
     [

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import importlib
 import json
 import os
@@ -103,6 +104,23 @@ def _closeout_state(
     )
 
 
+def _malformed_clean_state(case: str):
+    state = copy.deepcopy(_closeout_state(clean=True))
+    if case == "head_sha":
+        state.head_sha = "not-a-sha"
+    elif case == "empty_branch":
+        state.branch = ""
+    elif case == "banana_relation":
+        state.default_base.status = "BANANA"
+    elif case == "uppercase_unknown_relation":
+        state.default_base.status = "UNKNOWN"
+    elif case == "schema":
+        state.schema_version = 999
+    elif case == "remote_freshness":
+        state.remote_freshness = "CURRENT"
+    return state
+
+
 def test_session_closeout_uses_canonical_clean_evidence_without_subprocess(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -133,6 +151,39 @@ def test_session_closeout_reports_canonical_dirty_paths(
 
     assert status == "DIRTY"
     assert paths == ["docs/SESSION_LOG.md"]
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "head_sha",
+        "empty_branch",
+        "banana_relation",
+        "uppercase_unknown_relation",
+        "schema",
+        "remote_freshness",
+    ],
+)
+def test_session_closeout_holds_malformed_canonical_contract_without_subprocess(
+    case: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    state = _malformed_clean_state(case)
+    monkeypatch.setattr(session, "collect_repository_state", lambda _repo: state)
+    monkeypatch.setattr(
+        session.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("closeout validation must not invoke a subprocess")
+        ),
+    )
+
+    evidence = session.get_closeout_git_evidence()
+
+    assert evidence[0] == "UNKNOWN"
+    assert session.report_closeout_git_evidence(evidence) is False
+    assert "Working tree clean" not in capsys.readouterr().out
 
 
 def test_session_closeout_holds_clean_action_hold_contradiction(
@@ -323,6 +374,33 @@ def test_session_end_query_failure_cannot_pass_or_print_clean(
     assert authority_calls == [["collect_repository_state"]]
     assert "Git state UNKNOWN/hold" in output
     assert "Doc-folder set UNKNOWN" in output
+    assert "Working tree clean" not in output
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "head_sha",
+        "empty_branch",
+        "banana_relation",
+        "uppercase_unknown_relation",
+        "schema",
+        "remote_freshness",
+    ],
+)
+def test_session_end_malformed_canonical_contract_fails_closed(
+    case: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    authority_calls, args = _patch_cmd_end_dependencies(
+        monkeypatch, _malformed_clean_state(case)
+    )
+
+    assert session.cmd_end(args) == 1
+    output = capsys.readouterr().out
+    assert authority_calls == [["collect_repository_state"]]
+    assert "Git state UNKNOWN/hold" in output
     assert "Working tree clean" not in output
 
 

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -7,7 +7,7 @@ import json
 import os
 import subprocess
 import sys
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import pytest
@@ -23,6 +23,7 @@ check_api = importlib.import_module("scripts.check_api")
 validate_script_refs = importlib.import_module("scripts.validate_script_refs")
 prompt_router = importlib.import_module("scripts.prompt_router")
 git_state = importlib.import_module("scripts.git_state")
+git_handoff_receipt = importlib.import_module("scripts.git_handoff_receipt")
 
 
 @pytest.mark.parametrize(
@@ -623,17 +624,137 @@ def test_session_end_preserves_current_same_day_handoff(
 <!-- HANDOFF:START -->
 - Date: 2026-08-07
 - Focus: obtain approval for the focused CI fixes
+- Git receipt: docs/receipt.json | sha256:test-hash | READY
 <!-- HANDOFF:END -->
 """
     next_brief.write_text(expected, encoding="utf-8")
     monkeypatch.setattr(session, "SESSION_LOG", session_log)
     monkeypatch.setattr(session, "NEXT_BRIEF", next_brief)
+    monkeypatch.setattr(
+        session,
+        "_resolve_git_receipt",
+        lambda block, explicit_path=None: (
+            {"local_state_receipt_hash": "sha256:test-hash"},
+            "docs/receipt.json",
+            [],
+        ),
+    )
 
     ok, message = session._do_handoff(preserve_current_same_day=True)
 
     assert ok is True
     assert "Preserved" in message
     assert next_brief.read_text(encoding="utf-8") == expected
+
+
+def test_handoff_round_trip_embeds_valid_receipt_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    now = datetime(2026, 8, 15, 9, 30, tzinfo=UTC)
+    head = "a" * 40
+    base = "b" * 40
+    state = git_state.RepositoryState(
+        schema_version=1,
+        observed_at_utc=now.isoformat(),
+        repository_root=str(tmp_path),
+        worktree_root=str(tmp_path),
+        git_dir=str(tmp_path / ".git"),
+        git_common_dir=str(tmp_path / ".git"),
+        linked_worktree=False,
+        branch="codex/git-7e",
+        head_sha=head,
+        default_base=git_state.Relation("origin/main", base, 1, 0, "ahead"),
+        upstream=git_state.Relation("origin/codex/git-7e", head, 0, 0, "equal"),
+        tree=git_state.TreeState(clean=True),
+        operation="none",
+        operation_markers=[],
+        locks=[],
+        remote_freshness="NOT_CHECKED",
+        derived_action="READY_LOCAL",
+        hold_reasons=[],
+        query_failures=[],
+        duration_ms=1.0,
+    )
+    not_applicable = {
+        "status": "NOT_APPLICABLE",
+        "reason_code": "LOCAL_ONLY_TASK_AT_HANDOFF",
+    }
+    receipt = git_handoff_receipt.build_receipt(
+        task_id="GIT-7E",
+        integration_owner="Main Agent",
+        local_state=state,
+        evidence={
+            "remote": not_applicable,
+            "pull_request": not_applicable,
+            "review": not_applicable,
+            "integration": not_applicable,
+            "retention": {
+                "status": "NOT_APPLICABLE",
+                "reason_code": "NO_RETENTION_ACTION_IN_SCOPE",
+            },
+            "authorization": {
+                "status": "OBSERVED",
+                "authorized_actions": ["CONTINUE_LOCAL_WORK"],
+                "prohibited_actions": ["DELETE_BRANCH"],
+                "next_action": "CONTINUE_LOCAL_VALIDATION",
+            },
+        },
+        now=now,
+    )
+    repo = tmp_path / "repo"
+    docs = repo / "docs"
+    docs.mkdir(parents=True)
+    receipt_path = docs / "receipt.json"
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+    session_log = docs / "SESSION_LOG.md"
+    session_log.write_text(
+        """# Log
+
+## 2026-08-15 — GIT-7E Session
+**Focus:** durable handoff
+
+**Completed:**
+- receipt contract
+""",
+        encoding="utf-8",
+    )
+    next_brief = docs / "next-session-brief.md"
+    next_brief.write_text("# Brief\n", encoding="utf-8")
+    monkeypatch.setattr(session, "REPO_ROOT", repo)
+    monkeypatch.setattr(session, "SESSION_LOG", session_log)
+    monkeypatch.setattr(session, "NEXT_BRIEF", next_brief)
+
+    ok, message = session._do_handoff(git_receipt=receipt_path)
+
+    handoff = next_brief.read_text(encoding="utf-8")
+    assert ok is True, message
+    assert receipt["local_state_receipt_hash"] in handoff
+    assert f"codex/git-7e@{head}" in handoff
+    assert "remote=NOT_APPLICABLE" in handoff
+    assert "Next action: CONTINUE_LOCAL_VALIDATION" in handoff
+
+
+def test_handoff_missing_receipt_is_an_explicit_hold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    session_log = tmp_path / "SESSION_LOG.md"
+    next_brief = tmp_path / "next-session-brief.md"
+    session_log.write_text(
+        """# Log
+
+## 2026-08-15 — GIT-7E Session
+**Focus:** missing receipt
+""",
+        encoding="utf-8",
+    )
+    next_brief.write_text("# Brief\n", encoding="utf-8")
+    monkeypatch.setattr(session, "SESSION_LOG", session_log)
+    monkeypatch.setattr(session, "NEXT_BRIEF", next_brief)
+
+    ok, message = session._do_handoff()
+
+    assert ok is False
+    assert "Missing task-to-Git handoff receipt" in message
 
 
 def test_session_log_completeness_uses_only_newest_same_day_entry(

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -22,6 +22,38 @@ session = importlib.import_module("scripts.session")
 check_api = importlib.import_module("scripts.check_api")
 validate_script_refs = importlib.import_module("scripts.validate_script_refs")
 prompt_router = importlib.import_module("scripts.prompt_router")
+
+
+def test_run_sh_routes_receipt_bound_handoff_help():
+    result = subprocess.run(
+        [str(REPO_ROOT / "run.sh"), "session", "handoff", "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--git-receipt" in result.stdout
+
+
+def test_handoff_replaces_maintained_legacy_heading(monkeypatch, tmp_path):
+    brief = tmp_path / "next-session-brief.md"
+    brief.write_text(
+        "# Brief\n\n## Latest Handoff\n\n"
+        f"{session.HANDOFF_START}\n- Date: old\n{session.HANDOFF_END}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(session, "NEXT_BRIEF", brief)
+
+    session._update_next_brief(["- Date: 2026-08-15", "- Git receipt: exact"])
+
+    updated = brief.read_text(encoding="utf-8")
+    assert "## Latest Handoff (auto)" in updated
+    assert "- Git receipt: exact" in updated
+    assert "- Date: old" not in updated
+
+
 git_state = importlib.import_module("scripts.git_state")
 git_handoff_receipt = importlib.import_module("scripts.git_handoff_receipt")
 

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from datetime import UTC, date, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -66,6 +67,18 @@ def _closeout_state(
     schema_version: int = 1,
 ):
     modified = list(paths or [])
+    query_failures = list(failures or [])
+    if query_failures:
+        derived_action = "HOLD_UNKNOWN"
+        hold_reasons = ["required Git evidence is unknown"]
+        if modified:
+            hold_reasons.append(f"changed paths: {len(modified)}")
+    elif clean:
+        derived_action = "READY_LOCAL"
+        hold_reasons = []
+    else:
+        derived_action = "HOLD_DIRTY"
+        hold_reasons = [f"changed paths: {len(modified)}"]
     return git_state.RepositoryState(
         schema_version=schema_version,
         observed_at_utc="2026-08-15T00:00:00+00:00",
@@ -83,9 +96,9 @@ def _closeout_state(
         operation_markers=[],
         locks=[],
         remote_freshness="NOT_CHECKED",
-        derived_action="READY_LOCAL" if clean else "HOLD_DIRTY",
-        hold_reasons=[] if clean else ["WORKTREE_DIRTY"],
-        query_failures=list(failures or []),
+        derived_action=derived_action,
+        hold_reasons=hold_reasons,
+        query_failures=query_failures,
         duration_ms=1.0,
     )
 
@@ -120,6 +133,50 @@ def test_session_closeout_reports_canonical_dirty_paths(
 
     assert status == "DIRTY"
     assert paths == ["docs/SESSION_LOG.md"]
+
+
+def test_session_closeout_holds_clean_action_hold_contradiction(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    state = _closeout_state(clean=True)
+    state.derived_action = "HOLD_DIRTY"
+    state.hold_reasons = ["WORKTREE_DIRTY"]
+    monkeypatch.setattr(session, "collect_repository_state", lambda _repo: state)
+
+    status, paths, reason = session.get_closeout_git_evidence()
+
+    assert status == "UNKNOWN"
+    assert paths == []
+    assert "contradicts" in reason
+
+
+def test_session_closeout_holds_dirty_ready_contradiction(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    state = _closeout_state(clean=False, paths=["docs/SESSION_LOG.md"])
+    state.derived_action = "READY_LOCAL"
+    state.hold_reasons = []
+    monkeypatch.setattr(session, "collect_repository_state", lambda _repo: state)
+
+    status, paths, reason = session.get_closeout_git_evidence()
+
+    assert status == "UNKNOWN"
+    assert paths == []
+    assert "contradicts" in reason
+
+
+def test_changed_doc_folders_uses_only_canonical_dirty_paths():
+    status, folders, reason = session.get_changed_doc_folders(
+        (
+            "DIRTY",
+            ["docs/SESSION_LOG.md", "docs/git-automation/index.json", "source.py"],
+            "canonical dirty paths",
+        )
+    )
+
+    assert status == "OBSERVED"
+    assert folders == [session.REPO_ROOT / "docs"]
+    assert reason == "canonical dirty paths inspected"
 
 
 def test_session_closeout_holds_nonzero_git_state_query(
@@ -185,6 +242,88 @@ def test_session_closeout_never_prints_clean_for_hold(
 
     assert session.report_closeout_git_evidence() is False
     assert "Working tree clean" not in capsys.readouterr().out
+
+
+def _patch_cmd_end_dependencies(
+    monkeypatch: pytest.MonkeyPatch, state
+) -> tuple[list[list[str]], SimpleNamespace]:
+    authority_calls = []
+
+    def collect(_repo):
+        authority_calls.append(["collect_repository_state"])
+        return state
+
+    subprocess_calls: list[list[str]] = []
+
+    def run(args, **_kwargs):
+        command = [str(part) for part in args]
+        subprocess_calls.append(command)
+        assert not (
+            command[:1] == ["git"]
+            and len(command) > 1
+            and command[1] in {"diff", "status"}
+        ), f"session end invoked a second Git-state reader: {command}"
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(session, "collect_repository_state", collect)
+    monkeypatch.setattr(session.subprocess, "run", run)
+    monkeypatch.setattr(
+        session, "run_handoff_check", lambda: (True, "All checks passed")
+    )
+    monkeypatch.setattr(session, "check_session_log_complete", lambda: (True, []))
+    monkeypatch.setattr(
+        session, "_latest_session_block", lambda _lines: ("2026-08-15", [])
+    )
+    monkeypatch.setattr(
+        session,
+        "_resolve_git_receipt",
+        lambda _block, _path: (
+            {
+                "local_state_receipt_hash": "sha256:" + "a" * 64,
+                "receipt_status": "HOLD",
+            },
+            "docs/research/git-governance/receipt.json",
+            [],
+        ),
+    )
+    monkeypatch.setattr(session, "check_doc_links", lambda: (True, "All links valid"))
+    monkeypatch.setattr(session, "archive_completed_tasks", lambda fix=False: (0, 0))
+    monkeypatch.setattr(session, "get_today_prs", list)
+    args = SimpleNamespace(fix=False, git_receipt=None, log_cost=False, agent="ops")
+    return authority_calls, args
+
+
+def test_session_end_reuses_one_clean_authority_query_and_skips_unknown_doc_set(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    authority_calls, args = _patch_cmd_end_dependencies(
+        monkeypatch, _closeout_state(clean=True)
+    )
+
+    assert session.cmd_end(args) == 0
+    output = capsys.readouterr().out
+    assert authority_calls == [["collect_repository_state"]]
+    assert "Working tree clean (scripts/git_state.py)" in output
+    assert "Doc-folder set UNKNOWN" in output
+    assert "no committed-diff path evidence" in output
+    assert "No doc folder changes detected" not in output
+
+
+def test_session_end_query_failure_cannot_pass_or_print_clean(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    state = _closeout_state(
+        clean=False,
+        failures=[git_state.QueryFailure("git status --porcelain=v2", "exit 128")],
+    )
+    authority_calls, args = _patch_cmd_end_dependencies(monkeypatch, state)
+
+    assert session.cmd_end(args) == 1
+    output = capsys.readouterr().out
+    assert authority_calls == [["collect_repository_state"]]
+    assert "Git state UNKNOWN/hold" in output
+    assert "Doc-folder set UNKNOWN" in output
+    assert "Working tree clean" not in output
 
 
 @pytest.mark.parametrize(

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -110,6 +110,8 @@ def _malformed_clean_state(case: str):
         state.head_sha = "not-a-sha"
     elif case == "empty_branch":
         state.branch = ""
+    elif case == "head_branch":
+        state.branch = "HEAD"
     elif case == "banana_relation":
         state.default_base.status = "BANANA"
     elif case == "uppercase_unknown_relation":
@@ -178,6 +180,7 @@ def test_session_closeout_reports_canonical_dirty_paths(
     [
         "head_sha",
         "empty_branch",
+        "head_branch",
         "banana_relation",
         "uppercase_unknown_relation",
         "schema",
@@ -412,6 +415,7 @@ def test_session_end_query_failure_cannot_pass_or_print_clean(
     [
         "head_sha",
         "empty_branch",
+        "head_branch",
         "banana_relation",
         "uppercase_unknown_relation",
         "schema",
@@ -442,6 +446,83 @@ def test_session_end_malformed_canonical_contract_fails_closed(
     assert authority_calls == [["collect_repository_state"]]
     assert "Git state UNKNOWN/hold" in output
     assert "Working tree clean" not in output
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_return", "expected_text"),
+    [
+        ("clean", 0, "Working tree: \x1b[2mclean"),
+        ("dirty", 1, "Uncommitted changes: 1 file(s)"),
+        ("detached", 1, "Branch: \x1b[32mDETACHED"),
+        ("held", 1, "UNKNOWN/hold (HOLD_BEHIND)"),
+        ("query_failed", 1, "Branch: \x1b[33mUNKNOWN"),
+        ("malformed", 1, "Branch: \x1b[33mUNKNOWN"),
+    ],
+)
+def test_session_context_uses_only_canonical_git_state_and_fails_closed(
+    case: str,
+    expected_return: int,
+    expected_text: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    state = _closeout_state(clean=True)
+    if case == "dirty":
+        state = _closeout_state(clean=False, paths=["docs/SESSION_LOG.md"])
+    elif case == "detached":
+        state.branch = "DETACHED"
+        state.derived_action = "HOLD_DETACHED"
+        state.hold_reasons = ["HEAD is detached"]
+    elif case == "held":
+        state.default_base = git_state.Relation("origin/main", "b" * 40, 0, 1, "behind")
+        state.derived_action = "HOLD_BEHIND"
+        state.hold_reasons = ["HEAD is behind a required ref"]
+    elif case == "query_failed":
+        state = _closeout_state(
+            clean=True,
+            failures=[git_state.QueryFailure("git status --porcelain=v2", "exit 128")],
+        )
+    elif case == "malformed":
+        state.branch = "HEAD"
+
+    monkeypatch.setattr(session, "collect_repository_state", lambda _repo: state)
+    monkeypatch.setattr(
+        session.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("session context must not invoke a Git subprocess")
+        ),
+    )
+
+    assert session.cmd_context(SimpleNamespace()) == expected_return
+    output = capsys.readouterr().out
+    assert expected_text in output
+    assert "Branch: \x1b[32m\x1b[0m" not in output
+    if case != "clean":
+        assert "Working tree: \x1b[2mclean" not in output
+
+
+def test_session_context_holds_authority_exception_without_subprocess_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    def raise_authority(_repo):
+        raise OSError("canonical authority unavailable")
+
+    monkeypatch.setattr(session, "collect_repository_state", raise_authority)
+    monkeypatch.setattr(
+        session.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("session context must not invoke a Git subprocess")
+        ),
+    )
+
+    assert session.cmd_context(SimpleNamespace()) == 1
+    output = capsys.readouterr().out
+    assert "Branch: \x1b[33mUNKNOWN" in output
+    assert "canonical authority unavailable" in output
+    assert "Working tree: \x1b[2mclean" not in output
 
 
 @pytest.mark.parametrize(

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -8,7 +8,7 @@ import json
 import os
 import subprocess
 import sys
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -82,7 +82,7 @@ def _closeout_state(
         hold_reasons = [f"changed paths: {len(modified)}"]
     return git_state.RepositoryState(
         schema_version=schema_version,
-        observed_at_utc="2026-08-15T00:00:00+00:00",
+        observed_at_utc=datetime.now(UTC).isoformat(),
         repository_root="/tmp/repo",
         worktree_root="/tmp/repo",
         git_dir="/tmp/repo/.git",
@@ -118,6 +118,26 @@ def _malformed_clean_state(case: str):
         state.schema_version = 999
     elif case == "remote_freshness":
         state.remote_freshness = "CURRENT"
+    elif case == "default_none_observed":
+        state.default_base.ref = "NONE"
+    elif case == "default_bad_ref":
+        state.default_base.ref = "bad ref"
+    elif case == "upstream_none_observed":
+        state.upstream.ref = "NONE"
+    elif case == "double_slash_branch":
+        state.branch = "codex//x"
+    elif case == "leading_dash_branch":
+        state.branch = "-bad"
+    elif case == "worktree_identity":
+        state.worktree_root = "/tmp/other"
+    elif case == "nan_duration":
+        state.duration_ms = float("nan")
+    elif case == "infinite_duration":
+        state.duration_ms = float("inf")
+    elif case == "future_timestamp":
+        state.observed_at_utc = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+    elif case == "stale_timestamp":
+        state.observed_at_utc = (datetime.now(UTC) - timedelta(days=1)).isoformat()
     return state
 
 
@@ -162,6 +182,16 @@ def test_session_closeout_reports_canonical_dirty_paths(
         "uppercase_unknown_relation",
         "schema",
         "remote_freshness",
+        "default_none_observed",
+        "default_bad_ref",
+        "upstream_none_observed",
+        "double_slash_branch",
+        "leading_dash_branch",
+        "worktree_identity",
+        "nan_duration",
+        "infinite_duration",
+        "future_timestamp",
+        "stale_timestamp",
     ],
 )
 def test_session_closeout_holds_malformed_canonical_contract_without_subprocess(
@@ -386,6 +416,16 @@ def test_session_end_query_failure_cannot_pass_or_print_clean(
         "uppercase_unknown_relation",
         "schema",
         "remote_freshness",
+        "default_none_observed",
+        "default_bad_ref",
+        "upstream_none_observed",
+        "double_slash_branch",
+        "leading_dash_branch",
+        "worktree_identity",
+        "nan_duration",
+        "infinite_duration",
+        "future_timestamp",
+        "stale_timestamp",
     ],
 )
 def test_session_end_malformed_canonical_contract_fails_closed(

--- a/agents/agent-9/KNOWLEDGE_BASE.md
+++ b/agents/agent-9/KNOWLEDGE_BASE.md
@@ -179,10 +179,10 @@ never reset or rewrite a published lane to make the push succeed.
 .venv/bin/python -m black Python/
 .venv/bin/python -m ruff check --fix Python/
 
-# Commit fixes
-git add -A
-git commit -m "style: apply black/ruff formatting"
-git push
+# Inspect formatter changes, then stage only the exact owned paths
+git diff -- Python/path/to/owned_file.py
+git add -- Python/path/to/owned_file.py
+# Have Codex create the conventional commit and push without rewriting history.
 ```
 
 **Prevention:** Use pre-commit hooks
@@ -228,13 +228,11 @@ sorted(items, key=lambda x: x.cost.total if x.cost else float('inf'))
 
 **Solution:**
 ```bash
-# Re-stage modified files and amend commit
-git add -A
-git commit --amend --no-edit
-
-# OR create new commit
-git add -A
-git commit -m "chore: apply pre-commit fixes"
+# Inspect hook changes, stage only exact owned paths, and have Codex create a
+# conventional follow-up commit after the gate passes. Do not amend or rewrite
+# a published commit merely to absorb hook edits.
+git diff -- path/to/owned_file
+git add -- path/to/owned_file
 ```
 
 **Note:** This is NORMAL - hooks are doing their job!
@@ -246,36 +244,12 @@ git commit -m "chore: apply pre-commit fixes"
 **Symptom:** Git reports conflicts during pull/merge
 
 **Solution:**
-```bash
-# View conflicted files
-git status
-
-# For each file:
-# - Open in editor
-# - Find conflict markers: <<<<<<< ======= >>>>>>>
-# - Manually resolve conflicts
-# - Remove conflict markers
-
-# After fixing:
-git add <fixed-files>
-
-# If rebasing:
-git rebase --continue
-
-# If merging:
-git commit --no-edit
-
-# Push resolved changes
-git push
-```
-
-**Alternative (Ours Strategy):**
-```bash
-# Keep our version (use with caution!)
-git checkout --ours <file>
-git add <file>
-git commit --no-edit
-```
+Run `./scripts/python_runtime.sh scripts/git_state.py --json` and hold while an
+operation is active. Preserve every side, classify the exact conflicted paths
+and owners, and resolve only the authorized owned paths through the canonical
+Codex workflow. Codex stages exact paths and continues the known operation only
+after the conflict markers, diff, and preservation evidence are reviewed.
+Never choose one side wholesale merely to escape the conflict.
 
 ---
 

--- a/agents/agent-9/KNOWLEDGE_BASE.md
+++ b/agents/agent-9/KNOWLEDGE_BASE.md
@@ -42,18 +42,16 @@ tags: [agents, governance]
 
 ### Recommended Workflow
 
-**For All Changes:**
+**For all changes, inspect first:**
 ```bash
-# Work on a task branch, inspect and stage only reviewed paths
-git switch -c codex/TASK-XXX-description
-git status --short
-git add <reviewed-paths>
-git commit -m "feat: implement X"
-git push -u origin codex/TASK-XXX-description
-# Create and inspect the PR with the connected GitHub integration or gh CLI.
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
 
-Merge and branch deletion remain explicit owner-confirmation actions. See
+Codex verifies current main, ownership, and source binding before creating the
+`codex/<task-slug>` lane. It inspects and stages exact owned paths, creates the
+conventional commit, pushes without rewriting history, and opens or updates the
+PR through the connected GitHub integration. Merge and branch deletion remain
+separate authority decisions. See
 `docs/git-automation/git-workflow-single-source.md` for the canonical workflow.
 
 ### Commit Message Convention
@@ -95,23 +93,16 @@ pre-commit install
 
 ### Hook Workflow
 
-**Normal Case:**
-```bash
-git add file.py
-git commit -m "feat: add function"
-# Hooks run automatically
-# If changes made: Files modified by hooks
-git add file.py  # Re-stage modified files
-git commit --amend --no-edit  # Amend commit
-```
+**Normal case:** Codex inspects the exact intended diff, stages only owned
+paths, and creates a conventional commit. If a hook changes files, stop and
+attribute every hook-created path before preserving the intended hook delta.
+Codex then restages only those exact reviewed paths and creates a normal
+follow-up commit when needed; this guide never authorizes amendment or history
+rewriting.
 
-**If Hooks Fail:**
-```bash
-# Read error message carefully
-# Fix the issue
-git add fixed-file.py
-git commit -m "feat: add function"
-```
+**If hooks fail:** Read the failure, trace its root cause, correct only the
+owned paths, rerun the focused gate, and return the reviewed diff to the same
+Codex lifecycle.
 
 ### CI/CD Workflows
 
@@ -135,10 +126,7 @@ git commit -m "feat: add function"
 ### Waiting for CI
 
 ```bash
-# After creating PR
-gh pr create --title "..." --body "..."
-
-# WAIT for CI (don't merge immediately!)
+# Read-only hosted wait after Codex creates or updates the PR
 gh pr checks <PR_NUMBER> --watch
 
 # Only after all checks pass, have Codex recheck the unchanged reviewed head,
@@ -181,8 +169,8 @@ never reset or rewrite a published lane to make the push succeed.
 
 # Inspect formatter changes, then stage only the exact owned paths
 git diff -- Python/path/to/owned_file.py
-git add -- Python/path/to/owned_file.py
-# Have Codex create the conventional commit and push without rewriting history.
+# Have Codex stage the reviewed path, create the conventional commit, and push
+# without rewriting history.
 ```
 
 **Prevention:** Use pre-commit hooks
@@ -232,7 +220,6 @@ sorted(items, key=lambda x: x.cost.total if x.cost else float('inf'))
 # conventional follow-up commit after the gate passes. Do not amend or rewrite
 # a published commit merely to absorb hook edits.
 git diff -- path/to/owned_file
-git add -- path/to/owned_file
 ```
 
 **Note:** This is NORMAL - hooks are doing their job!
@@ -306,23 +293,18 @@ complete exact-target disposition evidence and separate authorization.
 - Tests fail
 - Application won't run
 
-**Immediate Action:**
-```bash
-# Option A: Revert last commit
-git revert HEAD
-git push
-
-# Option B: Revert to specific commit
-git revert <bad-commit-hash>
-git push
-```
+**Immediate action:** Establish the failing main head and current hosted checks
+from fresh evidence. Preserve the exact bad and prior-good trees, identify the
+owning change, and hold if any identity or ownership fact is unknown. Codex may
+prepare a normal `codex/<task-slug>` revert/fix PR only after the exact target
+and authority are known; this guide does not authorize a direct main mutation.
 
 **Follow-Up:**
-1. Create fix branch
-2. Repair issue
-3. Test thoroughly
-4. Open PR
-5. Merge when CI passes
+1. Verify the source-bound task lane from current main.
+2. Repair only the owned issue.
+3. Run focused and repository gates.
+4. Have Codex open the normal PR.
+5. Recheck exact head, checks, review, and merge authority.
 
 ---
 
@@ -356,20 +338,17 @@ do not delete markers, abort/continue blindly, reset, stash, or switch lanes.
 
 **Detection:** Work disappeared after git operation
 
-**Recovery:**
+**Inspection only:**
 ```bash
-# Check reflog for lost commits
-git reflog
-
-# Find your work (look for commit messages)
-git show <commit-hash>
-
-# Recover work
-git cherry-pick <commit-hash>
-
-# OR create new branch from lost commit
-git checkout -b recovery-branch <commit-hash>
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
+
+Codex may inspect reflog/object candidates without moving a ref. Record exact
+commit and tree identities, prove ownership, preserve the candidate, and hold
+on conflicts or unknown provenance. Recovery onto a fresh verified
+`codex/<task-slug>` lane requires explicit target/action authority and the
+canonical Codex lifecycle; this guide authorizes neither broad patch replay nor
+ad-hoc recovery-branch creation.
 
 ---
 
@@ -448,10 +427,10 @@ Agent 9's WIP limits (2 worktrees, 5 PRs, 10 docs, 3 research) prevent context f
 **Git Operations:**
 - Use native scoped Git operations and the connected GitHub integration
 - Wait for CI before merging PRs
-- Pull before push (especially after merging PRs)
-- Use feature branches for significant changes
-- Amend commits when pre-commit modifies files (if not yet pushed)
-- Check git status before committing
+- Refresh remote evidence before publication decisions
+- Use verified `codex/<task-slug>` lanes for scoped changes
+- Attribute hook changes and use a normal follow-up commit when needed
+- Inspect with `git_state.py` before any lifecycle mutation
 
 **Commit Hygiene:**
 - Use conventional commits (`feat:`, `fix:`, `docs:`)
@@ -463,7 +442,7 @@ Agent 9's WIP limits (2 worktrees, 5 PRs, 10 docs, 3 research) prevent context f
 - Use pre-commit hooks (install once, saves time)
 - Run tests locally before pushing
 - Check formatting locally: `black Python/ && ruff check Python/`
-- Fix CI failures immediately or revert
+- Trace CI failures and route the scoped correction through the normal PR
 
 ---
 
@@ -486,28 +465,18 @@ Agent 9's WIP limits (2 worktrees, 5 PRs, 10 docs, 3 research) prevent context f
 
 ## Quick Reference Commands
 
-### Daily Operations
+### Daily inspection and hosted checks
 ```bash
-# Start work
-git pull --ff-only
+# Inspect the local lane and sibling worktrees
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 
-# Commit changes
-git add <reviewed-paths>
-git commit -m "type: description"
-
-# Create PR
-git push -u origin codex/TASK-XXX-description
-gh pr create --draft --fill
-
-# Wait for CI
+# After Codex creates or updates the exact-head PR, wait read-only for CI
 gh pr checks <PR_NUM> --watch
-
-# Merge only after Codex rechecks the unchanged reviewed head and required
-# checks. Branch/worktree retention is separate.
-
-# Sync after merge
-git pull --ff-only
 ```
+
+Codex owns branch creation, exact-path staging, commit, push, PR, readiness, and
+normal merge after the required unchanged-head rechecks. Branch/worktree
+retention and every deletion remain separate decisions.
 
 ### Health Checks
 ```bash
@@ -529,19 +498,13 @@ tree. No pruning or deletion is part of routine health checks.
 
 ### Emergency
 ```bash
-# Check for stuck states
-ls .git/MERGE_* .git/rebase-*
-
-# Inspect exact recovery state; stop before choosing a destructive action
-git status
-git reflog
-
-# Revert bad commit
-git revert HEAD
-
-# Find lost work
-git reflog
+# Inspect exact operation, lock, dirty, branch, and worktree state
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
+
+Stop on any hold. Codex may inspect exact object/reflog evidence read-only, but
+recovery, revert, ref movement, history replay, or lane creation requires known
+ownership and explicit target/action authority through the canonical workflow.
 
 ---
 

--- a/agents/agent-9/KNOWLEDGE_BASE.md
+++ b/agents/agent-9/KNOWLEDGE_BASE.md
@@ -1,13 +1,18 @@
 ---
 owner: Governance Agent
 status: active
-last_updated: 2026-08-07
+last_updated: 2026-08-15
 doc_type: reference
 complexity: advanced
 tags: [agents, governance]
 ---
 
 # Agent 9: Git & CI Governance Knowledge Base
+
+> Current repository boundary: `AGENTS.md` and the canonical Codex-native Git
+> workflow control. Use `scripts/git_state.py` for local facts. Codex performs
+> authorized Git/GitHub mutations; this guide never authorizes recovery,
+> cleanup, deletion, history rewriting, or bypass.
 
 **Purpose:** Git/CI best practices, troubleshooting guides, and research citations
 **Source:** Extracted from `docs/_internal/git-governance.md` + sustainability research
@@ -136,8 +141,9 @@ gh pr create --title "..." --body "..."
 # WAIT for CI (don't merge immediately!)
 gh pr checks <PR_NUMBER> --watch
 
-# Only after all checks pass
-gh pr merge <PR_NUMBER> --squash --delete-branch
+# Only after all checks pass, have Codex recheck the unchanged reviewed head,
+# required checks, mergeability, and unresolved blockers before normal merge.
+# Retain the branch/worktree until a separate disposition decision.
 ```
 
 ---
@@ -153,19 +159,11 @@ gh pr merge <PR_NUMBER> --squash --delete-branch
 
 **Cause:** Remote has commits you don't have locally
 
-**Solution:**
-```bash
-# Pull and rebase
-git pull --rebase origin main
-git push
-
-# Alternative: fetch and reset
-git fetch origin
-git rebase origin/main
-git push
-```
-
-**Prevention:** Always pull before pushing
+**Solution:** Stop and inspect with `scripts/git_state.py --json --worktrees`.
+Refresh remote evidence through Codex, then choose a normal non-rewriting
+integration path only after ownership and exact heads are known. A query
+failure, `NOT_CHECKED`, behind, or diverged result remains an `UNKNOWN`/hold;
+never reset or rewrite a published lane to make the push succeed.
 
 ---
 
@@ -289,60 +287,39 @@ git commit --no-edit
 - ✅ Required status checks must pass
 - ✅ Force pushes disabled
 - ✅ Branch deletion disabled
-- ✅ PR-first for code/CI/deps
-- ✅ Direct commits allowed for docs only
+- ✅ PR-required for every change to `main`
 
 ### Branch Naming Convention
 
-- `feat/task-XXX-description` - Feature branches
-- `fix/task-XXX-description` - Bug fix branches
-- `docs/task-XXX-description` - Documentation branches
-- `refactor/task-XXX-description` - Refactoring branches
+- `codex/<task-slug>` - all normal task branches
 
 **Examples:**
 ```
-feat/task-017-etabs-import
-fix/task-012-shear-bug
-docs/task-025-api-reference
+codex/task-017-etabs-import
+codex/task-012-shear-bug
+codex/task-025-api-reference
 ```
 
-### Branch Cleanup
+### Branch Disposition
 
-```bash
-# Delete local merged branches
-git branch --merged | grep -v "\*\|main" | xargs -n 1 git branch -d
-
-# Delete remote merged branches
-gh pr list --state merged --limit 20 --json headRefName | \
-  jq -r '.[].headRefName' | \
-  xargs -I {} git push origin --delete {}
-
-# Prune remote references
-git remote prune origin
-git fetch --prune
-```
+Use `scripts/classify_branch_disposition.py` only after exact caller-supplied
+remote, PR, ownership, and retention evidence is available. `NOT_CHECKED`,
+missing, stale, contradictory, or query-failed evidence is `UNKNOWN`. Even
+`RETIREMENT_READY_PENDING_APPROVAL` requires separate exact local-branch,
+remote-branch, and worktree authorization plus immediate reinspection. The
+classifier never fetches, prunes, removes a worktree, or deletes a ref.
 
 ### Worktree Management
 
-**Create Worktree:**
+Inspect the current and sibling topology without changing it:
+
 ```bash
-git worktree add ../worktree-agent-6 -b feat/ui-feature
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
 
-**List Worktrees:**
-```bash
-git worktree list
-```
-
-**Remove Worktree:**
-```bash
-git worktree remove ../worktree-agent-6
-```
-
-**Prune Stale Worktrees:**
-```bash
-git worktree prune
-```
+Codex may create a fresh `codex/<task-slug>` worktree after verifying current
+main and ownership. Removal or pruning is never a routine follow-up: it needs
+complete exact-target disposition evidence and separate authorization.
 
 ---
 
@@ -379,19 +356,11 @@ git push
 
 **Detection:** History rewritten, commits lost
 
-**Recovery:**
-```bash
-# Find lost commit in reflog
-git reflog
-
-# Reset to lost commit
-git reset --hard <lost-commit-hash>
-
-# Force push (only if you're sure!)
-git push --force-with-lease
-```
-
-**Prevention:** Branch protection prevents force push
+**Recovery:** Inspect the reflog and current `git_state.py` receipt without
+moving a ref. Preserve the exact candidate commit/tree as evidence, establish
+ownership, and recover intended paths onto a fresh lane. Never hard-reset or
+force-push as a shortcut; a published-history decision needs explicit owner
+authority beyond this guide.
 
 ---
 
@@ -402,27 +371,10 @@ git push --force-with-lease
 - Commands failing unexpectedly
 - Merge states stuck
 
-**Recovery:**
-```bash
-# Check for unfinished merges
-ls .git/MERGE_*
-
-# If unfinished merge exists:
-git commit --no-edit  # Complete merge
-# OR
-git merge --abort     # Abort merge
-
-# Check for unfinished rebases
-ls .git/rebase-*
-
-# If unfinished rebase:
-git rebase --continue  # Complete rebase
-# OR
-git rebase --abort     # Abort rebase
-
-# Nuclear option (last resort):
-git reset --hard origin/main
-```
+**Recovery:** Run `scripts/git_state.py --json --worktrees`; it resolves real
+linked-worktree operation markers and locks. Stop on `HOLD_OPERATION`,
+`HOLD_LOCKED`, or `HOLD_UNKNOWN`. Inspect the owning operation and exact paths;
+do not delete markers, abort/continue blindly, reset, stash, or switch lanes.
 
 ---
 
@@ -576,8 +528,8 @@ gh pr create --draft --fill
 # Wait for CI
 gh pr checks <PR_NUM> --watch
 
-# Merge PR
-gh pr merge <PR_NUM> --squash --delete-branch
+# Merge only after Codex rechecks the unchanged reviewed head and required
+# checks. Branch/worktree retention is separate.
 
 # Sync after merge
 git pull --ff-only
@@ -591,24 +543,15 @@ git pull --ff-only
 # Check version consistency
 ./scripts/check_version_consistency.sh
 
-# Check git state
-git status
-git worktree list
-gh pr list --state open
+# Check local Git state through the sole authority
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
 
-### Cleanup
-```bash
-# Archive old docs
-./scripts/archive_old_sessions.sh
+### Disposition review
 
-# Clean worktrees
-git worktree prune
-
-# Clean branches
-git remote prune origin
-git fetch --prune
-```
+Run the inspection-only classifier with exact evidence. Do not infer cleanup
+authority from age, reachability, a merged PR, task archive state, or a clean
+tree. No pruning or deletion is part of routine health checks.
 
 ### Emergency
 ```bash

--- a/agents/agent-9/KNOWLEDGE_BASE.md
+++ b/agents/agent-9/KNOWLEDGE_BASE.md
@@ -450,7 +450,9 @@ Agent 9's WIP limits (2 worktrees, 5 PRs, 10 docs, 3 research) prevent context f
 
 **Git Operations:**
 - Don't merge immediately after creating PR (wait for CI)
-- Don't push to PR branch without pulling first
+- Don't push until `scripts/git_state.py --json --worktrees` proves the branch,
+  upstream, ownership, and ahead/behind state. Behind, diverged, query-failed,
+  or `NOT_CHECKED` evidence remains a hold.
 - Don't force-push to main (branch protection prevents this)
 - Don't skip pre-commit hooks (they catch issues early)
 - Don't commit generated files (use .gitignore)

--- a/agents/agent-9/index.json
+++ b/agents/agent-9/index.json
@@ -32,10 +32,10 @@
     {
       "name": "KNOWLEDGE_BASE.md",
       "type": "documentation",
-      "size_lines": 558,
+      "size_lines": 521,
       "last_updated": "2026-08-15",
       "description": "> Current repository boundary: AGENTS.md and the canonical Codex-native Git > workflow control. Use scripts/git_state.py for local facts. Codex performs",
-      "content_hash": "404b83cae735"
+      "content_hash": "f5ed3bdcb28f"
     },
     {
       "name": "METRICS.md",
@@ -99,5 +99,5 @@
       "file_count": 1
     }
   ],
-  "content_hash": "d25048447a9e3f91"
+  "content_hash": "156e3e98007aa529"
 }

--- a/agents/agent-9/index.json
+++ b/agents/agent-9/index.json
@@ -2,98 +2,89 @@
   "folder": "agents/agent-9",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-03-25",
+  "last_updated": "2026-08-15",
   "file_count": 10,
   "files": [
     {
       "name": "AGENT_9_IMPLEMENTATION_ROADMAP.md",
       "type": "documentation",
-      "size_lines": 1159,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9 Implementation Roadmap",
+      "size_lines": 1168,
+      "last_updated": "2026-08-15",
       "description": "- **Phase A (v0.17.0):** Critical infrastructure (archive, CI checks, metrics) - **Phase B (v0.18.0):** Automation & observability (dashboards, alerts)",
-      "content_hash": "8bd9fbb6986a"
+      "content_hash": "21bb16c31511"
     },
     {
       "name": "AUTOMATION.md",
       "type": "documentation",
-      "size_lines": 840,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9: Automation Scripts Specifications",
+      "size_lines": 849,
+      "last_updated": "2026-08-15",
       "description": "1. Archive Old Sessions Script 2. Check WIP Limits Script",
-      "content_hash": "2b7bc8b95a4e"
+      "content_hash": "a3f3725fb2a8"
     },
     {
       "name": "CHECKLISTS.md",
       "type": "documentation",
-      "size_lines": 504,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9: Operational Checklists",
+      "size_lines": 513,
+      "last_updated": "2026-08-15",
       "description": "1. Weekly Maintenance Checklist 2. Pre-Release Checklist",
-      "content_hash": "1cb57c0fc81c"
+      "content_hash": "dac833683939"
     },
     {
       "name": "KNOWLEDGE_BASE.md",
       "type": "documentation",
-      "size_lines": 631,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9: Git & CI Governance Knowledge Base",
-      "description": "1. Git Workflow Best Practices 2. Pre-Commit Hooks & CI",
-      "content_hash": "2d4793718942"
+      "size_lines": 584,
+      "last_updated": "2026-08-15",
+      "description": "> Current repository boundary: AGENTS.md and the canonical Codex-native Git > workflow control. Use scripts/git_state.py for local facts. Codex performs",
+      "content_hash": "e57a9dd452a6"
     },
     {
       "name": "METRICS.md",
       "type": "documentation",
-      "size_lines": 598,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9: Metrics & Tracking Templates",
+      "size_lines": 607,
+      "last_updated": "2026-08-15",
       "description": "1. Weekly Metrics Dashboard 2. Monthly Metrics Dashboard",
-      "content_hash": "fba35f7ef515"
+      "content_hash": "c658cc11629d"
     },
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 408,
-      "last_updated": "2026-01-23",
+      "last_updated": "2026-08-15",
       "title": "Agent 9: Governance & Sustainability Agent",
       "description": "| Document | Purpose | |----------|---------|",
-      "content_hash": "170af38a152c"
+      "content_hash": "3bec4ae81334"
     },
     {
       "name": "RESEARCH_PLAN.md",
       "type": "documentation",
-      "size_lines": 811,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9 Research Plan",
+      "size_lines": 822,
+      "last_updated": "2026-08-15",
       "description": "- ✅ Research complete in 3-5 hours - ✅ Findings documented with citations",
-      "content_hash": "46db5e7220f2"
+      "content_hash": "2e9f3129b7cc"
     },
     {
       "name": "RESEARCH_QUICK_REF.md",
       "type": "documentation",
-      "size_lines": 259,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9 Research Plan - Quick Reference Card",
+      "size_lines": 268,
+      "last_updated": "2026-08-15",
       "description": "Research evidence-based governance for sustainable AI-assisted development (3-5 hours, 5-10 actionable tasks) - [ ] **RESEARCH-001** - Historical patterns (SESSION_LOG analysis) — 15 min",
-      "content_hash": "e2b21d0769df"
+      "content_hash": "784bdc2093d5"
     },
     {
       "name": "SESSION_TEMPLATES.md",
       "type": "documentation",
-      "size_lines": 975,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9: Session Planning Templates",
+      "size_lines": 984,
+      "last_updated": "2026-08-15",
       "description": "1. Weekly Maintenance Session Template 2. Pre-Release Session Template",
-      "content_hash": "e90bfff6289e"
+      "content_hash": "5eed967084a3"
     },
     {
       "name": "WORKFLOWS.md",
       "type": "documentation",
-      "size_lines": 646,
-      "last_updated": "2026-01-23",
-      "title": "Agent 9: Operational Workflows",
+      "size_lines": 655,
+      "last_updated": "2026-08-15",
       "description": "1. Weekly Maintenance Session 2. Pre-Release Governance",
-      "content_hash": "08229a01e0b0"
+      "content_hash": "de144273cfab"
     }
   ],
   "subfolders": [
@@ -108,5 +99,5 @@
       "file_count": 1
     }
   ],
-  "content_hash": "17587bba4823caa5"
+  "content_hash": "cab33f90610decec"
 }

--- a/agents/agent-9/index.json
+++ b/agents/agent-9/index.json
@@ -32,10 +32,10 @@
     {
       "name": "KNOWLEDGE_BASE.md",
       "type": "documentation",
-      "size_lines": 521,
+      "size_lines": 523,
       "last_updated": "2026-08-15",
       "description": "> Current repository boundary: AGENTS.md and the canonical Codex-native Git > workflow control. Use scripts/git_state.py for local facts. Codex performs",
-      "content_hash": "f5ed3bdcb28f"
+      "content_hash": "f4548f378602"
     },
     {
       "name": "METRICS.md",
@@ -99,5 +99,5 @@
       "file_count": 1
     }
   ],
-  "content_hash": "156e3e98007aa529"
+  "content_hash": "5d246480bf817c33"
 }

--- a/agents/agent-9/index.json
+++ b/agents/agent-9/index.json
@@ -32,10 +32,10 @@
     {
       "name": "KNOWLEDGE_BASE.md",
       "type": "documentation",
-      "size_lines": 584,
+      "size_lines": 558,
       "last_updated": "2026-08-15",
       "description": "> Current repository boundary: AGENTS.md and the canonical Codex-native Git > workflow control. Use scripts/git_state.py for local facts. Codex performs",
-      "content_hash": "e57a9dd452a6"
+      "content_hash": "404b83cae735"
     },
     {
       "name": "METRICS.md",
@@ -99,5 +99,5 @@
       "file_count": 1
     }
   ],
-  "content_hash": "cab33f90610decec"
+  "content_hash": "d25048447a9e3f91"
 }

--- a/agents/agent-9/index.md
+++ b/agents/agent-9/index.md
@@ -11,7 +11,7 @@
 | [AGENT_9_IMPLEMENTATION_ROADMAP.md](AGENT_9_IMPLEMENTATION_ROADMAP.md) |  | - **Phase A (v0.17.0):** Critical infrastructure (archive, C | 1168 |
 | [AUTOMATION.md](AUTOMATION.md) |  | 1. Archive Old Sessions Script 2. Check WIP Limits Script | 849 |
 | [CHECKLISTS.md](CHECKLISTS.md) |  | 1. Weekly Maintenance Checklist 2. Pre-Release Checklist | 513 |
-| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) |  | > Current repository boundary: AGENTS.md and the canonical C | 558 |
+| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) |  | > Current repository boundary: AGENTS.md and the canonical C | 521 |
 | [METRICS.md](METRICS.md) |  | 1. Weekly Metrics Dashboard 2. Monthly Metrics Dashboard | 607 |
 | [README.md](README.md) | Agent 9: Governance & Sustainability Age | | Document | Purpose | |----------|---------| | 408 |
 | [RESEARCH_PLAN.md](RESEARCH_PLAN.md) |  | - ✅ Research complete in 3-5 hours - ✅ Findings documented w | 822 |

--- a/agents/agent-9/index.md
+++ b/agents/agent-9/index.md
@@ -11,7 +11,7 @@
 | [AGENT_9_IMPLEMENTATION_ROADMAP.md](AGENT_9_IMPLEMENTATION_ROADMAP.md) |  | - **Phase A (v0.17.0):** Critical infrastructure (archive, C | 1168 |
 | [AUTOMATION.md](AUTOMATION.md) |  | 1. Archive Old Sessions Script 2. Check WIP Limits Script | 849 |
 | [CHECKLISTS.md](CHECKLISTS.md) |  | 1. Weekly Maintenance Checklist 2. Pre-Release Checklist | 513 |
-| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) |  | > Current repository boundary: AGENTS.md and the canonical C | 584 |
+| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) |  | > Current repository boundary: AGENTS.md and the canonical C | 558 |
 | [METRICS.md](METRICS.md) |  | 1. Weekly Metrics Dashboard 2. Monthly Metrics Dashboard | 607 |
 | [README.md](README.md) | Agent 9: Governance & Sustainability Age | | Document | Purpose | |----------|---------| | 408 |
 | [RESEARCH_PLAN.md](RESEARCH_PLAN.md) |  | - ✅ Research complete in 3-5 hours - ✅ Findings documented w | 822 |

--- a/agents/agent-9/index.md
+++ b/agents/agent-9/index.md
@@ -1,23 +1,23 @@
 # Agent 9
 
 **Type:** Documentation
-**Last Updated:** 2026-03-25
+**Last Updated:** 2026-08-15
 **Files:** 10
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [AGENT_9_IMPLEMENTATION_ROADMAP.md](AGENT_9_IMPLEMENTATION_ROADMAP.md) | Agent 9 Implementation Roadmap | - **Phase A (v0.17.0):** Critical infrastructure (archive, C | 1159 |
-| [AUTOMATION.md](AUTOMATION.md) | Agent 9: Automation Scripts Specificatio | 1. Archive Old Sessions Script 2. Check WIP Limits Script | 840 |
-| [CHECKLISTS.md](CHECKLISTS.md) | Agent 9: Operational Checklists | 1. Weekly Maintenance Checklist 2. Pre-Release Checklist | 504 |
-| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) | Agent 9: Git & CI Governance Knowledge B | 1. Git Workflow Best Practices 2. Pre-Commit Hooks & CI | 631 |
-| [METRICS.md](METRICS.md) | Agent 9: Metrics & Tracking Templates | 1. Weekly Metrics Dashboard 2. Monthly Metrics Dashboard | 598 |
+| [AGENT_9_IMPLEMENTATION_ROADMAP.md](AGENT_9_IMPLEMENTATION_ROADMAP.md) |  | - **Phase A (v0.17.0):** Critical infrastructure (archive, C | 1168 |
+| [AUTOMATION.md](AUTOMATION.md) |  | 1. Archive Old Sessions Script 2. Check WIP Limits Script | 849 |
+| [CHECKLISTS.md](CHECKLISTS.md) |  | 1. Weekly Maintenance Checklist 2. Pre-Release Checklist | 513 |
+| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) |  | > Current repository boundary: AGENTS.md and the canonical C | 584 |
+| [METRICS.md](METRICS.md) |  | 1. Weekly Metrics Dashboard 2. Monthly Metrics Dashboard | 607 |
 | [README.md](README.md) | Agent 9: Governance & Sustainability Age | | Document | Purpose | |----------|---------| | 408 |
-| [RESEARCH_PLAN.md](RESEARCH_PLAN.md) | Agent 9 Research Plan | - ✅ Research complete in 3-5 hours - ✅ Findings documented w | 811 |
-| [RESEARCH_QUICK_REF.md](RESEARCH_QUICK_REF.md) | Agent 9 Research Plan - Quick Reference  | Research evidence-based governance for sustainable AI-assist | 259 |
-| [SESSION_TEMPLATES.md](SESSION_TEMPLATES.md) | Agent 9: Session Planning Templates | 1. Weekly Maintenance Session Template 2. Pre-Release Sessio | 975 |
-| [WORKFLOWS.md](WORKFLOWS.md) | Agent 9: Operational Workflows | 1. Weekly Maintenance Session 2. Pre-Release Governance | 646 |
+| [RESEARCH_PLAN.md](RESEARCH_PLAN.md) |  | - ✅ Research complete in 3-5 hours - ✅ Findings documented w | 822 |
+| [RESEARCH_QUICK_REF.md](RESEARCH_QUICK_REF.md) |  | Research evidence-based governance for sustainable AI-assist | 268 |
+| [SESSION_TEMPLATES.md](SESSION_TEMPLATES.md) |  | 1. Weekly Maintenance Session Template 2. Pre-Release Sessio | 984 |
+| [WORKFLOWS.md](WORKFLOWS.md) |  | 1. Weekly Maintenance Session 2. Pre-Release Governance | 655 |
 
 ## Subfolders
 

--- a/agents/agent-9/index.md
+++ b/agents/agent-9/index.md
@@ -11,7 +11,7 @@
 | [AGENT_9_IMPLEMENTATION_ROADMAP.md](AGENT_9_IMPLEMENTATION_ROADMAP.md) |  | - **Phase A (v0.17.0):** Critical infrastructure (archive, C | 1168 |
 | [AUTOMATION.md](AUTOMATION.md) |  | 1. Archive Old Sessions Script 2. Check WIP Limits Script | 849 |
 | [CHECKLISTS.md](CHECKLISTS.md) |  | 1. Weekly Maintenance Checklist 2. Pre-Release Checklist | 513 |
-| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) |  | > Current repository boundary: AGENTS.md and the canonical C | 521 |
+| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) |  | > Current repository boundary: AGENTS.md and the canonical C | 523 |
 | [METRICS.md](METRICS.md) |  | 1. Weekly Metrics Dashboard 2. Monthly Metrics Dashboard | 607 |
 | [README.md](README.md) | Agent 9: Governance & Sustainability Age | | Document | Purpose | |----------|---------| | 408 |
 | [RESEARCH_PLAN.md](RESEARCH_PLAN.md) |  | - ✅ Research complete in 3-5 hours - ✅ Findings documented w | 822 |

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -243,9 +243,9 @@ at the locally and hosted green draft PR head for independent audit
   state was clean and ready at the verified PR #750 merge SHA.
 - Focused receipt, semantic, and session regression suite: 135 passed after the
   sixth independent-audit blocker fix.
-- Semantic workflow passes for the seventh candidate. Strict docs, links, quick,
-  full, efficiency, session-end, preservation replay, and hosted checks are
-  replayed before the exact-head audit handoff.
+- Semantic workflow, strict docs 5/5, links, quick 10/10, full 30/30, and
+  efficiency pass for the seventh candidate. Session-end, preservation replay,
+  and hosted checks are replayed on the committed/published exact head.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -125,6 +125,13 @@ at the locally and hosted green draft PR head for independent audit
   stale while the new code head was not yet available.
 - The eleventh pre-hook Ruff check rejected import ordering in the two edited
   test modules before staging.
+- A twelfth exact-head audit found nine remaining canonical-schema mutations
+  could still validate as READY_LOCAL and let session-end print CLEAN: observed
+  relations using placeholder or malformed refs, invalid branch refnames,
+  contradictory worktree identity, non-finite duration, and future evidence.
+- The first twelfth focused replay used an actual `none` upstream fixture when
+  reproducing the auditor's observed/equal `ref="NONE"` mutation, so it did not
+  construct the claimed contradictory relation and one assertion failed.
 - The first ninth-head focused replay rejected valid canonical state fixtures
   loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
@@ -343,6 +350,20 @@ at the locally and hosted green draft PR head for independent audit
 - Formatter resolution: apply Ruff's scoped import ordering to only the two
   edited tests, regenerate the maintained tests index, and replay Ruff clean;
   no hook or unrelated path was involved.
+- Twelfth state root cause: the canonical consistency validator checked
+  relation refs only as nonempty strings, branches only for whitespace, paths
+  only for absolute shape, timestamps only for parseability, and durations only
+  for numeric/nonnegative shape. Resolution: add a pure Git-ref/refname grammar,
+  status-aware `NONE` placeholder rules, repository/worktree and linked Git-dir
+  identity checks, finite duration enforcement, and an injectable validation
+  clock with five-minute maximum age and five-second future skew. All rules
+  remain in `git_state.py`; session closeout still delegates to that one
+  validator. Evidence: all nine exact auditor mutations plus stale evidence
+  return UNKNOWN without subprocess access, while valid linked-worktree refs,
+  boundary timestamps, and finite durations pass.
+- Focused-replay resolution: replace the no-upstream fixture with an explicit
+  observed/equal relation carrying `ref="NONE"`; the exact mutation then fails
+  for the intended relation-ref reason without changing production behavior.
 - Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
   as distinct module identities, so nominal `isinstance` checks rejected the
   same schema; historical grammar included `says` but omitted `said`.
@@ -391,6 +412,10 @@ at the locally and hosted green draft PR head for independent audit
   `sha256:ca5c3e527a8fd269a743c00fc6071865bbbd51243621b48a1226520e08a77b3d`.
   Preservation replay and hosted checks remain pending until the final
   documentation head exists.
+- Twelfth-candidate focused receipt/semantic/Git-state/session regressions pass
+  256 tests and the full indexed semantic corpus passes. Final docs, repository,
+  receipt, session-end, preservation, and hosted gates are replayed only after
+  the exact receipt-bound candidate head exists.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -74,6 +74,10 @@ at the locally and hosted green draft PR head for independent audit
   filter-branch, checkout-overwrite, and reset recovery. The first contextual
   semantic replay then exposed equivalent broad-staging and wholesale
   checkout-ours instructions in the maintained Agent 9 knowledge base.
+- A third exact-head audit found nested `authority_source.query_status` was
+  ignored and upgraded to `OK`, while the maintained Agent 9 knowledge base
+  still directly prescribed commit amendment, cherry-pick, ad-hoc recovery
+  branches, direct revert/push, and other outcome-changing lifecycle commands.
 
 ### Root causes and resolutions
 
@@ -153,13 +157,28 @@ at the locally and hosted green draft PR head for independent audit
   retain historical prose as non-authority. Evidence: five active unsafe forms
   fail in fixtures, harmless incident prose passes, and the live indexed
   repository semantic check passes.
+- Root cause: source freshness validation constructed a synthetic mapping with
+  `query_status: OK`, overwriting caller evidence. Resolution: validate the
+  nested source mapping itself and require its status, query result, and
+  timestamp to survive unchanged through hold derivation. Evidence: exact
+  FAILED, UNKNOWN, missing, malformed, future, stale, and missing/malformed-time
+  regressions all derive source-specific holds and reject false readiness.
+- Root cause: Agent 9 was correctly indexed and actively linked as maintained
+  authority, but its legacy examples mixed read-only inspection with imperative
+  Git mutation and the semantic patterns did not cover amendment, patch replay,
+  or ad-hoc/non-Codex branch creation. Resolution: audit the entire live file,
+  route all lifecycle mutations through `git_state.py`, preservation/ownership
+  checks, and Codex authority, and add instruction-context patterns while
+  allowing unambiguous historical incident prose. Evidence: the file contains
+  no imperative Git mutation command, nine unsafe context fixtures fail, four
+  historical-prose fixtures pass, and the live repository semantic check passes.
 
 ### Verification
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 90 passed after the
-  second independent-audit blocker fix.
+- Focused receipt, semantic, and session regression suite: 104 passed after the
+  third independent-audit blocker fix.
 - Remaining semantic, docs/index, quick 10/10, full 30/30, efficiency,
   session-end, preservation replay, and hosted checks are recorded before PR
   audit handoff.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -385,8 +385,12 @@ at the locally and hosted green draft PR head for independent audit
 - Eleventh-candidate focused receipt/semantic/Git-state/session regressions pass
   223 tests and the full indexed semantic corpus passes. Strict docs pass 5/5,
   1,107 links have zero failures, quick passes 10/10, full passes 30/30, and
-  efficiency passes. Session-end, preservation, and hosted checks remain
-  pending until the exact receipt-bound head exists.
+  efficiency passes. On receipt commit `4ae58117695e9993f4dcd7d0faf47b9d942f7087`,
+  session-end passes using canonical `git_state.py` evidence and validates the
+  fail-closed HOLD receipt with hash
+  `sha256:ca5c3e527a8fd269a743c00fc6071865bbbd51243621b48a1226520e08a77b3d`.
+  Preservation replay and hosted checks remain pending until the final
+  documentation head exists.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -261,9 +261,9 @@ at the locally and hosted green draft PR head for independent audit
   state was clean and ready at the verified PR #750 merge SHA.
 - Focused receipt, semantic, and session regression suite: 143 passed after the
   seventh independent-audit blocker fix.
-- The full indexed semantic corpus passes for the eighth candidate. Strict docs,
-  links, quick, full, efficiency, session-end, preservation replay, and hosted
-  checks are replayed before exact-head audit handoff.
+- The full indexed semantic corpus, strict docs 5/5, 1,107 links, quick 10/10,
+  full 30/30, and efficiency pass for the eighth candidate. Session-end,
+  preservation replay, and hosted checks are replayed on the exact final head.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -89,6 +89,10 @@ at the locally and hosted green draft PR head for independent audit
 - A sixth exact-head audit found the direct-prefix approximation rejected four
   genuine prohibitions: Markdown exact-object suffixes using `do not run` or
   `never use`, inner `not to run`, and `do not fail to avoid`.
+- A seventh exact-head audit found maintained Agent 9 guidance still required
+  pulling before every PR-branch push, bypassing branch/upstream/ownership and
+  behind/diverged inspection. The semantic index missed the prose-equivalent
+  because its patterns required a literal `git` command.
 - A read-only inventory regex containing a backtick was initially passed with
   unsafe shell quoting and zsh rejected it before the search ran.
 - The first sixth-head session-end replay held because it was intentionally run
@@ -97,6 +101,9 @@ at the locally and hosted green draft PR head for independent audit
   controls while all prefix-polarity controls passed.
 - The first seventh-head Black check required mechanical multiline formatting
   in the checker before the validation sequence could continue.
+- Eighth-head index generation refused a live write for `docs/git-automation`
+  because that folder has no maintained index topology, although dry-run listed
+  the prospective target.
 
 ### Root causes and resolutions
 
@@ -220,6 +227,14 @@ at the locally and hosted green draft PR head for independent audit
   exact-object suffix independently within the local clause. Evidence: all four
   auditor forms and Markdown variants pass, their auxiliary/directly-negated
   contrasts fail, clause boundaries stay isolated, and history controls pass.
+- Root cause: semantic mutation patterns covered `git pull`-style command text
+  but not unconditional pull-before-push prose, while Agent 9 retained one stale
+  checklist bullet inconsistent with its own correct inspection-first recovery
+  procedure. Resolution: replace that bullet with exact `git_state.py
+  --json --worktrees` inspection and fail-closed holds, and add a data-driven
+  omitted-`git` pattern for pull-before-push/pull-first forms. Evidence:
+  unconditional and double-negative mandate fixtures fail; direct prohibitions
+  plus historical/deprecated narration pass; the full indexed corpus is green.
 - Terminal issue resolution: rerun the read-only inventory with the regex in
   literal single quotes; it completed without any repository mutation.
 - Session-end correctly treats uncommitted receipt evidence as incomplete.
@@ -236,16 +251,19 @@ at the locally and hosted green draft PR head for independent audit
   embedded words such as `whenever`.
 - Formatter resolution: run Black only on the two scoped Python paths and replay
   `--check`; both then passed without touching unrelated files.
+- Index resolution: do not use `--allow-new-index`; refresh the maintained
+  Python/tests, Agent 9, and top-level docs indexes only. The refusal created no
+  files and prevented an unintended parallel index authority.
 
 ### Verification
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 135 passed after the
-  sixth independent-audit blocker fix.
-- Semantic workflow, strict docs 5/5, links, quick 10/10, full 30/30, and
-  efficiency pass for the seventh candidate. Session-end, preservation replay,
-  and hosted checks are replayed on the committed/published exact head.
+- Focused receipt, semantic, and session regression suite: 143 passed after the
+  seventh independent-audit blocker fix.
+- The full indexed semantic corpus passes for the eighth candidate. Strict docs,
+  links, quick, full, efficiency, session-end, preservation replay, and hosted
+  checks are replayed before exact-head audit handoff.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -109,6 +109,8 @@ at the locally and hosted green draft PR head for independent audit
 - The first tenth-candidate commit attempt stopped after Ruff converted one
   test-only zero-argument lambda to the equivalent callable; no commit was
   created and no path outside the 14 staged task paths changed.
+- A post-generation receipt display snippet assumed `task_id` was top-level and
+  raised `KeyError` after the receipt had already validated successfully.
 - The first ninth-head focused replay rejected valid canonical state fixtures
   loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
@@ -291,6 +293,9 @@ at the locally and hosted green draft PR head for independent audit
   afterward the sole unstaged path was
   `Python/tests/test_session_automation.py`, with binary-diff SHA-256
   `f5835eff85348ecc7d723a87c2ed6e8e0bee7efdc07c085cee92dd8f456ed347`.
+- Terminal issue resolution: inspect the schema directly and read
+  `task.task_id`; validation remained green and no receipt field was changed by
+  the failed display-only snippet.
 - Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
   as distinct module identities, so nominal `isinstance` checks rejected the
   same schema; historical grammar included `says` but omitted `said`.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -58,6 +58,9 @@ at the locally and hosted green draft PR head for independent audit
   change, and the correct `bash -n run.sh` syntax check passed.
 - The first commit attempt was stopped by the end-of-file hook because the
   generated global docs index omitted its required final newline.
+- Independent exact-head audit reproduced that clearing serialized `holds` and
+  changing `receipt_status` to `READY` made stored validation return `[]`, even
+  when `DELETE_BRANCH` and `MERGE` were also inserted into authorized actions.
 
 ### Root causes and resolutions
 
@@ -94,12 +97,24 @@ at the locally and hosted green draft PR head for independent audit
   hook-required terminal newline. Resolution: retain the hook's normalization,
   restage the exact generated file, and require a clean second hook pass before
   commit; no validation was bypassed.
+- Root cause: stored validation treated caller-controlled serialized holds as
+  authority and checked false `READY` only against those stored values; it did
+  not independently derive semantic holds or validate the authorization source
+  and target. Resolution: use one evidence-to-holds derivation for creation and
+  validation, require an exact hold-set/status match, close the status enum,
+  require `receipt_grants_authority: false`, and validate external authorization
+  source plus task/branch/head/action binding. Evidence: both auditor tamper
+  reproductions now return `FALSE_READY_CLAIM`, hold-set/status contradictions,
+  and the missing evidence/authorization holds; focused regressions cover
+  clearing all holds, removing one hold, invalid status/next action, authority-
+  boundary tampering, and injected destructive/merge actions.
 
 ### Verification
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 66 passed.
+- Focused receipt, semantic, and session regression suite: 76 passed after the
+  independent-audit blocker fix.
 - Remaining semantic, docs/index, quick 10/10, full 30/30, efficiency,
   session-end, preservation replay, and hosted checks are recorded before PR
   audit handoff.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -43,12 +43,19 @@ at the locally and hosted green draft PR head for independent audit
   rollback, deletion, reset, and force-push recovery.
 - Session handoff persisted prose and optional PR numbers only; session end could
   not validate durable local/hosted identity, freshness, hashes, or contradictory
-  claims. The automation map also classified a writing handoff as read-only.
+  claims. The automation map also classified a writing handoff as read-only,
+  while `run.sh` did not dispatch its maintained `handoff` alias at all.
 - The first focused run exposed three implementation defects: receipt local
   payload construction referenced an unset variable, deprecated frontmatter was
   incorrectly accepted as its own historical marker, and the new receipt alias
   was absent from the automation registry.
 - A targeted `rg` search beginning with `--delete` was parsed as an option.
+- The first receipt command left the `refs/**` boundary unquoted, so zsh
+  rejected the unmatched glob before the receipt tool ran.
+- The first real handoff reported success but left the current brief unchanged
+  because its maintained legacy heading lacked the newer `(auto)` suffix.
+- A formatter check was mistakenly aimed at the shell dispatcher; it made no
+  change, and the correct `bash -n run.sh` syntax check passed.
 - The first commit attempt was stopped by the end-of-file hook because the
   generated global docs index omitted its required final newline.
 
@@ -70,10 +77,19 @@ at the locally and hosted green draft PR head for independent audit
   consumed it; historical detection treated a metadata status as narrative; the
   automation registry had no receipt entry. Resolution: construct the payload in
   `build_receipt`, require an explicit historical banner, and register read-only
-  validation plus `WorkspaceWrite` output/handoff modes. Evidence: the corrected
-  focused suite passes 64 tests.
+  validation plus `WorkspaceWrite` output/handoff modes and route the alias
+  through `session.py`. Evidence: the corrected focused suite and live
+  `./run.sh session handoff --help` dispatch pass.
+- Root cause: the handoff updater detected generic markers but its replacement
+  regex accepted only the newer heading, creating a false-success no-op on the
+  live brief. Resolution: accept both maintained heading forms and regress the
+  legacy form; the real receipt-bound handoff now writes exact identity lines.
 - Terminal issue resolution: insert `--` before a ripgrep pattern that begins
   with a hyphen; the corrected search completed without changing scope.
+- Terminal issue resolution: quote the literal `refs/**` receipt argument; the
+  corrected command produced and validated the intended receipt.
+- Terminal issue resolution: use Black only for Python paths and `bash -n` for
+  `run.sh`; both relevant formatter/syntax checks then passed.
 - Root cause: the docs-index generator emitted JSON without the repository's
   hook-required terminal newline. Resolution: retain the hook's normalization,
   restage the exact generated file, and require a clean second hook pass before
@@ -83,7 +99,7 @@ at the locally and hosted green draft PR head for independent audit
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 64 passed.
+- Focused receipt, semantic, and session regression suite: 66 passed.
 - Remaining semantic, docs/index, quick 10/10, full 30/30, efficiency,
   session-end, preservation replay, and hosted checks are recorded before PR
   audit handoff.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -132,6 +132,10 @@ at the locally and hosted green draft PR head for independent audit
 - The first twelfth focused replay used an actual `none` upstream fixture when
   reproducing the auditor's observed/equal `ref="NONE"` mutation, so it did not
   construct the claimed contradictory relation and one assertion failed.
+- The first twelfth receipt commit command placed `&& git commit` on the same
+  line as a Python here-document terminator, so Python parsed the shell suffix
+  and raised `SyntaxError` before the commit ran. The intended two receipt paths
+  remained staged with zero unstaged paths.
 - The first ninth-head focused replay rejected valid canonical state fixtures
   loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
@@ -364,6 +368,12 @@ at the locally and hosted green draft PR head for independent audit
 - Focused-replay resolution: replace the no-upstream fixture with an explicit
   observed/equal relation carrying `ref="NONE"`; the exact mutation then fails
   for the intended relation-ref reason without changing production behavior.
+- Terminal issue resolution: end the here-document on its own line, replay the
+  two-path staged inventory and hash, then run the commit separately. Evidence:
+  the staged set remained exactly the receipt JSON plus its maintained index,
+  with SHA-256 `d4be2299c68df90db6d9896dbb92299d0d292a7cc7e24967311131b6cd12d21c`,
+  zero unstaged paths, and no symlinks or non-regular files; the separate commit
+  and all hooks passed.
 - Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
   as distinct module identities, so nominal `isinstance` checks rejected the
   same schema; historical grammar included `says` but omitted `said`.
@@ -413,9 +423,14 @@ at the locally and hosted green draft PR head for independent audit
   Preservation replay and hosted checks remain pending until the final
   documentation head exists.
 - Twelfth-candidate focused receipt/semantic/Git-state/session regressions pass
-  256 tests and the full indexed semantic corpus passes. Final docs, repository,
-  receipt, session-end, preservation, and hosted gates are replayed only after
-  the exact receipt-bound candidate head exists.
+  256 tests and the full indexed semantic corpus passes. Strict docs pass 5/5,
+  1,107 links have zero failures, quick passes 10/10, full passes 30/30, and
+  efficiency plus session-end pass on receipt commit
+  `c93d6ccfcc5eb3e45ec99559a63f0bbc285136d4`. The validated fail-closed HOLD
+  receipt hash is
+  `sha256:05100369e50b3c9fd495f160439171572bedb1ab0cf24204d1d1abb80473e091`.
+  Preservation and hosted checks remain pending until the final documentation
+  head exists.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -136,6 +136,13 @@ at the locally and hosted green draft PR head for independent audit
   line as a Python here-document terminator, so Python parsed the shell suffix
   and raised `SyntaxError` before the commit ran. The intended two receipt paths
   remained staged with zero unstaged paths.
+- A completed twelfth-head audit found the pure branch grammar accepted the
+  exact pseudo-ref `HEAD`, although read-only
+  `git check-ref-format --branch HEAD` exits 128; tampered canonical evidence
+  could therefore remain READY_LOCAL and let session closeout report CLEAN.
+- The same audit found maintained `./run.sh session context` independently ran
+  `git status --porcelain` and `git rev-parse`; blank stdout with return code 128
+  produced an empty branch, `Working tree: clean`, and process exit 0.
 - The first ninth-head focused replay rejected valid canonical state fixtures
   loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
@@ -374,6 +381,22 @@ at the locally and hosted green draft PR head for independent audit
   with SHA-256 `d4be2299c68df90db6d9896dbb92299d0d292a7cc7e24967311131b6cd12d21c`,
   zero unstaged paths, and no symlinks or non-regular files; the separate commit
   and all hooks passed.
+- Local-only branch root cause: the pure grammar implemented general ref-format
+  character/component rules but omitted Git's branch-mode special rejection of
+  uppercase `HEAD`, while also rejecting the branch-valid one-level name `@`.
+  Resolution: make those two branch-mode rules exact and add a representative
+  parity corpus against read-only `git check-ref-format --branch`, retaining
+  earlier valid names and every malformed separator, component, suffix, and
+  character boundary. Evidence: the parity corpus and canonical/session `HEAD`
+  tamper regressions pass without any production subprocess or network access.
+- Local-only context root cause: `cmd_context` predated the canonical state
+  kernel and never checked the three Git subprocess return codes, forming a
+  second fail-open authority. Resolution: remove its status, rev-parse, and log
+  subprocesses; collect and validate the canonical evidence once, print its
+  branch/HEAD/tree facts, and return nonzero for dirty, detached, held,
+  malformed, query-failed, or exceptional evidence. Evidence: end-to-end clean,
+  dirty, detached, behind, failed-query, malformed, and exception cases pass
+  while a subprocess spy rejects every fallback Git command.
 - Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
   as distinct module identities, so nominal `isinstance` checks rejected the
   same schema; historical grammar included `says` but omitted `said`.
@@ -431,6 +454,10 @@ at the locally and hosted green draft PR head for independent audit
   `sha256:05100369e50b3c9fd495f160439171572bedb1ab0cf24204d1d1abb80473e091`.
   Preservation and hosted checks remain pending until the final documentation
   head exists.
+- Local-only follow-up candidate passes 292 focused semantic, receipt,
+  Git-state, and session tests plus the indexed semantic checker. Per the
+  orchestrator boundary, no full repository gate, push, hosted run, ready, or
+  merge action is performed before independent inspection of the local object.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -86,10 +86,17 @@ at the locally and hosted green draft PR head for independent audit
   negated reminder/encouragement auxiliaries such as `do not forget to run`,
   `never hesitate to recover`, and `never fail to create`; those sentences
   direct the unsafe action rather than prohibit it.
+- A sixth exact-head audit found the direct-prefix approximation rejected four
+  genuine prohibitions: Markdown exact-object suffixes using `do not run` or
+  `never use`, inner `not to run`, and `do not fail to avoid`.
 - A read-only inventory regex containing a backtick was initially passed with
   unsafe shell quoting and zsh rejected it before the search ran.
 - The first sixth-head session-end replay held because it was intentionally run
   before the newly generated receipt and index were committed.
+- The first seventh-head focused replay rejected the two Markdown suffix
+  controls while all prefix-polarity controls passed.
+- The first seventh-head Black check required mechanical multiline formatting
+  in the checker before the validation sequence could continue.
 
 ### Root causes and resolutions
 
@@ -206,21 +213,39 @@ at the locally and hosted green draft PR head for independent audit
   colon was not admitted between the directive and direct action. Resolution:
   allow only intervening Markdown/directive punctuation before the action and
   add the exact colon form as a safe regression; auxiliary words remain unsafe.
+- Root cause: direct governance was modeled only as the first action after a
+  prefix negation, so it could not represent a suffix referring to the matched
+  expression or the nearest inner action/polarity of `not to` and `avoid`.
+  Resolution: evaluate the nearest prefix action, non-negated avoidance, and an
+  exact-object suffix independently within the local clause. Evidence: all four
+  auditor forms and Markdown variants pass, their auxiliary/directly-negated
+  contrasts fail, clause boundaries stay isolated, and history controls pass.
 - Terminal issue resolution: rerun the read-only inventory with the regex in
   literal single quotes; it completed without any repository mutation.
 - Session-end correctly treats uncommitted receipt evidence as incomplete.
   Resolution: validate and commit the exact receipt packet first, then replay
   session-end on the clean tree; no hold was suppressed or auto-fixed.
+- Root cause: indexed unsafe-command patterns intentionally match the unsafe
+  token prefix rather than every argument, so the suffix classifier saw
+  `--hard` or a commit ID between the match end and the em-dash prohibition.
+  Resolution: recognize that bounded same-clause command continuation only when
+  it terminates at an em-dash exact-object suffix; semicolon/period clause
+  boundaries and non-deictic suffixes remain instructions. The remaining italic
+  `_never` case exposed Python's underscore-as-word boundary; directive starts
+  now exclude only letters/digits, so Markdown delimiters work without matching
+  embedded words such as `whenever`.
+- Formatter resolution: run Black only on the two scoped Python paths and replay
+  `--check`; both then passed without touching unrelated files.
 
 ### Verification
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 123 passed after the
-  fifth independent-audit blocker fix.
-- Semantic workflow, strict docs 5/5, links, quick 10/10, full 30/30, and
-  efficiency passed for the sixth candidate. Session-end, preservation replay,
-  and hosted checks are replayed on the committed/published exact head.
+- Focused receipt, semantic, and session regression suite: 135 passed after the
+  sixth independent-audit blocker fix.
+- Semantic workflow passes for the seventh candidate. Strict docs, links, quick,
+  full, efficiency, session-end, preservation replay, and hosted checks are
+  replayed before the exact-head audit handoff.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -56,11 +56,24 @@ at the locally and hosted green draft PR head for independent audit
   because its maintained legacy heading lacked the newer `(auto)` suffix.
 - A formatter check was mistakenly aimed at the shell dispatcher; it made no
   change, and the correct `bash -n run.sh` syntax check passed.
+- A targeted index-generation command correctly refused `docs/git-automation`
+  because that folder has no maintained index topology.
+- A repository-wide pre-commit invocation created 1,745 unstaged mechanical
+  edits across unrelated tracked files and surfaced known all-tree JSON/Bandit
+  baselines instead of a scoped task result. Before the hook the worktree had
+  exactly 22 staged task paths and zero unstaged paths.
 - The first commit attempt was stopped by the end-of-file hook because the
   generated global docs index omitted its required final newline.
 - Independent exact-head audit reproduced that clearing serialized `holds` and
   changing `receipt_status` to `READY` made stored validation return `[]`, even
   when `DELETE_BRANCH` and `MERGE` were also inserted into authorized actions.
+- A second exact-head audit found that changing only `authorization.next_action`
+  to `DELETE_BRANCH` or `MERGE`, aging the authorization source, or recording an
+  authorization query failure still validated successfully.
+- The maintained indexed Git learning guide still prescribed broad staging,
+  filter-branch, checkout-overwrite, and reset recovery. The first contextual
+  semantic replay then exposed equivalent broad-staging and wholesale
+  checkout-ours instructions in the maintained Agent 9 knowledge base.
 
 ### Root causes and resolutions
 
@@ -93,6 +106,22 @@ at the locally and hosted green draft PR head for independent audit
   corrected command produced and validated the intended receipt.
 - Terminal issue resolution: use Black only for Python paths and `bash -n` for
   `run.sh`; both relevant formatter/syntax checks then passed.
+- Terminal issue resolution: inspect the folder for existing index files, do
+  not use `--allow-new-index`, and regenerate only maintained parent/global
+  indexes; no new topology was created.
+- Terminal issue resolution: retain the staged task snapshot and stage the
+  intended `docs/docs-index.json` newline normalization, leaving 1,744 hook-only
+  unstaged paths. Verify every remaining path was a tracked regular-file
+  modification with no traversal or symlink, then restore exactly that
+  NUL-delimited path set and use scoped pre-commit paths thereafter. The staged
+  22-file task snapshot was preserved. A read-only replay of the hook algorithms
+  reconstructed all 1,745 paths with path-set SHA-256
+  `9f7d1ccd79326e4cf2d6cd0c52e51d81de5d0e519aea7404d0adb4f0e0d07976`;
+  the only trailing-whitespace path was historical
+  `docs/_archive/VALIDATION_COMPLETE.md`, with the union otherwise attributable
+  to end-of-file normalization. The later orchestrator restriction against
+  `git restore` arrived after this exact path-bounded reversal had completed;
+  no further reversal command was run.
 - Root cause: the docs-index generator emitted JSON without the repository's
   hook-required terminal newline. Resolution: retain the hook's normalization,
   restage the exact generated file, and require a clean second hook pass before
@@ -108,13 +137,29 @@ at the locally and hosted green draft PR head for independent audit
   and the missing evidence/authorization holds; focused regressions cover
   clearing all holds, removing one hold, invalid status/next action, authority-
   boundary tampering, and injected destructive/merge actions.
+- Root cause: authorization was structurally checked but did not pass through
+  freshness/query semantics, while `next_action` was not constrained to an
+  authorized exact-target action or a closed safe hold/wait set. Resolution:
+  derive authorization and source freshness/query holds, require every active
+  next action to be externally authorized and target-bound, and permit only four
+  explicit non-mutating hold/wait actions without mutation authority. Evidence:
+  direct DELETE_BRANCH/MERGE injection, stale provenance, and query-failure
+  regressions fail closed; all four safe hold actions round-trip.
+- Root cause: the semantic control covered lifecycle categories and destructive
+  command tokens but not instruction-context broad staging or history/file-
+  changing recovery forms. Resolution: add indexed instruction patterns applied
+  only to live command/instruction contexts, correct the active learning and
+  Agent 9 guidance to exact-path staging and preservation-first inspection, and
+  retain historical prose as non-authority. Evidence: five active unsafe forms
+  fail in fixtures, harmless incident prose passes, and the live indexed
+  repository semantic check passes.
 
 ### Verification
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 76 passed after the
-  independent-audit blocker fix.
+- Focused receipt, semantic, and session regression suite: 90 passed after the
+  second independent-audit blocker fix.
 - Remaining semantic, docs/index, quick 10/10, full 30/30, efficiency,
   session-end, preservation replay, and hosted checks are recorded before PR
   audit handoff.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -88,6 +88,8 @@ at the locally and hosted green draft PR head for independent audit
   direct the unsafe action rather than prohibit it.
 - A read-only inventory regex containing a backtick was initially passed with
   unsafe shell quoting and zsh rejected it before the search ran.
+- The first sixth-head session-end replay held because it was intentionally run
+  before the newly generated receipt and index were committed.
 
 ### Root causes and resolutions
 
@@ -206,6 +208,9 @@ at the locally and hosted green draft PR head for independent audit
   add the exact colon form as a safe regression; auxiliary words remain unsafe.
 - Terminal issue resolution: rerun the read-only inventory with the regex in
   literal single quotes; it completed without any repository mutation.
+- Session-end correctly treats uncommitted receipt evidence as incomplete.
+  Resolution: validate and commit the exact receipt packet first, then replay
+  session-end on the clean tree; no hold was suppressed or auto-fixed.
 
 ### Verification
 
@@ -213,9 +218,9 @@ at the locally and hosted green draft PR head for independent audit
   state was clean and ready at the verified PR #750 merge SHA.
 - Focused receipt, semantic, and session regression suite: 123 passed after the
   fifth independent-audit blocker fix.
-- Remaining semantic, docs/index, quick 10/10, full 30/30, efficiency,
-  session-end, preservation replay, and hosted checks are recorded before PR
-  audit handoff.
+- Semantic workflow, strict docs 5/5, links, quick 10/10, full 30/30, and
+  efficiency passed for the sixth candidate. Session-end, preservation replay,
+  and hosted checks are replayed on the committed/published exact head.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -143,6 +143,9 @@ at the locally and hosted green draft PR head for independent audit
 - The same audit found maintained `./run.sh session context` independently ran
   `git status --porcelain` and `git rev-parse`; blank stdout with return code 128
   produced an empty branch, `Working tree: clean`, and process exit 0.
+- The first final-closeout receipt generation ran after the LOCAL PASS session
+  note was edited, so canonical evidence truthfully added `LOCAL_HOLD_DIRTY`
+  instead of representing the clean audited implementation object.
 - The first ninth-head focused replay rejected valid canonical state fixtures
   loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
@@ -397,6 +400,13 @@ at the locally and hosted green draft PR head for independent audit
   malformed, query-failed, or exceptional evidence. Evidence: end-to-end clean,
   dirty, detached, behind, failed-query, malformed, and exception cases pass
   while a subprocess spy rejects every fallback Git command.
+- Final-closeout ordering root cause: the task-owned session note was written
+  before collecting the audited code-head state. Resolution: reverse only the
+  exact session/receipt edits with path-bounded patches, verify the worktree was
+  clean, generate the receipt from immutable head `abfdb968`, then reapply the
+  note for the single packet commit. Evidence: the corrected receipt records
+  `READY_LOCAL`, has no local hold, and retains only explicit remote, PR, and
+  review `NOT_CHECKED` holds.
 - Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
   as distinct module identities, so nominal `isinstance` checks rejected the
   same schema; historical grammar included `says` but omitted `said`.
@@ -458,6 +468,12 @@ at the locally and hosted green draft PR head for independent audit
   Git-state, and session tests plus the indexed semantic checker. Per the
   orchestrator boundary, no full repository gate, push, hosted run, ready, or
   merge action is performed before independent inspection of the local object.
+- Independent local audit granted PASS for immutable implementation head
+  `abfdb968991290504a8facaab2172fa09876bae1`, tree
+  `af8386cdc758e0231e108eda56f16f88e93825b5`, confirming the two frozen roots:
+  branch-mode parity rejects `HEAD`, and maintained session context has no
+  competing Git-state subprocess or false-clean path. The final receipt remains
+  HOLD/NOT_CHECKED until the separately authorized hosted closeout completes.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -283,9 +283,9 @@ at the locally and hosted green draft PR head for independent audit
   state was clean and ready at the verified PR #750 merge SHA.
 - Focused receipt, semantic, and session regression suite: 160 passed after the
   eighth independent-audit blocker fix.
-- The full indexed semantic corpus passes for the ninth candidate. Strict docs,
-  links, quick, full, efficiency, session-end, preservation replay, and hosted
-  checks are replayed before exact-head audit handoff.
+- The full indexed semantic corpus, strict docs 5/5, 1,107 links, quick 10/10,
+  full 30/30, and efficiency pass for the ninth candidate. Session-end,
+  preservation replay, and hosted checks are replayed on the exact final head.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -93,6 +93,13 @@ at the locally and hosted green draft PR head for independent audit
   pulling before every PR-branch push, bypassing branch/upstream/ownership and
   behind/diverged inspection. The semantic index missed the prose-equivalent
   because its patterns required a literal `git` command.
+- An eighth exact-head audit found the omitted-`git` prose pattern missed
+  intervening-pronoun mandates such as `pull before you push` and overreached
+  into non-Git objects such as a lead horse or first-aid supplies. The same audit
+  found session-end independently ran `git status --porcelain`, treated
+  exceptions/nonzero results as an empty list, and could print a false CLEAN.
+- The first ninth-head focused replay rejected valid canonical state fixtures
+  loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
   unsafe shell quoting and zsh rejected it before the search ran.
 - The first sixth-head session-end replay held because it was intentionally run
@@ -235,6 +242,21 @@ at the locally and hosted green draft PR head for independent audit
   omitted-`git` pattern for pull-before-push/pull-first forms. Evidence:
   unconditional and double-negative mandate fixtures fail; direct prohibitions
   plus historical/deprecated narration pass; the full indexed corpus is green.
+- Root cause: the prose pattern treated `pull first` as sufficient without a
+  paired push action and did not allow the subject `you`; session closeout also
+  retained a legacy subprocess calculation instead of consuming the already
+  imported Git-state kernel. Resolution: require a bounded pull/push action pair
+  (including `before you push`) and route closeout through
+  `collect_repository_state` only. Query failure, exception, schema/type
+  mismatch, or contradictory tree evidence is UNKNOWN/hold; only canonical
+  clean evidence prints CLEAN. Evidence: exact imperative/non-Git/history pairs
+  and clean/dirty/nonzero/exception/malformed authority regressions pass, with
+  no closeout Git/network/mutation subprocess.
+- Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
+  as distinct module identities, so nominal `isinstance` checks rejected the
+  same schema; historical grammar included `says` but omitted `said`.
+  Resolution: validate canonical evidence structurally by schema/required fields
+  and add the explicit past-tense narration token. Malformed fields still hold.
 - Terminal issue resolution: rerun the read-only inventory with the regex in
   literal single quotes; it completed without any repository mutation.
 - Session-end correctly treats uncommitted receipt evidence as incomplete.
@@ -259,11 +281,11 @@ at the locally and hosted green draft PR head for independent audit
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 143 passed after the
-  seventh independent-audit blocker fix.
-- The full indexed semantic corpus, strict docs 5/5, 1,107 links, quick 10/10,
-  full 30/30, and efficiency pass for the eighth candidate. Session-end,
-  preservation replay, and hosted checks are replayed on the exact final head.
+- Focused receipt, semantic, and session regression suite: 160 passed after the
+  eighth independent-audit blocker fix.
+- The full indexed semantic corpus passes for the ninth candidate. Strict docs,
+  links, quick, full, efficiency, session-end, preservation replay, and hosted
+  checks are replayed before exact-head audit handoff.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -78,6 +78,12 @@ at the locally and hosted green draft PR head for independent audit
   ignored and upgraded to `OK`, while the maintained Agent 9 knowledge base
   still directly prescribed commit amendment, cherry-pick, ad-hoc recovery
   branches, direct revert/push, and other outcome-changing lifecycle commands.
+- A fourth exact-head audit found the semantic checker blanket-skipped every
+  line containing `never`/`do not` and recognized only seven instruction verbs,
+  so equivalent imperative prose such as amend, cherry-pick, create, or replay
+  could bypass otherwise-correct unsafe-command patterns.
+- A read-only inventory regex containing a backtick was initially passed with
+  unsafe shell quoting and zsh rejected it before the search ran.
 
 ### Root causes and resolutions
 
@@ -172,13 +178,24 @@ at the locally and hosted green draft PR head for independent audit
   allowing unambiguous historical incident prose. Evidence: the file contains
   no imperative Git mutation command, nine unsafe context fixtures fail, four
   historical-prose fixtures pass, and the live repository semantic check passes.
+- Root cause: instruction classification depended on a narrow verb allowlist
+  and line-wide negation rather than the grammatical relationship to the unsafe
+  command. Resolution: treat every indexed unsafe Git expression as authority
+  unless its local clause genuinely prohibits that expression or it is explicit
+  past-tense historical narration; clause boundaries prevent unrelated earlier
+  negation from suppressing a later imperative. Evidence: amend, cherry-pick,
+  create, replay, and adversarial-negation fixtures fail; four governing-
+  prohibition and four historical controls pass; the repository semantic check
+  remains green.
+- Terminal issue resolution: rerun the read-only inventory with the regex in
+  literal single quotes; it completed without any repository mutation.
 
 ### Verification
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 104 passed after the
-  third independent-audit blocker fix.
+- Focused receipt, semantic, and session regression suite: 114 passed after the
+  fourth independent-audit blocker fix.
 - Remaining semantic, docs/index, quick 10/10, full 30/30, efficiency,
   session-end, preservation replay, and hosted checks are recorded before PR
   audit handoff.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -82,6 +82,10 @@ at the locally and hosted green draft PR head for independent audit
   line containing `never`/`do not` and recognized only seven instruction verbs,
   so equivalent imperative prose such as amend, cherry-pick, create, or replay
   could bypass otherwise-correct unsafe-command patterns.
+- A fifth exact-head audit found that clause-local negation still accepted
+  negated reminder/encouragement auxiliaries such as `do not forget to run`,
+  `never hesitate to recover`, and `never fail to create`; those sentences
+  direct the unsafe action rather than prohibit it.
 - A read-only inventory regex containing a backtick was initially passed with
   unsafe shell quoting and zsh rejected it before the search ran.
 
@@ -187,6 +191,19 @@ at the locally and hosted green draft PR head for independent audit
   create, replay, and adversarial-negation fixtures fail; four governing-
   prohibition and four historical controls pass; the repository semantic check
   remains green.
+- Root cause: the governing-prohibition check treated any negating directive in
+  the local clause as governing the later Git expression, even when the
+  negation governed an auxiliary such as forget, hesitate, fail, remember, or
+  omit. Resolution: require a lifecycle action verb to directly follow the
+  negating directive; retain exact-expression suffix prohibitions separately.
+  Evidence: the three auditor reproductions and equivalent auxiliary forms fail
+  closed, while direct `do not run`/`never use` prohibitions and historical
+  narration remain safe.
+- Focused tests passed after the direct-governance change, but the live semantic
+  replay rejected canonical `NEVER: git ...` prohibition lines because the
+  colon was not admitted between the directive and direct action. Resolution:
+  allow only intervening Markdown/directive punctuation before the action and
+  add the exact colon form as a safe regression; auxiliary words remain unsafe.
 - Terminal issue resolution: rerun the read-only inventory with the regex in
   literal single quotes; it completed without any repository mutation.
 
@@ -194,8 +211,8 @@ at the locally and hosted green draft PR head for independent audit
 
 - Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
   state was clean and ready at the verified PR #750 merge SHA.
-- Focused receipt, semantic, and session regression suite: 114 passed after the
-  fourth independent-audit blocker fix.
+- Focused receipt, semantic, and session regression suite: 123 passed after the
+  fifth independent-audit blocker fix.
 - Remaining semantic, docs/index, quick 10/10, full 30/30, efficiency,
   session-end, preservation replay, and hosted checks are recorded before PR
   audit handoff.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -111,6 +111,9 @@ at the locally and hosted green draft PR head for independent audit
   created and no path outside the 14 staged task paths changed.
 - A post-generation receipt display snippet assumed `task_id` was top-level and
   raised `KeyError` after the receipt had already validated successfully.
+- Final receipt inspection found its inherited integration reason said the draft
+  PR was not open, although PR #751 existed; the section made no integration
+  claim, but its explanation was stale.
 - The first ninth-head focused replay rejected valid canonical state fixtures
   loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
@@ -296,6 +299,12 @@ at the locally and hosted green draft PR head for independent audit
 - Terminal issue resolution: inspect the schema directly and read
   `task.task_id`; validation remained green and no receipt field was changed by
   the failed display-only snippet.
+- Receipt root cause: the caller evidence retained a pre-PR reason code across
+  later exact-head refreshes. Resolution: keep integration reasoned
+  `NOT_APPLICABLE` before audit/merge but replace the false fact with
+  `NO_INTEGRATION_CLAIM_PRE_AUDIT`; remote, PR, and review facts remain explicit
+  `NOT_CHECKED` holds rather than being inferred from that section. Evidence:
+  stored receipt validation and session-end remain fail-closed.
 - Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
   as distinct module identities, so nominal `isinstance` checks rejected the
   same schema; historical grammar included `says` but omitted `said`.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -98,6 +98,17 @@ at the locally and hosted green draft PR head for independent audit
   into non-Git objects such as a lead horse or first-aid supplies. The same audit
   found session-end independently ran `git status --porcelain`, treated
   exceptions/nonzero results as an empty list, and could print a false CLEAN.
+- A ninth exact-head audit found the paired pull/push regex still classified
+  physical sled/actuator instructions as Git guidance; clean tree evidence was
+  not reconciled with `derived_action`/holds; and session-end still queried
+  `git diff` plus `git status --porcelain` for README folder discovery.
+- The first tenth-head focused replay showed the lifecycle-context regex
+  consumed a leading direct prohibition, while the initial grammar correction
+  would have misclassified the double-negative mandate `don't push ... without
+  pulling first` as safe.
+- The first tenth-candidate commit attempt stopped after Ruff converted one
+  test-only zero-argument lambda to the equivalent callable; no commit was
+  created and no path outside the 14 staged task paths changed.
 - The first ninth-head focused replay rejected valid canonical state fixtures
   loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
@@ -252,6 +263,34 @@ at the locally and hosted green draft PR head for independent audit
   clean evidence prints CLEAN. Evidence: exact imperative/non-Git/history pairs
   and clean/dirty/nonzero/exception/malformed authority regressions pass, with
   no closeout Git/network/mutation subprocess.
+- Root cause: a bounded pull/push pair still lacked an explicit Git object or
+  lifecycle context, the closeout adapter validated tree fields independently
+  of the kernel action/holds, and README discovery retained its own historical
+  Git queries. Resolution: require Git lifecycle context except for three narrow
+  standalone imperative forms; add a read-only `git_state` consistency API that
+  recomputes action/holds from the supplied canonical evidence; require
+  READY_LOCAL plus empty holds for CLEAN and coherent HOLD_DIRTY evidence for
+  DIRTY; and reuse that one evidence tuple for README discovery. A clean state
+  has no committed-diff path set, so the advisory step reports UNKNOWN/skipped
+  instead of claiming no doc changes. Evidence: 191 focused receipt, semantic,
+  Git-state, and session tests pass with exact physical/Git pairs,
+  clean/dirty/action-hold contradictions, query failures, and cmd_end/subprocess
+  spies; the full indexed semantic corpus is green.
+- Focused-replay root cause: the Git-context lookahead deliberately included
+  leading prose, making the match start too early for direct-governance parsing;
+  blindly shifting to the first negated action would then hide a `without`
+  mandate. Resolution: locate the directly governed action only for a leading
+  negation without a same-match `without` clause. Evidence: direct `do not pull`
+  controls pass while the existing double-negative mandate and every prior
+  auxiliary, suffix, historical, and clause-boundary case retain their polarity.
+- Hook root cause: the new session-end spy used `lambda: []`, which Ruff's
+  unnecessary-lambda rule rewrites to `list`. Resolution: retain that exact
+  regular-file mechanical edit, regenerate the task-owned indexes, and rerun the
+  scoped tests/hooks. Evidence: before the hook there were 14 staged task paths,
+  zero unstaged paths, and staged SHA-256 `525049d9024920566ed6549290b2f61289dcb37e697915c89324f53333bec668`;
+  afterward the sole unstaged path was
+  `Python/tests/test_session_automation.py`, with binary-diff SHA-256
+  `f5835eff85348ecc7d723a87c2ed6e8e0bee7efdc07c085cee92dd8f456ed347`.
 - Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
   as distinct module identities, so nominal `isinstance` checks rejected the
   same schema; historical grammar included `says` but omitted `said`.
@@ -283,9 +322,14 @@ at the locally and hosted green draft PR head for independent audit
   state was clean and ready at the verified PR #750 merge SHA.
 - Focused receipt, semantic, and session regression suite: 160 passed after the
   eighth independent-audit blocker fix.
-- The full indexed semantic corpus, strict docs 5/5, 1,107 links, quick 10/10,
-  full 30/30, and efficiency pass for the ninth candidate. Session-end,
-  preservation replay, and hosted checks are replayed on the exact final head.
+- The ninth candidate completed the full indexed semantic corpus, strict docs,
+  links, quick/full gates, efficiency, session-end, preservation replay, and
+  hosted checks before its independent-audit rejection.
+- Tenth-candidate focused receipt/semantic/Git-state/session regressions pass
+  191 tests; the full indexed semantic corpus passes; strict docs pass 5/5;
+  1,107 links have zero failures; and quick 10/10 plus full 30/30 pass. Final
+  efficiency, session-end, preservation, and hosted checks are replayed only on
+  the exact receipt-bound head.
 
 ### Preservation and next boundary
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,97 @@
 
 ---
 
+## 2026-08-15 — Session: GIT-7E Semantic Guidance and Durable Handoff
+
+**Agent:** Codex (`ops`, sole writer/integration owner; no subagents)
+
+**Branch:** `codex/git-7e-semantic-handoff`, created from freshly fetched and
+verified `origin/main = b91838f594a04aff1d21c43bf6f87a64710b0748`
+
+**Task start:** `2026-08-15T09:12:34Z`
+
+**Focus:** Add semantic coherence over deterministically discovered maintained
+Git guidance and a durable, fail-closed task-to-Git handoff receipt, then pause
+at the locally and hosted green draft PR head for independent audit
+
+**Git handoff receipt:** `docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json`
+
+### Summary
+
+- Replaced the hand-maintained semantic surface list with an indexed discovery
+  contract whose live, generated-index, and historical boundaries are tested.
+- Corrected only the confirmed main-process live contradictions in Git learning,
+  migration, governance, Agent 9, and maintained guide surfaces.
+- Added a versioned task-to-Git receipt that consumes `git_state.py` for local
+  facts and caller evidence for hosted facts, without an independent Git/network
+  reader or any mutation path.
+- Routed session handoff/end through receipt path, hash, freshness,
+  contradiction, and round-trip validation; corrected the handoff automation
+  permission to `WorkspaceWrite`.
+- Updated the task, handoff, phase, canonical workflow, session skill, CI, and
+  generated indexes only where GIT-7E changed current truth. GIT-7D1/GIT-7D2
+  behavior and all protected lanes remain unchanged.
+
+### Issues encountered
+
+- The old semantic checker passed while indexed live guidance still recommended
+  retired wrappers, non-Codex branch/main-checkout flows, stash/destructive
+  rollback, deletion, reset, and force-push recovery.
+- Session handoff persisted prose and optional PR numbers only; session end could
+  not validate durable local/hosted identity, freshness, hashes, or contradictory
+  claims. The automation map also classified a writing handoff as read-only.
+- The first focused run exposed three implementation defects: receipt local
+  payload construction referenced an unset variable, deprecated frontmatter was
+  incorrectly accepted as its own historical marker, and the new receipt alias
+  was absent from the automation registry.
+- A targeted `rg` search beginning with `--delete` was parsed as an option.
+- The first commit attempt was stopped by the end-of-file hook because the
+  generated global docs index omitted its required final newline.
+
+### Root causes and resolutions
+
+- Root cause: semantic coverage depended on hard-coded files/tokens rather than
+  the maintained indexes and explicit historical boundary. Resolution: add the
+  deterministic live-guidance index, discover active indexed entries and globs,
+  require explicit historical wording, and reject lifecycle contradictions by
+  semantic category. Evidence: live contradiction/coherent/archive fixtures and
+  the repository semantic check pass.
+- Root cause: prose-only handoff had no schema or exact evidence binding.
+  Resolution: add the read-only receipt builder/validator, canonical hash,
+  explicit `UNKNOWN`/`NOT_CHECKED`/reasoned `NOT_APPLICABLE`, exact-head/check
+  binding, squash-tree rules, and session validation. Evidence: receipt and real
+  session-handoff round-trip regressions pass, including malformed, stale,
+  query-failed, dirty, contradictory, and squash cases.
+- Root cause: the initial local payload assignment was placed in the helper that
+  consumed it; historical detection treated a metadata status as narrative; the
+  automation registry had no receipt entry. Resolution: construct the payload in
+  `build_receipt`, require an explicit historical banner, and register read-only
+  validation plus `WorkspaceWrite` output/handoff modes. Evidence: the corrected
+  focused suite passes 64 tests.
+- Terminal issue resolution: insert `--` before a ripgrep pattern that begins
+  with a hyphen; the corrected search completed without changing scope.
+- Root cause: the docs-index generator emitted JSON without the repository's
+  hook-required terminal newline. Resolution: retain the hook's normalization,
+  restage the exact generated file, and require a clean second hook pass before
+  commit; no validation was bypassed.
+
+### Verification
+
+- Worktree-bound runtime diagnosis reported `source_bound=true`; startup local
+  state was clean and ready at the verified PR #750 merge SHA.
+- Focused receipt, semantic, and session regression suite: 64 passed.
+- Remaining semantic, docs/index, quick 10/10, full 30/30, efficiency,
+  session-end, preservation replay, and hosted checks are recorded before PR
+  audit handoff.
+
+### Preservation and next boundary
+
+- No cleanup, deletion, prune, reset, rebase, stash, force push, protected-lane
+  synchronization, release, product, or IS-code action is authorized or taken.
+- After local green, open a normal draft PR and pause. Ready/merge requires the
+  supervising orchestrator's independent audit of the unchanged exact base,
+  head, and tree.
+
 ## 2026-08-15 — Session: Eight-Branch Retirement Authorization Proposal
 
 **Agent:** Codex (`ops`, sole writer/integration owner; no subagents)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -114,6 +114,17 @@ at the locally and hosted green draft PR head for independent audit
 - Final receipt inspection found its inherited integration reason said the draft
   PR was not open, although PR #751 existed; the section made no integration
   claim, but its explanation was stale.
+- An eleventh exact-head audit found the pull rule missed an intervening remote-
+  branch object and a later unsafe clause, while unbounded/case-insensitive
+  context tokens matched `PR` inside `spring`/`appropriate` and crossed into a
+  later repository sentence. It also proved `git_state` derivation accepted
+  malformed schema, SHA, branch, relation, and freshness inputs as READY_LOCAL.
+- The first eleventh focused replay treated a failed status query's fail-closed
+  `clean=false`/zero-path state as contradictory and used an unchanged relation
+  count in one adversarial fixture. The prior receipt also correctly became
+  stale while the new code head was not yet available.
+- The eleventh pre-hook Ruff check rejected import ordering in the two edited
+  test modules before staging.
 - The first ninth-head focused replay rejected valid canonical state fixtures
   loaded through the package alias and one past-tense historical control.
 - A read-only inventory regex containing a backtick was initially passed with
@@ -305,6 +316,33 @@ at the locally and hosted green draft PR head for independent audit
   `NO_INTEGRATION_CLAIM_PRE_AUDIT`; remote, PR, and review facts remain explicit
   `NOT_CHECKED` holds rather than being inferred from that section. Evidence:
   stored receipt validation and session-end remain fail-closed.
+- Eleventh semantic root cause: one monolithic regex searched context to the end
+  of the line, lacked lexical boundaries, consumed prose before the governed
+  action, and encoded only the PR-branch object. Resolution: replace only that
+  rule with a data-driven clause-action contract containing an action pattern,
+  word-bounded lifecycle context, and narrow standalone full-clause forms;
+  split context at sentence/semicolon boundaries and pass the action-starting
+  span to the existing prohibition/history grammar. Evidence: all five auditor
+  strings have verbatim polarity tests, the remote object match starts at
+  `Pull`, and every earlier physical/history/prohibition/double-negation case
+  remains green.
+- Eleventh state root cause: the consistency API recomputed derived action and
+  holds but assumed every source field already conformed to the canonical
+  schema. Resolution: make `git_state.py` validate its own full evidence
+  contract—supported schema, timestamps/paths/types, SHA/branch coherence,
+  relation counts/status, tree count/clean state, operation markers, locks,
+  query failures, freshness and derived enums—before recomputation; session-end
+  now consumes that one validator without a partial schema. Evidence: exact
+  malformed auditor inputs and paired relation/tree/operation/query cases return
+  UNKNOWN without subprocess I/O, and malformed cmd_end runs return nonzero
+  without printing CLEAN.
+- Focused-replay resolution: permit `clean=false` with zero known paths only
+  when required query-failure evidence exists, and change the relation-count
+  fixture to an actual count/status contradiction. Receipt staleness remains a
+  hold until exact-head evidence is regenerated after the code commit.
+- Formatter resolution: apply Ruff's scoped import ordering to only the two
+  edited tests, regenerate the maintained tests index, and replay Ruff clean;
+  no hook or unrelated path was involved.
 - Focused-replay root cause: Python loaded `git_state` and `scripts.git_state`
   as distinct module identities, so nominal `isinstance` checks rejected the
   same schema; historical grammar included `says` but omitted `said`.
@@ -344,6 +382,11 @@ at the locally and hosted green draft PR head for independent audit
   1,107 links have zero failures; and quick 10/10 plus full 30/30 pass. Final
   efficiency, session-end, preservation, and hosted checks are replayed only on
   the exact receipt-bound head.
+- Eleventh-candidate focused receipt/semantic/Git-state/session regressions pass
+  223 tests and the full indexed semantic corpus passes. Strict docs pass 5/5,
+  1,107 links have zero failures, quick passes 10/10, full passes 30/30, and
+  efficiency passes. Session-end, preservation, and hosted checks remain
+  pending until the exact receipt-bound head exists.
 
 ### Preservation and next boundary
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-15 — GIT-7D complete; the eight-branch retirement proposal holds every exact target on unknown retention; GIT-7E is not started
+**Updated:** 2026-08-15 — PR #750 integrated the held retirement proposal at `b91838f`; GIT-7E semantic guidance and durable handoff implementation is active
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🔎 RETIREMENT PROPOSAL — eight exact unattached merged tips are `HOLD_UNKNOWN_OWNER` / `RETENTION_EVIDENCE_UNKNOWN`; no deletion is authorized; GIT-7E is not started |
+| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
 
 ## Up Next
 

--- a/docs/agents/guides/README.md
+++ b/docs/agents/guides/README.md
@@ -1,4 +1,14 @@
+---
+owner: Main Agent
+status: deprecated
+last_updated: 2026-08-15
+doc_type: reference
+---
+
 # Agent Guides
+
+> Historical navigation only. Current agent roles and Git/GitHub instructions
+> are in `.github/agents/`, `AGENTS.md`, and the Codex-native Git workflow.
 
 **Purpose:** Stable reference documentation for each agent's protocols, tools, and best practices.
 

--- a/docs/agents/guides/agent-6-comprehensive-onboarding.md
+++ b/docs/agents/guides/agent-6-comprehensive-onboarding.md
@@ -1,13 +1,16 @@
 ---
 owner: Main Agent
-status: active
-last_updated: 2026-03-30
+status: deprecated
+last_updated: 2026-08-15
 doc_type: guide
 complexity: intermediate
 tags: []
 ---
 
 # Agent 6 Comprehensive Onboarding Guide
+
+> Historical only. The maintained frontend is React; wrapper-based Git
+> instructions below are not current authority.
 
 **Type:** Guide
 **Audience:** Agent 6 (Streamlit UI Specialist)

--- a/docs/agents/guides/agent-6-quick-start.md
+++ b/docs/agents/guides/agent-6-quick-start.md
@@ -1,13 +1,16 @@
 ---
 owner: Main Agent
-status: active
-last_updated: 2026-03-30
+status: deprecated
+last_updated: 2026-08-15
 doc_type: guide
 complexity: intermediate
 tags: []
 ---
 
 # Agent 6 Quick Start (Streamlit UI Specialist)
+
+> Historical only. The maintained frontend is React; current agent and Git
+> guidance lives in `.github/agents/`, `AGENTS.md`, and the canonical workflow.
 
 **Role:** Build production-ready Streamlit dashboards for structural engineering
 **Time to onboard:** 60 seconds

--- a/docs/agents/guides/agent-9-quick-start.md
+++ b/docs/agents/guides/agent-9-quick-start.md
@@ -118,8 +118,8 @@ rg "old/path.md" docs/ agents/ .github/
 # 4. Validate links
 .venv/bin/python scripts/check_links.py
 
-# 5. Commit with Agent 8
-./scripts/ai_commit.sh "docs: move X to follow governance rules"
+# 5. Have Codex inspect and stage only the intended paths, then create a
+# conventional commit and normal draft PR without rewriting history.
 ```
 
 ### Task 2: Create Agent Entry Point
@@ -185,8 +185,9 @@ open docs/guidelines/migration-workflow-guide.md
 ## PR Workflow for Structure Changes
 
 ```bash
-# 1. Create task branch
-./scripts/create_task_pr.sh GOV-001 "Reorganize X per rules"
+# 1. Inspect with git_state.py, then have Codex create a codex/<task-slug>
+# branch from verified current main.
+./scripts/python_runtime.sh scripts/git_state.py --json
 
 # 2. Make changes (safe_file_move.py for moves)
 .venv/bin/python scripts/safe_file_move.py old/path.md new/path.md
@@ -198,14 +199,10 @@ open docs/guidelines/migration-workflow-guide.md
 .venv/bin/python scripts/check_governance.py --structure
 .venv/bin/python scripts/check_links.py
 
-# 5. Commit
-./scripts/ai_commit.sh "docs: reorganize X per governance rules"
-
-# 6. Create PR
-./scripts/finish_task_pr.sh GOV-001 "Reorganize X"
-
-# 7. Merge when green
-gh pr merge <num> --squash --delete-branch
+# 5. Have Codex stage only intended paths and create a conventional commit.
+# 6. Push without rewriting history and open a normal draft PR.
+# 7. Recheck the unchanged head, required checks, conflicts, and blockers
+# before normal merge. Branch/worktree retention remains a separate decision.
 ```
 
 ---

--- a/docs/agents/guides/agent-quick-reference.md
+++ b/docs/agents/guides/agent-quick-reference.md
@@ -1,13 +1,16 @@
 ---
 owner: Main Agent
-status: active
-last_updated: 2026-03-30
+status: deprecated
+last_updated: 2026-08-15
 doc_type: reference
 complexity: intermediate
 tags: []
 ---
 
 # Agent Workflow Quick Reference Card
+
+> Historical only. Use `AGENTS.md`, `.github/agents/`, and the canonical
+> Codex-native Git workflow for current instructions.
 **Version:** 1.2.0 | **Print this and keep it visible!**
 
 ---

--- a/docs/agents/guides/index.json
+++ b/docs/agents/guides/index.json
@@ -1,40 +1,39 @@
 {
   "folder": "docs/agents/guides",
   "type": "documentation",
-  "description": "",
-  "last_updated": "2026-08-11",
+  "description": "owner: Main Agent",
+  "last_updated": "2026-08-15",
   "file_count": 14,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
-      "size_lines": 62,
-      "last_updated": "2026-03-26",
-      "title": "Agent Guides",
-      "description": "- agent-8-automation.md - Quick start + script index (start here) - agent-8-git-ops.md - Core protocol (1,320 lines)",
-      "content_hash": "87cedb3b70bb"
+      "size_lines": 72,
+      "last_updated": "2026-08-15",
+      "description": "> Historical navigation only. Current agent roles and Git/GitHub instructions > are in .github/agents/, AGENTS.md, and the Codex-native Git workflow.",
+      "content_hash": "c14d4cfe2971"
     },
     {
       "name": "agent-6-comprehensive-onboarding.md",
       "type": "documentation",
-      "size_lines": 528,
-      "last_updated": "2026-03-30",
-      "description": "Your mission: Build and maintain production-ready Streamlit dashboards for the IS 456 structural engineering library. You own all code in streamlit_app/ (~20,000 lines). bash",
-      "content_hash": "db4f82380567"
+      "size_lines": 531,
+      "last_updated": "2026-08-15",
+      "description": "> Historical only. The maintained frontend is React; wrapper-based Git > instructions below are not current authority.",
+      "content_hash": "4609420d268c"
     },
     {
       "name": "agent-6-quick-start.md",
       "type": "documentation",
-      "size_lines": 96,
-      "last_updated": "2026-03-30",
-      "description": "You build the **Streamlit web interface** for the structural engineering library. This includes beam design calculators, results visualization, and user-friendly forms.",
-      "content_hash": "3d33f626370f"
+      "size_lines": 99,
+      "last_updated": "2026-08-15",
+      "description": "> Historical only. The maintained frontend is React; current agent and Git > guidance lives in .github/agents/, AGENTS.md, and the canonical workflow.",
+      "content_hash": "284585fa8688"
     },
     {
       "name": "agent-8-automation.md",
       "type": "documentation",
       "size_lines": 341,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-15",
       "description": "> Historical only. The wrapper scripts below were retired on 2026-08-09; use > docs/git-automation/git-workflow-single-source.md for current work.",
       "content_hash": "c4a1a80614ee"
     },
@@ -42,15 +41,15 @@
       "name": "agent-8-git-ops.md",
       "type": "documentation",
       "size_lines": 1319,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-15",
       "description": "> Historical only. Codex now owns Git/GitHub closeout; repository lifecycle > wrappers and enforcement hooks were retired on 2026-08-09.",
-      "content_hash": "559f75b55435"
+      "content_hash": "93fa3a405e34"
     },
     {
       "name": "agent-8-mistakes-prevention-guide.md",
       "type": "documentation",
       "size_lines": 1124,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-15",
       "description": "> Historical only. Wrapper commands below are not current instructions. <!-- lint-ignore-git -->",
       "content_hash": "6c20d15c404e"
     },
@@ -58,7 +57,7 @@
       "name": "agent-8-multi-agent-coordination.md",
       "type": "documentation",
       "size_lines": 338,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-15",
       "description": "> Historical only. Codex now owns scoped Git/GitHub closeout. Agent 8 workflow (ai_commit.sh + safe_push.sh) now supports **concurrent multi-agent operations** with automatic worktree detection and br",
       "content_hash": "9230dc1f6dc2"
     },
@@ -66,30 +65,30 @@
       "name": "agent-8-operations-log-spec.md",
       "type": "documentation",
       "size_lines": 48,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-15",
       "content_hash": "b9ec697be5f2"
     },
     {
       "name": "agent-9-governance-hub.md",
       "type": "documentation",
       "size_lines": 146,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "Agent 9 manages **governance, documentation structure, and migration safety** for the project. It ensures sustainable information architecture through clear rules and validation. This is the canonical",
       "content_hash": "ae9236fe4a82"
     },
     {
       "name": "agent-9-quick-start.md",
       "type": "documentation",
-      "size_lines": 277,
-      "last_updated": "2026-03-30",
+      "size_lines": 274,
+      "last_updated": "2026-08-15",
       "description": "Agent 9 is the **governance and documentation structure agent**, ensuring sustainable information architecture, migration safety, and folder organization rules. bash",
-      "content_hash": "a5df270ce0b7"
+      "content_hash": "09396ecf72e6"
     },
     {
       "name": "agent-automation-system.md",
       "type": "documentation",
       "size_lines": 366,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-15",
       "description": "> Historical architecture. Git lifecycle wrappers described below were retired > in favor of the Codex-native workflow.",
       "content_hash": "f415026b8f4e"
     },
@@ -97,27 +96,27 @@
       "name": "agent-bootstrap-complete-review.md",
       "type": "documentation",
       "size_lines": 125,
-      "last_updated": "2026-08-10",
+      "last_updated": "2026-08-15",
       "description": "docs/getting-started/agent-bootstrap.md is the 60-second onboarding entrypoint for any agent. This review enumerates every link in that file, explains why it exists, and notes the current startup flow",
       "content_hash": "616528f6eb9c"
     },
     {
       "name": "agent-quick-reference.md",
       "type": "documentation",
-      "size_lines": 345,
-      "last_updated": "2026-03-30",
-      "description": "| Need | Guide | Use When | |------|-------|----------|",
-      "content_hash": "cd23be37eebd"
+      "size_lines": 348,
+      "last_updated": "2026-08-15",
+      "description": "> Historical only. Use AGENTS.md, .github/agents/, and the canonical > Codex-native Git workflow for current instructions.",
+      "content_hash": "404930d44c7f"
     },
     {
       "name": "agent-workflow-master-guide.md",
       "type": "documentation",
       "size_lines": 713,
-      "last_updated": "2026-08-09",
+      "last_updated": "2026-08-15",
       "description": "> Historical workflow. Use the current AGENTS.md and Codex-native Git workflow. > **Deep reference guide.** Start with agent-bootstrap.md first.",
       "content_hash": "95a1d1c7649c"
     }
   ],
   "subfolders": [],
-  "content_hash": "283b1abc787329d8"
+  "content_hash": "26f973af50df6a9d"
 }

--- a/docs/agents/guides/index.md
+++ b/docs/agents/guides/index.md
@@ -1,24 +1,26 @@
 # Guides
 
+owner: Main Agent
+
 **Type:** Documentation
-**Last Updated:** 2026-08-11
+**Last Updated:** 2026-08-15
 **Files:** 14
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [README.md](README.md) | Agent Guides | - agent-8-automation.md - Quick start + script index (start  | 62 |
-| [agent-6-comprehensive-onboarding.md](agent-6-comprehensive-onboarding.md) |  | Your mission: Build and maintain production-ready Streamlit  | 528 |
-| [agent-6-quick-start.md](agent-6-quick-start.md) |  | You build the **Streamlit web interface** for the structural | 96 |
+| [README.md](README.md) |  | > Historical navigation only. Current agent roles and Git/Gi | 72 |
+| [agent-6-comprehensive-onboarding.md](agent-6-comprehensive-onboarding.md) |  | > Historical only. The maintained frontend is React; wrapper | 531 |
+| [agent-6-quick-start.md](agent-6-quick-start.md) |  | > Historical only. The maintained frontend is React; current | 99 |
 | [agent-8-automation.md](agent-8-automation.md) |  | > Historical only. The wrapper scripts below were retired on | 341 |
 | [agent-8-git-ops.md](agent-8-git-ops.md) |  | > Historical only. Codex now owns Git/GitHub closeout; repos | 1319 |
 | [agent-8-mistakes-prevention-guide.md](agent-8-mistakes-prevention-guide.md) |  | > Historical only. Wrapper commands below are not current in | 1124 |
 | [agent-8-multi-agent-coordination.md](agent-8-multi-agent-coordination.md) |  | > Historical only. Codex now owns scoped Git/GitHub closeout | 338 |
 | [agent-8-operations-log-spec.md](agent-8-operations-log-spec.md) |  |  | 48 |
 | [agent-9-governance-hub.md](agent-9-governance-hub.md) |  | Agent 9 manages **governance, documentation structure, and m | 146 |
-| [agent-9-quick-start.md](agent-9-quick-start.md) |  | Agent 9 is the **governance and documentation structure agen | 277 |
+| [agent-9-quick-start.md](agent-9-quick-start.md) |  | Agent 9 is the **governance and documentation structure agen | 274 |
 | [agent-automation-system.md](agent-automation-system.md) |  | > Historical architecture. Git lifecycle wrappers described  | 366 |
 | [agent-bootstrap-complete-review.md](agent-bootstrap-complete-review.md) |  | docs/getting-started/agent-bootstrap.md is the 60-second onb | 125 |
-| [agent-quick-reference.md](agent-quick-reference.md) |  | | Need | Guide | Use When | |------|-------|----------| | 345 |
+| [agent-quick-reference.md](agent-quick-reference.md) |  | > Historical only. Use AGENTS.md, .github/agents/, and the c | 348 |
 | [agent-workflow-master-guide.md](agent-workflow-master-guide.md) |  | > Historical workflow. Use the current AGENTS.md and Codex-n | 713 |

--- a/docs/contributing/handoff.md
+++ b/docs/contributing/handoff.md
@@ -21,11 +21,16 @@ operation identity, hosted PR/review/check facts or explicit `UNKNOWN`,
 retention evidence, authorization, prohibited actions, and next permitted
 action. `NOT_APPLICABLE` requires a reason and is never a substitute for
 unknown. Task or transcript archive state is not Git retention evidence.
+The receipt must state `receipt_grants_authority: false`: it records external
+authority evidence but never grants authority. Authorization requires source
+provenance and exact task/branch/head/action binding, and cannot override holds
+recomputed from the remaining evidence.
 
 Reference the receipt in the newest session entry as `**Git handoff receipt:**
 <tracked-path>`, then run `scripts/session.py handoff --git-receipt
 <tracked-path>`. Session end validates schema, hash, exact-head contradictions,
-and the round trip; missing or invalid evidence is a hold.
+and the round trip. It recomputes required holds/status rather than trusting the
+serialized values; missing or invalid evidence is a hold.
 
 Goal: enable the next agent to resume in under 2 minutes.
 

--- a/docs/contributing/handoff.md
+++ b/docs/contributing/handoff.md
@@ -1,13 +1,31 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-03-30
+last_updated: 2026-08-15
 doc_type: guide
 complexity: intermediate
 tags: []
 ---
 
 # Handoff Quick Start
+
+> Current Git/session boundary: start with `./run.sh session brief --agent
+> <role>`, `./run.sh session start`, `scripts/python_runtime.sh --diagnose`, and
+> `scripts/git_state.py --json --worktrees`. The state authority is local-only;
+> remote freshness remains `NOT_CHECKED` unless separately established.
+
+Every durable task handoff uses a tracked machine-readable receipt built and
+validated by `scripts/git_handoff_receipt.py`. It records the
+`local_state_receipt_hash`, exact branch/head/upstream/base/worktree/tree/
+operation identity, hosted PR/review/check facts or explicit `UNKNOWN`,
+retention evidence, authorization, prohibited actions, and next permitted
+action. `NOT_APPLICABLE` requires a reason and is never a substitute for
+unknown. Task or transcript archive state is not Git retention evidence.
+
+Reference the receipt in the newest session entry as `**Git handoff receipt:**
+<tracked-path>`, then run `scripts/session.py handoff --git-receipt
+<tracked-path>`. Session end validates schema, hash, exact-head contradictions,
+and the round trip; missing or invalid evidence is a hold.
 
 Goal: enable the next agent to resume in under 2 minutes.
 
@@ -23,7 +41,7 @@ Goal: enable the next agent to resume in under 2 minutes.
    - **Jan 11 2026**: Session 13 - Folder Governance + Agent Onboarding
    - Created unified `agent_start.sh` (replaces 4 commands with 1)
    - Archived 4 redundant docs, consolidated agent-automation-system.md v1.1.0
-4. If releasing: `./scripts/ci_local.sh` then `.venv/bin/python scripts/release.py verify --version X.Y.Z --source pypi`
+4. Release work remains separately authorized; use the maintained release-preflight workflow when in scope.
 
 ### Quick output sample (agent_start.sh --quick)
 ```
@@ -44,19 +62,19 @@ $ ./scripts/agent_start.sh --quick
 ```
 
 ### Release verify (clean venv)
-- Local wheel (pre-release): `.venv/bin/python scripts/release.py verify --source wheel --wheel-dir Python/dist`
-- PyPI (post-release): `.venv/bin/python scripts/release.py verify --version X.Y.Z --source pypi`
+- Local wheel (pre-release): `./scripts/python_runtime.sh scripts/release.py verify --source wheel --wheel-dir Python/dist`
+- PyPI (post-release): `./scripts/python_runtime.sh scripts/release.py verify --version X.Y.Z --source pypi`
 
 ## Handoff (ending)
 
 > **📋 Full workflow:** See [contributing/end-of-session-workflow.md](end-of-session-workflow.md) for comprehensive checklist
 
 **Quick steps (5 minutes):**
-1. Run: `.venv/bin/python scripts/session.py end --fix`
+1. Validate the tracked Git receipt and run `./run.sh session end --agent <role>`.
 2. Update `docs/planning/next-session-brief.md` with summary + blockers.
 3. Update `docs/TASKS.md` (move items to Done/Active).
 4. Document issues in `docs/contributing/session-issues.md` (if encountered).
-5. Ensure clean tree: `git status -sb`
+5. Inspect the exact local tree with `./scripts/python_runtime.sh scripts/git_state.py --json`.
 
 ## Debug Snapshot Checklist
 
@@ -64,7 +82,7 @@ When encountering persistent errors, collect this information for handoff:
 
 1. **Collect diagnostics bundle:**
    ```bash
-   .venv/bin/python scripts/collect_diagnostics.py > diagnostics.txt
+   ./scripts/python_runtime.sh scripts/collect_diagnostics.py > diagnostics.txt
    ```
 
 2. **Enable debug mode** (Streamlit):
@@ -73,14 +91,14 @@ When encountering persistent errors, collect this information for handoff:
    ```
 
 3. **Check log files:**
-   - `logs/git_workflow.log` (git operations)
+   - the versioned task-to-Git receipt (Git identity and holds)
    - `logs/ci_monitor.log` (CI status)
 
 4. **Run validators:**
    ```bash
-   .venv/bin/python scripts/generate_api_manifest.py --check
-   .venv/bin/python scripts/check_scripts_index.py
-   .venv/bin/python scripts/check_links.py
+   ./scripts/python_runtime.sh scripts/generate_api_manifest.py --check
+   ./scripts/python_runtime.sh scripts/check_scripts_index.py
+   ./scripts/python_runtime.sh scripts/check_links.py
    ```
 
 5. **Include in handoff:**
@@ -90,6 +108,6 @@ When encountering persistent errors, collect this information for handoff:
    - Steps to reproduce
 
 ## Common Traps (fast fixes)
-- CI watch times out: re-run `gh pr checks <num> --watch`.
-- PR behind base: `gh pr update-branch <num>` then re-check CI.
+- CI query times out: record `UNKNOWN`/hold and have Codex re-query the exact head.
+- PR behind base: inspect exact base/head and let Codex choose a normal, non-rewriting update path.
 - PyPI verification: always use a clean venv.

--- a/docs/contributing/index.json
+++ b/docs/contributing/index.json
@@ -121,10 +121,10 @@
     {
       "name": "handoff.md",
       "type": "documentation",
-      "size_lines": 114,
+      "size_lines": 119,
       "last_updated": "2026-08-15",
       "description": "> Current Git/session boundary: start with ./run.sh session brief --agent > <role>, ./run.sh session start, scripts/python_runtime.sh --diagnose, and",
-      "content_hash": "8c226602f0d2"
+      "content_hash": "d110ef150429"
     },
     {
       "name": "learning-paths.md",
@@ -200,5 +200,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "99ed160407354ddb"
+  "content_hash": "7aaee256ae04db64"
 }

--- a/docs/contributing/index.json
+++ b/docs/contributing/index.json
@@ -2,14 +2,14 @@
   "folder": "docs/contributing",
   "type": "documentation",
   "description": "Guides for developers and maintainers of the structural engineering library.",
-  "last_updated": "2026-08-12",
+  "last_updated": "2026-08-15",
   "file_count": 24,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 99,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "title": "Contributing",
       "description": "Guides for developers and maintainers of the structural engineering library. | I want to... | Do this |",
       "content_hash": "2380100c5572"
@@ -18,7 +18,7 @@
       "name": "agent-coding-standards.md",
       "type": "documentation",
       "size_lines": 753,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This guide ensures AI agents write code that is: - ✅ Compatible with existing structural_lib code",
       "content_hash": "9ff3bdbaf9cc"
     },
@@ -26,7 +26,7 @@
       "name": "agent-collaboration-framework.md",
       "type": "documentation",
       "size_lines": 685,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This project uses **agent-assisted maintenance** where specialist names describe quality roles. One parent task owns the outcome. It may use up to **2 concurrent",
       "content_hash": "e332e2485aad"
     },
@@ -34,7 +34,7 @@
       "name": "agent-onboarding-message.md",
       "type": "documentation",
       "size_lines": 54,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "> **Copy-paste this exact message to any new agent starting work on this project.** ",
       "content_hash": "32346386a56f"
     },
@@ -42,7 +42,7 @@
       "name": "background-agent-guide.md",
       "type": "documentation",
       "size_lines": 594,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "- **Background AI Agents:** Other AI assistant instances (Claude, Copilot, ChatGPT) working on assigned tasks - **MAIN Agent/User:** You (the project owner) coordinating work and handling all remote G",
       "content_hash": "52410753ee6d"
     },
@@ -50,7 +50,7 @@
       "name": "changelog-deprecation-template.md",
       "type": "documentation",
       "size_lines": 186,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This template guides you when adding deprecation entries to CHANGELOG.md. Deprecations go under the **### Deprecated** section for the **current unreleased version**.",
       "content_hash": "275198126a80"
     },
@@ -58,7 +58,7 @@
       "name": "commit-message-conventions.md",
       "type": "documentation",
       "size_lines": 205,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": " <type>(<scope>): <subject>",
       "content_hash": "9711fc2fd5b2"
     },
@@ -66,7 +66,7 @@
       "name": "development-guide.md",
       "type": "documentation",
       "size_lines": 1522,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "1. Overview 2. Project Structure",
       "content_hash": "d319f0976e62"
     },
@@ -74,7 +74,7 @@
       "name": "doc-template.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Copy this header to new documentation files and fill in the metadata. - owner: Who maintains this doc (Main Agent, Agent 9, User)",
       "content_hash": "26a72045dd70"
     },
@@ -82,7 +82,7 @@
       "name": "docstring-style-guide.md",
       "type": "documentation",
       "size_lines": 377,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "> **Purpose:** Standard docstring format for all Python modules in structural_lib > **Style:** Google Style (readable, widely adopted in scientific Python)",
       "content_hash": "d3d735663a66"
     },
@@ -90,7 +90,7 @@
       "name": "end-of-session-workflow.md",
       "type": "documentation",
       "size_lines": 498,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "> **Standard procedure for ALL agents when ending a session.** bash",
       "content_hash": "4fb720ae571f"
     },
@@ -98,7 +98,7 @@
       "name": "git-workflow-ai-agents.md",
       "type": "documentation",
       "size_lines": 29,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "The canonical workflow is git-workflow-single-source.md.",
       "content_hash": "7be09837c9ca"
     },
@@ -106,7 +106,7 @@
       "name": "git-workflow-testing.md",
       "type": "documentation",
       "size_lines": 346,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "> Historical test strategy for the retired wrapper layer. Do not execute these > commands; current enforcement is scripts/check_codex_git_workflow.py.",
       "content_hash": "8e9b091fe332"
     },
@@ -114,23 +114,23 @@
       "name": "github-workflow.md",
       "type": "documentation",
       "size_lines": 55,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Codex owns the repository's Git and GitHub lifecycle. The old shell wrappers that staged everything, synchronized branches, pushed, created PRs, or attempted",
       "content_hash": "ff959d36734a"
     },
     {
       "name": "handoff.md",
       "type": "documentation",
-      "size_lines": 96,
-      "last_updated": "2026-08-12",
-      "description": "Goal: enable the next agent to resume in under 2 minutes. 1. Run: ./scripts/agent_start.sh --quick (or with --agent governance for governance work)",
-      "content_hash": "b1e2ef6f85ed"
+      "size_lines": 114,
+      "last_updated": "2026-08-15",
+      "description": "> Current Git/session boundary: start with ./run.sh session brief --agent > <role>, ./run.sh session start, scripts/python_runtime.sh --diagnose, and",
+      "content_hash": "8c226602f0d2"
     },
     {
       "name": "learning-paths.md",
       "type": "documentation",
       "size_lines": 99,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Pick the smallest reading path that still protects quality. Each path lists the minimum docs to read before you work. | Task type | Path | Read first |",
       "content_hash": "3ab159a5ad1c"
     },
@@ -138,7 +138,7 @@
       "name": "lesson-incomplete-implementation.md",
       "type": "documentation",
       "size_lines": 374,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "> Historical incident lesson. Wrapper commands below were retired on 2026-08-09. ✅ \"Background agents work on worktrees (local commits only)\"",
       "content_hash": "8784afe1f209"
     },
@@ -146,7 +146,7 @@
       "name": "naming-conventions.md",
       "type": "documentation",
       "size_lines": 77,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This document defines naming standards for files, modules, and symbols in this repository.",
       "content_hash": "a12ec3641964"
     },
@@ -154,7 +154,7 @@
       "name": "quickstart-checklist.md",
       "type": "documentation",
       "size_lines": 509,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Quick reference for common development tasks with step-by-step checklists. - [ ] **1. Create page file:** streamlit_app/pages/NN_📋_page_name.py",
       "content_hash": "fc45765618da"
     },
@@ -162,7 +162,7 @@
       "name": "repo-professionalism.md",
       "type": "documentation",
       "size_lines": 216,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This doc does not replace existing rules. It links to the canonical sources and adds a practical \"what to do next\" map. bash",
       "content_hash": "9bfeb1c84183"
     },
@@ -170,7 +170,7 @@
       "name": "session-issues.md",
       "type": "documentation",
       "size_lines": 69,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Purpose: capture recurring friction points and the fixes so we do not repeat them. - Pre-commit failures (files changed by hooks after staging)",
       "content_hash": "22ac3fe3a061"
     },
@@ -178,7 +178,7 @@
       "name": "solo-maintainer-operating-system.md",
       "type": "documentation",
       "size_lines": 133,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "- Deterministic outputs, explicit units, stable contracts. - One active task at a time (WIP=1).",
       "content_hash": "f22665a84705"
     },
@@ -186,7 +186,7 @@
       "name": "testing-strategy.md",
       "type": "documentation",
       "size_lines": 283,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "- Location: Python/tests/ - Runner: pytest",
       "content_hash": "6f72025a7f7f"
     },
@@ -194,11 +194,11 @@
       "name": "workflow-professional-review.md",
       "type": "documentation",
       "size_lines": 460,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "> Historical review of the retired wrapper design. It is not current guidance. | Feature | Status | Notes |",
       "content_hash": "4871421bb24a"
     }
   ],
   "subfolders": [],
-  "content_hash": "32aa6383993053ea"
+  "content_hash": "99ed160407354ddb"
 }

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -3,7 +3,7 @@
 Guides for developers and maintainers of the structural engineering library.
 
 **Type:** Documentation
-**Last Updated:** 2026-08-12
+**Last Updated:** 2026-08-15
 **Files:** 24
 
 ## Documentation Files
@@ -24,7 +24,7 @@ Guides for developers and maintainers of the structural engineering library.
 | [git-workflow-ai-agents.md](git-workflow-ai-agents.md) |  | The canonical workflow is git-workflow-single-source.md. | 29 |
 | [git-workflow-testing.md](git-workflow-testing.md) |  | > Historical test strategy for the retired wrapper layer. Do | 346 |
 | [github-workflow.md](github-workflow.md) |  | Codex owns the repository's Git and GitHub lifecycle. The ol | 55 |
-| [handoff.md](handoff.md) |  | Goal: enable the next agent to resume in under 2 minutes. 1. | 96 |
+| [handoff.md](handoff.md) |  | > Current Git/session boundary: start with ./run.sh session  | 114 |
 | [learning-paths.md](learning-paths.md) |  | Pick the smallest reading path that still protects quality.  | 99 |
 | [lesson-incomplete-implementation.md](lesson-incomplete-implementation.md) |  | > Historical incident lesson. Wrapper commands below were re | 374 |
 | [naming-conventions.md](naming-conventions.md) |  | This document defines naming standards for files, modules, a | 77 |

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -24,7 +24,7 @@ Guides for developers and maintainers of the structural engineering library.
 | [git-workflow-ai-agents.md](git-workflow-ai-agents.md) |  | The canonical workflow is git-workflow-single-source.md. | 29 |
 | [git-workflow-testing.md](git-workflow-testing.md) |  | > Historical test strategy for the retired wrapper layer. Do | 346 |
 | [github-workflow.md](github-workflow.md) |  | Codex owns the repository's Git and GitHub lifecycle. The ol | 55 |
-| [handoff.md](handoff.md) |  | > Current Git/session boundary: start with ./run.sh session  | 114 |
+| [handoff.md](handoff.md) |  | > Current Git/session boundary: start with ./run.sh session  | 119 |
 | [learning-paths.md](learning-paths.md) |  | Pick the smallest reading path that still protects quality.  | 99 |
 | [lesson-incomplete-implementation.md](lesson-incomplete-implementation.md) |  | > Historical incident lesson. Wrapper commands below were re | 374 |
 | [naming-conventions.md](naming-conventions.md) |  | This document defines naming standards for files, modules, a | 77 |

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T15:47:36.957947",
+  "generated": "2026-08-15T15:48:56.562832",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {
@@ -2226,7 +2226,7 @@
         "Destructive-action holds",
         "Session closeout"
       ],
-      "size_bytes": 7895
+      "size_bytes": 7872
     },
     "docs/planning/is456-solid-slabs-master-plan.md": {
       "title": "IS 456 Solid Slabs Expansion Master Plan",

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T16:00:54.910207",
+  "generated": "2026-08-15T16:01:55.285233",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T15:48:56.562832",
+  "generated": "2026-08-15T16:00:54.910207",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {
@@ -21,7 +21,7 @@
         "2026-08-13 \u2014 Session: GIT-001 Phase 1 Completion",
         "2026-08-12 \u2014 Session: GIT-001 Future-Work Plan Closeout"
       ],
-      "size_bytes": 263357
+      "size_bytes": 264828
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -460,7 +460,7 @@
         "Receipt contract",
         "Validation boundary"
       ],
-      "size_bytes": 4351
+      "size_bytes": 4445
     },
     "docs/research/git-governance/GIT-001-next-agent-disposition-plan.md": {
       "title": "GIT-001 \u2014 Reconciled Future-Work and Disposition Plan",
@@ -2127,7 +2127,7 @@
         "Local hooks",
         "Historical material"
       ],
-      "size_bytes": 7790
+      "size_bytes": 7910
     },
     "docs/git-automation/README.md": {
       "title": "Codex-Native Git and GitHub",

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-07T16:14:27.256590",
-  "total_docs": 282,
+  "generated": "2026-08-15T15:11:46.314399",
+  "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {
       "title": "Session Log",
@@ -10,18 +10,18 @@
       "folder": "root",
       "tags": [],
       "sections": [
-        "2026-08-07 \u2014 Maintenance Recovery Session",
-        "2026-04-07 \u2014 Session \u2014 CI Fixes & v0.21.6 Release",
-        "Session \u2014 2026-04-06 \u2014 Response Envelope Fix",
-        "2026-04-05 \u2014 External PyPI Audit Resolution",
-        "2026-04-05 \u2014 Session",
-        "2026-04-04 \u2014 Session",
-        "2026-03-31 \u2014 Session 106",
-        "2026-03-28 \u2014 Session 105",
-        "2026-03-28 \u2014 Session 104",
-        "2026-03-27 \u2014 Session 103 (Mac Mini sync + IPv6 fix)"
+        "2026-08-15 \u2014 Session: GIT-7E Semantic Guidance and Durable Handoff",
+        "2026-08-15 \u2014 Session: Eight-Branch Retirement Authorization Proposal",
+        "2026-08-15 \u2014 Session: GIT-7D Cleanup and Retrospective Reconciliation",
+        "2026-08-15 \u2014 Session: GIT-7D2 Inspection-Only Branch Disposition",
+        "2026-08-15 \u2014 Session: GIT-7C2 Receipt and GIT-7D1 Targeted Generation",
+        "2026-08-14 \u2014 Session: GIT-001 Phase 7C1 Required CI Topology",
+        "2026-08-13 \u2014 Session: GIT-001 Phase 7B State and Intake Kernel",
+        "2026-08-13 \u2014 Session: GIT-001 Phases 2-6 Upgrade Proposal",
+        "2026-08-13 \u2014 Session: GIT-001 Phase 1 Completion",
+        "2026-08-12 \u2014 Session: GIT-001 Future-Work Plan Closeout"
       ],
-      "size_bytes": 25371
+      "size_bytes": 257805
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -30,18 +30,18 @@
       "folder": "root",
       "tags": [],
       "sections": [
-        "\ud83d\udccb Quick Navigation (Semantic Index)",
+        "Start here",
+        "Browse by topic",
         "\ud83d\udd0d Document Type Legend",
-        "Quick CLI Reference (v0.11.0+)",
+        "Quick CLI Reference",
         "Documentation Maintenance",
         "Canonical Sources Map",
         "For Developers (Building on the Platform)",
         "For Most Users (recommended reading order)",
         "Visual Outputs (v0.11.0+)",
-        "DXF Rendering (optional)",
-        "For Beginners (more explanation, slower pace)"
+        "DXF Rendering (optional)"
       ],
-      "size_bytes": 11809
+      "size_bytes": 11971
     },
     "docs/TASKS.md": {
       "title": "Task Board",
@@ -61,7 +61,7 @@
         "Completed (Archived)",
         "External Audit Remediation \u2014 v0.21.6 \u2705 DONE"
       ],
-      "size_bytes": 44768
+      "size_bytes": 49873
     },
     "docs/WORKLOG.md": {
       "title": "Work Log",
@@ -73,7 +73,7 @@
         "Rules",
         "Log"
       ],
-      "size_bytes": 34760
+      "size_bytes": 40200
     },
     "docs/index.md": {
       "title": "Docs",
@@ -86,7 +86,7 @@
         "Documentation Files",
         "Subfolders"
       ],
-      "size_bytes": 3035
+      "size_bytes": 3022
     },
     "docs/_active/maintenance-plan-v0-21-sprint.md": {
       "title": "Maintenance Plan \u2014 Post v0.20.0 Sprint",
@@ -109,7 +109,7 @@
         "Execution Priority Matrix",
         "Success Criteria"
       ],
-      "size_bytes": 16776
+      "size_bytes": 16808
     },
     "docs/_active/git-workflow-hardening-plan.md": {
       "title": "Git Workflow Hardening Plan v1.0",
@@ -128,7 +128,7 @@
         "Implementation Notes",
         "Related Documents"
       ],
-      "size_bytes": 16422
+      "size_bytes": 16683
     },
     "docs/_active/agent-evolver-plan.md": {
       "title": "Agent-Evolver: Self-Evolving Meta-Agent \u2014 v2.0",
@@ -154,7 +154,7 @@
         "8. Performance Scoring Framework (11 Dimensions)",
         "9. Scoring Rubric (Anchored Examples)"
       ],
-      "size_bytes": 56521
+      "size_bytes": 56812
     },
     "docs/_active/README.md": {
       "title": "Active Work Directory",
@@ -214,7 +214,7 @@
         "7. Workflow Orchestration (from `$team`/`$ralph` modes + `coordinator/`)",
         "8. Testing & Quality Patterns (from `tests/` + parity audit)"
       ],
-      "size_bytes": 68119
+      "size_bytes": 68125
     },
     "docs/research/innovation-sustainability-scoring.md": {
       "title": "Innovation: Sustainability Scoring \u2014 Embodied Carbon per Beam Design",
@@ -311,7 +311,7 @@
     "docs/research/index.md": {
       "title": "Research",
       "type": "research",
-      "complexity": "advanced",
+      "complexity": "beginner",
       "folder": "research",
       "tags": [
         "investigation",
@@ -321,7 +321,349 @@
         "Documentation Files",
         "Subfolders"
       ],
-      "size_bytes": 15596
+      "size_bytes": 1282
+    },
+    "docs/research/git-governance/GIT-001-phase-7C1-required-ci-topology.md": {
+      "title": "GIT-001 Phase 7C1 \u2014 Required CI Topology",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Authorization and boundary",
+        "Lane and preservation receipt",
+        "Implemented topology",
+        "Cancellation and duplicate-work control",
+        "Regression contract",
+        "Issue and root-cause evidence",
+        "Scenario status",
+        "Local verification",
+        "Next gate"
+      ],
+      "size_bytes": 7870
+    },
+    "docs/research/git-governance/GIT-001-phase-7D1-targeted-index-generation.md": {
+      "title": "GIT-001 Phase 7D1 \u2014 Targeted Index Generation",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Scope and confirmed defect",
+        "Implemented contract",
+        "Acceptance evidence",
+        "Timing experiment",
+        "Non-goals and next gate"
+      ],
+      "size_bytes": 4010
+    },
+    "docs/research/git-governance/GIT-001-phase-0-preservation-baseline.md": {
+      "title": "GIT-001 Phase 0 \u2014 Preservation Baseline",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Receipt identity",
+        "Research-lane identity",
+        "Worktree inventory",
+        "Local branch inventory relative to `origin/main`",
+        "GitHub inventory",
+        "Recovery and operation state",
+        "Preserved lanes and holds",
+        "Unknown or not assessed",
+        "Reproduction commands",
+        "Phase 0 decision"
+      ],
+      "size_bytes": 8024
+    },
+    "docs/research/git-governance/GIT-001-phase-3-gap-risk-matrix.md": {
+      "title": "GIT-001 Phase 3 \u2014 Outcome-Focused Gap and Risk Matrix",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Decision boundary",
+        "Priority model",
+        "Outcome matrix",
+        "Evidence by gap",
+        "Existing controls that pass the comparison",
+        "Phase 4 routing",
+        "Phase 3 acceptance gate"
+      ],
+      "size_bytes": 16190
+    },
+    "docs/research/git-governance/GIT-001-phase-7B-state-intake-kernel.md": {
+      "title": "GIT-001 Phase 7B \u2014 Read-Only State and Intake Kernel",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Authorization and boundary",
+        "Lane and preservation receipt",
+        "Implemented authority",
+        "Focused CI contract",
+        "Scenario evidence",
+        "Issues encountered",
+        "Root causes and resolutions",
+        "Closeout gate"
+      ],
+      "size_bytes": 7062
+    },
+    "docs/research/git-governance/GIT-001-phase-2-incident-register.md": {
+      "title": "GIT-001 Phase 2 \u2014 Project Incident Register",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Purpose and authority boundary",
+        "Method and evidence standard",
+        "Incident ledger",
+        "GIT-I01 \u2014 diverged push falsely reported as ready",
+        "GIT-I02 \u2014 dirty Spark lane and shared-surface collision",
+        "GIT-I03 \u2014 stale mixed PR could not be integrated as a unit",
+        "GIT-I04 \u2014 linked-worktree source identity leaked",
+        "GIT-I05 \u2014 global index generation polluted bounded changes",
+        "GIT-I06 \u2014 nondeterministic timing blocked unrelated PRs",
+        "GIT-I07 \u2014 release preflight and CI surface skew"
+      ],
+      "size_bytes": 21146
+    },
+    "docs/research/git-governance/GIT-001-eight-branch-retirement-authorization-proposal.md": {
+      "title": "GIT-001 Eight-Branch Retirement Authorization Proposal",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Decision",
+        "Fresh evidence boundary",
+        "Exact disposition table",
+        "Classifier command and outcome",
+        "Protected holds preserved",
+        "Next explicit authorization boundary"
+      ],
+      "size_bytes": 7028
+    },
+    "docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md": {
+      "title": "GIT-7E \u2014 Semantic Live Guidance and Durable Git Handoff",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Exact boundary",
+        "Semantic rules",
+        "Receipt contract",
+        "Validation boundary"
+      ],
+      "size_bytes": 3550
+    },
+    "docs/research/git-governance/GIT-001-next-agent-disposition-plan.md": {
+      "title": "GIT-001 \u2014 Reconciled Future-Work and Disposition Plan",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Purpose",
+        "Snapshot and reading rule",
+        "Outcome first: the revised order",
+        "What changed from the original priorities",
+        "Completed ledger \u2014 do not repeat",
+        "Current worktree topology",
+        "Priority 1 \u2014 preserve completed GIT-001 evidence and start fresh",
+        "Priority 2 \u2014 decide Excel planning ownership",
+        "Priority 3 \u2014 preserve and reassess merged Alpha worktrees",
+        "Priority 4 \u2014 future branch-disposition packet"
+      ],
+      "size_bytes": 22367
+    },
+    "docs/research/git-governance/GIT-001-README.md": {
+      "title": "GIT-001 \u2014 Git Research, Project Workflow, and Future-Proof Governance",
+      "type": "index",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Authority boundary",
+        "Objective",
+        "Starting topology",
+        "Phase ledger",
+        "Artifact map",
+        "Ownership and non-goals",
+        "Research method"
+      ],
+      "size_bytes": 6618
+    },
+    "docs/research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.md": {
+      "title": "GIT-001 Phase 7D \u2014 Non-Destructive Cleanup Reconciliation",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Outcome and authority boundary",
+        "Evidence identity",
+        "Preservation blockers",
+        "Attached integrated worktrees",
+        "Unattached merged branches",
+        "Owner decisions and exact deletion prerequisites",
+        "GitHub and non-mutation receipt",
+        "Next boundary: GIT-7E"
+      ],
+      "size_bytes": 12626
+    },
+    "docs/research/git-governance/GIT-001-lifecycle-research.md": {
+      "title": "GIT-001 Phase 1 \u2014 Factual Lifecycle Map",
+      "type": "research",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Status and reading key",
+        "Foundational state model",
+        "Lifecycle stage map",
+        "Path maps",
+        "Hold-state evidence matrix",
+        "Not-applicable findings for the current topology",
+        "Phase 1 boundary result"
+      ],
+      "size_bytes": 14898
+    },
+    "docs/research/git-governance/index.md": {
+      "title": "Git Governance",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Config Files",
+        "Documentation Files"
+      ],
+      "size_bytes": 3552
+    },
+    "docs/research/git-governance/GIT-001-phase-7A-preservation-workflow-recovery.md": {
+      "title": "GIT-001 Phase 7A \u2014 Preservation and Workflow Recovery",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Authorization and boundary",
+        "Column PMM disposition",
+        "PR #723 selective recovery",
+        "Verification and retirement gate",
+        "Integration receipt"
+      ],
+      "size_bytes": 3584
+    },
+    "docs/research/git-governance/GIT-001-phase-7C2-server-enforcement.md": {
+      "title": "GIT-001 Phase 7C2 \u2014 Server Enforcement",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Authorization and prerequisite",
+        "GIT-7C1 integration receipt",
+        "Applied current-to-target delta",
+        "Transaction, rollback, and risk receipt",
+        "Phase 5 acceptance status"
+      ],
+      "size_bytes": 5083
+    },
+    "docs/research/git-governance/GIT-001-phase-4-operating-model.md": {
+      "title": "GIT-001 Phase 4 \u2014 Proposed Git Operating Model",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Executive decision",
+        "Design laws",
+        "Control-plane architecture",
+        "Plane 1 \u2014 one read-only state and intake kernel",
+        "Lane lifecycle and ownership",
+        "Plane 2 \u2014 publication, CI, and server enforcement",
+        "Plane 3 \u2014 generated data and cleanup",
+        "Plane 4 \u2014 guidance, discovery, and handoff",
+        "Recovery matrix",
+        "Controlled implementation packets"
+      ],
+      "size_bytes": 20239
+    },
+    "docs/research/git-governance/GIT-001-official-evidence-register.md": {
+      "title": "GIT-001 Phase 1 \u2014 Official Evidence Register",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Register contract",
+        "Git sources",
+        "GitHub sources",
+        "OpenAI Codex sources",
+        "Current project observations",
+        "Explicitly unresolved product facts",
+        "Coverage disposition",
+        "Phase 1 coverage gate"
+      ],
+      "size_bytes": 19346
+    },
+    "docs/research/git-governance/GIT-001-phase-5-scenario-validation.md": {
+      "title": "GIT-001 Phase 5 \u2014 Scenario and Feasibility Validation",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Validation boundary",
+        "Scenario matrix",
+        "Disposable Git scenario receipt",
+        "Live project read-only receipt",
+        "Packet acceptance scenarios",
+        "Phase 5 result"
+      ],
+      "size_bytes": 11679
+    },
+    "docs/research/git-governance/GIT-001-phase-7D2-branch-disposition.md": {
+      "title": "GIT-001 Phase 7D2 \u2014 Inspection-Only Branch Disposition",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Scope and migration decision",
+        "Preferred command",
+        "Evidence boundary",
+        "Outcomes",
+        "Non-mutation controls",
+        "Acceptance evidence",
+        "Integration completion",
+        "Non-goals and retained state"
+      ],
+      "size_bytes": 6460
+    },
+    "docs/research/git-governance/GIT-001-phase-6-canonical-policy-proposal.md": {
+      "title": "GIT-001 Phase 6 \u2014 Canonical Policy Proposal and First Packet",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-governance",
+      "tags": [],
+      "sections": [
+        "Recommended owner decision",
+        "Evidence supporting acceptance",
+        "Exact canonical decisions proposed",
+        "Proposed canonical-file disposition",
+        "GIT-7B \u2014 exact first implementation packet",
+        "Held packets",
+        "Owner response contract"
+      ],
+      "size_bytes": 11591
     },
     "docs/blog-drafts/performance-engineering-structural-calcs.md": {
       "title": "Performance Engineering for Structural Calculations: Speed Up Your Analysis 10x",
@@ -666,10 +1008,10 @@
         "Part 5: Branches \u2014 Working in Parallel",
         "Part 6: Pull Requests \u2014 Code Review Gateway",
         "Part 7: Git Hooks \u2014 Automatic Checks",
-        "Part 8: Git Automation \u2014 ai_commit.sh",
+        "Part 8: Repository Git Control Plane",
         "Part 9: .gitignore \u2014 What NOT to Track"
       ],
-      "size_bytes": 12219
+      "size_bytes": 12356
     },
     "docs/learning-foundations/03-tech-stack.md": {
       "title": "Module 3: The Tech Stack \u2014 Languages, Tools, and Why",
@@ -761,7 +1103,7 @@
         "Part 8: Release Pipeline",
         "Part 9: CI/CD Best Practices"
       ],
-      "size_bytes": 12951
+      "size_bytes": 12959
     },
     "docs/learning-foundations/04-apis.md": {
       "title": "Module 4: APIs \u2014 How Software Talks to Software",
@@ -789,16 +1131,28 @@
     "docs/images/README.md": {
       "title": "Documentation Images",
       "type": "index",
-      "complexity": "beginner",
+      "complexity": "intermediate",
       "folder": "images",
       "tags": [],
       "sections": [
         "\ud83d\udcf7 Image Categories",
         "\ud83d\udd27 Adding New Images",
         "\ud83d\udccb Excel Tutorial Screenshots",
+        "\ud83c\udf10 GitHub Social Preview",
         "\ud83d\udcda Related Documentation"
       ],
-      "size_bytes": 1450
+      "size_bytes": 2243
+    },
+    "docs/images/product/README.md": {
+      "title": "Product Screenshots",
+      "type": "index",
+      "complexity": "beginner",
+      "folder": "product",
+      "tags": [],
+      "sections": [
+        "Capture notes"
+      ],
+      "size_bytes": 1114
     },
     "docs/specs/csv-import-schema.md": {
       "title": "CSV Import Schema Specification",
@@ -910,7 +1264,7 @@
         "Documentation Updates",
         "Behavioral Verification (CRITICAL)"
       ],
-      "size_bytes": 9068
+      "size_bytes": 9154
     },
     "docs/contributing/workflow-professional-review.md": {
       "title": "Git Workflow Professional Review & Recommendations",
@@ -933,7 +1287,7 @@
         "Final Verdict",
         "Cost-Benefit Analysis"
       ],
-      "size_bytes": 11678
+      "size_bytes": 11762
     },
     "docs/contributing/quickstart-checklist.md": {
       "title": "Quick-Start Checklist (Solution 4 - Developer Guides)",
@@ -954,7 +1308,7 @@
         "\ud83d\udcda Reference Links",
         "\u26a1 Quick Commands"
       ],
-      "size_bytes": 11504
+      "size_bytes": 11531
     },
     "docs/contributing/development-guide.md": {
       "title": "IS 456 RC Beam Design Library \u2014 Development Guide",
@@ -977,7 +1331,7 @@
         "8. Error Handling",
         "9. Documentation Standards"
       ],
-      "size_bytes": 42443
+      "size_bytes": 42539
     },
     "docs/contributing/naming-conventions.md": {
       "title": "Naming Conventions",
@@ -1034,7 +1388,7 @@
         "\ud83c\udfd7\ufe0f Layer Architecture (Must Follow)",
         "\ud83d\udcda Related Documentation"
       ],
-      "size_bytes": 2986
+      "size_bytes": 2958
     },
     "docs/contributing/agent-coding-standards.md": {
       "title": "Agent Coding Standards for structural_lib",
@@ -1076,11 +1430,11 @@
         "Subject Line Rules",
         "Body (Optional)",
         "Footer (Optional)",
-        "Multi-Line Messages with ai_commit.sh",
+        "Multi-Line Messages",
         "Enforcement",
         "Common Patterns"
       ],
-      "size_bytes": 5275
+      "size_bytes": 5047
     },
     "docs/contributing/learning-paths.md": {
       "title": "Learning Paths for Contributors",
@@ -1098,7 +1452,7 @@
         "Path C: Advanced (refactor, API, or release)",
         "Scenario map (examples)"
       ],
-      "size_bytes": 3167
+      "size_bytes": 3128
     },
     "docs/contributing/git-workflow-testing.md": {
       "title": "Git Workflow Testing Strategy",
@@ -1121,7 +1475,7 @@
         "\ud83c\udf93 Learning Resources",
         "\ud83d\udd04 Continuous Improvement"
       ],
-      "size_bytes": 8696
+      "size_bytes": 8890
     },
     "docs/contributing/solo-maintainer-operating-system.md": {
       "title": "Solo Maintainer Operating System (Public)",
@@ -1152,22 +1506,19 @@
       "complexity": "intermediate",
       "folder": "contributing",
       "tags": [
+        "codex",
         "development",
+        "git",
+        "github",
         "workflow"
       ],
       "sections": [
-        "\ud83c\udfaf Quick Decision: Direct Commit or PR?",
-        "\u2705 Direct Commits (Low-Risk Only)",
-        "\ud83d\udd00 Pull Requests (All Production Code)",
-        "\ud83c\udfaf When to Use Direct Commits vs PRs",
-        "\u26a1 Fast CI Strategy",
-        "\ud83d\udccb Typical Workflows",
-        "\ud83d\udee1\ufe0f Safety Features",
-        "\ud83d\udcca Performance Comparison",
-        "\ud83c\udf93 Best Practices",
-        "\ud83d\udd27 Troubleshooting"
+        "Pull request policy",
+        "Normal flow",
+        "Failure handling",
+        "CI evidence"
       ],
-      "size_bytes": 7906
+      "size_bytes": 2076
     },
     "docs/contributing/index.md": {
       "title": "Contributing",
@@ -1181,7 +1532,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 3190
+      "size_bytes": 3256
     },
     "docs/contributing/repo-professionalism.md": {
       "title": "Repo Professionalism Playbook",
@@ -1250,7 +1601,7 @@
         "\ud83d\udca1 Pro Tips",
         "\ud83d\udcdd Templates"
       ],
-      "size_bytes": 13460
+      "size_bytes": 13451
     },
     "docs/contributing/session-issues.md": {
       "title": "Session Issues and Fixes",
@@ -1266,7 +1617,7 @@
         "2025-12-29 (v0.11.0 release)",
         "2025-12-30 (Main Branch Guard)"
       ],
-      "size_bytes": 3261
+      "size_bytes": 3161
     },
     "docs/contributing/agent-onboarding-message.md": {
       "title": "First Message for New Agents",
@@ -1282,7 +1633,7 @@
         "Why This Works",
         "For Different AI Tools"
       ],
-      "size_bytes": 1537
+      "size_bytes": 1534
     },
     "docs/contributing/background-agent-guide.md": {
       "title": "Background Agent Parallel Work Guide",
@@ -1305,7 +1656,7 @@
         "Question: [ROLE] \u2192 MAIN",
         "Parallel Coordination Rules (Strict)"
       ],
-      "size_bytes": 16488
+      "size_bytes": 16602
     },
     "docs/contributing/agent-collaboration-framework.md": {
       "title": "Agent Collaboration Framework",
@@ -1328,26 +1679,22 @@
         "6. Troubleshooting",
         "References"
       ],
-      "size_bytes": 16885
+      "size_bytes": 16640
     },
     "docs/contributing/git-workflow-ai-agents.md": {
-      "title": "Git Workflow for AI Agents (Canonical)",
+      "title": "Git Workflow for AI Agents",
       "type": "documentation",
-      "complexity": "intermediate",
+      "complexity": "beginner",
       "folder": "contributing",
       "tags": [
+        "codex",
         "development",
+        "git",
+        "github",
         "workflow"
       ],
-      "sections": [
-        "One Rule",
-        "Decision Path",
-        "What safe_push.sh Does (Important)",
-        "Recovery (When Git Is Broken)",
-        "Formatting Policy",
-        "FAQ"
-      ],
-      "size_bytes": 2556
+      "sections": [],
+      "size_bytes": 1144
     },
     "docs/contributing/handoff.md": {
       "title": "Handoff Quick Start",
@@ -1364,7 +1711,7 @@
         "Debug Snapshot Checklist",
         "Common Traps (fast fixes)"
       ],
-      "size_bytes": 3097
+      "size_bytes": 4416
     },
     "docs/contributing/testing-strategy.md": {
       "title": "Testing Strategy & Setup (Python-first, VBA parity aware)",
@@ -1385,7 +1732,7 @@
         "7) Property-Based Testing (Hypothesis)",
         "8) Definition of \"good\" (target state)"
       ],
-      "size_bytes": 9178
+      "size_bytes": 9348
     },
     "docs/contributing/changelog-deprecation-template.md": {
       "title": "CHANGELOG Template for Deprecations",
@@ -1536,7 +1883,7 @@
         "8. Documentation Infrastructure",
         "9. Metrics and Results"
       ],
-      "size_bytes": 52422
+      "size_bytes": 52634
     },
     "docs/publications/README.md": {
       "title": "Publications & Blog Posts",
@@ -1732,40 +2079,94 @@
       ],
       "size_bytes": 15306
     },
-    "docs/git-automation/git-workflow-single-source.md": {
-      "title": "Git Workflow \u2014 Single Source of Truth",
+    "docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md": {
+      "title": "Git governance case study: GIT-7D2 and the cleanup audit",
       "type": "documentation",
       "complexity": "advanced",
       "folder": "git-automation",
-      "tags": [],
-      "sections": [
-        "Table of Contents",
-        "1. Quick Start",
-        "2. System Architecture",
-        "3. Complete Script Inventory",
-        "4. The 7-Step Workflow",
-        "5. Call Chain & Data Flow",
-        "6. Git Hooks",
-        "7. Pre-Commit Framework",
-        "8. Environment Variables",
-        "9. PR Workflow"
+      "tags": [
+        "cleanup",
+        "git",
+        "github",
+        "learning",
+        "worktree"
       ],
-      "size_bytes": 30627
+      "sections": [
+        "Why this case matters",
+        "The observed state",
+        "Examples, invariants, and the misses",
+        "Example tests versus invariants",
+        "Evidence identity and freshness",
+        "Schema and shell discovery card",
+        "Cleanup disposition ladder",
+        "Eight-branch proposal: authority is not retention evidence",
+        "Teach-back",
+        "1/3/7-day review"
+      ],
+      "size_bytes": 12214
+    },
+    "docs/git-automation/git-workflow-single-source.md": {
+      "title": "Codex-Native Git and GitHub Workflow",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "git-automation",
+      "tags": [
+        "codex",
+        "git",
+        "github",
+        "workflow"
+      ],
+      "sections": [
+        "Ownership boundary",
+        "Read-only Git state authority",
+        "Durable task-to-Git handoff",
+        "Verification before publication",
+        "Inspection-only branch disposition",
+        "Fail-closed recovery",
+        "Owner-approved operations",
+        "Local hooks",
+        "Historical material"
+      ],
+      "size_bytes": 6944
     },
     "docs/git-automation/README.md": {
-      "title": "Git Automation for AI Agents",
+      "title": "Codex-Native Git and GitHub",
       "type": "index",
       "complexity": "beginner",
       "folder": "git-automation",
-      "tags": [],
-      "sections": [
-        "Single Source of Truth",
-        "Quick Start (3 Commands)",
-        "Common Tasks",
-        "The One Rule",
-        "Archived Docs"
+      "tags": [
+        "codex",
+        "git",
+        "github"
       ],
-      "size_bytes": 1718
+      "sections": [],
+      "size_bytes": 1101
+    },
+    "docs/git-automation/git-recovery-case-study-column-pmm.md": {
+      "title": "Git recovery case study: Column PMM",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "git-automation",
+      "tags": [
+        "git",
+        "learning",
+        "recovery",
+        "scripts",
+        "worktree"
+      ],
+      "sections": [
+        "Why this case matters",
+        "Starting evidence and decision",
+        "Branch and worktree are different tools",
+        "Recovery graph",
+        "The execution sequence",
+        "Script behavior learned in this session",
+        "Index-generator recurrence control",
+        "Issues, root causes, and reusable solutions",
+        "How this work could be even better next time",
+        "Teach-back questions"
+      ],
+      "size_bytes": 11517
     },
     "docs/api-reference/index.md": {
       "title": "API Reference",
@@ -1783,8 +2184,8 @@
       ],
       "size_bytes": 2046
     },
-    "docs/planning/next-session-brief.md": {
-      "title": "Next Session Briefing",
+    "docs/planning/gpt-5-3-codex-spark-work-program.md": {
+      "title": "GPT-5.3-Codex-Spark Work Program",
       "type": "documentation",
       "complexity": "advanced",
       "folder": "planning",
@@ -1793,18 +2194,131 @@
         "tasks"
       ],
       "sections": [
-        "Latest Handoff (auto)",
-        "Start Here",
-        "Current Evidence",
-        "Maintenance Sequence",
-        "Previous Handoff (2026-04-07)",
-        "What Was Completed (v0.21.7 Session 1)",
-        "Current Version State",
-        "Priorities \u2014 v0.21.7 Remaining",
-        "Infrastructure Notes",
-        "Required Reading"
+        "1. Executive decision",
+        "2. Authority, status, and relationship to other work",
+        "3. Verified model facts and planning assumptions",
+        "4. Repository baseline",
+        "5. Existing lane protection",
+        "6. Program outcome and definition of done",
+        "7. Main-process and architecture contract",
+        "8. Protected areas and non-goals",
+        "9. Spark suitability and escalation matrix",
+        "10. Worker packet contract"
       ],
-      "size_bytes": 9519
+      "size_bytes": 30629
+    },
+    "docs/planning/next-session-brief.md": {
+      "title": "Next Session Briefing",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "planning",
+      "tags": [
+        "roadmap",
+        "tasks"
+      ],
+      "sections": [
+        "Latest Handoff",
+        "Required Reading",
+        "Start commands",
+        "Verified current Git facts",
+        "Preservation and disposition holds",
+        "GIT-7E exact boundary",
+        "Destructive-action holds",
+        "Session closeout"
+      ],
+      "size_bytes": 7370
+    },
+    "docs/planning/is456-solid-slabs-master-plan.md": {
+      "title": "IS 456 Solid Slabs Expansion Master Plan",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "planning",
+      "tags": [
+        "roadmap",
+        "tasks"
+      ],
+      "sections": [
+        "1. Executive decision",
+        "2. Why this is an extension, not a new slab engine",
+        "3. Scope contract",
+        "4. Authority, research, and source policy",
+        "5. Engineering domain model",
+        "6. Calculation design",
+        "7. Public API and compatibility plan",
+        "8. FastAPI plan",
+        "9. React slab workbench",
+        "10. Evidence and benchmark ledger"
+      ],
+      "size_bytes": 53400
+    },
+    "docs/planning/compact-modernization-plan.md": {
+      "title": "MAINT-008 Compact Project Modernization Plan",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "planning",
+      "tags": [
+        "roadmap",
+        "tasks"
+      ],
+      "sections": [
+        "1. Outcome",
+        "2. Main-process contract",
+        "3. Proven baseline that must not regress",
+        "4. Confirmed current-state problems",
+        "5. Non-goals and protected areas",
+        "6. Execution rules",
+        "7. Minimum gate ladder",
+        "8. Target end state",
+        "9. Dependency order",
+        "10. Packet 0 \u2014 Parent/operations setup"
+      ],
+      "size_bytes": 34386
+    },
+    "docs/planning/ui-experience-foundation-master-plan.md": {
+      "title": "UI Experience Foundation and Structural Workbench Master Plan",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "planning",
+      "tags": [
+        "roadmap",
+        "tasks"
+      ],
+      "sections": [
+        "1. Executive decision",
+        "2. Plan authority and relationship to existing work",
+        "3. Product outcome",
+        "4. Verified current baseline",
+        "5. Feature usefulness contract",
+        "6. Users and core journeys",
+        "7. Target information architecture",
+        "8. Compact professional visual system",
+        "9. 3D product plan",
+        "10. Schema-driven capability foundation"
+      ],
+      "size_bytes": 123750
+    },
+    "docs/planning/adoption-trust-surface-plan.md": {
+      "title": "ADOPT-001 Adoption and Trust Surface Plan",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "planning",
+      "tags": [
+        "roadmap",
+        "tasks"
+      ],
+      "sections": [
+        "1. Outcome",
+        "2. Main-process contract",
+        "3. Verified starting problems",
+        "4. Recent-session incident review",
+        "5. Protected areas and non-goals",
+        "6. Execution rules",
+        "7. Dependency-ordered packets",
+        "8. Completed implementation",
+        "9. Gate ladder",
+        "10. Stop conditions"
+      ],
+      "size_bytes": 16366
     },
     "docs/planning/next-phase-improvements-plan.md": {
       "title": "Next Phase: What to Build and Why",
@@ -1829,6 +2343,29 @@
       ],
       "size_bytes": 54456
     },
+    "docs/planning/is456-library-first-master-plan.md": {
+      "title": "IS 456 Library-First Completion and PyPI Master Plan",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "planning",
+      "tags": [
+        "roadmap",
+        "tasks"
+      ],
+      "sections": [
+        "1. Executive decision",
+        "2. Relationship to current repository plans",
+        "3. Why this plan exists",
+        "4. Current baseline",
+        "5. Program scope contract",
+        "6. Completion definitions",
+        "7. Target architecture and dependency direction",
+        "8. Source, benchmark, and provenance foundation",
+        "9. Agent operating model",
+        "10. Verification and gate ladder"
+      ],
+      "size_bytes": 72809
+    },
     "docs/planning/library-expansion-blueprint-v5.md": {
       "title": "Library Expansion Blueprint v5.0 \u2014 Multi-Code, Multi-Element",
       "type": "documentation",
@@ -1850,12 +2387,12 @@
         "8. Phase 4 \u2014 EC2 (EN 1992-1-1)",
         "9. Phase 5 \u2014 Fill the Matrix"
       ],
-      "size_bytes": 48215
+      "size_bytes": 48808
     },
     "docs/planning/pre-release-checklist.md": {
       "title": "Pre-Release Checklist",
       "type": "documentation",
-      "complexity": "beginner",
+      "complexity": "intermediate",
       "folder": "planning",
       "tags": [
         "roadmap",
@@ -1863,14 +2400,15 @@
       ],
       "sections": [
         "Current State",
+        "Next Alpha Readiness Checklist",
         "Beta Readiness Checklist"
       ],
-      "size_bytes": 1402
+      "size_bytes": 5263
     },
     "docs/planning/README.md": {
       "title": "Planning",
       "type": "index",
-      "complexity": "intermediate",
+      "complexity": "advanced",
       "folder": "planning",
       "tags": [
         "roadmap",
@@ -1885,7 +2423,7 @@
         "Templates & Workflow",
         "Rules"
       ],
-      "size_bytes": 6437
+      "size_bytes": 8124
     },
     "docs/planning/memory.md": {
       "title": "Project Memory - Persistent Context",
@@ -1908,7 +2446,7 @@
         "Roadmap Snapshot",
         "Contact & Escalation"
       ],
-      "size_bytes": 16927
+      "size_bytes": 19507
     },
     "docs/planning/etabs-killer-masterplan.md": {
       "title": "Project BHEEM: Open-Source Structural Design Software Masterplan",
@@ -1936,7 +2474,7 @@
     "docs/planning/index.md": {
       "title": "Planning",
       "type": "documentation",
-      "complexity": "beginner",
+      "complexity": "intermediate",
       "folder": "planning",
       "tags": [
         "roadmap",
@@ -1945,7 +2483,30 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 1556
+      "size_bytes": 2667
+    },
+    "docs/planning/professional-library-remediation-plan.md": {
+      "title": "Professional Library Remediation Plan",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "planning",
+      "tags": [
+        "roadmap",
+        "tasks"
+      ],
+      "sections": [
+        "1. Outcome and release decision",
+        "2. Audit basis and present state",
+        "3. Confirmed findings",
+        "4. Recent-work reconciliation: do not repeat these projects",
+        "5. Dependency-ordered remediation packets",
+        "6. Verification ladder",
+        "7. Stop conditions and escalation",
+        "8. Definition of done",
+        "9. Software remediation checkpoint \u2014 2026-08-09",
+        "10. Bounded closeout checkpoint \u2014 2026-08-10"
+      ],
+      "size_bytes": 28931
     },
     "docs/planning/react-ux-improvement-plan.md": {
       "title": "React App \u2014 UX & Visual Improvement Plan",
@@ -1968,7 +2529,7 @@
         "Visual System",
         "Implementation Priority"
       ],
-      "size_bytes": 38269
+      "size_bytes": 38724
     },
     "docs/planning/dependency-security-baseline.md": {
       "title": "Dependency and Security Baseline",
@@ -1985,7 +2546,7 @@
         "Reproduction",
         "Automation"
       ],
-      "size_bytes": 3426
+      "size_bytes": 3459
     },
     "docs/planning/democratization-vision.md": {
       "title": "Democratizing Structural Engineering",
@@ -2023,7 +2584,7 @@
         "Quick Links",
         "Related Documentation"
       ],
-      "size_bytes": 2853
+      "size_bytes": 2885
     },
     "docs/agents/index.md": {
       "title": "Agents",
@@ -2098,7 +2659,7 @@
     "docs/agents/guides/agent-6-quick-start.md": {
       "title": "Agent 6 Quick Start (Streamlit UI Specialist)",
       "type": "documentation",
-      "complexity": "beginner",
+      "complexity": "intermediate",
       "folder": "guides",
       "tags": [],
       "sections": [
@@ -2110,7 +2671,7 @@
         "Common Patterns",
         "Next Step"
       ],
-      "size_bytes": 1877
+      "size_bytes": 2037
     },
     "docs/agents/guides/agent-9-quick-start.md": {
       "title": "Agent 9 Quick Start - Governance & Documentation Structure",
@@ -2130,7 +2691,7 @@
         "Common Mistakes to Avoid",
         "Emergency Recovery"
       ],
-      "size_bytes": 7663
+      "size_bytes": 7880
     },
     "docs/agents/guides/agent-8-git-ops.md": {
       "title": "Agent 8: GIT OPERATIONS SPECIALIST",
@@ -2150,7 +2711,7 @@
         "Full Test Matrix Performance",
         "Handoff: [AGENT] \u2192 GIT OPERATIONS"
       ],
-      "size_bytes": 36570
+      "size_bytes": 37217
     },
     "docs/agents/guides/agent-6-comprehensive-onboarding.md": {
       "title": "Agent 6 Comprehensive Onboarding Guide",
@@ -2170,7 +2731,7 @@
         "\ud83d\udccb Current Tasks (v0.17.5)",
         "\ud83d\udd17 Quick Links"
       ],
-      "size_bytes": 12798
+      "size_bytes": 12922
     },
     "docs/agents/guides/agent-8-operations-log-spec.md": {
       "title": "Agent 8 Operations Log Spec",
@@ -2181,7 +2742,7 @@
       "sections": [
         "2026-01-08 19:30 UTC \u2014 Agent 6 Research Commit"
       ],
-      "size_bytes": 1343
+      "size_bytes": 1422
     },
     "docs/agents/guides/agent-bootstrap-complete-review.md": {
       "title": "Agent Bootstrap - Complete Review & Link Analysis",
@@ -2219,7 +2780,7 @@
         "\u2705 API Touchpoints (Public API Changes)",
         "\ud83d\udd0e Scanner & Validation (Streamlit)"
       ],
-      "size_bytes": 10066
+      "size_bytes": 10198
     },
     "docs/agents/guides/README.md": {
       "title": "Agent Guides",
@@ -2232,18 +2793,18 @@
         "Agent 9 - Governance & Documentation Structure",
         "Adding New Agent Guides"
       ],
-      "size_bytes": 2228
+      "size_bytes": 2474
     },
     "docs/agents/guides/index.md": {
       "title": "Guides",
       "type": "documentation",
-      "complexity": "beginner",
+      "complexity": "intermediate",
       "folder": "guides",
       "tags": [],
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 1992
+      "size_bytes": 2006
     },
     "docs/agents/guides/agent-workflow-master-guide.md": {
       "title": "Agent Workflow Master Guide",
@@ -2263,7 +2824,7 @@
         "\ud83c\udfad Agent Role Patterns",
         "\ud83d\udcca Quality Gates"
       ],
-      "size_bytes": 19713
+      "size_bytes": 19799
     },
     "docs/agents/guides/agent-8-automation.md": {
       "title": "Agent 8 Automation - Scripts & Tools Index",
@@ -2283,7 +2844,7 @@
         "Related Infrastructure",
         "Script Dependencies"
       ],
-      "size_bytes": 8511
+      "size_bytes": 8665
     },
     "docs/agents/guides/agent-9-governance-hub.md": {
       "title": "Agent 9 Governance Hub",
@@ -2319,7 +2880,7 @@
         "\ud83d\udea8 Emergency: If Mistake Happens Anyway",
         "\ud83c\udfaf Agent 8 Mission: Zero Mistakes"
       ],
-      "size_bytes": 29999
+      "size_bytes": 30075
     },
     "docs/agents/guides/agent-automation-system.md": {
       "title": "Agent Automation System v1.1.0",
@@ -2339,7 +2900,7 @@
         "Troubleshooting",
         "Maintenance"
       ],
-      "size_bytes": 8734
+      "size_bytes": 8859
     },
     "docs/agents/guides/agent-8-multi-agent-coordination.md": {
       "title": "Agent 8 Multi-Agent Coordination",
@@ -2359,7 +2920,7 @@
         "Implementation Status",
         "Testing"
       ],
-      "size_bytes": 7808
+      "size_bytes": 7875
     },
     "docs/cookbook/README.md": {
       "title": "Cookbook",
@@ -2410,7 +2971,7 @@
         "Exit Codes",
         "Related"
       ],
-      "size_bytes": 13515
+      "size_bytes": 14127
     },
     "docs/cookbook/python-recipes.md": {
       "title": "Python Recipes",
@@ -2456,7 +3017,26 @@
         "9. Tolerances and Rounding",
         "10. Adding New Verification Cases"
       ],
-      "size_bytes": 43513
+      "size_bytes": 43515
+    },
+    "docs/verification/bundled-sample-boq-evidence.md": {
+      "title": "Bundled Sample BOQ Evidence",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "boq",
+        "etabs",
+        "evidence",
+        "testing",
+        "validation",
+        "verification"
+      ],
+      "sections": [
+        "Accepted software record",
+        "Reconciliation of the older record"
+      ],
+      "size_bytes": 2326
     },
     "docs/verification/validation-pack.md": {
       "title": "Validation Pack \u2014 Benchmark Beams & Columns",
@@ -2474,12 +3054,53 @@
         "Additional Verification",
         "Tolerance Policy"
       ],
-      "size_bytes": 11920
+      "size_bytes": 11922
+    },
+    "docs/verification/is456-slab-evidence.md": {
+      "title": "IS 456 Solid Slab Source and Benchmark Ledger",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Source lock",
+        "Clause and behavior map",
+        "Accepted benchmark ledger",
+        "Holds and claim ceiling",
+        "Implementation verification \u2014 2026-08-10",
+        "IS456-SLAB-001A closeout evidence \u2014 2026-08-10"
+      ],
+      "size_bytes": 8573
+    },
+    "docs/verification/ui-experience-session-2-acceptance.md": {
+      "title": "UIX-001 Session 2 Acceptance",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "fastapi",
+        "react",
+        "testing",
+        "uix",
+        "validation",
+        "verification",
+        "workflow"
+      ],
+      "sections": [
+        "Accepted product story",
+        "Root-cause fixes found during acceptance",
+        "Verification matrix",
+        "Holds and tooling limits"
+      ],
+      "size_bytes": 4912
     },
     "docs/verification/README.md": {
       "title": "Verification",
       "type": "index",
-      "complexity": "beginner",
+      "complexity": "intermediate",
       "folder": "verification",
       "tags": [
         "testing",
@@ -2491,7 +3112,7 @@
         "\u2705 Why Verification Matters",
         "\ud83d\udcda Related Documentation"
       ],
-      "size_bytes": 1931
+      "size_bytes": 2347
     },
     "docs/verification/external-cli-test.md": {
       "title": "External CLI Test (S-007)",
@@ -2513,16 +3134,17 @@
     "docs/verification/index.md": {
       "title": "Verification",
       "type": "documentation",
-      "complexity": "beginner",
+      "complexity": "intermediate",
       "folder": "verification",
       "tags": [
         "testing",
         "validation"
       ],
       "sections": [
+        "Config Files",
         "Documentation Files"
       ],
-      "size_bytes": 1111
+      "size_bytes": 2309
     },
     "docs/verification/pack.md": {
       "title": "Verification Pack",
@@ -2541,6 +3163,55 @@
       ],
       "size_bytes": 1835
     },
+    "docs/verification/alpha-0231-local-prepublication-rehearsal.md": {
+      "title": "v0.23.1a1 Local Prepublication Rehearsal",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Preserved artifacts",
+        "Bound receipts",
+        "Installed-wheel evidence",
+        "Clean-tree candidate preflight",
+        "Authority boundary"
+      ],
+      "size_bytes": 3463
+    },
+    "docs/verification/release-artifact-evidence-template.md": {
+      "title": "Release Artifact Evidence Template",
+      "type": "documentation",
+      "complexity": "beginner",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [],
+      "size_bytes": 1284
+    },
+    "docs/verification/column-pmm-benchmark.md": {
+      "title": "Column PMM independent analytical benchmark",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Purpose and claim boundary",
+        "Exact case",
+        "Closed-form concrete calculation",
+        "Exact steel calculation",
+        "Independent expected response",
+        "Supported conclusion and exclusions"
+      ],
+      "size_bytes": 4317
+    },
     "docs/verification/insights-verification-pack.md": {
       "title": "Insights Module Verification Pack",
       "type": "documentation",
@@ -2558,7 +3229,27 @@
         "Verification Philosophy",
         "For Contributors"
       ],
-      "size_bytes": 3574
+      "size_bytes": 3640
+    },
+    "docs/verification/is456-library-first-evidence.md": {
+      "title": "IS 456 Library-First Evidence and Claim Crosswalk",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Controlled sources",
+        "Claim-to-evidence crosswalk",
+        "C2 final product UAT",
+        "Production release evidence",
+        "Release evidence contract",
+        "Local prepublication rehearsal",
+        "C4 frozen review scope"
+      ],
+      "size_bytes": 9847
     },
     "docs/architecture/unified-architecture-v1.md": {
       "title": "Unified Architecture \u2014 structural_engineering_lib v1.0",
@@ -2581,7 +3272,7 @@
         "9. Version Roadmap",
         "10. API Design Principles (Inspired by NumPy/pandas/scikit-learn)"
       ],
-      "size_bytes": 75936
+      "size_bytes": 75968
     },
     "docs/architecture/architecture-review-2025-12-27.md": {
       "title": "Architecture Review \u2014 2025-12-27",
@@ -2807,6 +3498,33 @@
       ],
       "size_bytes": 16608
     },
+    "docs/audit/automation-scripts-audit-2026-08-09.md": {
+      "title": "Automation Script Audit \u2014 2026-08-09",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "audit",
+      "tags": [
+        "archive",
+        "audit",
+        "automation",
+        "maint-008",
+        "maintenance",
+        "scripts"
+      ],
+      "sections": [
+        "Outcome",
+        "P0 implementation update \u2014 2026-08-09",
+        "P0 Batch 2 implementation update \u2014 2026-08-09",
+        "P1 Batch 3 implementation update \u2014 2026-08-09",
+        "Terminal/worktree runtime repair \u2014 2026-08-09",
+        "Remaining batches completion update \u2014 2026-08-10",
+        "Snapshot and scope",
+        "Method",
+        "Verification summary",
+        "Highest-priority confirmed issues"
+      ],
+      "size_bytes": 51095
+    },
     "docs/audit/onboarding-audit-session93.md": {
       "title": "Agent Onboarding Audit \u2014 Session 93",
       "type": "documentation",
@@ -2840,11 +3558,11 @@
         "Outcome",
         "Audit scope",
         "Completed maintenance",
-        "Open findings",
+        "Closeout findings",
         "Maintenance sequence",
         "Guardrails retained"
       ],
-      "size_bytes": 9010
+      "size_bytes": 9261
     },
     "docs/audit/audit-readiness.md": {
       "title": "Audit Readiness Checklist",
@@ -2860,7 +3578,7 @@
         "Per-Release Checklist",
         "Related Files"
       ],
-      "size_bytes": 5163
+      "size_bytes": 5145
     },
     "docs/audit/README.md": {
       "title": "Audit Evidence & Readiness",
@@ -2909,7 +3627,7 @@
         "Documentation Files",
         "Subfolders"
       ],
-      "size_bytes": 1391
+      "size_bytes": 1548
     },
     "docs/audit/evidence-bundle-template.md": {
       "title": "Evidence Bundle Template \u2014 Release vX.Y.Z",
@@ -2928,7 +3646,7 @@
         "7. Sign-Off",
         "Appendix: File Manifest"
       ],
-      "size_bytes": 4619
+      "size_bytes": 4635
     },
     "docs/audit/agent-testing-audit-2026-03-28.md": {
       "title": "Agent System Testing & Audit Report",
@@ -2986,26 +3704,22 @@
       "size_bytes": 2217
     },
     "docs/getting-started/copilot-quick-start.md": {
-      "title": "GitHub Copilot Agent Quick Start",
+      "title": "Agent Quick Start",
       "type": "tutorial",
-      "complexity": "intermediate",
+      "complexity": "beginner",
       "folder": "getting-started",
       "tags": [
         "beginner",
+        "codex",
+        "git",
+        "setup",
         "tutorial"
       ],
       "sections": [
-        "\ud83d\ude80 Quick Start (One Command)",
-        "Git Pager Prevention (Handled by agent_start.sh)",
-        "Quick Commands",
-        "Common Workflows",
-        "What NOT to Do",
-        "If Terminal Gets Stuck",
-        "Session Checklist",
-        "Useful Aliases (Created by Setup Script)",
-        "Additional Resources"
+        "Git and GitHub",
+        "Closeout"
       ],
-      "size_bytes": 4991
+      "size_bytes": 1147
     },
     "docs/getting-started/fix-copilot-terminal.md": {
       "title": "Fix Copilot Terminal Lockup - Manual Steps",
@@ -3040,6 +3754,7 @@
       ],
       "sections": [
         "Release Process",
+        "v0.23.0 \u2014 Supported IS 456 RC Core (2026-08-10)",
         "v0.21.6 \u2014 API Quality & Introspection (2026-04-07)",
         "v0.21.5",
         "v0.21.4",
@@ -3047,10 +3762,9 @@
         "v0.21.2",
         "v0.21.1",
         "v0.21.0",
-        "v0.17.0",
-        "v0.16.6"
+        "v0.17.0"
       ],
-      "size_bytes": 46424
+      "size_bytes": 52681
     },
     "docs/getting-started/cost-optimization-guide.md": {
       "title": "Cost Optimization Guide",
@@ -3111,7 +3825,7 @@
         "8. Units Reference",
         "9. Getting Help"
       ],
-      "size_bytes": 4750
+      "size_bytes": 4752
     },
     "docs/getting-started/mac-mini-setup.md": {
       "title": "Mac Mini Setup Guide",
@@ -3134,7 +3848,7 @@
         "Daily Workflow Commands",
         "Architecture Overview"
       ],
-      "size_bytes": 9651
+      "size_bytes": 9480
     },
     "docs/getting-started/agent-bootstrap.md": {
       "title": "Agent Bootstrap \u2014 structural_engineering_lib",
@@ -3148,7 +3862,7 @@
       "sections": [
         "\u26a0 Agent Quick-Scan (read this FIRST)",
         "1. Project Identity",
-        "2. THE ONE RULE",
+        "2. Codex-Native Git/GitHub",
         "3. V3 Architecture",
         "4. What Exists \u2014 DON'T Reinvent",
         "5. Launching the App",
@@ -3157,7 +3871,7 @@
         "8. Key Scripts",
         "9. Golden Rules"
       ],
-      "size_bytes": 38044
+      "size_bytes": 37298
     },
     "docs/getting-started/python-quickstart.md": {
       "title": "Python Quickstart (Beginner-Friendly)",
@@ -3180,7 +3894,7 @@
         "7) Column Design (IS 456)",
         "8) Packaging notes (contributors only)"
       ],
-      "size_bytes": 6492
+      "size_bytes": 6424
     },
     "docs/getting-started/index.md": {
       "title": "Getting Started",
@@ -3194,7 +3908,30 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 2296
+      "size_bytes": 2376
+    },
+    "docs/getting-started/product-tour.md": {
+      "title": "StructLib Product Tour",
+      "type": "tutorial",
+      "complexity": "intermediate",
+      "folder": "getting-started",
+      "tags": [
+        "beginner",
+        "fastapi",
+        "product-tour",
+        "react",
+        "screenshots",
+        "tutorial"
+      ],
+      "sections": [
+        "1. Import and verify the model",
+        "2. Review the building in 3D",
+        "3. Inspect a member",
+        "4. Understand the batch",
+        "Try the same workflow",
+        "Continue exploring"
+      ],
+      "size_bytes": 3476
     },
     "docs/getting-started/agent-essentials.md": {
       "title": "Agent Essentials",
@@ -3223,7 +3960,7 @@
         "Common fixes",
         "Next steps"
       ],
-      "size_bytes": 4103
+      "size_bytes": 4105
     },
     "docs/getting-started/ai-context-pack.md": {
       "title": "AI Context Pack",
@@ -3347,7 +4084,7 @@
         "6. Error Handling",
         "7. Documentation Standards"
       ],
-      "size_bytes": 24836
+      "size_bytes": 24733
     },
     "docs/guides/code-reuse-and-library-structure.md": {
       "title": "Code Reuse and Library Structure",
@@ -3383,7 +4120,7 @@
         "4. Implementation Checklist",
         "Summary"
       ],
-      "size_bytes": 6252
+      "size_bytes": 6461
     },
     "docs/guides/fastapi-deployment-guide.md": {
       "title": "FastAPI Deployment Guide",
@@ -3421,7 +4158,7 @@
         "Related Documentation",
         "Changelog"
       ],
-      "size_bytes": 32082
+      "size_bytes": 31287
     },
     "docs/guides/maintenance-checklist.md": {
       "title": "Maintenance Checklist",
@@ -3439,7 +4176,7 @@
         "Maintenance Pipeline (Who Does What)",
         "Tracking"
       ],
-      "size_bytes": 5476
+      "size_bytes": 5679
     },
     "docs/guides/README.md": {
       "title": "User Guides",
@@ -3501,7 +4238,7 @@
         "Context Management \u2014 Working Through Long Sessions",
         "Efficiency Patterns"
       ],
-      "size_bytes": 18243
+      "size_bytes": 18191
     },
     "docs/governance/maintenance-playbook.md": {
       "title": "Governance & Maintenance Playbook",
@@ -3521,7 +4258,7 @@
         "9. Release Checklist",
         "10. Incident Response"
       ],
-      "size_bytes": 6713
+      "size_bytes": 6795
     },
     "docs/guidelines/documentation-standard.md": {
       "title": "API Documentation & Discoverability Standard",
@@ -3576,7 +4313,7 @@
         "\ud83d\udcc1 Special Folder Rules",
         "\ud83e\udd16 For AI Agents"
       ],
-      "size_bytes": 8581
+      "size_bytes": 8773
     },
     "docs/guidelines/folder-cleanup-workflow.md": {
       "title": "Folder Cleanup Workflow",
@@ -3596,7 +4333,7 @@
         "Phase 3: Plan (Prepare Operations)",
         "Phase 4: Execute (Apply Changes)"
       ],
-      "size_bytes": 6701
+      "size_bytes": 6758
     },
     "docs/guidelines/migration-workflow-guide.md": {
       "title": "IS 456 Module Migration Workflow",
@@ -3616,7 +4353,7 @@
         "Phase 6: Migrate compliance.py",
         "Phase 7: Migrate ductile.py"
       ],
-      "size_bytes": 9849
+      "size_bytes": 10842
     },
     "docs/guidelines/ai-token-efficiency.md": {
       "title": "AI Token-Efficiency Policy",
@@ -3636,7 +4373,7 @@
         "Reusable Task Preamble",
         "Official References"
       ],
-      "size_bytes": 10247
+      "size_bytes": 10770
     },
     "docs/guidelines/result-object-standard.md": {
       "title": "Result Object Design Standard",
@@ -3723,7 +4460,7 @@
         "Config Files",
         "Documentation Files"
       ],
-      "size_bytes": 2227
+      "size_bytes": 2235
     },
     "docs/guidelines/folder-structure-governance.md": {
       "title": "Folder Structure Governance",
@@ -4298,7 +5035,7 @@
         "\ud83d\udcac Can You Explain?",
         "\ud83d\udcce References"
       ],
-      "size_bytes": 14759
+      "size_bytes": 14784
     },
     "docs/migration/learning/day-20-data-flow-e2e.md": {
       "title": "Day 20: End-to-End Data Flow \u2014 Tracing a Beam from CSV Upload to 3D Render",
@@ -4409,7 +5146,7 @@
         "Part 8: Exercises",
         "Part 9: Self-Check Q&A"
       ],
-      "size_bytes": 15802
+      "size_bytes": 15958
     },
     "docs/migration/learning/day-19-3d-visualization.md": {
       "title": "Day 19: 3D Visualization \u2014 Rendering Concrete, Rebar & Stirrups with React Three Fiber",
@@ -4492,7 +5229,7 @@
         "\ud83d\udcac Can You Explain?",
         "\ud83d\udcce References"
       ],
-      "size_bytes": 14189
+      "size_bytes": 14248
     },
     "docs/migration/learning/day-01-concrete-basics.md": {
       "title": "Day 1: Concrete & Steel Basics",
@@ -4609,7 +5346,7 @@
         "\ud83d\udcac Can You Explain?",
         "\ud83d\udcce References"
       ],
-      "size_bytes": 12832
+      "size_bytes": 12845
     },
     "docs/migration/learning/day-02-beam-flexure.md": {
       "title": "Day 2: Beam Flexure Design",
@@ -4866,7 +5603,7 @@
         "2. Flexure Module (`M06_Flexure` / `flexure.py`)",
         "3. Shear Module (`M07_Shear` / `shear.py`)"
       ],
-      "size_bytes": 124735
+      "size_bytes": 128420
     },
     "docs/reference/clause-map.md": {
       "title": "IS 456 Clause-to-Function Mapping",
@@ -4915,7 +5652,7 @@
       "size_bytes": 7285
     },
     "docs/reference/sdk-api-contract-v1.md": {
-      "title": "Structural SDK API Contract \u2014 v1.0",
+      "title": "Historical Structural SDK Target Contract \u2014 v1.0",
       "type": "reference",
       "complexity": "advanced",
       "folder": "reference",
@@ -4935,7 +5672,7 @@
         "Error Handling",
         "Backward Compatibility"
       ],
-      "size_bytes": 23668
+      "size_bytes": 24063
     },
     "docs/reference/troubleshooting.md": {
       "title": "Troubleshooting Guide",
@@ -4979,7 +5716,7 @@
         "Output Schema Stability",
         "How to Report Breaking Changes"
       ],
-      "size_bytes": 18236
+      "size_bytes": 20512
     },
     "docs/reference/dxf-layer-standards.md": {
       "title": "DXF Layer Standards & Drawing Conventions",
@@ -5042,6 +5779,21 @@
       ],
       "size_bytes": 1276
     },
+    "docs/reference/beam-tool-manifest.md": {
+      "title": "Beam Tool Manifest",
+      "type": "reference",
+      "complexity": "beginner",
+      "folder": "reference",
+      "tags": [
+        "ai-readiness",
+        "api",
+        "catalogue",
+        "technical",
+        "tools"
+      ],
+      "sections": [],
+      "size_bytes": 1135
+    },
     "docs/reference/error-schema.md": {
       "title": "Error Schema v1",
       "type": "reference",
@@ -5065,23 +5817,28 @@
     "docs/reference/fastapi-rest-api.md": {
       "title": "FastAPI REST API Reference",
       "type": "reference",
-      "complexity": "advanced",
+      "complexity": "intermediate",
       "folder": "reference",
       "tags": [
         "api",
+        "fastapi",
+        "is456",
+        "openapi",
+        "rest",
         "technical"
       ],
       "sections": [
         "Overview",
-        "Authentication",
-        "Endpoints",
-        "Error Codes",
-        "Rate Limiting",
-        "Client SDKs",
-        "OpenAPI Specification",
-        "Related Documents"
+        "Authentication boundary",
+        "Response envelope",
+        "Health checks",
+        "Executable beam-design example",
+        "Endpoint families",
+        "Client generation status",
+        "Validation commands",
+        "Related documents"
       ],
-      "size_bytes": 10301
+      "size_bytes": 6899
     },
     "docs/reference/README.md": {
       "title": "Reference Documentation",
@@ -5101,7 +5858,7 @@
         "VBA Development",
         "Project Health & Automation"
       ],
-      "size_bytes": 2640
+      "size_bytes": 2755
     },
     "docs/reference/3d-visualization-performance.md": {
       "title": "3D Visualization Performance Benchmarks",
@@ -5177,7 +5934,7 @@
         "Documentation Files",
         "Subfolders"
       ],
-      "size_bytes": 3423
+      "size_bytes": 3597
     },
     "docs/reference/bbs-dxf-contract.md": {
       "title": "BBS + DXF Contract (v1.x)",
@@ -5225,6 +5982,7 @@
         "technical"
       ],
       "sections": [
+        "GeometrySpaceV1 workbench boundary",
         "Overview",
         "TypeScript Type Definitions",
         "Sample JSON Payload",
@@ -5235,7 +5993,7 @@
         "Related Files",
         "Changelog"
       ],
-      "size_bytes": 11919
+      "size_bytes": 14208
     },
     "docs/reference/agent-automation-pitfalls.md": {
       "title": "Agent Automation Pitfalls and Best Practices",
@@ -5257,7 +6015,7 @@
         "Testing Automation Scripts",
         "Additional Resources"
       ],
-      "size_bytes": 15050
+      "size_bytes": 15118
     },
     "docs/reference/api-levels.md": {
       "title": "Which API Should I Use?",
@@ -5276,7 +6034,7 @@
         "Decision Tree",
         "See Also"
       ],
-      "size_bytes": 3377
+      "size_bytes": 4186
     },
     "docs/reference/error-codes.md": {
       "title": "Error Code Reference",
@@ -5312,30 +6070,26 @@
         "Development Dependencies",
         "How to Refresh This File"
       ],
-      "size_bytes": 1000
+      "size_bytes": 990
     },
     "docs/reference/automation-catalog.md": {
-      "title": "Automation Script Catalog",
+      "title": "Automation Catalog",
       "type": "reference",
-      "complexity": "advanced",
+      "complexity": "intermediate",
       "folder": "reference",
       "tags": [
         "api",
+        "automation",
+        "codex",
+        "scripts",
         "technical"
       ],
       "sections": [
-        "Quick Index",
-        "Catalog Scope",
-        "Recently Added Scripts (Not Yet Expanded in Catalog)",
-        "Session Management",
-        "Git Workflow",
-        "Documentation Quality",
-        "Release Management",
-        "Testing & Quality",
-        "Code Quality",
-        "Streamlit QA"
+        "Primary entry points",
+        "Git/GitHub is not repository automation",
+        "Maintenance rule"
       ],
-      "size_bytes": 70545
+      "size_bytes": 2137
     },
     "docs/reference/insights-api.md": {
       "title": "Insights API Reference",
@@ -5461,9 +6215,10 @@
         "docs/contributing/git-workflow-ai-agents.md",
         "docs/learning/glossary.md",
         "docs/publications/research-paper-git-infrastructure.md",
-        "docs/git-automation/README.md",
+        "docs/planning/compact-modernization-plan.md",
         "docs/agents/README.md",
         "docs/agents/index.md",
+        "docs/verification/is456-library-first-evidence.md",
         "docs/audit/maintenance-recovery-audit-2026-08-07.md",
         "docs/getting-started/ai-context-pack.md",
         "docs/guides/ai-agent-coding-guide.md",
@@ -5520,6 +6275,7 @@
     "by_topic": {
       "maintenance": [
         "docs/_active/maintenance-plan-v0-21-sprint.md",
+        "docs/audit/automation-scripts-audit-2026-08-09.md",
         "docs/audit/maintenance-recovery-audit-2026-08-07.md"
       ],
       "planning": [
@@ -5582,7 +6338,9 @@
         "docs/learning-foundations/06-testing.md",
         "docs/learning-foundations/08-backend.md",
         "docs/learning-foundations/10-ci-cd.md",
-        "docs/learning-foundations/04-apis.md"
+        "docs/learning-foundations/04-apis.md",
+        "docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md",
+        "docs/git-automation/git-recovery-case-study-column-pmm.md"
       ],
       "design": [
         "docs/specs/csv-import-schema.md",
@@ -5663,7 +6421,33 @@
         "docs/contributing/git-workflow-ai-agents.md",
         "docs/contributing/handoff.md",
         "docs/contributing/testing-strategy.md",
-        "docs/contributing/changelog-deprecation-template.md"
+        "docs/contributing/changelog-deprecation-template.md",
+        "docs/git-automation/git-workflow-single-source.md",
+        "docs/verification/ui-experience-session-2-acceptance.md"
+      ],
+      "codex": [
+        "docs/contributing/github-workflow.md",
+        "docs/contributing/git-workflow-ai-agents.md",
+        "docs/git-automation/git-workflow-single-source.md",
+        "docs/git-automation/README.md",
+        "docs/getting-started/copilot-quick-start.md",
+        "docs/reference/automation-catalog.md"
+      ],
+      "git": [
+        "docs/contributing/github-workflow.md",
+        "docs/contributing/git-workflow-ai-agents.md",
+        "docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md",
+        "docs/git-automation/git-workflow-single-source.md",
+        "docs/git-automation/README.md",
+        "docs/git-automation/git-recovery-case-study-column-pmm.md",
+        "docs/getting-started/copilot-quick-start.md"
+      ],
+      "github": [
+        "docs/contributing/github-workflow.md",
+        "docs/contributing/git-workflow-ai-agents.md",
+        "docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md",
+        "docs/git-automation/git-workflow-single-source.md",
+        "docs/git-automation/README.md"
       ],
       "education": [
         "docs/learning/exercises.md",
@@ -5743,28 +6527,58 @@
         "docs/migration/learning/day-14-optimization.md",
         "docs/migration/learning/day-11-services-api.md"
       ],
+      "cleanup": [
+        "docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md"
+      ],
+      "worktree": [
+        "docs/git-automation/git-governance-case-study-git-7d2-cleanup-audit.md",
+        "docs/git-automation/git-recovery-case-study-column-pmm.md"
+      ],
+      "recovery": [
+        "docs/git-automation/git-recovery-case-study-column-pmm.md",
+        "docs/audit/maintenance-recovery-audit-2026-08-07.md"
+      ],
+      "scripts": [
+        "docs/git-automation/git-recovery-case-study-column-pmm.md",
+        "docs/audit/automation-scripts-audit-2026-08-09.md",
+        "docs/reference/automation-catalog.md"
+      ],
       "roadmap": [
+        "docs/planning/gpt-5-3-codex-spark-work-program.md",
         "docs/planning/next-session-brief.md",
+        "docs/planning/is456-solid-slabs-master-plan.md",
+        "docs/planning/compact-modernization-plan.md",
+        "docs/planning/ui-experience-foundation-master-plan.md",
+        "docs/planning/adoption-trust-surface-plan.md",
         "docs/planning/next-phase-improvements-plan.md",
+        "docs/planning/is456-library-first-master-plan.md",
         "docs/planning/library-expansion-blueprint-v5.md",
         "docs/planning/pre-release-checklist.md",
         "docs/planning/README.md",
         "docs/planning/memory.md",
         "docs/planning/etabs-killer-masterplan.md",
         "docs/planning/index.md",
+        "docs/planning/professional-library-remediation-plan.md",
         "docs/planning/react-ux-improvement-plan.md",
         "docs/planning/dependency-security-baseline.md",
         "docs/planning/democratization-vision.md"
       ],
       "tasks": [
+        "docs/planning/gpt-5-3-codex-spark-work-program.md",
         "docs/planning/next-session-brief.md",
+        "docs/planning/is456-solid-slabs-master-plan.md",
+        "docs/planning/compact-modernization-plan.md",
+        "docs/planning/ui-experience-foundation-master-plan.md",
+        "docs/planning/adoption-trust-surface-plan.md",
         "docs/planning/next-phase-improvements-plan.md",
+        "docs/planning/is456-library-first-master-plan.md",
         "docs/planning/library-expansion-blueprint-v5.md",
         "docs/planning/pre-release-checklist.md",
         "docs/planning/README.md",
         "docs/planning/memory.md",
         "docs/planning/etabs-killer-masterplan.md",
         "docs/planning/index.md",
+        "docs/planning/professional-library-remediation-plan.md",
         "docs/planning/react-ux-improvement-plan.md",
         "docs/planning/dependency-security-baseline.md",
         "docs/planning/democratization-vision.md"
@@ -5775,7 +6589,9 @@
       ],
       "automation": [
         "docs/agents/README.md",
-        "docs/agents/index.md"
+        "docs/agents/index.md",
+        "docs/audit/automation-scripts-audit-2026-08-09.md",
+        "docs/reference/automation-catalog.md"
       ],
       "examples": [
         "docs/cookbook/README.md",
@@ -5791,21 +6607,60 @@
       ],
       "testing": [
         "docs/verification/examples.md",
+        "docs/verification/bundled-sample-boq-evidence.md",
         "docs/verification/validation-pack.md",
+        "docs/verification/is456-slab-evidence.md",
+        "docs/verification/ui-experience-session-2-acceptance.md",
         "docs/verification/README.md",
         "docs/verification/external-cli-test.md",
         "docs/verification/index.md",
         "docs/verification/pack.md",
-        "docs/verification/insights-verification-pack.md"
+        "docs/verification/alpha-0231-local-prepublication-rehearsal.md",
+        "docs/verification/release-artifact-evidence-template.md",
+        "docs/verification/column-pmm-benchmark.md",
+        "docs/verification/insights-verification-pack.md",
+        "docs/verification/is456-library-first-evidence.md"
       ],
       "validation": [
         "docs/verification/examples.md",
+        "docs/verification/bundled-sample-boq-evidence.md",
         "docs/verification/validation-pack.md",
+        "docs/verification/is456-slab-evidence.md",
+        "docs/verification/ui-experience-session-2-acceptance.md",
         "docs/verification/README.md",
         "docs/verification/external-cli-test.md",
         "docs/verification/index.md",
         "docs/verification/pack.md",
-        "docs/verification/insights-verification-pack.md"
+        "docs/verification/alpha-0231-local-prepublication-rehearsal.md",
+        "docs/verification/release-artifact-evidence-template.md",
+        "docs/verification/column-pmm-benchmark.md",
+        "docs/verification/insights-verification-pack.md",
+        "docs/verification/is456-library-first-evidence.md"
+      ],
+      "boq": [
+        "docs/verification/bundled-sample-boq-evidence.md"
+      ],
+      "etabs": [
+        "docs/verification/bundled-sample-boq-evidence.md"
+      ],
+      "evidence": [
+        "docs/verification/bundled-sample-boq-evidence.md"
+      ],
+      "verification": [
+        "docs/verification/bundled-sample-boq-evidence.md",
+        "docs/verification/ui-experience-session-2-acceptance.md"
+      ],
+      "fastapi": [
+        "docs/verification/ui-experience-session-2-acceptance.md",
+        "docs/getting-started/product-tour.md",
+        "docs/reference/fastapi-rest-api.md"
+      ],
+      "react": [
+        "docs/verification/ui-experience-session-2-acceptance.md",
+        "docs/getting-started/product-tour.md"
+      ],
+      "uix": [
+        "docs/verification/ui-experience-session-2-acceptance.md"
       ],
       "structure": [
         "docs/architecture/unified-architecture-v1.md",
@@ -5822,13 +6677,17 @@
         "docs/architecture/project-overview.md",
         "docs/architecture/canonical-data-format.md"
       ],
+      "archive": [
+        "docs/audit/automation-scripts-audit-2026-08-09.md"
+      ],
       "audit": [
+        "docs/audit/automation-scripts-audit-2026-08-09.md",
         "docs/audit/maintenance-recovery-audit-2026-08-07.md"
+      ],
+      "maint-008": [
+        "docs/audit/automation-scripts-audit-2026-08-09.md"
       ],
       "mac-mini": [
-        "docs/audit/maintenance-recovery-audit-2026-08-07.md"
-      ],
-      "recovery": [
         "docs/audit/maintenance-recovery-audit-2026-08-07.md"
       ],
       "v0.21.7": [
@@ -5846,6 +6705,7 @@
         "docs/getting-started/agent-bootstrap.md",
         "docs/getting-started/python-quickstart.md",
         "docs/getting-started/index.md",
+        "docs/getting-started/product-tour.md",
         "docs/getting-started/agent-essentials.md",
         "docs/getting-started/beginners-guide.md",
         "docs/getting-started/ai-context-pack.md",
@@ -5866,6 +6726,7 @@
         "docs/getting-started/agent-bootstrap.md",
         "docs/getting-started/python-quickstart.md",
         "docs/getting-started/index.md",
+        "docs/getting-started/product-tour.md",
         "docs/getting-started/agent-essentials.md",
         "docs/getting-started/beginners-guide.md",
         "docs/getting-started/ai-context-pack.md",
@@ -5873,6 +6734,15 @@
         "docs/getting-started/colab-workflow.md",
         "docs/getting-started/NEW-DEVELOPER-ONBOARDING.md",
         "docs/getting-started/insights-guide.md"
+      ],
+      "setup": [
+        "docs/getting-started/copilot-quick-start.md"
+      ],
+      "product-tour": [
+        "docs/getting-started/product-tour.md"
+      ],
+      "screenshots": [
+        "docs/getting-started/product-tour.md"
       ],
       "aci318": [
         "docs/migration/01-adr-library-separation.md"
@@ -5884,7 +6754,8 @@
         "docs/migration/01-adr-library-separation.md"
       ],
       "is456": [
-        "docs/migration/01-adr-library-separation.md"
+        "docs/migration/01-adr-library-separation.md",
+        "docs/reference/fastapi-rest-api.md"
       ],
       "library": [
         "docs/migration/01-adr-library-separation.md"
@@ -5915,6 +6786,7 @@
         "docs/reference/dxf-layer-standards.md",
         "docs/reference/deprecation-policy.md",
         "docs/reference/repo-health-baseline-2026-01-07.md",
+        "docs/reference/beam-tool-manifest.md",
         "docs/reference/error-schema.md",
         "docs/reference/fastapi-rest-api.md",
         "docs/reference/README.md",
@@ -5943,6 +6815,7 @@
         "docs/reference/dxf-layer-standards.md",
         "docs/reference/deprecation-policy.md",
         "docs/reference/repo-health-baseline-2026-01-07.md",
+        "docs/reference/beam-tool-manifest.md",
         "docs/reference/error-schema.md",
         "docs/reference/fastapi-rest-api.md",
         "docs/reference/README.md",
@@ -5959,6 +6832,21 @@
         "docs/reference/third-party-licenses.md",
         "docs/reference/automation-catalog.md",
         "docs/reference/insights-api.md"
+      ],
+      "ai-readiness": [
+        "docs/reference/beam-tool-manifest.md"
+      ],
+      "catalogue": [
+        "docs/reference/beam-tool-manifest.md"
+      ],
+      "tools": [
+        "docs/reference/beam-tool-manifest.md"
+      ],
+      "openapi": [
+        "docs/reference/fastapi-rest-api.md"
+      ],
+      "rest": [
+        "docs/reference/fastapi-rest-api.md"
       ],
       "reference": [
         "docs/reference/api-levels.md"

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T16:11:38.723453",
+  "generated": "2026-08-15T16:12:41.232901",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T15:29:03.563035",
+  "generated": "2026-08-15T15:47:36.957947",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {
@@ -21,7 +21,7 @@
         "2026-08-13 \u2014 Session: GIT-001 Phase 1 Completion",
         "2026-08-12 \u2014 Session: GIT-001 Future-Work Plan Closeout"
       ],
-      "size_bytes": 260117
+      "size_bytes": 263357
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -460,7 +460,7 @@
         "Receipt contract",
         "Validation boundary"
       ],
-      "size_bytes": 4056
+      "size_bytes": 4351
     },
     "docs/research/git-governance/GIT-001-next-agent-disposition-plan.md": {
       "title": "GIT-001 \u2014 Reconciled Future-Work and Disposition Plan",
@@ -1011,7 +1011,7 @@
         "Part 8: Repository Git Control Plane",
         "Part 9: .gitignore \u2014 What NOT to Track"
       ],
-      "size_bytes": 12356
+      "size_bytes": 12943
     },
     "docs/learning-foundations/03-tech-stack.md": {
       "title": "Module 3: The Tech Stack \u2014 Languages, Tools, and Why",
@@ -2127,7 +2127,7 @@
         "Local hooks",
         "Historical material"
       ],
-      "size_bytes": 7495
+      "size_bytes": 7790
     },
     "docs/git-automation/README.md": {
       "title": "Codex-Native Git and GitHub",

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T15:28:09.470045",
+  "generated": "2026-08-15T15:29:03.563035",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {
@@ -2226,7 +2226,7 @@
         "Destructive-action holds",
         "Session closeout"
       ],
-      "size_bytes": 7869
+      "size_bytes": 7895
     },
     "docs/planning/is456-solid-slabs-master-plan.md": {
       "title": "IS 456 Solid Slabs Expansion Master Plan",

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T15:15:12.811472",
+  "generated": "2026-08-15T15:28:09.470045",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {
@@ -21,7 +21,7 @@
         "2026-08-13 \u2014 Session: GIT-001 Phase 1 Completion",
         "2026-08-12 \u2014 Session: GIT-001 Future-Work Plan Closeout"
       ],
-      "size_bytes": 258990
+      "size_bytes": 260117
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -460,7 +460,7 @@
         "Receipt contract",
         "Validation boundary"
       ],
-      "size_bytes": 3550
+      "size_bytes": 4056
     },
     "docs/research/git-governance/GIT-001-next-agent-disposition-plan.md": {
       "title": "GIT-001 \u2014 Reconciled Future-Work and Disposition Plan",
@@ -1711,7 +1711,7 @@
         "Debug Snapshot Checklist",
         "Common Traps (fast fixes)"
       ],
-      "size_bytes": 4416
+      "size_bytes": 4771
     },
     "docs/contributing/testing-strategy.md": {
       "title": "Testing Strategy & Setup (Python-first, VBA parity aware)",
@@ -2127,7 +2127,7 @@
         "Local hooks",
         "Historical material"
       ],
-      "size_bytes": 6944
+      "size_bytes": 7495
     },
     "docs/git-automation/README.md": {
       "title": "Codex-Native Git and GitHub",

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T16:01:55.285233",
+  "generated": "2026-08-15T16:11:38.723453",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {
@@ -21,7 +21,7 @@
         "2026-08-13 \u2014 Session: GIT-001 Phase 1 Completion",
         "2026-08-12 \u2014 Session: GIT-001 Future-Work Plan Closeout"
       ],
-      "size_bytes": 264828
+      "size_bytes": 266057
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -460,7 +460,7 @@
         "Receipt contract",
         "Validation boundary"
       ],
-      "size_bytes": 4445
+      "size_bytes": 4801
     },
     "docs/research/git-governance/GIT-001-next-agent-disposition-plan.md": {
       "title": "GIT-001 \u2014 Reconciled Future-Work and Disposition Plan",

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-15T15:11:46.314399",
+  "generated": "2026-08-15T15:15:12.811472",
   "total_docs": 322,
   "docs": {
     "docs/SESSION_LOG.md": {
@@ -21,7 +21,7 @@
         "2026-08-13 \u2014 Session: GIT-001 Phase 1 Completion",
         "2026-08-12 \u2014 Session: GIT-001 Future-Work Plan Closeout"
       ],
-      "size_bytes": 257805
+      "size_bytes": 258990
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -544,7 +544,7 @@
         "Config Files",
         "Documentation Files"
       ],
-      "size_bytes": 3552
+      "size_bytes": 3635
     },
     "docs/research/git-governance/GIT-001-phase-7A-preservation-workflow-recovery.md": {
       "title": "GIT-001 Phase 7A \u2014 Preservation and Workflow Recovery",
@@ -2217,7 +2217,7 @@
         "tasks"
       ],
       "sections": [
-        "Latest Handoff",
+        "Latest Handoff (auto)",
         "Required Reading",
         "Start commands",
         "Verified current Git facts",
@@ -2226,7 +2226,7 @@
         "Destructive-action holds",
         "Session closeout"
       ],
-      "size_bytes": 7370
+      "size_bytes": 7869
     },
     "docs/planning/is456-solid-slabs-master-plan.md": {
       "title": "IS 456 Solid Slabs Expansion Master Plan",

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -65,6 +65,15 @@ caller-supplied and identity-bound. The receipt records its
 operation state, hosted identities or explicit `UNKNOWN`/`NOT_CHECKED`, reviewed
 head/base/tree, retention evidence, and authorization boundaries.
 
+The receipt records authority evidence but grants no authority itself;
+`receipt_grants_authority` must be `false`. Authorization evidence requires a
+named external source plus exact task, branch, head, and action binding.
+Serialized `holds` and `receipt_status` are not trusted: validation independently
+recomputes the required hold set from evidence and rejects missing holds, false
+`READY`, malformed next actions, or action/provenance contradictions. External
+authorization never erases remote, PR, review, check, retention, or local-state
+holds.
+
 Missing, malformed, stale, query-failed, or contradictory facts are holds.
 `NOT_APPLICABLE` requires a reason and cannot replace unknown evidence. A
 squash-merged PR requires reviewed-tree/merged-tree equivalence and never makes

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -68,6 +68,10 @@ head/base/tree, retention evidence, and authorization boundaries.
 The receipt records authority evidence but grants no authority itself;
 `receipt_grants_authority` must be `false`. Authorization evidence requires a
 named external source plus exact task, branch, head, and action binding.
+Authorization observations and their source times must be fresh and
+query-successful. The next action must be either a closed safe hold/wait action
+or one of the externally authorized actions bound to that exact target;
+destructive or merge actions cannot be injected as an unbound next action.
 Serialized `holds` and `receipt_status` are not trusted: validation independently
 recomputes the required hold set from evidence and rejects missing holds, false
 `READY`, malformed next actions, or action/provenance contradictions. External

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -55,6 +55,27 @@ Ahead and no-upstream are publication facts rather than local-safety failures.
 The retained shell entrypoints are compatibility delegates and must not contain
 independent Git classification.
 
+## Durable task-to-Git handoff
+
+Use `scripts/git_handoff_receipt.py` for a versioned machine-readable handoff.
+It consumes local facts only from `scripts/git_state.py`; remote, PR, review,
+check, integration, retention, authorization, and next-action facts must be
+caller-supplied and identity-bound. The receipt records its
+`local_state_receipt_hash`, exact branch/head/upstream/base/worktree/tree/
+operation state, hosted identities or explicit `UNKNOWN`/`NOT_CHECKED`, reviewed
+head/base/tree, retention evidence, and authorization boundaries.
+
+Missing, malformed, stale, query-failed, or contradictory facts are holds.
+`NOT_APPLICABLE` requires a reason and cannot replace unknown evidence. A
+squash-merged PR requires reviewed-tree/merged-tree equivalence and never makes
+ancestry or task archive state into retirement authority. Receipt validation is
+read-only and performs no fetch, prune, ref/worktree mutation, or GitHub query.
+
+Session handoff validates the versioned receipt, embeds its path/hash and exact
+identity summary into `next-session-brief.md`, and fails closed if the receipt
+is missing or invalid. The full JSON remains the audit contract; prose and PR
+numbers alone are not a durable Git receipt.
+
 ## Verification before publication
 
 - Run focused checks while editing.

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -68,8 +68,10 @@ head/base/tree, retention evidence, and authorization boundaries.
 The receipt records authority evidence but grants no authority itself;
 `receipt_grants_authority` must be `false`. Authorization evidence requires a
 named external source plus exact task, branch, head, and action binding.
-Authorization observations and their source times must be fresh and
-query-successful. The next action must be either a closed safe hold/wait action
+Authorization observations and the nested external-source evidence must each
+retain caller-supplied status/query/time and be fresh and query-successful;
+validation never fabricates or upgrades those facts. The next action must be
+either a closed safe hold/wait action
 or one of the externally authorized actions bound to that exact target;
 destructive or merge actions cannot be injected as an unbound next action.
 Serialized `holds` and `receipt_status` are not trusted: validation independently

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -69,7 +69,7 @@
     "(^|[` ])git\\s+cherry-pick(?:\\s|`|$)",
     "(^|[` ])git\\s+checkout\\s+-b(?:\\s|`|$)",
     "(^|[` ])git\\s+switch\\s+-c\\s+(?!codex/)",
-    "(?:(?<![A-Za-z0-9])(?:do not|don't|never)\\s+push\\b[^\\n.;!?]*\\bwithout\\s+pull(?:ing)?\\s+first\\b|\\bpull(?:\\s+(?:the\\s+)?(?:PR\\s+)?branch)?\\s+before\\s+(?:you\\s+)?push(?:ing)?\\b|\\bpull\\s+first\\b[^\\n.;!?]{0,40}\\b(?:then\\s+)?push(?:ing)?\\b|\\bbefore\\s+you\\s+push\\b[^\\n.;!?]{0,40}\\bpull\\s+first\\b)"
+    "(?:(?<![A-Za-z0-9])(?:do not|don't|never)\\s+push\\b[^\\n.;!?]*\\bwithout\\s+pull(?:ing)?\\s+first\\b|(?=[^\\n]*(?:git|PR|branch|remote|repository|upstream|commit))[^\\n.;!?]*\\bpull(?:\\s+(?:the\\s+)?(?:PR\\s+)?branch)?\\s+before\\s+(?:you\\s+)?push(?:ing)?\\b|(?=[^\\n]*(?:git|PR|branch|remote|repository|upstream|commit))[^\\n.;!?]*\\bpull\\s+first\\b[^\\n.;!?]{0,40}\\b(?:then\\s+)?push(?:ing)?\\b|^\\s*(?:always\\s+)?pull\\s+before\\s+you\\s+push(?:\\s+to\\s+(?:the\\s+)?PR\\s+branch)?[.!]?\\s*$|^\\s*pull\\s+first\\s*,?\\s*then\\s+push(?:\\s+the\\s+change)?[.!]?\\s*$|^\\s*before\\s+you\\s+push\\s*,\\s*pull\\s+first[.!]?\\s*$)"
   ],
   "required_contracts": {
     "AGENTS.md": [

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "canonical": "docs/git-automation/git-workflow-single-source.md",
+  "live_surfaces": [
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".github/copilot-instructions.md",
+    "docs/git-automation/git-workflow-single-source.md",
+    "docs/governance/maintenance-playbook.md",
+    "docs/guides/maintenance-checklist.md",
+    "docs/guidelines/migration-workflow-guide.md",
+    "docs/guidelines/folder-cleanup-workflow.md",
+    "docs/guidelines/file-operations-safety-guide.md",
+    "docs/contributing/handoff.md",
+    "docs/learning-foundations/09-git.md",
+    "agents/agent-9/KNOWLEDGE_BASE.md",
+    "scripts/README.md",
+    "scripts/automation-map.json"
+  ],
+  "live_globs": [
+    ".github/agents/*.agent.md",
+    ".github/instructions/*.md",
+    ".github/skills/*/SKILL.md"
+  ],
+  "indexed_surface_sets": [
+    {
+      "index": "docs/agents/guides/index.json",
+      "root": "docs/agents/guides",
+      "historical_statuses": ["deprecated"],
+      "ignore_names": ["index.md"]
+    }
+  ],
+  "historical_exclusions": [
+    {
+      "glob": "docs/_archive/**",
+      "boundary": "archive_path"
+    },
+    {
+      "glob": "scripts/_archive/**",
+      "boundary": "archive_path"
+    }
+  ],
+  "forbidden_tokens": [
+    "ai_commit.sh",
+    "safe_push.sh",
+    "recover_git_state.sh",
+    "finish_task_pr.sh",
+    "create_task_pr.sh",
+    "should_use_pr.sh",
+    "cleanup_stale_branches.py",
+    "--finish",
+    "--delete-branch"
+  ],
+  "forbidden_command_patterns": [
+    "(^|[` ])git\\s+reset\\s+--hard(?:[` ]|$)",
+    "(^|[` ])git\\s+push\\b[^\\n]*--force(?:-with-lease)?(?:[` ]|$)",
+    "(^|[` ])git\\s+checkout\\s+main(?:[` ]|$)",
+    "(^|[` ])git\\s+branch\\s+-D(?:[` ]|$)",
+    "(^|[` ])git\\s+stash(?:\\s|`|$)",
+    "(^|[` ])git\\s+worktree\\s+(remove|prune)(?:\\s|`|$)",
+    "(^|[` ])git\\s+(fetch|remote)\\b[^\\n]*--prune(?:[` ]|$)"
+  ],
+  "required_contracts": {
+    "AGENTS.md": [
+      "scripts/git_state.py",
+      "NOT_CHECKED",
+      "classify_branch_disposition.py"
+    ],
+    ".github/skills/session-management/SKILL.md": [
+      "git_handoff_receipt.py",
+      "local_state_receipt_hash"
+    ],
+    "docs/git-automation/git-workflow-single-source.md": [
+      "scripts/git_state.py",
+      "NOT_CHECKED",
+      "UNKNOWN",
+      "git_handoff_receipt.py"
+    ],
+    "docs/contributing/handoff.md": [
+      "git_handoff_receipt.py",
+      "NOT_CHECKED",
+      "UNKNOWN"
+    ]
+  }
+}

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -68,18 +68,21 @@
     ],
     ".github/skills/session-management/SKILL.md": [
       "git_handoff_receipt.py",
-      "local_state_receipt_hash"
+      "local_state_receipt_hash",
+      "receipt_grants_authority"
     ],
     "docs/git-automation/git-workflow-single-source.md": [
       "scripts/git_state.py",
       "NOT_CHECKED",
       "UNKNOWN",
-      "git_handoff_receipt.py"
+      "git_handoff_receipt.py",
+      "receipt_grants_authority"
     ],
     "docs/contributing/handoff.md": [
       "git_handoff_receipt.py",
       "NOT_CHECKED",
-      "UNKNOWN"
+      "UNKNOWN",
+      "receipt_grants_authority"
     ]
   }
 }

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -68,7 +68,8 @@
     "(^|[` ])git\\s+commit\\b[^\\n]*--amend(?:[` ]|$)",
     "(^|[` ])git\\s+cherry-pick(?:\\s|`|$)",
     "(^|[` ])git\\s+checkout\\s+-b(?:\\s|`|$)",
-    "(^|[` ])git\\s+switch\\s+-c\\s+(?!codex/)"
+    "(^|[` ])git\\s+switch\\s+-c\\s+(?!codex/)",
+    "(?:(?<![A-Za-z0-9])(?:do not|don't|never)\\s+push\\b[^\\n.;!?]*\\bwithout\\s+pull(?:ing)?\\s+first\\b|\\bpull(?:\\s+(?:the\\s+)?(?:PR\\s+)?branch)?\\s+before\\s+push(?:ing)?\\b|\\bpull\\s+first\\b)"
   ],
   "required_contracts": {
     "AGENTS.md": [

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -69,7 +69,17 @@
     "(^|[` ])git\\s+cherry-pick(?:\\s|`|$)",
     "(^|[` ])git\\s+checkout\\s+-b(?:\\s|`|$)",
     "(^|[` ])git\\s+switch\\s+-c\\s+(?!codex/)",
-    "(?:(?<![A-Za-z0-9])(?:do not|don't|never)\\s+push\\b[^\\n.;!?]*\\bwithout\\s+pull(?:ing)?\\s+first\\b|(?=[^\\n]*(?:git|PR|branch|remote|repository|upstream|commit))[^\\n.;!?]*\\bpull(?:\\s+(?:the\\s+)?(?:PR\\s+)?branch)?\\s+before\\s+(?:you\\s+)?push(?:ing)?\\b|(?=[^\\n]*(?:git|PR|branch|remote|repository|upstream|commit))[^\\n.;!?]*\\bpull\\s+first\\b[^\\n.;!?]{0,40}\\b(?:then\\s+)?push(?:ing)?\\b|^\\s*(?:always\\s+)?pull\\s+before\\s+you\\s+push(?:\\s+to\\s+(?:the\\s+)?PR\\s+branch)?[.!]?\\s*$|^\\s*pull\\s+first\\s*,?\\s*then\\s+push(?:\\s+the\\s+change)?[.!]?\\s*$|^\\s*before\\s+you\\s+push\\s*,\\s*pull\\s+first[.!]?\\s*$)"
+    "(?<![A-Za-z0-9])(?:do not|don't|never)\\s+push\\b[^\\n.;!?]*\\bwithout\\s+pull(?:ing)?\\s+first\\b",
+    {
+      "kind": "clause_action",
+      "action_pattern": "\\bpull(?:\\s+(?:the\\s+)?(?:(?:pr|remote|upstream)\\s+)?branch)?\\s+before\\s+(?:you\\s+)?push(?:ing)?\\b|\\bpull\\s+first\\b[^\\n.;!?]{0,40}\\b(?:then\\s+)?push(?:ing)?\\b|\\bpull\\s+first\\b",
+      "context_pattern": "\\b(?:git|pr|branch|remote|repository|upstream|commit)\\b",
+      "standalone_clause_patterns": [
+        "(?:then\\s+)?(?:always\\s+)?pull\\s+before\\s+you\\s+push(?:\\s+to\\s+(?:the\\s+)?pr\\s+branch)?",
+        "(?:then\\s+)?pull\\s+first\\s*,?\\s*then\\s+push(?:\\s+the\\s+change)?",
+        "(?:then\\s+)?before\\s+you\\s+push\\s*,\\s*pull\\s+first"
+      ]
+    }
   ],
   "required_contracts": {
     "AGENTS.md": [

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -64,7 +64,11 @@
     "(^|[` ])git\\s+add\\s+(?:\\.|-A|--all)(?:[` ]|$)",
     "(^|[` ])git\\s+filter-branch(?:[` ]|$)",
     "(^|[` ])git\\s+checkout\\b[^\\n]*(?:HEAD|--)\\b",
-    "(^|[` ])git\\s+reset(?:\\s|`|$)"
+    "(^|[` ])git\\s+reset(?:\\s|`|$)",
+    "(^|[` ])git\\s+commit\\b[^\\n]*--amend(?:[` ]|$)",
+    "(^|[` ])git\\s+cherry-pick(?:\\s|`|$)",
+    "(^|[` ])git\\s+checkout\\s+-b(?:\\s|`|$)",
+    "(^|[` ])git\\s+switch\\s+-c\\s+(?!codex/)"
   ],
   "required_contracts": {
     "AGENTS.md": [

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -60,6 +60,12 @@
     "(^|[` ])git\\s+worktree\\s+(remove|prune)(?:\\s|`|$)",
     "(^|[` ])git\\s+(fetch|remote)\\b[^\\n]*--prune(?:[` ]|$)"
   ],
+  "forbidden_instruction_patterns": [
+    "(^|[` ])git\\s+add\\s+(?:\\.|-A|--all)(?:[` ]|$)",
+    "(^|[` ])git\\s+filter-branch(?:[` ]|$)",
+    "(^|[` ])git\\s+checkout\\b[^\\n]*(?:HEAD|--)\\b",
+    "(^|[` ])git\\s+reset(?:\\s|`|$)"
+  ],
   "required_contracts": {
     "AGENTS.md": [
       "scripts/git_state.py",

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -69,7 +69,7 @@
     "(^|[` ])git\\s+cherry-pick(?:\\s|`|$)",
     "(^|[` ])git\\s+checkout\\s+-b(?:\\s|`|$)",
     "(^|[` ])git\\s+switch\\s+-c\\s+(?!codex/)",
-    "(?:(?<![A-Za-z0-9])(?:do not|don't|never)\\s+push\\b[^\\n.;!?]*\\bwithout\\s+pull(?:ing)?\\s+first\\b|\\bpull(?:\\s+(?:the\\s+)?(?:PR\\s+)?branch)?\\s+before\\s+push(?:ing)?\\b|\\bpull\\s+first\\b)"
+    "(?:(?<![A-Za-z0-9])(?:do not|don't|never)\\s+push\\b[^\\n.;!?]*\\bwithout\\s+pull(?:ing)?\\s+first\\b|\\bpull(?:\\s+(?:the\\s+)?(?:PR\\s+)?branch)?\\s+before\\s+(?:you\\s+)?push(?:ing)?\\b|\\bpull\\s+first\\b[^\\n.;!?]{0,40}\\b(?:then\\s+)?push(?:ing)?\\b|\\bbefore\\s+you\\s+push\\b[^\\n.;!?]{0,40}\\bpull\\s+first\\b)"
   ],
   "required_contracts": {
     "AGENTS.md": [

--- a/docs/guidelines/index.json
+++ b/docs/guidelines/index.json
@@ -2,14 +2,14 @@
   "folder": "docs/guidelines",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-07",
+  "last_updated": "2026-08-15",
   "file_count": 16,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 74,
-      "last_updated": "2026-03-29",
+      "last_updated": "2026-08-15",
       "title": "Guidelines Index",
       "description": "Development standards and best practices for the structural engineering library. | Need To... | Read This |",
       "content_hash": "33a845020aca"
@@ -17,16 +17,16 @@
     {
       "name": "ai-token-efficiency.md",
       "type": "documentation",
-      "size_lines": 206,
-      "last_updated": "2026-08-07",
+      "size_lines": 217,
+      "last_updated": "2026-08-15",
       "description": "This is the canonical low-token operating policy for AI-assisted work in this repository. It controls avoidable context and agent fan-out without weakening",
-      "content_hash": "5d45072a3764"
+      "content_hash": "c9b5747bac10"
     },
     {
       "name": "api-design-guidelines.md",
       "type": "documentation",
       "size_lines": 2626,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "This document consolidates all Phase 1 and Phase 2 API research into a **single, actionable reference** for developing structural_engineering_lib APIs. Use this as the \"north star\" for all API design ",
       "content_hash": "69b32bfec1a0"
     },
@@ -34,7 +34,7 @@
       "name": "api-evolution-standard.md",
       "type": "documentation",
       "size_lines": 1691,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "> **Standard for API versioning, deprecation, and backward compatibility** > Part of: API Improvement Research (TASK-207)",
       "content_hash": "5816feab7380"
     },
@@ -42,7 +42,7 @@
       "name": "blog-writing-guide.md",
       "type": "documentation",
       "size_lines": 860,
-      "last_updated": "2026-04-01",
+      "last_updated": "2026-08-15",
       "description": "| Audience | Tone | Example | |----------|------|---------|",
       "content_hash": "b7c4234e5431"
     },
@@ -50,7 +50,7 @@
       "name": "doc-naming-conventions.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "Reduce duplication, improve findability, and ensure every topic has a clear canonical home. 1. **One topic = one canonical file.** Check docs/docs-canonical.json first.",
       "content_hash": "e9614c2283ad"
     },
@@ -58,7 +58,7 @@
       "name": "documentation-standard.md",
       "type": "documentation",
       "size_lines": 1614,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "> **Standard for documentation, docstrings, and API discoverability** > Part of: API Improvement Research (TASK-206)",
       "content_hash": "6931309770e9"
     },
@@ -66,46 +66,46 @@
       "name": "error-handling-standard.md",
       "type": "documentation",
       "size_lines": 1935,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "> **Standard for exception design, error messages, and validation patterns** > Part of: API Improvement Research (TASK-204)",
       "content_hash": "5e23a429bea3"
     },
     {
       "name": "file-operations-safety-guide.md",
       "type": "documentation",
-      "size_lines": 302,
-      "last_updated": "2026-03-31",
+      "size_lines": 308,
+      "last_updated": "2026-08-15",
       "description": "File operations (delete, move, rename) can break: - Internal markdown links",
-      "content_hash": "dcbdf13b3d9c"
+      "content_hash": "3bdf4e50bb20"
     },
     {
       "name": "folder-cleanup-workflow.md",
       "type": "documentation",
-      "size_lines": 288,
-      "last_updated": "2026-03-30",
+      "size_lines": 294,
+      "last_updated": "2026-08-15",
       "description": "This workflow provides a systematic approach to cleaning up folders: 1. **Audit** - Identify cleanup candidates",
-      "content_hash": "de78a15cf215"
+      "content_hash": "e5e2eca12a9f"
     },
     {
       "name": "folder-structure-governance.md",
       "type": "documentation",
       "size_lines": 530,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "1. **Progressive Disclosure** - Short entry docs, detailed content one level down 2. **Clear Ownership** - Every folder has a clear purpose and maintainer",
-      "content_hash": "0e47662a1fa4"
+      "content_hash": "6aed96cb759b"
     },
     {
       "name": "function-signature-standard.md",
       "type": "documentation",
       "size_lines": 1352,
-      "last_updated": "2026-04-04",
+      "last_updated": "2026-08-15",
       "description": "This document defines the standard for function signatures in the structural_engineering_lib to ensure: - **Discoverability**: IDE autocomplete and type checkers work effectively",
       "content_hash": "4feea637cd31"
     },
     {
       "name": "governance-limits.json",
       "type": "config",
-      "last_updated": "2026-04-07",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "root",
         "docs_root",
@@ -118,27 +118,27 @@
       "name": "migration-preflight-checklist.md",
       "type": "documentation",
       "size_lines": 284,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "bash .venv/bin/python scripts/pre_migration_check.py",
       "content_hash": "be5802ce0399"
     },
     {
       "name": "migration-workflow-guide.md",
       "type": "documentation",
-      "size_lines": 459,
-      "last_updated": "2026-03-30",
-      "description": "bash .venv/bin/python scripts/pre_migration_check.py",
-      "content_hash": "e8b78737134b"
+      "size_lines": 460,
+      "last_updated": "2026-08-15",
+      "description": "bash ./scripts/python_runtime.sh scripts/pre_migration_check.py",
+      "content_hash": "cc62b460fc3e"
     },
     {
       "name": "result-object-standard.md",
       "type": "documentation",
       "size_lines": 1437,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-08-15",
       "description": "This document defines standards for result objects returned by functions in structural_engineering_lib. Result objects replace primitive returns (tuples, dicts) with structured, self-documenting, type",
       "content_hash": "c613ac1f4ae5"
     }
   ],
   "subfolders": [],
-  "content_hash": "ee2ca6cc7bb777cd"
+  "content_hash": "7096a108d9400caa"
 }

--- a/docs/guidelines/index.md
+++ b/docs/guidelines/index.md
@@ -1,7 +1,7 @@
 # Guidelines
 
 **Type:** Documentation
-**Last Updated:** 2026-08-07
+**Last Updated:** 2026-08-15
 **Files:** 16
 
 ## Config Files
@@ -13,17 +13,17 @@
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Guidelines Index | Development standards and best practices for the structural  | 74 |
-| [ai-token-efficiency.md](ai-token-efficiency.md) |  | This is the canonical low-token operating policy for AI-assi | 206 |
+| [ai-token-efficiency.md](ai-token-efficiency.md) |  | This is the canonical low-token operating policy for AI-assi | 217 |
 | [api-design-guidelines.md](api-design-guidelines.md) |  | This document consolidates all Phase 1 and Phase 2 API resea | 2626 |
 | [api-evolution-standard.md](api-evolution-standard.md) |  | > **Standard for API versioning, deprecation, and backward c | 1691 |
 | [blog-writing-guide.md](blog-writing-guide.md) |  | | Audience | Tone | Example | |----------|------|---------| | 860 |
 | [doc-naming-conventions.md](doc-naming-conventions.md) |  | Reduce duplication, improve findability, and ensure every to | 92 |
 | [documentation-standard.md](documentation-standard.md) |  | > **Standard for documentation, docstrings, and API discover | 1614 |
 | [error-handling-standard.md](error-handling-standard.md) |  | > **Standard for exception design, error messages, and valid | 1935 |
-| [file-operations-safety-guide.md](file-operations-safety-guide.md) |  | File operations (delete, move, rename) can break: - Internal | 302 |
-| [folder-cleanup-workflow.md](folder-cleanup-workflow.md) |  | This workflow provides a systematic approach to cleaning up  | 288 |
+| [file-operations-safety-guide.md](file-operations-safety-guide.md) |  | File operations (delete, move, rename) can break: - Internal | 308 |
+| [folder-cleanup-workflow.md](folder-cleanup-workflow.md) |  | This workflow provides a systematic approach to cleaning up  | 294 |
 | [folder-structure-governance.md](folder-structure-governance.md) |  | 1. **Progressive Disclosure** - Short entry docs, detailed c | 530 |
 | [function-signature-standard.md](function-signature-standard.md) |  | This document defines the standard for function signatures i | 1352 |
 | [migration-preflight-checklist.md](migration-preflight-checklist.md) |  | bash .venv/bin/python scripts/pre_migration_check.py | 284 |
-| [migration-workflow-guide.md](migration-workflow-guide.md) |  | bash .venv/bin/python scripts/pre_migration_check.py | 459 |
+| [migration-workflow-guide.md](migration-workflow-guide.md) |  | bash ./scripts/python_runtime.sh scripts/pre_migration_check | 460 |
 | [result-object-standard.md](result-object-standard.md) |  | This document defines standards for result objects returned  | 1437 |

--- a/docs/guidelines/migration-workflow-guide.md
+++ b/docs/guidelines/migration-workflow-guide.md
@@ -24,17 +24,17 @@ tags: []
 
 ```bash
 # Pre-flight check (run first!)
-.venv/bin/python scripts/pre_migration_check.py
+./scripts/python_runtime.sh scripts/pre_migration_check.py
 
 # Migrate a single module
-.venv/bin/python scripts/migrate_module.py tables --dry-run
-.venv/bin/python scripts/migrate_module.py tables
+./scripts/python_runtime.sh scripts/migrate_module.py tables --dry-run
+./scripts/python_runtime.sh scripts/migrate_module.py tables
 
 # Check migration status
-.venv/bin/python scripts/migrate_module.py --list
+./scripts/python_runtime.sh scripts/migrate_module.py --list
 
 # Validate after migration
-.venv/bin/python scripts/validate_migration.py --verbose
+./scripts/python_runtime.sh scripts/validate_migration.py --verbose
 ```
 
 ---
@@ -80,12 +80,14 @@ structural_lib/flexure.py              (re-export stub)
 
 ### Step 0.1: Initialize Session
 ```bash
-.venv/bin/python scripts/start_session.py --quick
+./run.sh session brief --agent backend
+./run.sh session start
+./scripts/python_runtime.sh --diagnose
 ```
 
 ### Step 0.2: Run Pre-Flight Checks
 ```bash
-.venv/bin/python scripts/pre_migration_check.py
+./scripts/python_runtime.sh scripts/pre_migration_check.py
 ```
 
 **Expected output:**
@@ -107,7 +109,7 @@ structural_lib/flexure.py              (re-export stub)
 
 ### Step 0.3: Create Feature Branch
 ```bash
-git checkout -b feat/migrate-is456-modules
+git switch -c codex/migrate-is456-modules
 ```
 
 **Important:** This provides rollback safety.
@@ -118,7 +120,7 @@ git checkout -b feat/migrate-is456-modules
 
 ### Step 1.1: Preview Migration
 ```bash
-.venv/bin/python scripts/migrate_module.py tables --dry-run
+./scripts/python_runtime.sh scripts/migrate_module.py tables --dry-run
 ```
 
 **Review:**
@@ -128,7 +130,7 @@ git checkout -b feat/migrate-is456-modules
 
 ### Step 1.2: Execute Migration
 ```bash
-.venv/bin/python scripts/migrate_module.py tables
+./scripts/python_runtime.sh scripts/migrate_module.py tables
 ```
 
 **Expected:**
@@ -140,7 +142,7 @@ git checkout -b feat/migrate-is456-modules
 
 ### Step 1.3: Run Module Tests
 ```bash
-.venv/bin/python -m pytest Python/tests/test_tables*.py Python/tests/test_shear*.py -v
+./scripts/python_runtime.sh -m pytest Python/tests/test_tables*.py Python/tests/test_shear*.py -v
 ```
 
 Tests should pass unchanged.
@@ -157,14 +159,14 @@ git commit -m "refactor: migrate tables.py to codes/is456/"
 
 ### Step 2.1: Preview and Execute
 ```bash
-.venv/bin/python scripts/migrate_module.py shear --dry-run
-.venv/bin/python scripts/migrate_module.py shear
+./scripts/python_runtime.sh scripts/migrate_module.py shear --dry-run
+./scripts/python_runtime.sh scripts/migrate_module.py shear
 ```
 
 ### Step 2.2: Verify
 ```bash
-.venv/bin/python -m pytest Python/tests/test_shear*.py -v
-.venv/bin/python -c "from structural_lib.shear import design_shear; print('OK')"
+./scripts/python_runtime.sh -m pytest Python/tests/test_shear*.py -v
+./scripts/python_runtime.sh -c "from structural_lib.shear import design_shear; print('OK')"
 ```
 
 ### Step 2.3: Commit
@@ -179,14 +181,14 @@ git commit -m "refactor: migrate shear.py to codes/is456/"
 
 ### Step 3.1: Preview and Execute
 ```bash
-.venv/bin/python scripts/migrate_module.py flexure --dry-run
-.venv/bin/python scripts/migrate_module.py flexure
+./scripts/python_runtime.sh scripts/migrate_module.py flexure --dry-run
+./scripts/python_runtime.sh scripts/migrate_module.py flexure
 ```
 
 ### Step 3.2: Verify
 ```bash
-.venv/bin/python -m pytest Python/tests/test_flexure*.py -v
-.venv/bin/python -c "from structural_lib.flexure import design_singly_reinforced; print('OK')"
+./scripts/python_runtime.sh -m pytest Python/tests/test_flexure*.py -v
+./scripts/python_runtime.sh -c "from structural_lib.flexure import design_singly_reinforced; print('OK')"
 ```
 
 ### Step 3.3: Commit
@@ -201,13 +203,13 @@ git commit -m "refactor: migrate flexure.py to codes/is456/"
 
 ### Step 4.1: Preview and Execute
 ```bash
-.venv/bin/python scripts/migrate_module.py detailing --dry-run
-.venv/bin/python scripts/migrate_module.py detailing
+./scripts/python_runtime.sh scripts/migrate_module.py detailing --dry-run
+./scripts/python_runtime.sh scripts/migrate_module.py detailing
 ```
 
 ### Step 4.2: Verify
 ```bash
-.venv/bin/python -m pytest Python/tests/test_detailing*.py -v
+./scripts/python_runtime.sh -m pytest Python/tests/test_detailing*.py -v
 ```
 
 ### Step 4.3: Commit
@@ -222,13 +224,13 @@ git commit -m "refactor: migrate detailing.py to codes/is456/"
 
 ### Step 5.1: Preview and Execute
 ```bash
-.venv/bin/python scripts/migrate_module.py serviceability --dry-run
-.venv/bin/python scripts/migrate_module.py serviceability
+./scripts/python_runtime.sh scripts/migrate_module.py serviceability --dry-run
+./scripts/python_runtime.sh scripts/migrate_module.py serviceability
 ```
 
 ### Step 5.2: Verify
 ```bash
-.venv/bin/python -m pytest Python/tests/test_serviceability*.py -v
+./scripts/python_runtime.sh -m pytest Python/tests/test_serviceability*.py -v
 ```
 
 ### Step 5.3: Commit
@@ -243,13 +245,13 @@ git commit -m "refactor: migrate serviceability.py to codes/is456/"
 
 ### Step 6.1: Preview and Execute
 ```bash
-.venv/bin/python scripts/migrate_module.py compliance --dry-run
-.venv/bin/python scripts/migrate_module.py compliance
+./scripts/python_runtime.sh scripts/migrate_module.py compliance --dry-run
+./scripts/python_runtime.sh scripts/migrate_module.py compliance
 ```
 
 ### Step 6.2: Verify
 ```bash
-.venv/bin/python -m pytest Python/tests/test_compliance*.py -v
+./scripts/python_runtime.sh -m pytest Python/tests/test_compliance*.py -v
 ```
 
 ### Step 6.3: Commit
@@ -264,13 +266,13 @@ git commit -m "refactor: migrate compliance.py to codes/is456/"
 
 ### Step 7.1: Preview and Execute
 ```bash
-.venv/bin/python scripts/migrate_module.py ductile --dry-run
-.venv/bin/python scripts/migrate_module.py ductile
+./scripts/python_runtime.sh scripts/migrate_module.py ductile --dry-run
+./scripts/python_runtime.sh scripts/migrate_module.py ductile
 ```
 
 ### Step 7.2: Verify
 ```bash
-.venv/bin/python -m pytest Python/tests/test_ductile*.py -v
+./scripts/python_runtime.sh -m pytest Python/tests/test_ductile*.py -v
 ```
 
 ### Step 7.3: Commit
@@ -285,7 +287,7 @@ git commit -m "refactor: migrate ductile.py to codes/is456/"
 
 ### Step 8.1: Full Validation
 ```bash
-.venv/bin/python scripts/validate_migration.py --verbose --run-tests
+./scripts/python_runtime.sh scripts/validate_migration.py --verbose --run-tests
 ```
 
 **Expected:**
@@ -297,14 +299,14 @@ git commit -m "refactor: migrate ductile.py to codes/is456/"
 
 ### Step 8.2: Full Test Suite
 ```bash
-.venv/bin/python -m pytest Python/tests/ -v --tb=short
+./scripts/python_runtime.sh -m pytest Python/tests/ -v --tb=short
 ```
 
 All tests should pass.
 
 ### Step 8.3: API Verification
 ```bash
-.venv/bin/python -c "
+./scripts/python_runtime.sh -c "
 from structural_lib.api import design_beam_is456
 from structural_lib import flexure, shear, detailing
 from structural_lib.codes.is456 import IS456Code
@@ -340,29 +342,20 @@ git commit -m "refactor: complete IS 456 module migration"
 
 ### Rollback Single Module
 
-```bash
-# Restore original from git
-git checkout HEAD~1 -- Python/structural_lib/flexure.py
-
-# Remove migrated file
-rm Python/structural_lib/codes/is456/flexure.py
-
-# Verify
-.venv/bin/python -c "from structural_lib.flexure import design_singly_reinforced; print('OK')"
-```
+Stop and inspect the exact diff/commit. Have Codex restore only the intended
+file content after confirming ownership; do not discard a whole tree or lane.
+Preview any file removal with `scripts/safe_file_delete.py --dry-run` and stop
+if references or ownership are unresolved. Then rerun the focused import and
+module tests through `scripts/python_runtime.sh` before publication.
 
 ### Rollback All (Emergency)
 
-```bash
-# Return to main branch
-git checkout main
-
-# Delete feature branch
-git branch -D feat/migrate-is456-modules
-
-# Verify clean state
-.venv/bin/python scripts/pre_migration_check.py
-```
+Stop and preserve the exact branch, head, tree, operation, and worktree state.
+Use `scripts/git_state.py --json --worktrees`; failed or missing evidence is an
+`UNKNOWN` hold. Do not reset, switch away, stash, delete a branch/worktree, or
+rewrite history as rollback. Recover intended content on a fresh
+`codex/<task-slug>` lane only after ownership is known. Any later branch or
+worktree retirement is a separate exact-target decision.
 
 ---
 
@@ -380,7 +373,7 @@ git branch -D feat/migrate-is456-modules
 ls Python/structural_lib/codes/is456/flexure.py
 
 # If missing, re-run migration
-.venv/bin/python scripts/migrate_module.py flexure
+./scripts/python_runtime.sh scripts/migrate_module.py flexure
 ```
 
 ### Circular Import Error
@@ -407,7 +400,7 @@ cat Python/structural_lib/flexure.py
 
 # Should show "Backward compatibility stub"
 # If not, recreate:
-.venv/bin/python scripts/create_reexport_stub.py flexure
+./scripts/python_runtime.sh scripts/create_reexport_stub.py flexure
 ```
 
 ### Stub Has Wrong Content
@@ -419,7 +412,7 @@ cat Python/structural_lib/flexure.py
 **Fix:**
 ```bash
 # Manually create stub
-.venv/bin/python scripts/create_reexport_stub.py flexure
+./scripts/python_runtime.sh scripts/create_reexport_stub.py flexure
 ```
 
 ---

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4508,
+      "size_lines": 4526,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "018580afb239"
+      "content_hash": "8e94476a0be7"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "6d57dfa04c3a3d05"
+  "content_hash": "eb7bb17f3c50c294"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4365,
+      "size_lines": 4380,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "40ac20d2630b"
+      "content_hash": "ffa8871627fc"
     },
     {
       "name": "TASKS.md",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "5d416f83bb9e"
+      "content_hash": "c949329ba357"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "060e15932c408c6f"
+  "content_hash": "7cb7e5d8116b9224"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4693,
+      "size_lines": 4720,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "1053fa555b68"
+      "content_hash": "279adac3e313"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "846bc17af548f613"
+  "content_hash": "b0e517d4367b8c8a"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4653,
+      "size_lines": 4678,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "9b36341167c9"
+      "content_hash": "67aa62e9caeb"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "bfacf4db032f9d84"
+  "content_hash": "b82f307422d78c0d"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4483,
+      "size_lines": 4508,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "b6295505dd20"
+      "content_hash": "558128090db7"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "dde5205e7dc41cb7"
+  "content_hash": "27d4fa04d3ece4a4"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4526,
+      "size_lines": 4548,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "8d15c10f7a22"
+      "content_hash": "61ad18e6ef58"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "9a1e7237268ee691"
+  "content_hash": "2812a52d16f82c72"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4597,
+      "size_lines": 4606,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "3adbb5e3e294"
+      "content_hash": "8dc13393d3a0"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "7403059379597d58"
+  "content_hash": "9b1c738078e742da"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4592,
+      "size_lines": 4597,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "12f2c4f112ff"
+      "content_hash": "3adbb5e3e294"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "1a23c8991f224256"
+  "content_hash": "7403059379597d58"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4720,
+      "size_lines": 4736,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "279adac3e313"
+      "content_hash": "912e7cadb897"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "b0e517d4367b8c8a"
+  "content_hash": "add306db2ec3e9c4"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "7e0802e31254"
+      "content_hash": "75d8e7270f0d"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "a12ccde1630fd192"
+  "content_hash": "aaa634327365fc39"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4444,
+      "size_lines": 4461,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "6d841bca7a1b"
+      "content_hash": "5c0c32882ca9"
     },
     {
       "name": "TASKS.md",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "0632b465350d"
+      "content_hash": "17b6c6f4bc3e"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "b606be0ed601ab00"
+  "content_hash": "c65aefb62dafdfcb"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "9c4b701cb1a6"
+      "content_hash": "0632b465350d"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "b076fb1031031b11"
+  "content_hash": "b606be0ed601ab00"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4548,
+      "size_lines": 4592,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "1c8c53eebfe1"
+      "content_hash": "12f2c4f112ff"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "97f68c84007e1ea0"
+  "content_hash": "1a23c8991f224256"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "c949329ba357"
+      "content_hash": "e446ce070b7e"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "7cb7e5d8116b9224"
+  "content_hash": "52c0b200c8ef9700"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -21,7 +21,7 @@
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "61ad18e6ef58"
+      "content_hash": "1c8c53eebfe1"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "2812a52d16f82c72"
+  "content_hash": "97f68c84007e1ea0"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4349,
+      "size_lines": 4365,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "fe9470a5e386"
+      "content_hash": "40ac20d2630b"
     },
     {
       "name": "TASKS.md",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "d62f83dfccf2"
+      "content_hash": "5d416f83bb9e"
     }
   ],
   "subfolders": [
@@ -197,7 +197,7 @@
     {
       "name": "research",
       "path": "research/",
-      "file_count": 32
+      "file_count": 33
     },
     {
       "name": "specs",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "eb57ba7df719b902"
+  "content_hash": "060e15932c408c6f"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4678,
+      "size_lines": 4693,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "67aa62e9caeb"
+      "content_hash": "1053fa555b68"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "b82f307422d78c0d"
+  "content_hash": "846bc17af548f613"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4380,
+      "size_lines": 4425,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "ffa8871627fc"
+      "content_hash": "b09aa3f4d485"
     },
     {
       "name": "TASKS.md",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "e446ce070b7e"
+      "content_hash": "7e0802e31254"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "52c0b200c8ef9700"
+  "content_hash": "a12ccde1630fd192"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4425,
+      "size_lines": 4444,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "b09aa3f4d485"
+      "content_hash": "6d841bca7a1b"
     },
     {
       "name": "TASKS.md",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "75d8e7270f0d"
+      "content_hash": "9c4b701cb1a6"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "aaa634327365fc39"
+  "content_hash": "b076fb1031031b11"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -21,7 +21,7 @@
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "8e94476a0be7"
+      "content_hash": "8d15c10f7a22"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "eb7bb17f3c50c294"
+  "content_hash": "9a1e7237268ee691"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4606,
+      "size_lines": 4649,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "8dc13393d3a0"
+      "content_hash": "d5c24a5d3f37"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "9b1c738078e742da"
+  "content_hash": "2b12a31043fa750a"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4649,
+      "size_lines": 4653,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "d5c24a5d3f37"
+      "content_hash": "9b36341167c9"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "2b12a31043fa750a"
+  "content_hash": "bfacf4db032f9d84"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "17b6c6f4bc3e"
+      "content_hash": "857266bc705a"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "c65aefb62dafdfcb"
+  "content_hash": "e19571b8e7c062fc"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -21,7 +21,7 @@
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "558128090db7"
+      "content_hash": "018580afb239"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "27d4fa04d3ece4a4"
+  "content_hash": "6d57dfa04c3a3d05"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4461,
+      "size_lines": 4483,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "5c0c32882ca9"
+      "content_hash": "b6295505dd20"
     },
     {
       "name": "TASKS.md",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "857266bc705a"
+      "content_hash": "adb124ecc534"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "e19571b8e7c062fc"
+  "content_hash": "dde5205e7dc41cb7"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4153,
+      "size_lines": 4349,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "087e19d4bf0c"
+      "content_hash": "fe9470a5e386"
     },
     {
       "name": "TASKS.md",
@@ -30,7 +30,7 @@
       "last_updated": "2026-08-15",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "27d1451f78d4"
+      "content_hash": "49a8da2f8efe"
     },
     {
       "name": "WORKLOG.md",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "0cdab30a83d4"
+      "content_hash": "d62f83dfccf2"
     }
   ],
   "subfolders": [
@@ -130,7 +130,7 @@
     {
       "name": "git-automation",
       "path": "git-automation/",
-      "file_count": 4,
+      "file_count": 5,
       "description": "owner: Main Agent"
     },
     {
@@ -197,7 +197,7 @@
     {
       "name": "research",
       "path": "research/",
-      "file_count": 28
+      "file_count": 32
     },
     {
       "name": "specs",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "444516192dd8a896"
+  "content_hash": "eb57ba7df719b902"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4649 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4653 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4653 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4678 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4678 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4693 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4693 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4720 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4508 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4526 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4365 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4380 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4380 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4425 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4444 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4461 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4720 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4736 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4597 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4606 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4483 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4508 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4548 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4592 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4349 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4365 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
@@ -46,6 +46,6 @@ Guides, references, evidence, and contributor material for the
 | [planning/](planning/) | 19 |  |
 | [publications/](publications/) | 11 | This directory contains blog posts, technical articles, and academic papers docu |
 | [reference/](reference/) | 1792 |  |
-| [research/](research/) | 32 |  |
+| [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
 | [verification/](verification/) | 17 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4425 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4444 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4153 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4349 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
@@ -34,7 +34,7 @@ Guides, references, evidence, and contributor material for the
 | [cookbook/](cookbook/) | 5 | Task-focused recipes and code snippets for common structural engineering workflo |
 | [developers/](developers/) | 6 | > **For developers building on top of the structural_engineering_lib platform** |
 | [getting-started/](getting-started/) | 21 | Quick onboarding guides for new users of the structural engineering library. |
-| [git-automation/](git-automation/) | 4 | owner: Main Agent |
+| [git-automation/](git-automation/) | 5 | owner: Main Agent |
 | [governance/](governance/) | 1 |  |
 | [guidelines/](guidelines/) | 18 |  |
 | [guides/](guides/) | 11 | End-user and developer guides for specific workflows. |
@@ -46,6 +46,6 @@ Guides, references, evidence, and contributor material for the
 | [planning/](planning/) | 19 |  |
 | [publications/](publications/) | 11 | This directory contains blog posts, technical articles, and academic papers docu |
 | [reference/](reference/) | 1792 |  |
-| [research/](research/) | 28 |  |
+| [research/](research/) | 32 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
 | [verification/](verification/) | 17 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4526 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4548 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4606 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4649 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4461 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4483 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4592 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4597 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/learning-foundations/09-git.md
+++ b/docs/learning-foundations/09-git.md
@@ -9,6 +9,10 @@ tags: [learning, foundations]
 
 # Module 9: Git and Version Control
 
+> Repository-specific rule: use the canonical Codex-native workflow for live
+> work. `scripts/git_state.py` is the sole local-state authority; Codex owns
+> branch, commit, push, pull-request, and merge mutations after inspection.
+
 ## The Big Idea
 
 **Git** tracks every change to every file in your project. It's like an infinite undo button — you can go back to any point in history. More importantly, it lets multiple people work on the same project without overwriting each other's work.
@@ -164,28 +168,28 @@ Examples:
 ### Branch strategy:
 ```
 main (stable)
-├── TASK-042-column-design      ← Feature branch
-├── TASK-043-fix-shear-table    ← Bug fix branch
-└── TASK-044-update-docs        ← Docs branch
+├── codex/task-042-column-design      ← Feature branch
+├── codex/task-043-fix-shear-table    ← Bug fix branch
+└── codex/task-044-update-docs        ← Docs branch
 ```
 
 **Rules:**
 - `main` is always stable and deployable
 - Each task gets its own branch
 - Work on your branch, then merge via Pull Request
-- Never commit directly to `main` (for production code)
+- Never commit directly to `main`
 
 ### Create a branch:
 ```bash
 # Create and switch to a new branch
-git checkout -b TASK-042-column-design
+git switch -c codex/task-042-column-design
 
 # Work on it...
 git commit -m "feat(column): add axial capacity calculation"
 git commit -m "test(column): add benchmark tests"
 
 # Push the branch
-git push -u origin TASK-042-column-design
+git push -u origin codex/task-042-column-design
 ```
 
 ---
@@ -267,35 +271,24 @@ scripts/hooks/
 
 ---
 
-## Part 8: Git Automation — ai_commit.sh
+## Part 8: Repository Git Control Plane
 
-This project wraps Git in a safety script that prevents common mistakes.
+This project deliberately does not wrap the Git/GitHub lifecycle in a script.
+That prevents a helper from silently staging unrelated files, rewriting a
+branch, compressing failed evidence into success, or coupling merge to cleanup.
 
-### Why?
-```
-PROBLEM: Manual git is error-prone
-  git add .                      ← Might add temp files
-  git commit -m "fix stuff"      ← Bad message
-  git push                       ← Might push to wrong branch
+Start with the read-only authority:
 
-SOLUTION: One script handles everything
-  ./scripts/ai_commit.sh "fix(shear): correct tau_c for M25"
-  → Stages all changes
-  → Validates commit message
-  → Runs pre-commit hooks
-  → Pulls latest changes
-  → Pushes safely
-```
-
-### Script flags:
 ```bash
-./scripts/ai_commit.sh "type: message"    # Standard commit + push
-./scripts/ai_commit.sh "msg" --preview    # Show what would be committed
-./scripts/ai_commit.sh --undo             # Undo last unpushed commit
-./scripts/ai_commit.sh --status           # Show project state
-./scripts/ai_commit.sh --branch TASK-042 "column design"  # Create task branch
-./scripts/ai_commit.sh --finish "done"    # Merge PR + cleanup
+./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
+
+The output keeps local branch, head, upstream, default base, tree, operation,
+locks, and `NOT_CHECKED` remote freshness separate. A failed or missing query is
+`UNKNOWN` and therefore a hold. After reviewing that evidence, Codex creates a
+`codex/<task-slug>` lane, stages only intended paths, commits conventionally,
+pushes without rewriting history, and opens or updates a draft pull request.
+Merge and later branch/worktree retention are separate decisions.
 
 ---
 
@@ -342,7 +335,7 @@ __pycache__/
 | Mistake | What Happens | Fix |
 |---------|-------------|-----|
 | Committed secrets | Secrets in public history | Rotate credentials IMMEDIATELY. Use `git filter-branch` to remove |
-| Committed to wrong branch | Changes on main instead of feature | `git stash`, checkout correct branch, `git stash pop` |
+| Committed to wrong branch | Changes on main instead of feature | Stop, inspect exact state with `git_state.py`, preserve the commit/tree, and choose an authorized fresh-lane recovery path |
 | Bad commit message | "fix stuff" in history | `git commit --amend -m "fix(shear): correct tau_c"` (before push only) |
 | Merge conflicts | Two people changed same line | Edit the file, remove conflict markers, commit |
 | Accidentally deleted file | File gone | `git checkout HEAD -- path/to/file` |

--- a/docs/learning-foundations/09-git.md
+++ b/docs/learning-foundations/09-git.md
@@ -102,27 +102,27 @@ main:     A ── B ── C ── D ── M    ← M includes changes from E
 | `git log --oneline -10` | Show recent history | Understanding what happened |
 | `git diff` | Show exact changes | Before committing |
 | `git branch` | List branches | See where you are |
-| `git checkout -b name` | Create new branch | Starting new work |
-| `git add .` | Stage all changes | Preparing to commit |
-| `git commit -m "msg"` | Save a snapshot | After meaningful changes |
-| `git push` | Upload to GitHub | Share with others |
-| `git pull` | Download from GitHub | Get others' changes |
+| `./scripts/python_runtime.sh scripts/git_state.py --json` | Inspect bounded local state | Before any Git mutation |
+| `git add -- path/to/owned-file` | Stage one verified owned path | Only after inspecting the exact diff |
+| Codex commit | Save the reviewed scoped snapshot | After focused and quick gates |
+| Codex push/PR | Publish without rewriting history | After exact branch/head recheck |
+| Fresh remote evidence | Establish current hosted state | Never infer it from `NOT_CHECKED` |
 
 ### Example workflow:
 ```bash
 # 1. Check current state
-git status                    # What files changed?
-git branch                    # What branch am I on?
+./scripts/python_runtime.sh scripts/git_state.py --json
+git diff -- path/to/owned-file
 
 # 2. Make changes
 # ... edit files ...
 
 # 3. Stage and commit
-git add .                     # Stage all changes
-git commit -m "feat: add column design"
+git add -- path/to/owned-file # Stage only the inspected owned path
+# Codex creates the conventional commit after the required gates.
 
 # 4. Push to remote
-git push
+# Codex rechecks the exact head, then pushes and opens/updates the PR.
 ```
 
 ---
@@ -334,12 +334,12 @@ __pycache__/
 
 | Mistake | What Happens | Fix |
 |---------|-------------|-----|
-| Committed secrets | Secrets in public history | Rotate credentials IMMEDIATELY. Use `git filter-branch` to remove |
+| Committed secrets | Secrets in public history | Rotate credentials immediately; preserve the exact state and obtain an authorized, reviewed history-remediation plan |
 | Committed to wrong branch | Changes on main instead of feature | Stop, inspect exact state with `git_state.py`, preserve the commit/tree, and choose an authorized fresh-lane recovery path |
-| Bad commit message | "fix stuff" in history | `git commit --amend -m "fix(shear): correct tau_c"` (before push only) |
-| Merge conflicts | Two people changed same line | Edit the file, remove conflict markers, commit |
-| Accidentally deleted file | File gone | `git checkout HEAD -- path/to/file` |
-| Want to undo last commit | Realize mistake after commit | `git reset --soft HEAD~1` (keeps changes) |
+| Bad commit message | "fix stuff" in history | Stop before publication; preserve and inspect the exact commit, then let Codex apply the authorized correction |
+| Merge conflicts | Two people changed same line | Hold the operation, inspect owned paths and operation markers, then resolve through the canonical Codex workflow |
+| Accidentally deleted file | File gone | Inspect the exact path diff and ownership; preserve current evidence before an authorized path-scoped restoration |
+| Want to undo last commit | Realize mistake after commit | Preserve the commit/tree, inspect with `git_state.py`, and recover compatible intent on an authorized fresh `codex/*` lane |
 
 ### Merge conflict example:
 ```

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -111,7 +111,7 @@
       "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "6ae998374f8a"
+      "content_hash": "7a0bee42cfa3"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "68d19a2d8b91fece"
+  "content_hash": "53b628d9550cd4a2"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -107,11 +107,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 131,
+      "size_lines": 135,
       "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "57f8b53e2277"
+      "content_hash": "5e569a988ca6"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "0ec8053d6a7af6b4"
+  "content_hash": "bb12919f42f34b79"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -107,11 +107,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 127,
+      "size_lines": 131,
       "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "db1ff9e73568"
+      "content_hash": "57f8b53e2277"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "e1e1a15512855ef6"
+  "content_hash": "0ec8053d6a7af6b4"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -111,7 +111,7 @@
       "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "0dbafd6b442e"
+      "content_hash": "c9028816a80e"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "a8f3e25a73f99efe"
+  "content_hash": "501eda91b4b8e5f6"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -111,7 +111,7 @@
       "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "7a0bee42cfa3"
+      "content_hash": "0dbafd6b442e"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "53b628d9550cd4a2"
+  "content_hash": "a8f3e25a73f99efe"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -111,7 +111,7 @@
       "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "5e569a988ca6"
+      "content_hash": "6ae998374f8a"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "bb12919f42f34b79"
+  "content_hash": "68d19a2d8b91fece"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -20,7 +20,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 131 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 135 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -20,7 +20,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 127 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 131 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -5,8 +5,8 @@
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
 - Focus: Add semantic coherence over deterministically discovered maintained
-- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:378ab4bb4c8b1aa844dcd7b37c231f63d249f05948be10b31ff5a0ec31d68dc7 | HOLD
-- Git identity: codex/git-7e-semantic-handoff@866fb3e67092415578971d0c40f30b2323da14f6 | upstream=origin/codex/git-7e-semantic-handoff@84fb824e10ba19c701ff47294e44ef6021d5c07d | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
+- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:5855f9b66f365c3c5de3d6c00bb216a1ca23e5f3bf09dd60cd96951901bcfae0 | HOLD
+- Git identity: codex/git-7e-semantic-handoff@64315d12b2647d85f60327856840c59c290a556f | upstream=origin/codex/git-7e-semantic-handoff@07d145e5cfd72230556fdd25b3eddcce7c0eaa18 | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: WAIT_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -5,10 +5,10 @@
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
 - Focus: Add semantic coherence over deterministically discovered maintained
-- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:1f3757962fd982c356d2f261356f0f5a919350fc81ead16f4382d214012a47d5 | HOLD
-- Git identity: codex/git-7e-semantic-handoff@253e2524555f19fc475f29bc09b73c2d0040274b | upstream=origin/codex/git-7e-semantic-handoff@f452c5c32d9cd1fe89767fbfda26dc1719e5cc35 | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
+- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:378ab4bb4c8b1aa844dcd7b37c231f63d249f05948be10b31ff5a0ec31d68dc7 | HOLD
+- Git identity: codex/git-7e-semantic-handoff@866fb3e67092415578971d0c40f30b2323da14f6 | upstream=origin/codex/git-7e-semantic-handoff@84fb824e10ba19c701ff47294e44ef6021d5c07d | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
-- Next action: PUSH_UPDATED_HEAD_AND_PAUSE_FOR_EXACT_HEAD_AUDIT
+- Next action: WAIT_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,12 +4,12 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: eight-branch retirement proposal holds every target on unknown retention; exact-head PR audit is the next gate; GIT-7E is not started
+- Focus: PR #750 integrated the held retirement proposal; GIT-7E is active on a fresh verified-main lane and remains paused before any ready/merge transition
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha
 
-**Refreshed Git anchor:** `origin/main = 670ea4beeb2a8765fff59e05bb130ff54752369e`
+**Refreshed Git anchor:** `origin/main = b91838f594a04aff1d21c43bf6f87a64710b0748`
 
 **Task board:** [TASKS.md](../TASKS.md)
 
@@ -17,9 +17,9 @@
 |---|---|---|
 | **Complete** | GIT-7B, GIT-7C, and GIT-7D | State kernel, exact-head CI/server enforcement, targeted generation, and inspection-only disposition are integrated |
 | **Complete** | GIT-7D2 | PR #747 merged as `0a784de5`; closeout lessons PR #748 merged as `bf4065f0`; both reviewed/merge trees were equal |
-| **Current** | Eight-branch retirement proposal | All eight exact targets are held as `HOLD_UNKNOWN_OWNER` / `RETENTION_EVIDENCE_UNKNOWN`; proposal integration awaits independent exact-head audit |
+| **Complete** | Eight-branch retirement proposal | PR #750 squash-merged as `b91838f`; all eight exact targets remain `HOLD_UNKNOWN_OWNER` / `RETENTION_EVIDENCE_UNKNOWN` and no deletion is authorized |
 | **Next** | Retention decision | Owner must state `NO_RETENTION` or `RETAIN` for each exact SHA before any fresh classifier run or approval request |
-| **Not started** | GIT-7E | Semantic live-guidance coherence and durable read-only task-to-Git handoff remains separate |
+| **Current** | GIT-7E | Semantic live-guidance coherence and durable read-only task-to-Git handoff are being implemented; exact-head audit remains the ready/merge boundary |
 | **Owner decision** | Excel planning lane | Name an active owner/next action or separately authorize a complete retirement assessment |
 | **Separate maintenance** | Seven dependency PRs | Do not close or merge the existing Dependabot PRs in GIT-001 |
 
@@ -43,10 +43,11 @@
 ./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
 
-Refresh and verify `origin/main` before relying on this handoff. Create a fresh
-`codex/<task-slug>` branch/worktree from verified current main for separately
-authorized GIT-7E work. Do not extend, reset, rebase, merge into, or reconcile a
-preserved squash-diverged lane.
+Refresh and verify `origin/main` before relying on this handoff. Resume GIT-7E
+only from its exact receipt-bound branch/head, or create another fresh
+`codex/<task-slug>` lane from verified current main if that evidence is unknown.
+Do not extend, reset, rebase, merge into, or reconcile a preserved
+squash-diverged lane.
 
 ## Verified current Git facts
 
@@ -106,10 +107,11 @@ GIT-7E must prove:
 5. task/transcript archive state is never represented as Git retention proof;
 6. aliases resolve maintained commands without permitting obsolete mutations.
 
-GIT-7E does not refresh remote state, mutate GitHub, change disposition logic,
+GIT-7E does not itself refresh remote state, mutate GitHub, change disposition logic,
 authorize cleanup/deletion, synchronize preserved lanes, modify GIT-7D1/7D2
-behavior, publish a release, or change product code. It requires separate owner
-authorization before implementation.
+behavior, publish a release, or change product code. Implementation was
+authorized in the GIT-7E task delegation; ready/merge remains held for
+independent exact-head audit.
 
 ## Destructive-action holds
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -5,10 +5,10 @@
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
 - Focus: Add semantic coherence over deterministically discovered maintained
-- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:25d20a03c4cc6e7b16b2eb52826b8475a7220d35ce3ea91022d96755cf5fbdad | HOLD
-- Git identity: codex/git-7e-semantic-handoff@6694e8b99d7c37f8e7b5954e321b896ef29e92f9 | upstream=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
+- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:1f3757962fd982c356d2f261356f0f5a919350fc81ead16f4382d214012a47d5 | HOLD
+- Git identity: codex/git-7e-semantic-handoff@253e2524555f19fc475f29bc09b73c2d0040274b | upstream=origin/codex/git-7e-semantic-handoff@f452c5c32d9cd1fe89767fbfda26dc1719e5cc35 | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
-- Next action: PUBLISH_DRAFT_PR_AND_PAUSE_FOR_EXACT_HEAD_AUDIT
+- Next action: PUSH_UPDATED_HEAD_AND_PAUSE_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -1,10 +1,14 @@
 # Next Session Briefing
 
-## Latest Handoff
+## Latest Handoff (auto)
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: PR #750 integrated the held retirement proposal; GIT-7E is active on a fresh verified-main lane and remains paused before any ready/merge transition
+- Focus: Add semantic coherence over deterministically discovered maintained
+- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:25d20a03c4cc6e7b16b2eb52826b8475a7220d35ce3ea91022d96755cf5fbdad | HOLD
+- Git identity: codex/git-7e-semantic-handoff@6694e8b99d7c37f8e7b5954e321b896ef29e92f9 | upstream=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
+- Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
+- Next action: PUBLISH_DRAFT_PR_AND_PAUSE_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->
 
 **Current release:** `v0.23.1a1` Alpha

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -5,8 +5,8 @@
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
 - Focus: Add semantic coherence over deterministically discovered maintained
-- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:5855f9b66f365c3c5de3d6c00bb216a1ca23e5f3bf09dd60cd96951901bcfae0 | HOLD
-- Git identity: codex/git-7e-semantic-handoff@64315d12b2647d85f60327856840c59c290a556f | upstream=origin/codex/git-7e-semantic-handoff@07d145e5cfd72230556fdd25b3eddcce7c0eaa18 | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
+- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:8ff1c88f16c39aa5ecb22d32916d199585bc6946ac87844d160ce04134132a97 | HOLD
+- Git identity: codex/git-7e-semantic-handoff@f7fcdb26a576399dd7b6462dc6e6132fa4798e2b | upstream=origin/codex/git-7e-semantic-handoff@942eddeca7ca225b62e8514826305e00d2322e48 | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: WAIT_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->

--- a/docs/research/git-governance/GIT-001-README.md
+++ b/docs/research/git-governance/GIT-001-README.md
@@ -21,9 +21,9 @@ and now includes the owner-accepted GIT-7B read-only state/intake contract.
 GIT-7C1 is integrated, GIT-7C2 server enforcement is applied, and GIT-7D is
 complete: GIT-7D1 integrated through PR #746, while GIT-7D2 integrated through
 PRs #747-#748 and has a non-destructive preservation/disposition reconciliation.
-The follow-on eight-branch retirement proposal holds all exact targets on
-unknown retention. GIT-7E semantic guidance and durable handoff are explicitly
-not started and remain a separate packet.
+The follow-on eight-branch retirement proposal was integrated by PR #750 as
+`b91838f` and still holds all exact targets on unknown retention. GIT-7E
+semantic guidance and durable handoff are active as a separate packet.
 
 ## Objective
 
@@ -52,7 +52,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 | 4 | Operating-model design | Complete as proposal | Four control planes, one typed state model, lane lifecycle, permissions, CI/server policy, recovery, and four packets defined |
 | 5 | Scenario validation | Complete for proposal | Disposable Git and live read-only checks reproduce current defects, validate primitives, and define falsifiable GIT-7B–7E gates |
 | 6 | Canonical policy proposal | Accepted 2026-08-13 | Owner accepted the operating model and authorized GIT-7B only |
-| 7 | Controlled implementation | 7A-7D complete; eight-branch proposal held; GIT-7E not started | GIT-7D2 merged through PRs #747-#748; the exact follow-on proposal returns `RETENTION_EVIDENCE_UNKNOWN` for all eight targets and authorizes no deletion |
+| 7 | Controlled implementation | 7A-7D complete; retirement proposal integrated with holds; GIT-7E active | GIT-7D2 merged through PRs #747-#748; PR #750 integrated the held proposal; GIT-7E exact-head audit is pending and no deletion is authorized |
 | 8 | Adoption and closeout | Not started | Integrated workflow verified; supersession and maintenance established |
 
 ## Artifact map
@@ -77,7 +77,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 - [Eight-branch retirement authorization proposal](GIT-001-eight-branch-retirement-authorization-proposal.md)
 - [Eight-branch machine-readable proposal receipt](GIT-001-eight-branch-retirement-authorization-proposal.json)
 - [Eight-branch classifier caller evidence](GIT-001-eight-branch-retirement-classifier-evidence.json)
-- Phase 7E durable handoff — planned
+- [Phase 7E semantic coherence and durable handoff](GIT-001-phase-7E-semantic-handoff.md)
 - Phase 8 adoption/closeout report — planned
 
 ## Ownership and non-goals

--- a/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
+++ b/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
@@ -53,6 +53,14 @@ The versioned JSON receipt records:
   Git-retention evidence; and
 - authorized/prohibited actions plus the exact next-action boundary.
 
+The receipt is evidence, not an authorization grant:
+`receipt_grants_authority` is always `false`. A recorded authorization needs a
+typed external source/reference/time and an exact task/branch/head/action
+binding. Stored validation recomputes the authoritative hold set from the facts
+instead of trusting serialized `holds` or `receipt_status`; editing actions,
+clearing holds, or writing `READY` cannot suppress independently required
+unknown, stale, query, identity, review, check, or retention holds.
+
 Missing, malformed, stale, query-failed, contradictory, or unreasoned
 `NOT_APPLICABLE` evidence yields `UNKNOWN`/`HOLD`. A squash merge is content
 evidence only when reviewed and merged trees match; it never implies ancestry

--- a/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
+++ b/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
@@ -56,8 +56,10 @@ The versioned JSON receipt records:
 The receipt is evidence, not an authorization grant:
 `receipt_grants_authority` is always `false`. A recorded authorization needs a
 typed external source/reference/time and an exact task/branch/head/action
-binding. Authorization and source observations use the same fail-closed
-freshness/query boundary as other evidence. `next_action` is limited to a closed
+binding. Authorization and nested source observations retain their own
+caller-supplied status/query/time and use the same fail-closed freshness/query
+boundary as other evidence; validation never upgrades them. `next_action` is
+limited to a closed
 safe hold/wait action or an externally authorized action bound to the exact
 target; an injected merge or destructive action is never self-authorizing.
 Stored validation recomputes the authoritative hold set from the facts

--- a/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
+++ b/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
@@ -1,0 +1,75 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: spec
+task: GIT-7E
+---
+
+# GIT-7E — Semantic Live Guidance and Durable Git Handoff
+
+## Exact boundary
+
+GIT-7E started at `2026-08-15T09:12:34Z` on
+`codex/git-7e-semantic-handoff` from freshly fetched and independently verified
+`origin/main = b91838f594a04aff1d21c43bf6f87a64710b0748` (merged PR #750).
+It changes instruction coherence and task handoff only. GIT-7D1/GIT-7D2,
+retirement classification, preserved lanes, remote refresh, deletion, release,
+and product/IS-code behavior remain unchanged.
+
+## Semantic rules
+
+`docs/git-automation/live-git-guidance-index.json` deterministically discovers
+maintained exact files, globs, and active indexed guide entries. An indexed
+deprecated entry is historical only when its opening text explicitly identifies
+it as historical, archived, or legacy. Repository archives are excluded by
+named paths. A file cannot silently escape validation merely by containing a
+deprecated metadata field.
+
+The semantic checker rejects live guidance that restores retired wrappers,
+cleanup entrypoints, destructive recovery, non-Codex task branches, direct
+lifecycle ownership, or remote-current claims based on `NOT_CHECKED`. Required
+contracts bind maintained session and handoff surfaces to `git_state.py`, the
+receipt, source-bound runtime diagnosis, inspection-only disposition, explicit
+unknowns, and reasoned `NOT_APPLICABLE`.
+
+## Receipt contract
+
+`scripts/git_handoff_receipt.py` is a read-only evidence consumer. It obtains
+local Git facts only through `scripts/git_state.py`; it contains no independent
+Git or network query and performs no fetch, prune, ref, worktree, or GitHub
+mutation. Caller-supplied hosted evidence is accepted only when fresh,
+query-successful, structurally complete, and exact-head-bound.
+
+The versioned JSON receipt records:
+
+- task, integration owner, and owned/shared/forbidden paths;
+- local branch, full head, upstream, base relation, worktree, dirty state,
+  operation, source identity, and a canonical local-state hash;
+- remote identity/freshness or explicit `NOT_CHECKED`;
+- PR number/state/base/head/merge state and exact-head required checks;
+- reviewed base/head/tree and squash tree-equivalence evidence;
+- retention owner/decision/holds, while marking task archive state as never
+  Git-retention evidence; and
+- authorized/prohibited actions plus the exact next-action boundary.
+
+Missing, malformed, stale, query-failed, contradictory, or unreasoned
+`NOT_APPLICABLE` evidence yields `UNKNOWN`/`HOLD`. A squash merge is content
+evidence only when reviewed and merged trees match; it never implies ancestry
+or retirement authority. `session handoff` persists the receipt path/hash and
+identity summary, and `session end` validates its schema, hashes, freshness,
+contradictions, and round trip.
+
+## Validation boundary
+
+Focused regressions cover all six Phase 5 scenarios: live contradiction
+rejection, coherent guidance, explicit archive/historical handling, local
+identity round trip, exact hosted evidence or unknown holds, archive/retention
+separation, and maintained aliases. The packet must also pass the semantic Git
+workflow check, strict documentation/index checks, quick 10/10, full 30/30,
+efficiency, and session-end validation.
+
+Opening a draft PR is authorized after local green. Ready/merge is held until
+the supervising orchestrator independently audits the exact PR base, head, and
+tree. Feature branch/worktree retention remains required; no cleanup or
+deletion is part of this packet.

--- a/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
+++ b/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
@@ -56,7 +56,11 @@ The versioned JSON receipt records:
 The receipt is evidence, not an authorization grant:
 `receipt_grants_authority` is always `false`. A recorded authorization needs a
 typed external source/reference/time and an exact task/branch/head/action
-binding. Stored validation recomputes the authoritative hold set from the facts
+binding. Authorization and source observations use the same fail-closed
+freshness/query boundary as other evidence. `next_action` is limited to a closed
+safe hold/wait action or an externally authorized action bound to the exact
+target; an injected merge or destructive action is never self-authorizing.
+Stored validation recomputes the authoritative hold set from the facts
 instead of trusting serialized `holds` or `receipt_status`; editing actions,
 clearing holds, or writing `READY` cannot suppress independently required
 unknown, stale, query, identity, review, check, or retention holds.

--- a/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
+++ b/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
@@ -34,10 +34,13 @@ receipt, source-bound runtime diagnosis, inspection-only disposition, explicit
 unknowns, and reasoned `NOT_APPLICABLE`.
 
 Unsafe Git expressions in maintained guidance fail closed regardless of the
-surrounding imperative verb. A negation is safe only when its local clause
-governs that exact expression; unrelated earlier `never`/`do not` text cannot
-suppress a later instruction. Clearly labeled past-tense historical narration
-remains evidence rather than current authority.
+surrounding imperative verb. A negation is safe only when the unsafe action
+verb directly follows and is governed by that negation, or when a tested suffix
+prohibition governs the exact matched expression. Negated reminders or
+encouragement such as `do not forget to run` remain instructions. Unrelated
+earlier `never`/`do not` text cannot suppress a later instruction. Clearly
+labeled past-tense historical narration remains evidence rather than current
+authority.
 
 ## Receipt contract
 

--- a/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
+++ b/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
@@ -34,11 +34,12 @@ receipt, source-bound runtime diagnosis, inspection-only disposition, explicit
 unknowns, and reasoned `NOT_APPLICABLE`.
 
 Unsafe Git expressions in maintained guidance fail closed regardless of the
-surrounding imperative verb. A negation is safe only when the unsafe action
-verb directly follows and is governed by that negation, or when a tested suffix
-prohibition governs the exact matched expression. Negated reminders or
-encouragement such as `do not forget to run` remain instructions. Unrelated
-earlier `never`/`do not` text cannot suppress a later instruction. Clearly
+surrounding imperative verb. The nearest governing action determines whether a
+negation is safe: a direct prefix or exact-object suffix prohibition, inner
+`not to <action>`, or non-negated `avoid <action>` prohibits the expression.
+Negated reminders or encouragement such as `do not forget to run` remain
+instructions, while `never forget not to run` preserves the inner prohibition.
+Unrelated earlier or later clauses cannot suppress an instruction. Clearly
 labeled past-tense historical narration remains evidence rather than current
 authority.
 

--- a/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
+++ b/docs/research/git-governance/GIT-001-phase-7E-semantic-handoff.md
@@ -33,6 +33,12 @@ contracts bind maintained session and handoff surfaces to `git_state.py`, the
 receipt, source-bound runtime diagnosis, inspection-only disposition, explicit
 unknowns, and reasoned `NOT_APPLICABLE`.
 
+Unsafe Git expressions in maintained guidance fail closed regardless of the
+surrounding imperative verb. A negation is safe only when its local clause
+governs that exact expression; unrelated earlier `never`/`do not` text cannot
+suppress a later instruction. Clearly labeled past-tense historical narration
+remains evidence rather than current authority.
+
 ## Receipt contract
 
 `scripts/git_handoff_receipt.py` is a read-only evidence consumer. It obtains

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T10:31:31Z",
+      "observed_at_utc": "2026-08-15T10:42:16Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:third-auditor-blocker-fix",
+      "reference": "task:GIT-7E:fourth-auditor-blocker-fix",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T10:31:31Z",
+    "observed_at_utc": "2026-08-15T10:42:16Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "64315d12b2647d85f60327856840c59c290a556f",
+      "head_sha": "f7fcdb26a576399dd7b6462dc6e6132fa4798e2b",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "5855f9b66f365c3c5de3d6c00bb216a1ca23e5f3bf09dd60cd96951901bcfae0",
+    "receipt_sha256": "8ff1c88f16c39aa5ecb22d32916d199585bc6946ac87844d160ce04134132a97",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 7,
+        "ahead": 9,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 90.468,
+      "duration_ms": 91.646,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "64315d12b2647d85f60327856840c59c290a556f",
+      "head_sha": "f7fcdb26a576399dd7b6462dc6e6132fa4798e2b",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T10:31:48.612198+00:00",
+      "observed_at_utc": "2026-08-15T10:42:32.771864+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "07d145e5cfd72230556fdd25b3eddcce7c0eaa18",
+        "sha": "942eddeca7ca225b62e8514826305e00d2322e48",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:5855f9b66f365c3c5de3d6c00bb216a1ca23e5f3bf09dd60cd96951901bcfae0",
+  "local_state_receipt_hash": "sha256:8ff1c88f16c39aa5ecb22d32916d199585bc6946ac87844d160ce04134132a97",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T10:31:48.612360+00:00",
+  "observed_at_utc": "2026-08-15T10:42:32.772072+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T10:31:31Z",
+    "observed_at_utc": "2026-08-15T10:42:16Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T11:20:21Z",
+      "observed_at_utc": "2026-08-15T11:32:16Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:seventh-auditor-blocker-fix",
+      "reference": "task:GIT-7E:eighth-auditor-blocker-fix",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T11:20:21Z",
+    "observed_at_utc": "2026-08-15T11:32:16Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "a8b7b8b125643b11e4d6f919059a402472d85a15",
+      "head_sha": "d217a05eedc750c14db81ea8e35cc903d12b45db",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "6b1fc4ae811523b44d9e47b5aa6c5c53b410dfc1d68d275e4f1f0872a6130dd7",
+    "receipt_sha256": "fd37151219040970cea505b8510036161893215038e211ccd327a9295a150a2d",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 15,
+        "ahead": 17,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 83.337,
+      "duration_ms": 84.124,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "a8b7b8b125643b11e4d6f919059a402472d85a15",
+      "head_sha": "d217a05eedc750c14db81ea8e35cc903d12b45db",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T11:20:38.450648+00:00",
+      "observed_at_utc": "2026-08-15T11:32:32.562615+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "4d98b339487dde4c8da8a9ff08b32f23e736639a",
+        "sha": "bc06470d2d1a16edf73128dee025594a92f5f9cd",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:6b1fc4ae811523b44d9e47b5aa6c5c53b410dfc1d68d275e4f1f0872a6130dd7",
+  "local_state_receipt_hash": "sha256:fd37151219040970cea505b8510036161893215038e211ccd327a9295a150a2d",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T11:20:38.450792+00:00",
+  "observed_at_utc": "2026-08-15T11:32:32.562765+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T11:20:21Z",
+    "observed_at_utc": "2026-08-15T11:32:16Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T11:32:16Z",
+      "observed_at_utc": "2026-08-15T11:52:51Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:eighth-auditor-blocker-fix",
+      "reference": "task:GIT-7E:ninth-auditor-blocker-fix",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T11:32:16Z",
+    "observed_at_utc": "2026-08-15T11:52:51Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "d217a05eedc750c14db81ea8e35cc903d12b45db",
+      "head_sha": "5f72bd3458a98901913c07e42ab9fb724fb1c74c",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "fd37151219040970cea505b8510036161893215038e211ccd327a9295a150a2d",
+    "receipt_sha256": "81d69320a93b2408ea9d417f71f0beb87e478ef47851fbce442c48ed50de9741",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 17,
+        "ahead": 19,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 84.124,
+      "duration_ms": 82.148,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "d217a05eedc750c14db81ea8e35cc903d12b45db",
+      "head_sha": "5f72bd3458a98901913c07e42ab9fb724fb1c74c",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T11:32:32.562615+00:00",
+      "observed_at_utc": "2026-08-15T11:53:08.264840+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "bc06470d2d1a16edf73128dee025594a92f5f9cd",
+        "sha": "dc8af427c254f6dce355104d694a33ec2fa84e57",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:fd37151219040970cea505b8510036161893215038e211ccd327a9295a150a2d",
+  "local_state_receipt_hash": "sha256:81d69320a93b2408ea9d417f71f0beb87e478ef47851fbce442c48ed50de9741",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T11:32:32.562765+00:00",
+  "observed_at_utc": "2026-08-15T11:53:08.264979+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T11:32:16Z",
+    "observed_at_utc": "2026-08-15T11:52:51Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -1,11 +1,16 @@
 {
   "authorization": {
+    "authority_source": {
+      "kind": "ORCHESTRATOR_DELEGATION",
+      "observed_at_utc": "2026-08-15T09:58:35Z",
+      "reference": "task:GIT-7E:auditor-blocker-fix"
+    },
     "authorized_actions": [
       "COMMIT_INTENDED_PATHS",
       "PUSH_FEATURE_BRANCH",
-      "OPEN_DRAFT_PR"
+      "UPDATE_DRAFT_PR"
     ],
-    "next_action": "PUBLISH_DRAFT_PR_AND_PAUSE_FOR_EXACT_HEAD_AUDIT",
+    "next_action": "PUSH_UPDATED_HEAD_AND_PAUSE_FOR_EXACT_HEAD_AUDIT",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -13,7 +18,17 @@
       "DELETE_WORKTREE",
       "DELETE_REF"
     ],
-    "status": "OBSERVED"
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/git-7e-semantic-handoff",
+      "head_sha": "253e2524555f19fc475f29bc09b73c2d0040274b",
+      "task_id": "GIT-7E"
+    }
   },
   "holds": [
     "PULL_REQUEST_NOT_CHECKED",
@@ -27,25 +42,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "25d20a03c4cc6e7b16b2eb52826b8475a7220d35ce3ea91022d96755cf5fbdad",
+    "receipt_sha256": "1f3757962fd982c356d2f261356f0f5a919350fc81ead16f4382d214012a47d5",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 1,
+        "ahead": 3,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 85.11,
+      "duration_ms": 85.354,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "6694e8b99d7c37f8e7b5954e321b896ef29e92f9",
+      "head_sha": "253e2524555f19fc475f29bc09b73c2d0040274b",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T09:42:42.177207+00:00",
+      "observed_at_utc": "2026-08-15T09:58:55.275167+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -64,20 +79,21 @@
       "upstream": {
         "ahead": 1,
         "behind": 0,
-        "ref": "origin/main",
-        "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
+        "ref": "origin/codex/git-7e-semantic-handoff",
+        "sha": "f452c5c32d9cd1fe89767fbfda26dc1719e5cc35",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:25d20a03c4cc6e7b16b2eb52826b8475a7220d35ce3ea91022d96755cf5fbdad",
+  "local_state_receipt_hash": "sha256:1f3757962fd982c356d2f261356f0f5a919350fc81ead16f4382d214012a47d5",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T09:42:42.177344+00:00",
+  "observed_at_utc": "2026-08-15T09:58:55.275302+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
   },
+  "receipt_grants_authority": false,
   "receipt_kind": "task_to_git_handoff",
   "receipt_status": "HOLD",
   "remote": {
@@ -87,7 +103,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T09:42:12Z",
+    "observed_at_utc": "2026-08-15T09:58:35Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,8 +2,10 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T10:18:28Z",
-      "reference": "task:GIT-7E:second-auditor-blocker-fix"
+      "observed_at_utc": "2026-08-15T10:31:31Z",
+      "query_status": "OK",
+      "reference": "task:GIT-7E:third-auditor-blocker-fix",
+      "status": "OBSERVED"
     },
     "authorized_actions": [
       "COMMIT_INTENDED_PATHS",
@@ -11,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T10:18:28Z",
+    "observed_at_utc": "2026-08-15T10:31:31Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -28,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "866fb3e67092415578971d0c40f30b2323da14f6",
+      "head_sha": "64315d12b2647d85f60327856840c59c290a556f",
       "task_id": "GIT-7E"
     }
   },
@@ -44,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "378ab4bb4c8b1aa844dcd7b37c231f63d249f05948be10b31ff5a0ec31d68dc7",
+    "receipt_sha256": "5855f9b66f365c3c5de3d6c00bb216a1ca23e5f3bf09dd60cd96951901bcfae0",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 5,
+        "ahead": 7,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 87.902,
+      "duration_ms": 90.468,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "866fb3e67092415578971d0c40f30b2323da14f6",
+      "head_sha": "64315d12b2647d85f60327856840c59c290a556f",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T10:18:46.075331+00:00",
+      "observed_at_utc": "2026-08-15T10:31:48.612198+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -82,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "84fb824e10ba19c701ff47294e44ef6021d5c07d",
+        "sha": "07d145e5cfd72230556fdd25b3eddcce7c0eaa18",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:378ab4bb4c8b1aa844dcd7b37c231f63d249f05948be10b31ff5a0ec31d68dc7",
+  "local_state_receipt_hash": "sha256:5855f9b66f365c3c5de3d6c00bb216a1ca23e5f3bf09dd60cd96951901bcfae0",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T10:18:46.075486+00:00",
+  "observed_at_utc": "2026-08-15T10:31:48.612360+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -105,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T10:18:28Z",
+    "observed_at_utc": "2026-08-15T10:31:31Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,15 +2,16 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T09:58:35Z",
-      "reference": "task:GIT-7E:auditor-blocker-fix"
+      "observed_at_utc": "2026-08-15T10:18:28Z",
+      "reference": "task:GIT-7E:second-auditor-blocker-fix"
     },
     "authorized_actions": [
       "COMMIT_INTENDED_PATHS",
       "PUSH_FEATURE_BRANCH",
       "UPDATE_DRAFT_PR"
     ],
-    "next_action": "PUSH_UPDATED_HEAD_AND_PAUSE_FOR_EXACT_HEAD_AUDIT",
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-15T10:18:28Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -18,6 +19,7 @@
       "DELETE_WORKTREE",
       "DELETE_REF"
     ],
+    "query_status": "OK",
     "status": "OBSERVED",
     "target_binding": {
       "actions": [
@@ -26,7 +28,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "253e2524555f19fc475f29bc09b73c2d0040274b",
+      "head_sha": "866fb3e67092415578971d0c40f30b2323da14f6",
       "task_id": "GIT-7E"
     }
   },
@@ -42,25 +44,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "1f3757962fd982c356d2f261356f0f5a919350fc81ead16f4382d214012a47d5",
+    "receipt_sha256": "378ab4bb4c8b1aa844dcd7b37c231f63d249f05948be10b31ff5a0ec31d68dc7",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 3,
+        "ahead": 5,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 85.354,
+      "duration_ms": 87.902,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "253e2524555f19fc475f29bc09b73c2d0040274b",
+      "head_sha": "866fb3e67092415578971d0c40f30b2323da14f6",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T09:58:55.275167+00:00",
+      "observed_at_utc": "2026-08-15T10:18:46.075331+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -80,15 +82,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "f452c5c32d9cd1fe89767fbfda26dc1719e5cc35",
+        "sha": "84fb824e10ba19c701ff47294e44ef6021d5c07d",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:1f3757962fd982c356d2f261356f0f5a919350fc81ead16f4382d214012a47d5",
+  "local_state_receipt_hash": "sha256:378ab4bb4c8b1aa844dcd7b37c231f63d249f05948be10b31ff5a0ec31d68dc7",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T09:58:55.275302+00:00",
+  "observed_at_utc": "2026-08-15T10:18:46.075486+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -103,7 +105,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T09:58:35Z",
+    "observed_at_utc": "2026-08-15T10:18:28Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T10:42:16Z",
+      "observed_at_utc": "2026-08-15T10:54:36Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:fourth-auditor-blocker-fix",
+      "reference": "task:GIT-7E:fifth-auditor-blocker-fix",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T10:42:16Z",
+    "observed_at_utc": "2026-08-15T10:54:36Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "f7fcdb26a576399dd7b6462dc6e6132fa4798e2b",
+      "head_sha": "bd75d54161ba21e292f94cb4f2de51174837c79a",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "8ff1c88f16c39aa5ecb22d32916d199585bc6946ac87844d160ce04134132a97",
+    "receipt_sha256": "00fab8808de654105de67670e507f4637cdb425e02272b84d84bea26defdb82c",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 9,
+        "ahead": 11,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 91.646,
+      "duration_ms": 90.342,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "f7fcdb26a576399dd7b6462dc6e6132fa4798e2b",
+      "head_sha": "bd75d54161ba21e292f94cb4f2de51174837c79a",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T10:42:32.771864+00:00",
+      "observed_at_utc": "2026-08-15T10:55:02.901857+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "942eddeca7ca225b62e8514826305e00d2322e48",
+        "sha": "18dd8576d92c8a808601143652894b3cccdbc974",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:8ff1c88f16c39aa5ecb22d32916d199585bc6946ac87844d160ce04134132a97",
+  "local_state_receipt_hash": "sha256:00fab8808de654105de67670e507f4637cdb425e02272b84d84bea26defdb82c",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T10:42:32.772072+00:00",
+  "observed_at_utc": "2026-08-15T10:55:02.902002+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T10:42:16Z",
+    "observed_at_utc": "2026-08-15T10:54:36Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -1,0 +1,121 @@
+{
+  "authorization": {
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "OPEN_DRAFT_PR"
+    ],
+    "next_action": "PUBLISH_DRAFT_PR_AND_PAUSE_FOR_EXACT_HEAD_AUDIT",
+    "prohibited_actions": [
+      "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
+      "MERGE_BEFORE_EXACT_HEAD_AUDIT",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF"
+    ],
+    "status": "OBSERVED"
+  },
+  "holds": [
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "DRAFT_PR_NOT_OPEN_AT_RECEIPT_OBSERVATION",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "25d20a03c4cc6e7b16b2eb52826b8475a7220d35ce3ea91022d96755cf5fbdad",
+    "state": {
+      "branch": "codex/git-7e-semantic-handoff",
+      "default_base": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
+        "status": "ahead"
+      },
+      "derived_action": "READY_LOCAL",
+      "duration_ms": 85.11,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
+      "head_sha": "6694e8b99d7c37f8e7b5954e321b896ef29e92f9",
+      "hold_reasons": [],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-15T09:42:42.177207+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": true,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": true,
+        "conflicted_paths": [],
+        "dirty_count": 0,
+        "modified_paths": [],
+        "staged_paths": [],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
+        "status": "ahead"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:25d20a03c4cc6e7b16b2eb52826b8475a7220d35ce3ea91022d96755cf5fbdad",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-15T09:42:42.177344+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-15T09:42:12Z",
+    "owner": "supervising orchestrator task delegation",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "refs/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "scripts/git_handoff_receipt.py",
+      "scripts/check_codex_git_workflow.py",
+      "scripts/session.py"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "GIT-7E"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T12:34:01Z",
+      "observed_at_utc": "2026-08-15T12:52:30Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:twelfth-auditor-blocker-fix",
+      "reference": "task:GIT-7E:local-independent-pass-closeout",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T12:34:01Z",
+    "observed_at_utc": "2026-08-15T12:52:30Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "d8d6269cfc20356088361ef58a6990c21dd3df41",
+      "head_sha": "abfdb968991290504a8facaab2172fa09876bae1",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "05100369e50b3c9fd495f160439171572bedb1ab0cf24204d1d1abb80473e091",
+    "receipt_sha256": "5ad2b548fab290b7a59635b7d2bb7f32c0abf4b85e695c4e240ef34a1f0e0dd0",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 25,
+        "ahead": 28,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 89.301,
+      "duration_ms": 89.159,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "d8d6269cfc20356088361ef58a6990c21dd3df41",
+      "head_sha": "abfdb968991290504a8facaab2172fa09876bae1",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T12:34:25.158690+00:00",
+      "observed_at_utc": "2026-08-15T12:54:14.262087+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "b5f4197f09952af206d6572e447bf391b2d03fac",
+        "sha": "048a1e2a1a4a79bae5ecf0359467ac68019cfac3",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:05100369e50b3c9fd495f160439171572bedb1ab0cf24204d1d1abb80473e091",
+  "local_state_receipt_hash": "sha256:5ad2b548fab290b7a59635b7d2bb7f32c0abf4b85e695c4e240ef34a1f0e0dd0",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T12:34:25.158834+00:00",
+  "observed_at_utc": "2026-08-15T12:54:14.262232+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T12:34:01Z",
+    "observed_at_utc": "2026-08-15T12:52:30Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -41,7 +41,7 @@
   ],
   "integration": {
     "query_status": "UNKNOWN",
-    "reason_code": "DRAFT_PR_NOT_OPEN_AT_RECEIPT_OBSERVATION",
+    "reason_code": "NO_INTEGRATION_CLAIM_PRE_AUDIT",
     "status": "NOT_APPLICABLE"
   },
   "local": {

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T12:16:06Z",
+      "observed_at_utc": "2026-08-15T12:34:01Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:eleventh-auditor-blocker-fix",
+      "reference": "task:GIT-7E:twelfth-auditor-blocker-fix",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T12:16:06Z",
+    "observed_at_utc": "2026-08-15T12:34:01Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "285718ba0d5028a9f0334633463aaee5f0637280",
+      "head_sha": "d8d6269cfc20356088361ef58a6990c21dd3df41",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "ca5c3e527a8fd269a743c00fc6071865bbbd51243621b48a1226520e08a77b3d",
+    "receipt_sha256": "05100369e50b3c9fd495f160439171572bedb1ab0cf24204d1d1abb80473e091",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 22,
+        "ahead": 25,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 82.418,
+      "duration_ms": 89.301,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "285718ba0d5028a9f0334633463aaee5f0637280",
+      "head_sha": "d8d6269cfc20356088361ef58a6990c21dd3df41",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T12:16:26.423397+00:00",
+      "observed_at_utc": "2026-08-15T12:34:25.158690+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "c6970446db7cdf986b08f9f430328e1e4a579e45",
+        "sha": "b5f4197f09952af206d6572e447bf391b2d03fac",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:ca5c3e527a8fd269a743c00fc6071865bbbd51243621b48a1226520e08a77b3d",
+  "local_state_receipt_hash": "sha256:05100369e50b3c9fd495f160439171572bedb1ab0cf24204d1d1abb80473e091",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T12:16:26.423530+00:00",
+  "observed_at_utc": "2026-08-15T12:34:25.158834+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T12:16:06Z",
+    "observed_at_utc": "2026-08-15T12:34:01Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T11:08:11Z",
+      "observed_at_utc": "2026-08-15T11:20:21Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:sixth-auditor-blocker-fix",
+      "reference": "task:GIT-7E:seventh-auditor-blocker-fix",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T11:08:11Z",
+    "observed_at_utc": "2026-08-15T11:20:21Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "01c42d874c6c7bcfc4da183f44fda879b1803a09",
+      "head_sha": "a8b7b8b125643b11e4d6f919059a402472d85a15",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "e11f19b330894e6ea30f5d13abac1dad91c0e6b6759355ada188428cab45062b",
+    "receipt_sha256": "6b1fc4ae811523b44d9e47b5aa6c5c53b410dfc1d68d275e4f1f0872a6130dd7",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 13,
+        "ahead": 15,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 84.088,
+      "duration_ms": 83.337,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "01c42d874c6c7bcfc4da183f44fda879b1803a09",
+      "head_sha": "a8b7b8b125643b11e4d6f919059a402472d85a15",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T11:08:26.583771+00:00",
+      "observed_at_utc": "2026-08-15T11:20:38.450648+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "12f9909fad9340e9ac16cfd18ee9c27cdceaf05e",
+        "sha": "4d98b339487dde4c8da8a9ff08b32f23e736639a",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:e11f19b330894e6ea30f5d13abac1dad91c0e6b6759355ada188428cab45062b",
+  "local_state_receipt_hash": "sha256:6b1fc4ae811523b44d9e47b5aa6c5c53b410dfc1d68d275e4f1f0872a6130dd7",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T11:08:26.583910+00:00",
+  "observed_at_utc": "2026-08-15T11:20:38.450792+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T11:08:11Z",
+    "observed_at_utc": "2026-08-15T11:20:21Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T11:52:51Z",
+      "observed_at_utc": "2026-08-15T12:16:06Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:ninth-auditor-blocker-fix",
+      "reference": "task:GIT-7E:eleventh-auditor-blocker-fix",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T11:52:51Z",
+    "observed_at_utc": "2026-08-15T12:16:06Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "5f72bd3458a98901913c07e42ab9fb724fb1c74c",
+      "head_sha": "285718ba0d5028a9f0334633463aaee5f0637280",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "81d69320a93b2408ea9d417f71f0beb87e478ef47851fbce442c48ed50de9741",
+    "receipt_sha256": "ca5c3e527a8fd269a743c00fc6071865bbbd51243621b48a1226520e08a77b3d",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 19,
+        "ahead": 22,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 82.148,
+      "duration_ms": 82.418,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "5f72bd3458a98901913c07e42ab9fb724fb1c74c",
+      "head_sha": "285718ba0d5028a9f0334633463aaee5f0637280",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T11:53:08.264840+00:00",
+      "observed_at_utc": "2026-08-15T12:16:26.423397+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "dc8af427c254f6dce355104d694a33ec2fa84e57",
+        "sha": "c6970446db7cdf986b08f9f430328e1e4a579e45",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:81d69320a93b2408ea9d417f71f0beb87e478ef47851fbce442c48ed50de9741",
+  "local_state_receipt_hash": "sha256:ca5c3e527a8fd269a743c00fc6071865bbbd51243621b48a1226520e08a77b3d",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T11:53:08.264979+00:00",
+  "observed_at_utc": "2026-08-15T12:16:26.423530+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T11:52:51Z",
+    "observed_at_utc": "2026-08-15T12:16:06Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
+++ b/docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json
@@ -2,9 +2,9 @@
   "authorization": {
     "authority_source": {
       "kind": "ORCHESTRATOR_DELEGATION",
-      "observed_at_utc": "2026-08-15T10:54:36Z",
+      "observed_at_utc": "2026-08-15T11:08:11Z",
       "query_status": "OK",
-      "reference": "task:GIT-7E:fifth-auditor-blocker-fix",
+      "reference": "task:GIT-7E:sixth-auditor-blocker-fix",
       "status": "OBSERVED"
     },
     "authorized_actions": [
@@ -13,7 +13,7 @@
       "UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-15T10:54:36Z",
+    "observed_at_utc": "2026-08-15T11:08:11Z",
     "prohibited_actions": [
       "MARK_PR_READY_BEFORE_EXACT_HEAD_AUDIT",
       "MERGE_BEFORE_EXACT_HEAD_AUDIT",
@@ -30,7 +30,7 @@
         "UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-7e-semantic-handoff",
-      "head_sha": "bd75d54161ba21e292f94cb4f2de51174837c79a",
+      "head_sha": "01c42d874c6c7bcfc4da183f44fda879b1803a09",
       "task_id": "GIT-7E"
     }
   },
@@ -46,25 +46,25 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "00fab8808de654105de67670e507f4637cdb425e02272b84d84bea26defdb82c",
+    "receipt_sha256": "e11f19b330894e6ea30f5d13abac1dad91c0e6b6759355ada188428cab45062b",
     "state": {
       "branch": "codex/git-7e-semantic-handoff",
       "default_base": {
-        "ahead": 11,
+        "ahead": 13,
         "behind": 0,
         "ref": "origin/main",
         "sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
         "status": "ahead"
       },
       "derived_action": "READY_LOCAL",
-      "duration_ms": 90.342,
+      "duration_ms": 84.088,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
-      "head_sha": "bd75d54161ba21e292f94cb4f2de51174837c79a",
+      "head_sha": "01c42d874c6c7bcfc4da183f44fda879b1803a09",
       "hold_reasons": [],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-15T10:55:02.901857+00:00",
+      "observed_at_utc": "2026-08-15T11:08:26.583771+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -84,15 +84,15 @@
         "ahead": 1,
         "behind": 0,
         "ref": "origin/codex/git-7e-semantic-handoff",
-        "sha": "18dd8576d92c8a808601143652894b3cccdbc974",
+        "sha": "12f9909fad9340e9ac16cfd18ee9c27cdceaf05e",
         "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/.codex/worktrees/0753/structural_engineering_lib"
     }
   },
-  "local_state_receipt_hash": "sha256:00fab8808de654105de67670e507f4637cdb425e02272b84d84bea26defdb82c",
+  "local_state_receipt_hash": "sha256:e11f19b330894e6ea30f5d13abac1dad91c0e6b6759355ada188428cab45062b",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-15T10:55:02.902002+00:00",
+  "observed_at_utc": "2026-08-15T11:08:26.583910+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -107,7 +107,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-15T10:54:36Z",
+    "observed_at_utc": "2026-08-15T11:08:11Z",
     "owner": "supervising orchestrator task delegation",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "8fe3a8041c4a"
+      "content_hash": "bb177836209d"
     }
   ],
   "subfolders": [],
-  "content_hash": "399e8feb812a22c3"
+  "content_hash": "d6f6bd3ccf40549a"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "7853a173ad3f"
+      "content_hash": "c2c37b858c16"
     }
   ],
   "subfolders": [],
-  "content_hash": "76e5f86ed18a92f7"
+  "content_hash": "7bfda7862a082840"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -200,10 +200,10 @@
     {
       "name": "GIT-001-phase-7E-semantic-handoff.md",
       "type": "documentation",
-      "size_lines": 96,
+      "size_lines": 99,
       "last_updated": "2026-08-15",
       "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
-      "content_hash": "23d6a294d519"
+      "content_hash": "a27b70b15a44"
     },
     {
       "name": "GIT-001-phase-7E-task-git-handoff.json",
@@ -225,5 +225,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "f1de5b13856249cb"
+  "content_hash": "76e5f86ed18a92f7"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -218,12 +218,12 @@
         "mutation_policy",
         "observed_at_utc",
         "pull_request",
-        "receipt_kind",
-        "receipt_status"
+        "receipt_grants_authority",
+        "receipt_kind"
       ],
-      "content_hash": "13f0ecc7997b"
+      "content_hash": "b477e04075dc"
     }
   ],
   "subfolders": [],
-  "content_hash": "fc581a0f7628ff3e"
+  "content_hash": "7c30e60d5d20bab8"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -200,10 +200,10 @@
     {
       "name": "GIT-001-phase-7E-semantic-handoff.md",
       "type": "documentation",
-      "size_lines": 90,
+      "size_lines": 96,
       "last_updated": "2026-08-15",
       "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
-      "content_hash": "8f4800e14897"
+      "content_hash": "23d6a294d519"
     },
     {
       "name": "GIT-001-phase-7E-task-git-handoff.json",
@@ -225,5 +225,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "7330e994cc2c0514"
+  "content_hash": "c370f92fe05d6bac"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "",
   "last_updated": "2026-08-15",
-  "file_count": 21,
+  "file_count": 22,
   "files": [
     {
       "name": "GIT-001-README.md",
@@ -11,7 +11,7 @@
       "size_lines": 107,
       "last_updated": "2026-08-15",
       "description": "This directory is the task-owned, non-normative research record for GIT-001. Its contents may describe official Git/GitHub/Codex facts, observed project",
-      "content_hash": "3e30669bc28a"
+      "content_hash": "eb0ab1194fa8"
     },
     {
       "name": "GIT-001-eight-branch-retirement-authorization-proposal.json",
@@ -196,8 +196,16 @@
       "last_updated": "2026-08-15",
       "description": "GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale_branches.py path with",
       "content_hash": "a51ad88ca239"
+    },
+    {
+      "name": "GIT-001-phase-7E-semantic-handoff.md",
+      "type": "documentation",
+      "size_lines": 76,
+      "last_updated": "2026-08-15",
+      "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
+      "content_hash": "f5a8e49bb516"
     }
   ],
   "subfolders": [],
-  "content_hash": "91f820b313c40c4e"
+  "content_hash": "37f544c34add4c2e"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "287d2a7f4228"
+      "content_hash": "aab116932ebd"
     }
   ],
   "subfolders": [],
-  "content_hash": "308d45ab50c1af4e"
+  "content_hash": "8cdda2122458f974"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -200,10 +200,10 @@
     {
       "name": "GIT-001-phase-7E-semantic-handoff.md",
       "type": "documentation",
-      "size_lines": 88,
+      "size_lines": 90,
       "last_updated": "2026-08-15",
       "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
-      "content_hash": "115852bf6e89"
+      "content_hash": "8f4800e14897"
     },
     {
       "name": "GIT-001-phase-7E-task-git-handoff.json",
@@ -225,5 +225,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "be74dc59588543cc"
+  "content_hash": "b0031c86c8a656c7"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "cfa6bcc50d90"
+      "content_hash": "a87e44fc0745"
     }
   ],
   "subfolders": [],
-  "content_hash": "b0031c86c8a656c7"
+  "content_hash": "7330e994cc2c0514"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -200,10 +200,10 @@
     {
       "name": "GIT-001-phase-7E-semantic-handoff.md",
       "type": "documentation",
-      "size_lines": 84,
+      "size_lines": 88,
       "last_updated": "2026-08-15",
       "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
-      "content_hash": "ae9ad774f1de"
+      "content_hash": "115852bf6e89"
     },
     {
       "name": "GIT-001-phase-7E-task-git-handoff.json",
@@ -225,5 +225,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "7c30e60d5d20bab8"
+  "content_hash": "0f93f4075fb29a59"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "a87e44fc0745"
+      "content_hash": "7853a173ad3f"
     }
   ],
   "subfolders": [],
-  "content_hash": "c370f92fe05d6bac"
+  "content_hash": "f1de5b13856249cb"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "cd1d35fdf09f"
+      "content_hash": "f379d995b4e4"
     }
   ],
   "subfolders": [],
-  "content_hash": "07abcb69e958ee33"
+  "content_hash": "1ae2d9c977ae544e"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "ca96f7575886"
+      "content_hash": "8fe3a8041c4a"
     }
   ],
   "subfolders": [],
-  "content_hash": "e06d609b53b91fcd"
+  "content_hash": "399e8feb812a22c3"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -200,10 +200,10 @@
     {
       "name": "GIT-001-phase-7E-semantic-handoff.md",
       "type": "documentation",
-      "size_lines": 99,
+      "size_lines": 100,
       "last_updated": "2026-08-15",
       "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
-      "content_hash": "a27b70b15a44"
+      "content_hash": "f80001d77308"
     },
     {
       "name": "GIT-001-phase-7E-task-git-handoff.json",
@@ -225,5 +225,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "7bfda7862a082840"
+  "content_hash": "cae5d791642a77cc"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -200,10 +200,10 @@
     {
       "name": "GIT-001-phase-7E-semantic-handoff.md",
       "type": "documentation",
-      "size_lines": 76,
+      "size_lines": 84,
       "last_updated": "2026-08-15",
       "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
-      "content_hash": "f5a8e49bb516"
+      "content_hash": "ae9ad774f1de"
     },
     {
       "name": "GIT-001-phase-7E-task-git-handoff.json",
@@ -225,5 +225,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "165e52f911398ffc"
+  "content_hash": "fc581a0f7628ff3e"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "f5445b781d4b"
+      "content_hash": "287d2a7f4228"
     }
   ],
   "subfolders": [],
-  "content_hash": "14fed03ad094ee04"
+  "content_hash": "308d45ab50c1af4e"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "c2c37b858c16"
+      "content_hash": "ca96f7575886"
     }
   ],
   "subfolders": [],
-  "content_hash": "cae5d791642a77cc"
+  "content_hash": "e06d609b53b91fcd"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "bb177836209d"
+      "content_hash": "cd1d35fdf09f"
     }
   ],
   "subfolders": [],
-  "content_hash": "d6f6bd3ccf40549a"
+  "content_hash": "07abcb69e958ee33"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "b477e04075dc"
+      "content_hash": "cfa6bcc50d90"
     }
   ],
   "subfolders": [],
-  "content_hash": "0f93f4075fb29a59"
+  "content_hash": "be74dc59588543cc"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -221,9 +221,9 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "f379d995b4e4"
+      "content_hash": "f5445b781d4b"
     }
   ],
   "subfolders": [],
-  "content_hash": "1ae2d9c977ae544e"
+  "content_hash": "14fed03ad094ee04"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "",
   "last_updated": "2026-08-15",
-  "file_count": 22,
+  "file_count": 23,
   "files": [
     {
       "name": "GIT-001-README.md",
@@ -204,8 +204,26 @@
       "last_updated": "2026-08-15",
       "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
       "content_hash": "f5a8e49bb516"
+    },
+    {
+      "name": "GIT-001-phase-7E-task-git-handoff.json",
+      "type": "config",
+      "last_updated": "2026-08-15",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_kind",
+        "receipt_status"
+      ],
+      "content_hash": "13f0ecc7997b"
     }
   ],
   "subfolders": [],
-  "content_hash": "37f544c34add4c2e"
+  "content_hash": "165e52f911398ffc"
 }

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -33,4 +33,4 @@
 | [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
 | [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |
-| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 96 |
+| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 99 |

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -2,7 +2,7 @@
 
 **Type:** Documentation
 **Last Updated:** 2026-08-15
-**Files:** 21
+**Files:** 22
 
 ## Config Files
 
@@ -32,3 +32,4 @@
 | [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
 | [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |
+| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 76 |

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -2,13 +2,14 @@
 
 **Type:** Documentation
 **Last Updated:** 2026-08-15
-**Files:** 22
+**Files:** 23
 
 ## Config Files
 
 - [GIT-001-eight-branch-retirement-authorization-proposal.json](GIT-001-eight-branch-retirement-authorization-proposal.json)
 - [GIT-001-eight-branch-retirement-classifier-evidence.json](GIT-001-eight-branch-retirement-classifier-evidence.json)
 - [GIT-001-phase-7D-cleanup-reconciliation.json](GIT-001-phase-7D-cleanup-reconciliation.json)
+- [GIT-001-phase-7E-task-git-handoff.json](GIT-001-phase-7E-task-git-handoff.json)
 
 ## Documentation Files
 

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -33,4 +33,4 @@
 | [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
 | [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |
-| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 84 |
+| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 88 |

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -33,4 +33,4 @@
 | [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
 | [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |
-| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 88 |
+| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 90 |

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -33,4 +33,4 @@
 | [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
 | [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |
-| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 76 |
+| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 84 |

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -33,4 +33,4 @@
 | [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
 | [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |
-| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 90 |
+| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 96 |

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -33,4 +33,4 @@
 | [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
 | [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |
-| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 99 |
+| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 100 |

--- a/run.sh
+++ b/run.sh
@@ -118,6 +118,10 @@ _cmd_session() {
             _require_venv
             "$VENV" "$SCRIPTS/session.py" end "$@"
             ;;
+        handoff)
+            _require_venv
+            "$VENV" "$SCRIPTS/session.py" handoff "$@"
+            ;;
         summary)
             _require_venv
             "$VENV" "$SCRIPTS/session.py" summary "$@"
@@ -158,6 +162,7 @@ Manage agent work sessions.
 Subcommands:
   start      Begin session (verify env, read priorities)
   end        Validate closeout; --fix updates handoff, --log-cost records a proxy
+  handoff    Write a receipt-bound durable task handoff
   summary    Preview summary from git log; pass --write to update docs
   sync       Check stale doc numbers; pass --fix to update them
   check      Check session docs for issues
@@ -982,7 +987,7 @@ _run_sh() {
     )
     local -a check_opts=('--quick' '--changed' '--pre-commit' '--category' '--fix' '--json' '--list' '--serial')
     local -a categories=('api' 'docs' 'arch' 'governance' 'fastapi' 'git' 'stale' 'code')
-    local -a session_subs=('start' 'end' 'summary' 'sync' 'check' 'context' 'brief' 'usage' 'costs' 'compact' 'trust')
+    local -a session_subs=('start' 'end' 'handoff' 'summary' 'sync' 'check' 'context' 'brief' 'usage' 'costs' 'compact' 'trust')
     local -a task_subs=('brief')
     local -a generate_subs=('indexes' 'sdk' 'manifest' 'docs-index' 'scaffold')
     local -a health_opts=('--fix' '--score' '--quick' '--category' '--json')

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -1,8 +1,8 @@
 {
   "_comment": "Task-to-script mapping - helps agents find the right automation for their task",
-  "_updated": "2026-08-13",
+  "_updated": "2026-08-15",
   "_usage": "Run: ./scripts/python_runtime.sh scripts/find_automation.py \"task description\" — or --list for all",
-  "_coverage": "107/107 scripts mapped",
+  "_coverage": "108/108 scripts mapped",
   "tasks": {
     "resolve python runtime": {
       "group": "Infrastructure",
@@ -224,7 +224,26 @@
     "session handoff": {
       "group": "Session",
       "script": "./scripts/python_runtime.sh scripts/session.py handoff",
-      "description": "Write next-session-brief.md for the next agent"
+      "description": "Validate a durable task-to-Git receipt and write next-session-brief.md for the next agent",
+      "aliases": ["session receipt handoff", "durable handoff"],
+      "permission": "WorkspaceWrite",
+      "options": {
+        "--git-receipt PATH": "Validate and embed the versioned receipt identity"
+      }
+    },
+    "task git handoff receipt": {
+      "group": "Git",
+      "script": "./scripts/python_runtime.sh scripts/git_handoff_receipt.py create",
+      "description": "Build or validate a fail-closed task-to-Git handoff receipt from git_state.py plus caller-supplied hosted evidence",
+      "aliases": ["git receipt", "handoff receipt", "task to git"],
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--output": "WorkspaceWrite"
+      },
+      "options": {
+        "create": "Build receipt; missing hosted facts remain UNKNOWN or NOT_CHECKED holds",
+        "validate": "Validate schema, hashes, exact-head binding, and contradictions"
+      }
     },
     "session check": {
       "group": "Session",

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -47,6 +47,76 @@ RETIRED_PATHS = (
 )
 
 HISTORICAL_MARKERS = ("historical", "archive", "legacy")
+HISTORICAL_CONTEXT = re.compile(
+    r"\b(?:historical|archived|deprecated|legacy|old workflow|"
+    r"incident (?:record|evidence|narrative))\b",
+    re.IGNORECASE,
+)
+HISTORICAL_NARRATION = re.compile(
+    r"\b(?:says?|records?|mentions?|describes?|documents?|was|were|used|ran|during)\b",
+    re.IGNORECASE,
+)
+IMPERATIVE_LIFECYCLE_VERBS = re.compile(
+    r"\b(?:use|run|execute|invoke|issue|perform|stage|restore|undo|recover|"
+    r"amend|cherry-pick|create|checkout|switch|reset|commit|push|pull|revert|"
+    r"merge|rebase|stash|clean|prune|delete|remove|force|replay|apply|move|"
+    r"branch|fetch)\b",
+    re.IGNORECASE,
+)
+CLAUSE_BOUNDARY = re.compile(
+    r"(?:[.;!?]\s+|\b(?:but|however|then|instead|nevertheless|yet)\b[:,]?\s*)",
+    re.IGNORECASE,
+)
+NEGATING_DIRECTIVE = re.compile(
+    r"\b(?:never|do not|don't|must not|should not|shall not|cannot|can't)\b"
+    r"|\b(?:forbidden|prohibited)\s*:\s*$",
+    re.IGNORECASE,
+)
+NEGATING_PREDICATE = re.compile(
+    r"\b(?:is|are)\s+(?:strictly\s+)?(?:forbidden|prohibited|not allowed)\b"
+    r"|\b(?:must|should|shall)\s+not\s+be\s+"
+    r"(?:used|run|executed)\b",
+    re.IGNORECASE,
+)
+
+
+def _local_clause(line: str, start: int, end: int) -> tuple[str, str]:
+    """Return text locally governing a command, excluding prior/later clauses."""
+    before = line[:start]
+    after = line[end:]
+    prior = list(CLAUSE_BOUNDARY.finditer(before))
+    following = CLAUSE_BOUNDARY.search(after)
+    return (
+        before[prior[-1].end() :] if prior else before,
+        after[: following.start()] if following else after,
+    )
+
+
+def _is_governing_prohibition(line: str, start: int, end: int) -> bool:
+    """True only when local negation governs this unsafe Git expression."""
+    before, after = _local_clause(line, start, end)
+    return NEGATING_DIRECTIVE.search(before) is not None or (
+        NEGATING_PREDICATE.search(after) is not None
+    )
+
+
+def _is_historical_narration(line: str, start: int) -> bool:
+    """Recognize explicit past evidence, not a historical-looking directive."""
+    prefix = line[:start]
+    if HISTORICAL_CONTEXT.search(line) is None:
+        return False
+    if HISTORICAL_NARRATION.search(line) is None:
+        return False
+    prior = list(CLAUSE_BOUNDARY.finditer(prefix))
+    local_prefix = prefix[prior[-1].end() :] if prior else prefix
+    return IMPERATIVE_LIFECYCLE_VERBS.search(local_prefix) is None
+
+
+def _unsafe_match_is_instruction(line: str, match: re.Match[str]) -> bool:
+    """Fail closed unless the command is locally prohibited or historical."""
+    return not _is_governing_prohibition(line, match.start(), match.end()) and not (
+        _is_historical_narration(line, match.start())
+    )
 
 
 def _front_matter_status(content: str) -> str | None:
@@ -171,34 +241,20 @@ def check_semantic_guidance(
             if stripped.startswith("```"):
                 in_fence = not in_fence
                 continue
-            lowered = line.lower()
-            if any(marker in lowered for marker in ("never:", "never ", "do not ")):
-                continue
             for pattern in patterns:
-                if pattern.search(line):
+                match = pattern.search(line)
+                if match and _unsafe_match_is_instruction(line, match):
                     errors.append(
                         f"{relative}:{line_number} prescribes prohibited Git mutation: "
                         f"{line.strip()}"
                     )
-            instruction_context = (
-                in_fence
-                or stripped.startswith(
-                    ("| `git ", "- `git ", "* `git ", "`git ", "git ")
-                )
-                or re.search(
-                    r"\b(use|run|execute|stage|restore|undo|recover)\b[^\n]*`?git\s",
-                    line,
-                    re.IGNORECASE,
-                )
-                is not None
-            )
-            if instruction_context:
-                for pattern in instruction_patterns:
-                    if pattern.search(line):
-                        errors.append(
-                            f"{relative}:{line_number} prescribes unsafe Git "
-                            f"instruction: {stripped}"
-                        )
+            for pattern in instruction_patterns:
+                match = pattern.search(line)
+                if match and _unsafe_match_is_instruction(line, match):
+                    errors.append(
+                        f"{relative}:{line_number} prescribes unsafe Git "
+                        f"instruction: {stripped}"
+                    )
         for phrase in required.get(relative, []):
             if phrase not in content:
                 errors.append(f"{relative} is missing semantic contract: {phrase}")

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -53,7 +53,8 @@ HISTORICAL_CONTEXT = re.compile(
     re.IGNORECASE,
 )
 HISTORICAL_NARRATION = re.compile(
-    r"\b(?:says?|records?|mentions?|describes?|documents?|was|were|used|ran|during)\b",
+    r"\b(?:says?|said|records?|mentions?|describes?|documents?|was|were|used|"
+    r"ran|during)\b",
     re.IGNORECASE,
 )
 IMPERATIVE_LIFECYCLE_VERBS = re.compile(

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -72,6 +72,14 @@ NEGATING_DIRECTIVE = re.compile(
     r"|\b(?:forbidden|prohibited)\s*:\s*$",
     re.IGNORECASE,
 )
+DIRECTLY_PROHIBITED_ACTION = re.compile(
+    r"^[\s`*_:~-]*(?:use|run|execute|invoke|issue|perform|stage|restore|undo|"
+    r"recover|amend|cherry-pick|create|checkout|switch|reset|commit|push|"
+    r"pull|revert|merge|rebase|stash|clean|prune|delete|remove|force|replay|"
+    r"apply|move|fetch)\b",
+    re.IGNORECASE,
+)
+DIRECTIVE_PUNCTUATION_ONLY = re.compile(r"^[\s`*_:~-]*$")
 NEGATING_PREDICATE = re.compile(
     r"\b(?:is|are)\s+(?:strictly\s+)?(?:forbidden|prohibited|not allowed)\b"
     r"|\b(?:must|should|shall)\s+not\s+be\s+"
@@ -95,9 +103,14 @@ def _local_clause(line: str, start: int, end: int) -> tuple[str, str]:
 def _is_governing_prohibition(line: str, start: int, end: int) -> bool:
     """True only when local negation governs this unsafe Git expression."""
     before, after = _local_clause(line, start, end)
-    return NEGATING_DIRECTIVE.search(before) is not None or (
-        NEGATING_PREDICATE.search(after) is not None
-    )
+    directives = list(NEGATING_DIRECTIVE.finditer(before))
+    if directives:
+        governed_text = before[directives[-1].end() :]
+        if DIRECTLY_PROHIBITED_ACTION.match(
+            governed_text
+        ) is not None or DIRECTIVE_PUNCTUATION_ONLY.fullmatch(governed_text):
+            return True
+    return NEGATING_PREDICATE.search(after) is not None
 
 
 def _is_historical_narration(line: str, start: int) -> bool:

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -68,18 +68,30 @@ CLAUSE_BOUNDARY = re.compile(
     re.IGNORECASE,
 )
 NEGATING_DIRECTIVE = re.compile(
-    r"\b(?:never|do not|don't|must not|should not|shall not|cannot|can't)\b"
+    r"(?<![A-Za-z0-9])(?:never|do not|don't|must not|should not|shall not|"
+    r"cannot|can't)\b"
     r"|\b(?:forbidden|prohibited)\s*:\s*$",
     re.IGNORECASE,
 )
-DIRECTLY_PROHIBITED_ACTION = re.compile(
-    r"^[\s`*_:~-]*(?:use|run|execute|invoke|issue|perform|stage|restore|undo|"
+DIRECT_ACTION = re.compile(
+    r"\b(?:use|run|execute|invoke|issue|perform|stage|restore|undo|"
     r"recover|amend|cherry-pick|create|checkout|switch|reset|commit|push|"
     r"pull|revert|merge|rebase|stash|clean|prune|delete|remove|force|replay|"
     r"apply|move|fetch)\b",
     re.IGNORECASE,
 )
-DIRECTIVE_PUNCTUATION_ONLY = re.compile(r"^[\s`*_:~-]*$")
+DIRECTIVE_PUNCTUATION_ONLY = re.compile(r"^[\s`*_:~—–\-()\[\]]*$")
+SUFFIX_EXACT_OBJECT_LEAD = re.compile(
+    r"^[^.;!?]*[—–][\s`*_~()\[\]-]*$",
+    re.IGNORECASE,
+)
+INNER_ACTION_NEGATION = re.compile(r"\bnot\s+to[\s`*_~]*$", re.IGNORECASE)
+AVOID_GOVERNOR = re.compile(r"\bavoid\b", re.IGNORECASE)
+EXACT_OBJECT_SUFFIX = re.compile(
+    r"^[\s`*_~]*(?:(?:this|that)\s+"
+    r"(?:command|form|expression|example))?[\s`*_~.!,:;()\[\]-]*$",
+    re.IGNORECASE,
+)
 NEGATING_PREDICATE = re.compile(
     r"\b(?:is|are)\s+(?:strictly\s+)?(?:forbidden|prohibited|not allowed)\b"
     r"|\b(?:must|should|shall)\s+not\s+be\s+"
@@ -101,15 +113,56 @@ def _local_clause(line: str, start: int, end: int) -> tuple[str, str]:
 
 
 def _is_governing_prohibition(line: str, start: int, end: int) -> bool:
-    """True only when local negation governs this unsafe Git expression."""
+    """True only when the nearest action prohibits this Git expression."""
     before, after = _local_clause(line, start, end)
-    directives = list(NEGATING_DIRECTIVE.finditer(before))
-    if directives:
-        governed_text = before[directives[-1].end() :]
-        if DIRECTLY_PROHIBITED_ACTION.match(
-            governed_text
-        ) is not None or DIRECTIVE_PUNCTUATION_ONLY.fullmatch(governed_text):
+    actions = list(DIRECT_ACTION.finditer(before))
+    if actions:
+        action = actions[-1]
+        action_prefix = before[: action.start()]
+        if INNER_ACTION_NEGATION.search(action_prefix) is not None:
             return True
+        directives = list(NEGATING_DIRECTIVE.finditer(action_prefix))
+        if directives and DIRECTIVE_PUNCTUATION_ONLY.fullmatch(
+            action_prefix[directives[-1].end() :]
+        ):
+            return True
+
+    avoidances = list(AVOID_GOVERNOR.finditer(before))
+    if avoidances and (not actions or avoidances[-1].start() > actions[-1].end()):
+        avoid = avoidances[-1]
+        directives = list(NEGATING_DIRECTIVE.finditer(before[: avoid.start()]))
+        directly_negated = directives and DIRECTIVE_PUNCTUATION_ONLY.fullmatch(
+            before[directives[-1].end() : avoid.start()]
+        )
+        if not directly_negated:
+            return True
+
+    directives = list(NEGATING_DIRECTIVE.finditer(before))
+    if directives and DIRECTIVE_PUNCTUATION_ONLY.fullmatch(
+        before[directives[-1].end() :]
+    ):
+        return True
+
+    suffix_directives = list(NEGATING_DIRECTIVE.finditer(after))
+    if suffix_directives:
+        directive = suffix_directives[0]
+        suffix_actions = list(DIRECT_ACTION.finditer(after[directive.end() :]))
+        if suffix_actions:
+            action = suffix_actions[0]
+            action_start = directive.end() + action.start()
+            action_end = directive.end() + action.end()
+            suffix_lead = after[: directive.start()]
+            if (
+                (
+                    DIRECTIVE_PUNCTUATION_ONLY.fullmatch(suffix_lead)
+                    or SUFFIX_EXACT_OBJECT_LEAD.fullmatch(suffix_lead)
+                )
+                and DIRECTIVE_PUNCTUATION_ONLY.fullmatch(
+                    after[directive.end() : action_start]
+                )
+                and EXACT_OBJECT_SUFFIX.fullmatch(after[action_end:])
+            ):
+                return True
     return NEGATING_PREDICATE.search(after) is not None
 
 

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -181,8 +181,19 @@ def _is_historical_narration(line: str, start: int) -> bool:
 
 def _unsafe_match_is_instruction(line: str, match: re.Match[str]) -> bool:
     """Fail closed unless the command is locally prohibited or historical."""
-    return not _is_governing_prohibition(line, match.start(), match.end()) and not (
-        _is_historical_narration(line, match.start())
+    start = match.start()
+    matched = match.group(0)
+    directive = NEGATING_DIRECTIVE.search(matched)
+    if (
+        directive is not None
+        and DIRECTIVE_PUNCTUATION_ONLY.fullmatch(matched[: directive.start()])
+        and re.search(r"\bwithout\b", matched[directive.end() :], re.IGNORECASE) is None
+    ):
+        action = DIRECT_ACTION.search(matched, directive.end())
+        if action is not None:
+            start += action.start()
+    return not _is_governing_prohibition(line, start, match.end()) and not (
+        _is_historical_narration(line, start)
     )
 
 

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -151,6 +151,12 @@ def check_semantic_guidance(
             patterns.append(re.compile(raw, re.IGNORECASE))
         except re.error as exc:
             errors.append(f"invalid semantic guidance pattern {raw!r}: {exc}")
+    instruction_patterns: list[re.Pattern[str]] = []
+    for raw in config.get("forbidden_instruction_patterns", []):
+        try:
+            instruction_patterns.append(re.compile(raw, re.IGNORECASE))
+        except re.error as exc:
+            errors.append(f"invalid semantic instruction pattern {raw!r}: {exc}")
     required = config.get("required_contracts", {})
 
     for path in surfaces:
@@ -159,7 +165,12 @@ def check_semantic_guidance(
         for token in forbidden_tokens:
             if token in content:
                 errors.append(f"{relative} prescribes retired lifecycle token: {token}")
+        in_fence = False
         for line_number, line in enumerate(content.splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_fence = not in_fence
+                continue
             lowered = line.lower()
             if any(marker in lowered for marker in ("never:", "never ", "do not ")):
                 continue
@@ -169,6 +180,25 @@ def check_semantic_guidance(
                         f"{relative}:{line_number} prescribes prohibited Git mutation: "
                         f"{line.strip()}"
                     )
+            instruction_context = (
+                in_fence
+                or stripped.startswith(
+                    ("| `git ", "- `git ", "* `git ", "`git ", "git ")
+                )
+                or re.search(
+                    r"\b(use|run|execute|stage|restore|undo|recover)\b[^\n]*`?git\s",
+                    line,
+                    re.IGNORECASE,
+                )
+                is not None
+            )
+            if instruction_context:
+                for pattern in instruction_patterns:
+                    if pattern.search(line):
+                        errors.append(
+                            f"{relative}:{line_number} prescribes unsafe Git "
+                            f"instruction: {stripped}"
+                        )
         for phrase in required.get(relative, []):
             if phrase not in content:
                 errors.append(f"{relative} is missing semantic contract: {phrase}")

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import json
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CANONICAL = REPO_ROOT / "docs/git-automation/git-workflow-single-source.md"
 GIT_STATE_AUTHORITY = REPO_ROOT / "scripts/git_state.py"
+HANDOFF_RECEIPT = REPO_ROOT / "scripts/git_handoff_receipt.py"
 DISPOSITION_CLASSIFIER = REPO_ROOT / "scripts/classify_branch_disposition.py"
 GIT_STATE_CONSUMERS = (
     "scripts/prompt_router.py",
@@ -27,6 +30,7 @@ GIT_STATE_COMPATIBILITY = (
 )
 FAST_CHECKS = REPO_ROOT / ".github/workflows/fast-checks.yml"
 DEPLOY_DOCS = REPO_ROOT / ".github/workflows/deploy-docs.yml"
+GUIDANCE_INDEX = REPO_ROOT / "docs/git-automation/live-git-guidance-index.json"
 
 RETIRED_PATHS = (
     "scripts/ai_commit.sh",
@@ -42,33 +46,133 @@ RETIRED_PATHS = (
     "scripts/cleanup_stale_branches.py",
 )
 
-DISPOSITION_GUIDANCE = (
-    "AGENTS.md",
-    "CLAUDE.md",
-    ".github/copilot-instructions.md",
-    ".github/instructions/terminal-rules.instructions.md",
-    "docs/git-automation/git-workflow-single-source.md",
-    "docs/governance/maintenance-playbook.md",
-    "docs/guides/maintenance-checklist.md",
-    "scripts/README.md",
-    "scripts/automation-map.json",
-)
+HISTORICAL_MARKERS = ("historical", "archive", "legacy")
 
-LIVE_FILES_WITHOUT_WRAPPER_CALLS = (
-    "AGENTS.md",
-    "CLAUDE.md",
-    ".github/copilot-instructions.md",
-    "run.sh",
-    "scripts/agent_start.sh",
-    "agents/agent-9/KNOWLEDGE_BASE.md",
-    "agents/agent-9/RESEARCH_PLAN.md",
-    "agents/agent-9/research/AGENT_9_CONSTRAINTS.md",
-    "agents/agent-9/workflows/LINK_GOVERNANCE.md",
-    "agents/roles/GOVERNANCE.md",
-    "docs/guidelines/migration-workflow-guide.md",
-    "docs/guidelines/folder-cleanup-workflow.md",
-    "docs/guidelines/file-operations-safety-guide.md",
-)
+
+def _front_matter_status(content: str) -> str | None:
+    if not content.startswith("---\n"):
+        return None
+    front_matter = content.split("---", 2)[1]
+    match = re.search(r"^status:\s*([^\s]+)\s*$", front_matter, re.MULTILINE)
+    return match.group(1).lower() if match else None
+
+
+def _historical_boundary_is_explicit(path: Path, boundary: str) -> bool:
+    if boundary == "archive_path":
+        return "_archive" in path.parts
+    content = path.read_text(encoding="utf-8", errors="replace")
+    first_lines = "\n".join(content.splitlines()[:24]).lower()
+    if boundary == "front_matter_status_deprecated":
+        return _front_matter_status(content) == "deprecated" and any(
+            marker in first_lines for marker in HISTORICAL_MARKERS
+        )
+    return False
+
+
+def discover_guidance_surfaces(
+    repo_root: Path = REPO_ROOT, index_path: Path = GUIDANCE_INDEX
+) -> tuple[list[Path], list[str], dict]:
+    """Resolve live guidance from the maintained index, failing on ambiguity."""
+    errors: list[str] = []
+    try:
+        config = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [], [f"live guidance index is missing or malformed: {exc}"], {}
+    if config.get("schema_version") != 1:
+        errors.append("live guidance index schema is unknown")
+
+    surfaces: set[Path] = set()
+    for relative in config.get("live_surfaces", []):
+        path = repo_root / relative
+        if path.is_file():
+            surfaces.add(path)
+        else:
+            errors.append(f"indexed live guidance is missing: {relative}")
+    for pattern in config.get("live_globs", []):
+        matches = sorted(repo_root.glob(pattern))
+        if not matches:
+            errors.append(f"indexed live guidance glob matched nothing: {pattern}")
+        surfaces.update(path for path in matches if path.is_file())
+
+    for surface_set in config.get("indexed_surface_sets", []):
+        index = repo_root / surface_set.get("index", "")
+        root = repo_root / surface_set.get("root", "")
+        try:
+            entries = json.loads(index.read_text(encoding="utf-8")).get("files", [])
+        except (OSError, json.JSONDecodeError, AttributeError) as exc:
+            errors.append(f"indexed guidance set is malformed: {index}: {exc}")
+            continue
+        ignored = set(surface_set.get("ignore_names", []))
+        historical_statuses = set(surface_set.get("historical_statuses", []))
+        for entry in entries:
+            name = entry.get("name") if isinstance(entry, dict) else None
+            if not name or name in ignored or not name.endswith(".md"):
+                continue
+            path = root / name
+            if not path.is_file():
+                errors.append(
+                    f"indexed guidance entry is missing: {path.relative_to(repo_root)}"
+                )
+                continue
+            content = path.read_text(encoding="utf-8", errors="replace")
+            status = _front_matter_status(content)
+            if status in historical_statuses:
+                if not _historical_boundary_is_explicit(
+                    path, "front_matter_status_deprecated"
+                ):
+                    errors.append(
+                        f"historical exclusion lacks an explicit boundary: "
+                        f"{path.relative_to(repo_root)}"
+                    )
+                continue
+            surfaces.add(path)
+
+    for exclusion in config.get("historical_exclusions", []):
+        pattern = exclusion.get("glob", "")
+        boundary = exclusion.get("boundary", "")
+        for path in repo_root.glob(pattern):
+            if path.is_file() and not _historical_boundary_is_explicit(path, boundary):
+                errors.append(
+                    f"historical exclusion lacks an explicit boundary: "
+                    f"{path.relative_to(repo_root)}"
+                )
+    return sorted(surfaces), errors, config
+
+
+def check_semantic_guidance(
+    repo_root: Path = REPO_ROOT, index_path: Path = GUIDANCE_INDEX
+) -> list[str]:
+    """Reject lifecycle contradictions across every indexed live surface."""
+    surfaces, errors, config = discover_guidance_surfaces(repo_root, index_path)
+    forbidden_tokens = tuple(config.get("forbidden_tokens", []))
+    patterns: list[re.Pattern[str]] = []
+    for raw in config.get("forbidden_command_patterns", []):
+        try:
+            patterns.append(re.compile(raw, re.IGNORECASE))
+        except re.error as exc:
+            errors.append(f"invalid semantic guidance pattern {raw!r}: {exc}")
+    required = config.get("required_contracts", {})
+
+    for path in surfaces:
+        relative = path.relative_to(repo_root).as_posix()
+        content = path.read_text(encoding="utf-8", errors="replace")
+        for token in forbidden_tokens:
+            if token in content:
+                errors.append(f"{relative} prescribes retired lifecycle token: {token}")
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            lowered = line.lower()
+            if any(marker in lowered for marker in ("never:", "never ", "do not ")):
+                continue
+            for pattern in patterns:
+                if pattern.search(line):
+                    errors.append(
+                        f"{relative}:{line_number} prescribes prohibited Git mutation: "
+                        f"{line.strip()}"
+                    )
+        for phrase in required.get(relative, []):
+            if phrase not in content:
+                errors.append(f"{relative} is missing semantic contract: {phrase}")
+    return errors
 
 
 def main() -> int:
@@ -119,6 +223,26 @@ def main() -> int:
         if "ls-remote" in source:
             errors.append("Git state authority must not contact a remote")
 
+    if not HANDOFF_RECEIPT.exists():
+        errors.append("task-to-Git handoff receipt contract is missing")
+    else:
+        source = HANDOFF_RECEIPT.read_text(encoding="utf-8")
+        for token in (
+            "collect_repository_state",
+            "receipt_sha256",
+            "NOT_CHECKED",
+            "UNKNOWN",
+            "is_git_retention_evidence",
+            "REVIEWED_HEAD_MISMATCH",
+            "SQUASH_TREE_EQUIVALENCE_UNKNOWN",
+        ):
+            if token not in source:
+                errors.append(f"handoff receipt is missing required contract: {token}")
+        if "subprocess" in source or "ls-remote" in source:
+            errors.append(
+                "handoff receipt must not read Git or remote state independently"
+            )
+
     if not DISPOSITION_CLASSIFIER.exists():
         errors.append(
             "inspection-only classifier is missing: "
@@ -157,18 +281,7 @@ def main() -> int:
                     f"branch disposition classifier exposes action flag: {action_flag}"
                 )
 
-    for relative in DISPOSITION_GUIDANCE:
-        path = REPO_ROOT / relative
-        if not path.exists():
-            errors.append(f"branch disposition guidance is missing: {relative}")
-            continue
-        content = path.read_text(encoding="utf-8")
-        if "cleanup_stale_branches.py" in content:
-            errors.append(f"{relative} still routes to deletion-oriented cleanup")
-        if "classify_branch_disposition.py" not in content:
-            errors.append(
-                f"{relative} does not route to the inspection-only classifier"
-            )
+    errors.extend(check_semantic_guidance())
 
     for relative in GIT_STATE_CONSUMERS:
         path = REPO_ROOT / relative
@@ -224,6 +337,8 @@ def main() -> int:
             "needs.changes.outputs.control_plane == 'true'",
             "needs.changes.outputs.docs == 'true'",
             "Python/tests/test_git_state.py",
+            "Python/tests/test_git_handoff_receipt.py",
+            "Python/tests/test_git_guidance_semantics.py",
             "Python/tests/test_branch_disposition.py",
             "Python/tests/test_session_automation.py",
             "Python/tests/test_session_store.py",
@@ -271,17 +386,6 @@ def main() -> int:
             errors.append("post-merge documentation concurrency is not scoped per ref")
         if "group: deploy-docs" in deploy_docs:
             errors.append("global documentation concurrency group is still active")
-
-    retired_names = tuple(Path(path).name for path in RETIRED_PATHS[:7])
-    for relative in LIVE_FILES_WITHOUT_WRAPPER_CALLS:
-        path = REPO_ROOT / relative
-        if not path.exists():
-            errors.append(f"required live instruction file is missing: {relative}")
-            continue
-        content = path.read_text(encoding="utf-8")
-        for name in retired_names:
-            if name in content:
-                errors.append(f"{relative} still invokes or prescribes retired {name}")
 
     if errors:
         print("Codex-native Git workflow check failed:")

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -68,6 +68,7 @@ CLAUSE_BOUNDARY = re.compile(
     r"(?:[.;!?]\s+|\b(?:but|however|then|instead|nevertheless|yet)\b[:,]?\s*)",
     re.IGNORECASE,
 )
+GUIDANCE_CONTEXT_BOUNDARY = re.compile(r"[.;!?](?:\s+|$)")
 NEGATING_DIRECTIVE = re.compile(
     r"(?<![A-Za-z0-9])(?:never|do not|don't|must not|should not|shall not|"
     r"cannot|can't)\b"
@@ -181,8 +182,11 @@ def _is_historical_narration(line: str, start: int) -> bool:
 
 def _unsafe_match_is_instruction(line: str, match: re.Match[str]) -> bool:
     """Fail closed unless the command is locally prohibited or historical."""
-    start = match.start()
-    matched = match.group(0)
+    return _instruction_span_is_unsafe(line, match.start(), match.end(), match.group(0))
+
+
+def _instruction_span_is_unsafe(line: str, start: int, end: int, matched: str) -> bool:
+    """Classify one action-starting span with the shared semantic grammar."""
     directive = NEGATING_DIRECTIVE.search(matched)
     if (
         directive is not None
@@ -192,9 +196,47 @@ def _unsafe_match_is_instruction(line: str, match: re.Match[str]) -> bool:
         action = DIRECT_ACTION.search(matched, directive.end())
         if action is not None:
             start += action.start()
-    return not _is_governing_prohibition(line, start, match.end()) and not (
+    return not _is_governing_prohibition(line, start, end) and not (
         _is_historical_narration(line, start)
     )
+
+
+def _clause_spans(line: str) -> list[tuple[int, int]]:
+    """Return sentence/semicolon-local spans without crossing context boundaries."""
+    spans: list[tuple[int, int]] = []
+    start = 0
+    for boundary in GUIDANCE_CONTEXT_BOUNDARY.finditer(line):
+        if boundary.start() > start:
+            spans.append((start, boundary.start()))
+        start = boundary.end()
+    if start < len(line):
+        spans.append((start, len(line)))
+    return spans
+
+
+def _structured_instruction_errors(
+    line: str,
+    action_pattern: re.Pattern[str],
+    context_pattern: re.Pattern[str],
+    standalone_patterns: tuple[re.Pattern[str], ...],
+) -> list[tuple[int, int]]:
+    """Match one data-driven action rule within its own lexical context clause."""
+    errors: list[tuple[int, int]] = []
+    for clause_start, clause_end in _clause_spans(line):
+        clause = line[clause_start:clause_end]
+        has_context = context_pattern.search(clause) is not None
+        is_standalone = any(
+            pattern.fullmatch(clause.strip()) is not None
+            for pattern in standalone_patterns
+        )
+        if not has_context and not is_standalone:
+            continue
+        for match in action_pattern.finditer(clause):
+            start = clause_start + match.start()
+            end = clause_start + match.end()
+            if _instruction_span_is_unsafe(line, start, end, match.group(0)):
+                errors.append((start, end))
+    return errors
 
 
 def _front_matter_status(content: str) -> str | None:
@@ -300,7 +342,31 @@ def check_semantic_guidance(
         except re.error as exc:
             errors.append(f"invalid semantic guidance pattern {raw!r}: {exc}")
     instruction_patterns: list[re.Pattern[str]] = []
+    structured_instruction_rules: list[
+        tuple[re.Pattern[str], re.Pattern[str], tuple[re.Pattern[str], ...]]
+    ] = []
     for raw in config.get("forbidden_instruction_patterns", []):
+        if isinstance(raw, dict):
+            if raw.get("kind") != "clause_action":
+                errors.append(f"invalid semantic instruction rule kind: {raw!r}")
+                continue
+            try:
+                structured_instruction_rules.append(
+                    (
+                        re.compile(raw["action_pattern"], re.IGNORECASE),
+                        re.compile(raw["context_pattern"], re.IGNORECASE),
+                        tuple(
+                            re.compile(pattern, re.IGNORECASE)
+                            for pattern in raw["standalone_clause_patterns"]
+                        ),
+                    )
+                )
+            except (KeyError, TypeError, re.error) as exc:
+                errors.append(f"invalid semantic instruction rule {raw!r}: {exc}")
+            continue
+        if not isinstance(raw, str):
+            errors.append(f"invalid semantic instruction pattern: {raw!r}")
+            continue
         try:
             instruction_patterns.append(re.compile(raw, re.IGNORECASE))
         except re.error as exc:
@@ -329,6 +395,12 @@ def check_semantic_guidance(
             for pattern in instruction_patterns:
                 match = pattern.search(line)
                 if match and _unsafe_match_is_instruction(line, match):
+                    errors.append(
+                        f"{relative}:{line_number} prescribes unsafe Git "
+                        f"instruction: {stripped}"
+                    )
+            for action, context, standalone in structured_instruction_rules:
+                if _structured_instruction_errors(line, action, context, standalone):
                     errors.append(
                         f"{relative}:{line_number} prescribes unsafe Git "
                         f"instruction: {stripped}"

--- a/scripts/git_handoff_receipt.py
+++ b/scripts/git_handoff_receipt.py
@@ -89,13 +89,16 @@ def _normalise_section(
     if raw is None:
         return _unknown(NOT_CHECKED), [f"{name.upper()}_NOT_CHECKED"]
     if not isinstance(raw, Mapping):
-        return _unknown(), [f"{name.upper()}_MALFORMED"]
+        section = _unknown()
+        section["evidence_error"] = "MALFORMED"
+        return section, [f"{name.upper()}_MALFORMED"]
     section = dict(raw)
     status, reason = _fresh_status(section, now, max_age=max_age)
     section["status"] = status
     if status != "OBSERVED":
         section["query_status"] = UNKNOWN
     if reason:
+        section["evidence_error"] = reason
         return section, [f"{name.upper()}_{reason}"]
     if status in {UNKNOWN, NOT_CHECKED}:
         return section, [f"{name.upper()}_{status}"]
@@ -109,6 +112,221 @@ def _local_payload(state: RepositoryState) -> dict[str, Any]:
         "receipt_sha256": _sha256(state_payload),
         "state": state_payload,
     }
+
+
+def _authorization_holds(
+    authorization: object,
+    *,
+    task: object,
+    local_state: object,
+) -> list[str]:
+    if not isinstance(authorization, Mapping):
+        return ["AUTHORIZATION_MALFORMED"]
+    holds: list[str] = []
+    status = authorization.get("status")
+    if status not in {"OBSERVED", UNKNOWN, NOT_CHECKED}:
+        holds.append("AUTHORIZATION_STATUS_INVALID")
+    elif status != "OBSERVED":
+        holds.append("AUTHORIZATION_UNKNOWN")
+    if (
+        not isinstance(authorization.get("next_action"), str)
+        or not authorization.get("next_action", "").strip()
+    ):
+        holds.append("NEXT_ACTION_UNKNOWN")
+    for field in ("authorized_actions", "prohibited_actions"):
+        actions = authorization.get(field)
+        if not isinstance(actions, list) or any(
+            not isinstance(action, str) or not action.strip() for action in actions
+        ):
+            holds.append("AUTHORIZATION_ACTIONS_MALFORMED")
+            break
+    authorized = authorization.get("authorized_actions", [])
+    prohibited = authorization.get("prohibited_actions", [])
+    if isinstance(authorized, list) and isinstance(prohibited, list):
+        if set(authorized) & set(prohibited):
+            holds.append("AUTHORIZATION_ACTION_CONTRADICTION")
+
+    source = authorization.get("authority_source")
+    if not isinstance(source, Mapping):
+        holds.append("AUTHORIZATION_PROVENANCE_UNKNOWN")
+    else:
+        if source.get("kind") not in {
+            "USER_DELEGATION",
+            "ORCHESTRATOR_DELEGATION",
+            "REPOSITORY_POLICY",
+            "GITHUB_REVIEW",
+        }:
+            holds.append("AUTHORIZATION_SOURCE_KIND_INVALID")
+        if (
+            not isinstance(source.get("reference"), str)
+            or not source.get("reference", "").strip()
+        ):
+            holds.append("AUTHORIZATION_SOURCE_REFERENCE_UNKNOWN")
+        if _parse_time(source.get("observed_at_utc")) is None:
+            holds.append("AUTHORIZATION_SOURCE_TIME_UNKNOWN")
+
+    binding = authorization.get("target_binding")
+    if not isinstance(binding, Mapping):
+        holds.append("AUTHORIZATION_TARGET_BINDING_UNKNOWN")
+    else:
+        task_id = task.get("task_id") if isinstance(task, Mapping) else None
+        branch = local_state.get("branch") if isinstance(local_state, Mapping) else None
+        head_sha = (
+            local_state.get("head_sha") if isinstance(local_state, Mapping) else None
+        )
+        if (
+            binding.get("task_id") != task_id
+            or binding.get("branch") != branch
+            or binding.get("head_sha") != head_sha
+        ):
+            holds.append("AUTHORIZATION_TARGET_MISMATCH")
+        bound_actions = binding.get("actions")
+        if not isinstance(bound_actions, list) or bound_actions != authorized:
+            holds.append("AUTHORIZATION_TARGET_ACTION_MISMATCH")
+    return holds
+
+
+def _stored_section_holds(
+    receipt: Mapping[str, Any], name: str, now: datetime, *, max_age: int
+) -> list[str]:
+    section = receipt.get(name)
+    prefix = name.upper()
+    if not isinstance(section, Mapping):
+        return [f"{prefix}_MALFORMED"]
+    status, reason = _fresh_status(section, now, max_age=max_age)
+    if reason:
+        return [f"{prefix}_{reason}"]
+    if status in {UNKNOWN, NOT_CHECKED}:
+        evidence_error = section.get("evidence_error")
+        if isinstance(evidence_error, str) and evidence_error:
+            return [f"{prefix}_{evidence_error}"]
+        return [f"{prefix}_{status}"]
+    return []
+
+
+def _derive_evidence_holds(
+    receipt: Mapping[str, Any], now: datetime, *, max_age: int
+) -> list[str]:
+    """Derive authority holds from facts; never trust serialized hold claims."""
+    holds: list[str] = []
+    local = receipt.get("local")
+    state = local.get("state") if isinstance(local, Mapping) else None
+    if not isinstance(state, Mapping):
+        holds.append("LOCAL_STATE_UNKNOWN")
+        local_head = None
+    else:
+        local_head = state.get("head_sha")
+        if (
+            state.get("query_failures")
+            or state.get("branch") == UNKNOWN
+            or not _is_sha(local_head)
+            or state.get("operation") == "unknown"
+        ):
+            holds.append("LOCAL_STATE_UNKNOWN")
+        if (
+            state.get("ready_local") is not True
+            or state.get("derived_action") != "READY_LOCAL"
+        ):
+            derived_action = state.get("derived_action", UNKNOWN)
+            holds.append(f"LOCAL_{derived_action}")
+
+    for name in ("remote", "pull_request", "review", "integration", "retention"):
+        holds.extend(_stored_section_holds(receipt, name, now, max_age=max_age))
+
+    remote = receipt.get("remote")
+    pr = receipt.get("pull_request")
+    review = receipt.get("review")
+    integration = receipt.get("integration")
+    retention = receipt.get("retention")
+
+    if isinstance(remote, Mapping) and remote.get("status") == "OBSERVED":
+        remote_head = remote.get("head_sha")
+        if not _is_sha(remote_head):
+            holds.append("REMOTE_HEAD_UNKNOWN")
+        if remote.get("branch_state") == "PRESENT" and remote_head != local_head:
+            holds.append("REMOTE_HEAD_MISMATCH")
+
+    pr_head = pr.get("head_sha") if isinstance(pr, Mapping) else None
+    if isinstance(pr, Mapping) and pr.get("status") == "OBSERVED":
+        required_pr = (
+            "number",
+            "state",
+            "base_ref",
+            "base_sha",
+            "head_ref",
+            "head_sha",
+            "merge_state",
+            "required_checks",
+        )
+        if any(pr.get(field) in (None, "", UNKNOWN) for field in required_pr):
+            holds.append("PULL_REQUEST_IDENTITY_UNKNOWN")
+        if not _is_sha(pr.get("base_sha")) or not _is_sha(pr_head):
+            holds.append("PULL_REQUEST_SHA_MALFORMED")
+        if pr_head != local_head:
+            holds.append("PULL_REQUEST_HEAD_MISMATCH")
+        checks = pr.get("required_checks")
+        if not isinstance(checks, list):
+            holds.append("REQUIRED_CHECKS_MALFORMED")
+        elif not checks:
+            holds.append("REQUIRED_CHECKS_UNKNOWN")
+        else:
+            for check in checks:
+                if not isinstance(check, Mapping):
+                    holds.append("REQUIRED_CHECK_MALFORMED")
+                    continue
+                if check.get("head_sha") != pr_head:
+                    holds.append("REQUIRED_CHECK_HEAD_MISMATCH")
+                if (
+                    check.get("status") != "COMPLETED"
+                    or check.get("conclusion") != "SUCCESS"
+                ):
+                    holds.append("REQUIRED_CHECK_NOT_SUCCESSFUL")
+
+    if isinstance(review, Mapping) and review.get("status") == "OBSERVED":
+        if any(
+            not _is_sha(review.get(field))
+            for field in ("base_sha", "head_sha", "tree_sha")
+        ):
+            holds.append("REVIEW_IDENTITY_UNKNOWN")
+        if review.get("head_sha") != pr_head:
+            holds.append("REVIEWED_HEAD_MISMATCH")
+        if not isinstance(pr, Mapping) or review.get("base_sha") != pr.get("base_sha"):
+            holds.append("REVIEWED_BASE_MISMATCH")
+
+    if isinstance(integration, Mapping) and integration.get("status") == "OBSERVED":
+        if integration.get("method") == "squash" and (
+            not _is_sha(integration.get("merge_sha"))
+            or integration.get("reviewed_tree_sha")
+            != integration.get("merged_tree_sha")
+            or not _is_sha(integration.get("reviewed_tree_sha"))
+        ):
+            holds.append("SQUASH_TREE_EQUIVALENCE_UNKNOWN")
+
+    if isinstance(retention, Mapping):
+        retention_holds = retention.get("holds", [])
+        if not isinstance(retention_holds, list) or any(
+            not isinstance(item, str) or not item for item in retention_holds
+        ):
+            holds.append("RETENTION_HOLDS_MALFORMED")
+        else:
+            holds.extend(retention_holds)
+
+    task_archive = receipt.get("task_archive")
+    if (
+        not isinstance(task_archive, Mapping)
+        or task_archive.get("is_git_retention_evidence") is not False
+    ):
+        holds.append("TASK_ARCHIVE_RETENTION_CONTRADICTION")
+    if receipt.get("receipt_grants_authority") is not False:
+        holds.append("RECEIPT_AUTHORITY_BOUNDARY_MISSING")
+    holds.extend(
+        _authorization_holds(
+            receipt.get("authorization"),
+            task=receipt.get("task"),
+            local_state=state,
+        )
+    )
+    return sorted(set(holds))
 
 
 def build_receipt(
@@ -126,107 +344,17 @@ def build_receipt(
     """Create one receipt. Missing or inconsistent facts become explicit holds."""
     observed_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     supplied = evidence or {}
-    holds: list[str] = []
-
-    if (
-        local_state.query_failures
-        or local_state.branch == UNKNOWN
-        or not _is_sha(local_state.head_sha)
-        or local_state.operation == "unknown"
-    ):
-        holds.append("LOCAL_STATE_UNKNOWN")
-    if not local_state.ready_local:
-        holds.append(f"LOCAL_{local_state.derived_action}")
-
-    remote, remote_holds = _normalise_section(
-        supplied, "remote", observed_now, max_age=max_age
-    )
-    pull_request, pr_holds = _normalise_section(
+    remote, _ = _normalise_section(supplied, "remote", observed_now, max_age=max_age)
+    pull_request, _ = _normalise_section(
         supplied, "pull_request", observed_now, max_age=max_age
     )
-    review, review_holds = _normalise_section(
-        supplied, "review", observed_now, max_age=max_age
-    )
-    retention, retention_holds = _normalise_section(
+    review, _ = _normalise_section(supplied, "review", observed_now, max_age=max_age)
+    retention, _ = _normalise_section(
         supplied, "retention", observed_now, max_age=max_age
     )
-    integration, integration_holds = _normalise_section(
+    integration, _ = _normalise_section(
         supplied, "integration", observed_now, max_age=max_age
     )
-    holds.extend(
-        remote_holds + pr_holds + review_holds + retention_holds + integration_holds
-    )
-
-    local_head = local_state.head_sha
-    remote_head = remote.get("head_sha")
-    pr_head = pull_request.get("head_sha")
-    reviewed_head = review.get("head_sha")
-    if remote.get("status") == "OBSERVED" and not _is_sha(remote_head):
-        holds.append("REMOTE_HEAD_UNKNOWN")
-    if pull_request.get("status") == "OBSERVED":
-        required_pr = (
-            "number",
-            "state",
-            "base_ref",
-            "base_sha",
-            "head_ref",
-            "head_sha",
-            "merge_state",
-            "required_checks",
-        )
-        if any(pull_request.get(field) in (None, "", UNKNOWN) for field in required_pr):
-            holds.append("PULL_REQUEST_IDENTITY_UNKNOWN")
-        if not _is_sha(pull_request.get("base_sha")) or not _is_sha(pr_head):
-            holds.append("PULL_REQUEST_SHA_MALFORMED")
-    if review.get("status") == "OBSERVED":
-        for field in ("base_sha", "head_sha", "tree_sha"):
-            if not _is_sha(review.get(field)):
-                holds.append("REVIEW_IDENTITY_UNKNOWN")
-                break
-
-    published_claim = (
-        remote.get("status") == "OBSERVED" and remote.get("branch_state") == "PRESENT"
-    )
-    if published_claim and local_head != remote_head:
-        holds.append("REMOTE_HEAD_MISMATCH")
-    if pull_request.get("status") == "OBSERVED" and pr_head != local_head:
-        holds.append("PULL_REQUEST_HEAD_MISMATCH")
-    if review.get("status") == "OBSERVED" and reviewed_head != pr_head:
-        holds.append("REVIEWED_HEAD_MISMATCH")
-    if (
-        review.get("status") == "OBSERVED"
-        and pull_request.get("status") == "OBSERVED"
-        and review.get("base_sha") != pull_request.get("base_sha")
-    ):
-        holds.append("REVIEWED_BASE_MISMATCH")
-
-    checks = pull_request.get("required_checks", [])
-    if checks not in (None, UNKNOWN) and not isinstance(checks, list):
-        holds.append("REQUIRED_CHECKS_MALFORMED")
-    if isinstance(checks, list):
-        if pull_request.get("status") == "OBSERVED" and not checks:
-            holds.append("REQUIRED_CHECKS_UNKNOWN")
-        for check in checks:
-            if not isinstance(check, Mapping):
-                holds.append("REQUIRED_CHECK_MALFORMED")
-                continue
-            if check.get("head_sha") != pr_head:
-                holds.append("REQUIRED_CHECK_HEAD_MISMATCH")
-            if (
-                check.get("status") != "COMPLETED"
-                or check.get("conclusion") != "SUCCESS"
-            ):
-                holds.append("REQUIRED_CHECK_NOT_SUCCESSFUL")
-
-    if integration.get("status") == "OBSERVED":
-        # Squash integration is content evidence, never ancestry/retention authority.
-        if integration.get("method") == "squash" and (
-            not _is_sha(integration.get("merge_sha"))
-            or integration.get("reviewed_tree_sha")
-            != integration.get("merged_tree_sha")
-            or not _is_sha(integration.get("reviewed_tree_sha"))
-        ):
-            holds.append("SQUASH_TREE_EQUIVALENCE_UNKNOWN")
 
     task_archive = supplied.get("task_archive", {"status": NOT_CHECKED})
     if not isinstance(task_archive, Mapping):
@@ -242,20 +370,17 @@ def build_receipt(
             "prohibited_actions": [],
             "next_action": "HOLD_FOR_EXACT_EVIDENCE",
         }
-        holds.append("AUTHORIZATION_UNKNOWN")
     else:
         authorization = dict(authorization)
         if not authorization.get("next_action"):
             authorization["next_action"] = "HOLD_FOR_EXACT_EVIDENCE"
-            holds.append("NEXT_ACTION_UNKNOWN")
 
-    holds.extend(str(item) for item in retention.get("holds", []) if item)
-    holds = sorted(set(holds))
     local = _local_payload(local_state)
-    return {
+    receipt = {
         "schema_version": SCHEMA_VERSION,
         "receipt_kind": RECEIPT_KIND,
-        "receipt_status": "HOLD" if holds else "READY",
+        "receipt_status": "HOLD",
+        "receipt_grants_authority": False,
         "observed_at_utc": observed_now.isoformat(),
         "task": {
             "task_id": task_id,
@@ -273,9 +398,13 @@ def build_receipt(
         "retention": retention,
         "task_archive": task_archive,
         "authorization": authorization,
-        "holds": holds,
+        "holds": [],
         "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
     }
+    derived_holds = _derive_evidence_holds(receipt, observed_now, max_age=max_age)
+    receipt["holds"] = derived_holds
+    receipt["receipt_status"] = "HOLD" if derived_holds else "READY"
+    return receipt
 
 
 def validate_receipt(
@@ -309,70 +438,42 @@ def validate_receipt(
         expected_hash = f"sha256:{local.get('receipt_sha256', '')}"
         if receipt.get("local_state_receipt_hash") != expected_hash:
             errors.append("LOCAL_STATE_RECEIPT_HASH_MISMATCH")
-    holds = receipt.get("holds")
-    if not isinstance(holds, list):
+    serialized_holds = receipt.get("holds")
+    if not isinstance(serialized_holds, list) or any(
+        not isinstance(hold, str) or not hold for hold in serialized_holds
+    ):
         errors.append("HOLDS_MALFORMED")
-    if receipt.get("receipt_status") == "READY" and (errors or holds):
-        errors.append("FALSE_READY_CLAIM")
+        serialized_hold_set: set[str] = set()
+    else:
+        serialized_hold_set = set(serialized_holds)
+        if len(serialized_hold_set) != len(serialized_holds):
+            errors.append("HOLDS_DUPLICATE")
+
+    receipt_status = receipt.get("receipt_status")
+    if receipt_status not in {"READY", "HOLD"}:
+        errors.append("RECEIPT_STATUS_INVALID")
     task_archive = receipt.get("task_archive")
     if (
         not isinstance(task_archive, Mapping)
         or task_archive.get("is_git_retention_evidence") is not False
     ):
         errors.append("TASK_ARCHIVE_RETENTION_CONTRADICTION")
-    for name in ("remote", "pull_request", "review", "integration", "retention"):
-        section = receipt.get(name)
-        if not isinstance(section, Mapping):
-            errors.append(f"{name.upper()}_MALFORMED")
-            continue
-        _status, reason = _fresh_status(section, observed_now, max_age=max_age)
-        if reason:
-            errors.append(f"{name.upper()}_{reason}")
-    if isinstance(local, Mapping) and isinstance(local.get("state"), Mapping):
-        local_state = local["state"]
-        local_head = local_state.get("head_sha")
-        remote = receipt.get("remote", {})
-        pr = receipt.get("pull_request", {})
-        review = receipt.get("review", {})
-        if isinstance(remote, Mapping) and remote.get("status") == "OBSERVED":
-            if (
-                remote.get("branch_state") == "PRESENT"
-                and remote.get("head_sha") != local_head
-            ):
-                errors.append("REMOTE_HEAD_MISMATCH")
-        if isinstance(pr, Mapping) and pr.get("status") == "OBSERVED":
-            if pr.get("head_sha") != local_head:
-                errors.append("PULL_REQUEST_HEAD_MISMATCH")
-            checks = pr.get("required_checks")
-            if not isinstance(checks, list):
-                errors.append("REQUIRED_CHECKS_MALFORMED")
-            else:
-                for check in checks:
-                    if not isinstance(check, Mapping):
-                        errors.append("REQUIRED_CHECK_MALFORMED")
-                    elif check.get("head_sha") != pr.get("head_sha"):
-                        errors.append("REQUIRED_CHECK_HEAD_MISMATCH")
-                    elif (
-                        check.get("status") != "COMPLETED"
-                        or check.get("conclusion") != "SUCCESS"
-                    ):
-                        errors.append("REQUIRED_CHECK_NOT_SUCCESSFUL")
-        if isinstance(review, Mapping) and review.get("status") == "OBSERVED":
-            if not isinstance(pr, Mapping) or review.get("head_sha") != pr.get(
-                "head_sha"
-            ):
-                errors.append("REVIEWED_HEAD_MISMATCH")
-            if not isinstance(pr, Mapping) or review.get("base_sha") != pr.get(
-                "base_sha"
-            ):
-                errors.append("REVIEWED_BASE_MISMATCH")
-    integration = receipt.get("integration")
-    if isinstance(integration, Mapping) and integration.get("status") == "OBSERVED":
-        if integration.get("method") == "squash" and (
-            integration.get("reviewed_tree_sha") != integration.get("merged_tree_sha")
-            or not _is_sha(integration.get("reviewed_tree_sha"))
-        ):
-            errors.append("SQUASH_TREE_EQUIVALENCE_UNKNOWN")
+    if receipt.get("receipt_grants_authority") is not False:
+        errors.append("RECEIPT_AUTHORITY_BOUNDARY_MISSING")
+
+    derived_holds = set(_derive_evidence_holds(receipt, observed_now, max_age=max_age))
+    for hold in sorted(derived_holds - serialized_hold_set):
+        errors.append(f"MISSING_REQUIRED_HOLD:{hold}")
+    for hold in sorted(serialized_hold_set - derived_holds):
+        errors.append(f"UNSUPPORTED_SERIALIZED_HOLD:{hold}")
+    if serialized_hold_set != derived_holds:
+        errors.append("HOLD_SET_MISMATCH")
+
+    expected_status = "HOLD" if derived_holds else "READY"
+    if receipt_status in {"READY", "HOLD"} and receipt_status != expected_status:
+        errors.append("RECEIPT_STATUS_CONTRADICTION")
+    if receipt_status == "READY" and (errors or derived_holds):
+        errors.append("FALSE_READY_CLAIM")
     return sorted(set(errors))
 
 

--- a/scripts/git_handoff_receipt.py
+++ b/scripts/git_handoff_receipt.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Build and validate fail-closed task-to-Git handoff receipts.
+
+Local facts come only from :mod:`scripts.git_state`. Remote, pull-request,
+review, check, and retention facts are caller-supplied evidence; this module
+does not contact a remote or mutate Git/GitHub state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lib.utils import REPO_ROOT
+from git_state import RepositoryState, collect_repository_state
+
+SCHEMA_VERSION = 1
+RECEIPT_KIND = "task_to_git_handoff"
+UNKNOWN = "UNKNOWN"
+NOT_CHECKED = "NOT_CHECKED"
+MAX_EVIDENCE_AGE_SECONDS = 900
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _unknown(status: str = UNKNOWN) -> dict[str, Any]:
+    return {"status": status, "query_status": UNKNOWN}
+
+
+def _is_sha(value: object) -> bool:
+    return isinstance(value, str) and SHA_RE.fullmatch(value) is not None
+
+
+def _parse_time(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _fresh_status(
+    section: Mapping[str, Any], now: datetime, *, max_age: int
+) -> tuple[str, str | None]:
+    status = section.get("status", UNKNOWN)
+    if status in {UNKNOWN, NOT_CHECKED}:
+        return str(status), None
+    if status == "NOT_APPLICABLE":
+        if not section.get("reason_code"):
+            return UNKNOWN, "NOT_APPLICABLE_WITHOUT_REASON"
+        return "NOT_APPLICABLE", None
+    if status != "OBSERVED":
+        return UNKNOWN, "MALFORMED_STATUS"
+    if section.get("query_status") != "OK":
+        return UNKNOWN, "QUERY_FAILED"
+    observed = _parse_time(section.get("observed_at_utc"))
+    if observed is None:
+        return UNKNOWN, "MALFORMED_OBSERVATION_TIME"
+    age = (now - observed).total_seconds()
+    if age < -5:
+        return UNKNOWN, "FUTURE_EVIDENCE"
+    if age > max_age:
+        return UNKNOWN, "STALE_EVIDENCE"
+    return "OBSERVED", None
+
+
+def _normalise_section(
+    evidence: Mapping[str, Any], name: str, now: datetime, *, max_age: int
+) -> tuple[dict[str, Any], list[str]]:
+    raw = evidence.get(name)
+    if raw is None:
+        return _unknown(NOT_CHECKED), [f"{name.upper()}_NOT_CHECKED"]
+    if not isinstance(raw, Mapping):
+        return _unknown(), [f"{name.upper()}_MALFORMED"]
+    section = dict(raw)
+    status, reason = _fresh_status(section, now, max_age=max_age)
+    section["status"] = status
+    if status != "OBSERVED":
+        section["query_status"] = UNKNOWN
+    if reason:
+        return section, [f"{name.upper()}_{reason}"]
+    if status in {UNKNOWN, NOT_CHECKED}:
+        return section, [f"{name.upper()}_{status}"]
+    return section, []
+
+
+def _local_payload(state: RepositoryState) -> dict[str, Any]:
+    state_payload = state.to_dict()
+    return {
+        "authority": "scripts/git_state.py",
+        "receipt_sha256": _sha256(state_payload),
+        "state": state_payload,
+    }
+
+
+def build_receipt(
+    *,
+    task_id: str,
+    integration_owner: str,
+    local_state: RepositoryState,
+    evidence: Mapping[str, Any] | None = None,
+    owned_paths: Sequence[str] = (),
+    shared_paths: Sequence[str] = (),
+    forbidden_paths: Sequence[str] = (),
+    now: datetime | None = None,
+    max_age: int = MAX_EVIDENCE_AGE_SECONDS,
+) -> dict[str, Any]:
+    """Create one receipt. Missing or inconsistent facts become explicit holds."""
+    observed_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    supplied = evidence or {}
+    holds: list[str] = []
+
+    if (
+        local_state.query_failures
+        or local_state.branch == UNKNOWN
+        or not _is_sha(local_state.head_sha)
+        or local_state.operation == "unknown"
+    ):
+        holds.append("LOCAL_STATE_UNKNOWN")
+    if not local_state.ready_local:
+        holds.append(f"LOCAL_{local_state.derived_action}")
+
+    remote, remote_holds = _normalise_section(
+        supplied, "remote", observed_now, max_age=max_age
+    )
+    pull_request, pr_holds = _normalise_section(
+        supplied, "pull_request", observed_now, max_age=max_age
+    )
+    review, review_holds = _normalise_section(
+        supplied, "review", observed_now, max_age=max_age
+    )
+    retention, retention_holds = _normalise_section(
+        supplied, "retention", observed_now, max_age=max_age
+    )
+    integration, integration_holds = _normalise_section(
+        supplied, "integration", observed_now, max_age=max_age
+    )
+    holds.extend(
+        remote_holds + pr_holds + review_holds + retention_holds + integration_holds
+    )
+
+    local_head = local_state.head_sha
+    remote_head = remote.get("head_sha")
+    pr_head = pull_request.get("head_sha")
+    reviewed_head = review.get("head_sha")
+    if remote.get("status") == "OBSERVED" and not _is_sha(remote_head):
+        holds.append("REMOTE_HEAD_UNKNOWN")
+    if pull_request.get("status") == "OBSERVED":
+        required_pr = (
+            "number",
+            "state",
+            "base_ref",
+            "base_sha",
+            "head_ref",
+            "head_sha",
+            "merge_state",
+            "required_checks",
+        )
+        if any(pull_request.get(field) in (None, "", UNKNOWN) for field in required_pr):
+            holds.append("PULL_REQUEST_IDENTITY_UNKNOWN")
+        if not _is_sha(pull_request.get("base_sha")) or not _is_sha(pr_head):
+            holds.append("PULL_REQUEST_SHA_MALFORMED")
+    if review.get("status") == "OBSERVED":
+        for field in ("base_sha", "head_sha", "tree_sha"):
+            if not _is_sha(review.get(field)):
+                holds.append("REVIEW_IDENTITY_UNKNOWN")
+                break
+
+    published_claim = (
+        remote.get("status") == "OBSERVED" and remote.get("branch_state") == "PRESENT"
+    )
+    if published_claim and local_head != remote_head:
+        holds.append("REMOTE_HEAD_MISMATCH")
+    if pull_request.get("status") == "OBSERVED" and pr_head != local_head:
+        holds.append("PULL_REQUEST_HEAD_MISMATCH")
+    if review.get("status") == "OBSERVED" and reviewed_head != pr_head:
+        holds.append("REVIEWED_HEAD_MISMATCH")
+    if (
+        review.get("status") == "OBSERVED"
+        and pull_request.get("status") == "OBSERVED"
+        and review.get("base_sha") != pull_request.get("base_sha")
+    ):
+        holds.append("REVIEWED_BASE_MISMATCH")
+
+    checks = pull_request.get("required_checks", [])
+    if checks not in (None, UNKNOWN) and not isinstance(checks, list):
+        holds.append("REQUIRED_CHECKS_MALFORMED")
+    if isinstance(checks, list):
+        if pull_request.get("status") == "OBSERVED" and not checks:
+            holds.append("REQUIRED_CHECKS_UNKNOWN")
+        for check in checks:
+            if not isinstance(check, Mapping):
+                holds.append("REQUIRED_CHECK_MALFORMED")
+                continue
+            if check.get("head_sha") != pr_head:
+                holds.append("REQUIRED_CHECK_HEAD_MISMATCH")
+            if (
+                check.get("status") != "COMPLETED"
+                or check.get("conclusion") != "SUCCESS"
+            ):
+                holds.append("REQUIRED_CHECK_NOT_SUCCESSFUL")
+
+    if integration.get("status") == "OBSERVED":
+        # Squash integration is content evidence, never ancestry/retention authority.
+        if integration.get("method") == "squash" and (
+            not _is_sha(integration.get("merge_sha"))
+            or integration.get("reviewed_tree_sha")
+            != integration.get("merged_tree_sha")
+            or not _is_sha(integration.get("reviewed_tree_sha"))
+        ):
+            holds.append("SQUASH_TREE_EQUIVALENCE_UNKNOWN")
+
+    task_archive = supplied.get("task_archive", {"status": NOT_CHECKED})
+    if not isinstance(task_archive, Mapping):
+        task_archive = {"status": UNKNOWN}
+    task_archive = dict(task_archive)
+    task_archive["is_git_retention_evidence"] = False
+
+    authorization = supplied.get("authorization")
+    if not isinstance(authorization, Mapping):
+        authorization = {
+            "status": UNKNOWN,
+            "authorized_actions": [],
+            "prohibited_actions": [],
+            "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+        }
+        holds.append("AUTHORIZATION_UNKNOWN")
+    else:
+        authorization = dict(authorization)
+        if not authorization.get("next_action"):
+            authorization["next_action"] = "HOLD_FOR_EXACT_EVIDENCE"
+            holds.append("NEXT_ACTION_UNKNOWN")
+
+    holds.extend(str(item) for item in retention.get("holds", []) if item)
+    holds = sorted(set(holds))
+    local = _local_payload(local_state)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "receipt_kind": RECEIPT_KIND,
+        "receipt_status": "HOLD" if holds else "READY",
+        "observed_at_utc": observed_now.isoformat(),
+        "task": {
+            "task_id": task_id,
+            "integration_owner": integration_owner,
+            "owned_paths": list(owned_paths),
+            "shared_paths": list(shared_paths),
+            "forbidden_paths": list(forbidden_paths),
+        },
+        "local_state_receipt_hash": f"sha256:{local['receipt_sha256']}",
+        "local": local,
+        "remote": remote,
+        "pull_request": pull_request,
+        "review": review,
+        "integration": integration,
+        "retention": retention,
+        "task_archive": task_archive,
+        "authorization": authorization,
+        "holds": holds,
+        "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+    }
+
+
+def validate_receipt(
+    receipt: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+    max_age: int = MAX_EVIDENCE_AGE_SECONDS,
+) -> list[str]:
+    """Validate a stored receipt without upgrading unknown evidence to success."""
+    errors: list[str] = []
+    observed_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if receipt.get("schema_version") != SCHEMA_VERSION:
+        errors.append("SCHEMA_VERSION_UNKNOWN")
+    if receipt.get("receipt_kind") != RECEIPT_KIND:
+        errors.append("RECEIPT_KIND_UNKNOWN")
+    task = receipt.get("task")
+    if not isinstance(task, Mapping) or not task.get("task_id"):
+        errors.append("TASK_ID_UNKNOWN")
+    local = receipt.get("local")
+    if (
+        not isinstance(local, Mapping)
+        or local.get("authority") != "scripts/git_state.py"
+    ):
+        errors.append("LOCAL_AUTHORITY_UNKNOWN")
+    else:
+        state = local.get("state")
+        if not isinstance(state, Mapping):
+            errors.append("LOCAL_STATE_UNKNOWN")
+        elif local.get("receipt_sha256") != _sha256(state):
+            errors.append("LOCAL_STATE_HASH_MISMATCH")
+        expected_hash = f"sha256:{local.get('receipt_sha256', '')}"
+        if receipt.get("local_state_receipt_hash") != expected_hash:
+            errors.append("LOCAL_STATE_RECEIPT_HASH_MISMATCH")
+    holds = receipt.get("holds")
+    if not isinstance(holds, list):
+        errors.append("HOLDS_MALFORMED")
+    if receipt.get("receipt_status") == "READY" and (errors or holds):
+        errors.append("FALSE_READY_CLAIM")
+    task_archive = receipt.get("task_archive")
+    if (
+        not isinstance(task_archive, Mapping)
+        or task_archive.get("is_git_retention_evidence") is not False
+    ):
+        errors.append("TASK_ARCHIVE_RETENTION_CONTRADICTION")
+    for name in ("remote", "pull_request", "review", "integration", "retention"):
+        section = receipt.get(name)
+        if not isinstance(section, Mapping):
+            errors.append(f"{name.upper()}_MALFORMED")
+            continue
+        _status, reason = _fresh_status(section, observed_now, max_age=max_age)
+        if reason:
+            errors.append(f"{name.upper()}_{reason}")
+    if isinstance(local, Mapping) and isinstance(local.get("state"), Mapping):
+        local_state = local["state"]
+        local_head = local_state.get("head_sha")
+        remote = receipt.get("remote", {})
+        pr = receipt.get("pull_request", {})
+        review = receipt.get("review", {})
+        if isinstance(remote, Mapping) and remote.get("status") == "OBSERVED":
+            if (
+                remote.get("branch_state") == "PRESENT"
+                and remote.get("head_sha") != local_head
+            ):
+                errors.append("REMOTE_HEAD_MISMATCH")
+        if isinstance(pr, Mapping) and pr.get("status") == "OBSERVED":
+            if pr.get("head_sha") != local_head:
+                errors.append("PULL_REQUEST_HEAD_MISMATCH")
+            checks = pr.get("required_checks")
+            if not isinstance(checks, list):
+                errors.append("REQUIRED_CHECKS_MALFORMED")
+            else:
+                for check in checks:
+                    if not isinstance(check, Mapping):
+                        errors.append("REQUIRED_CHECK_MALFORMED")
+                    elif check.get("head_sha") != pr.get("head_sha"):
+                        errors.append("REQUIRED_CHECK_HEAD_MISMATCH")
+                    elif (
+                        check.get("status") != "COMPLETED"
+                        or check.get("conclusion") != "SUCCESS"
+                    ):
+                        errors.append("REQUIRED_CHECK_NOT_SUCCESSFUL")
+        if isinstance(review, Mapping) and review.get("status") == "OBSERVED":
+            if not isinstance(pr, Mapping) or review.get("head_sha") != pr.get(
+                "head_sha"
+            ):
+                errors.append("REVIEWED_HEAD_MISMATCH")
+            if not isinstance(pr, Mapping) or review.get("base_sha") != pr.get(
+                "base_sha"
+            ):
+                errors.append("REVIEWED_BASE_MISMATCH")
+    integration = receipt.get("integration")
+    if isinstance(integration, Mapping) and integration.get("status") == "OBSERVED":
+        if integration.get("method") == "squash" and (
+            integration.get("reviewed_tree_sha") != integration.get("merged_tree_sha")
+            or not _is_sha(integration.get("reviewed_tree_sha"))
+        ):
+            errors.append("SQUASH_TREE_EQUIVALENCE_UNKNOWN")
+    return sorted(set(errors))
+
+
+def load_receipt(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("receipt root must be an object")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    create = sub.add_parser(
+        "create", help="Build a receipt from local state and supplied evidence"
+    )
+    create.add_argument("--task-id", required=True)
+    create.add_argument("--integration-owner", required=True)
+    create.add_argument("--repo", type=Path, default=REPO_ROOT)
+    create.add_argument("--evidence", type=Path)
+    create.add_argument("--owned-path", action="append", default=[])
+    create.add_argument("--shared-path", action="append", default=[])
+    create.add_argument("--forbidden-path", action="append", default=[])
+    create.add_argument("--output", type=Path)
+    validate = sub.add_parser("validate", help="Validate one stored receipt")
+    validate.add_argument("receipt", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "validate":
+        try:
+            receipt = load_receipt(args.receipt)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"Task-to-Git handoff receipt invalid: {exc}")
+            return 1
+        errors = validate_receipt(receipt)
+        if errors:
+            print("Task-to-Git handoff receipt invalid:")
+            for error in errors:
+                print(f"  - {error}")
+            return 1
+        print(
+            "Task-to-Git handoff receipt valid: "
+            f"{receipt['task']['task_id']} | {receipt['receipt_status']}"
+        )
+        return 0
+
+    evidence: dict[str, Any] = {}
+    if args.evidence:
+        try:
+            value = json.loads(args.evidence.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"Evidence query failed or malformed: {exc}", file=sys.stderr)
+            value = {}
+        if isinstance(value, dict):
+            evidence = value
+    receipt = build_receipt(
+        task_id=args.task_id,
+        integration_owner=args.integration_owner,
+        local_state=collect_repository_state(args.repo),
+        evidence=evidence,
+        owned_paths=args.owned_path,
+        shared_paths=args.shared_path,
+        forbidden_paths=args.forbidden_path,
+    )
+    payload = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/git_handoff_receipt.py
+++ b/scripts/git_handoff_receipt.py
@@ -177,15 +177,7 @@ def _authorization_holds(
             or not source.get("reference", "").strip()
         ):
             holds.append("AUTHORIZATION_SOURCE_REFERENCE_UNKNOWN")
-        source_status, source_reason = _fresh_status(
-            {
-                "status": "OBSERVED",
-                "query_status": "OK",
-                "observed_at_utc": source.get("observed_at_utc"),
-            },
-            now,
-            max_age=max_age,
-        )
+        source_status, source_reason = _fresh_status(source, now, max_age=max_age)
         if source_status != "OBSERVED":
             holds.append("AUTHORIZATION_SOURCE_" + (source_reason or "TIME_UNKNOWN"))
 

--- a/scripts/git_handoff_receipt.py
+++ b/scripts/git_handoff_receipt.py
@@ -27,6 +27,14 @@ UNKNOWN = "UNKNOWN"
 NOT_CHECKED = "NOT_CHECKED"
 MAX_EVIDENCE_AGE_SECONDS = 900
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SAFE_HOLD_NEXT_ACTIONS = frozenset(
+    {
+        "HOLD_FOR_EXACT_EVIDENCE",
+        "WAIT_FOR_EXACT_HEAD_AUDIT",
+        "WAIT_FOR_OWNER_DECISION",
+        "STOP_AND_REINSPECT",
+    }
+)
 
 
 def _canonical_json(value: object) -> str:
@@ -119,19 +127,19 @@ def _authorization_holds(
     *,
     task: object,
     local_state: object,
+    now: datetime,
+    max_age: int,
 ) -> list[str]:
     if not isinstance(authorization, Mapping):
         return ["AUTHORIZATION_MALFORMED"]
     holds: list[str] = []
-    status = authorization.get("status")
-    if status not in {"OBSERVED", UNKNOWN, NOT_CHECKED}:
-        holds.append("AUTHORIZATION_STATUS_INVALID")
-    elif status != "OBSERVED":
-        holds.append("AUTHORIZATION_UNKNOWN")
-    if (
-        not isinstance(authorization.get("next_action"), str)
-        or not authorization.get("next_action", "").strip()
-    ):
+    status, freshness_reason = _fresh_status(authorization, now, max_age=max_age)
+    if freshness_reason:
+        holds.append(f"AUTHORIZATION_{freshness_reason}")
+    elif status in {UNKNOWN, NOT_CHECKED}:
+        holds.append(f"AUTHORIZATION_{status}")
+    next_action = authorization.get("next_action")
+    if not isinstance(next_action, str) or not next_action.strip():
         holds.append("NEXT_ACTION_UNKNOWN")
     for field in ("authorized_actions", "prohibited_actions"):
         actions = authorization.get(field)
@@ -145,6 +153,13 @@ def _authorization_holds(
     if isinstance(authorized, list) and isinstance(prohibited, list):
         if set(authorized) & set(prohibited):
             holds.append("AUTHORIZATION_ACTION_CONTRADICTION")
+        if (
+            isinstance(next_action, str)
+            and next_action.strip()
+            and next_action not in SAFE_HOLD_NEXT_ACTIONS
+            and next_action not in authorized
+        ):
+            holds.append("NEXT_ACTION_NOT_AUTHORIZED")
 
     source = authorization.get("authority_source")
     if not isinstance(source, Mapping):
@@ -162,8 +177,17 @@ def _authorization_holds(
             or not source.get("reference", "").strip()
         ):
             holds.append("AUTHORIZATION_SOURCE_REFERENCE_UNKNOWN")
-        if _parse_time(source.get("observed_at_utc")) is None:
-            holds.append("AUTHORIZATION_SOURCE_TIME_UNKNOWN")
+        source_status, source_reason = _fresh_status(
+            {
+                "status": "OBSERVED",
+                "query_status": "OK",
+                "observed_at_utc": source.get("observed_at_utc"),
+            },
+            now,
+            max_age=max_age,
+        )
+        if source_status != "OBSERVED":
+            holds.append("AUTHORIZATION_SOURCE_" + (source_reason or "TIME_UNKNOWN"))
 
     binding = authorization.get("target_binding")
     if not isinstance(binding, Mapping):
@@ -324,6 +348,8 @@ def _derive_evidence_holds(
             receipt.get("authorization"),
             task=receipt.get("task"),
             local_state=state,
+            now=now,
+            max_age=max_age,
         )
     )
     return sorted(set(holds))

--- a/scripts/git_state.py
+++ b/scripts/git_state.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -26,6 +27,27 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SCHEMA_VERSION = 1
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 1.0
 SIBLING_COMMAND_TIMEOUT_SECONDS = 0.5
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+RELATION_STATUSES = frozenset(
+    {"ahead", "behind", "diverged", "equal", "none", "unknown"}
+)
+OPERATION_STATUSES = frozenset(
+    {"none", "merge", "cherry_pick", "revert", "bisect", "rebase"}
+)
+DERIVED_ACTIONS = frozenset(
+    {
+        "READY_LOCAL",
+        "HOLD_UNKNOWN",
+        "HOLD_OPERATION",
+        "HOLD_LOCKED",
+        "HOLD_DETACHED",
+        "HOLD_MAIN",
+        "HOLD_DIVERGED",
+        "HOLD_BEHIND",
+        "HOLD_DIRTY",
+    }
+)
+REMOTE_FRESHNESS_STATUSES = frozenset({"NOT_CHECKED"})
 
 
 @dataclass
@@ -357,23 +379,264 @@ def _derive_action(
     return reasons[0][0], [message for _action, message in reasons]
 
 
-def validate_repository_state_consistency(state: RepositoryState) -> list[str]:
-    """Recompute derived action/holds from supplied evidence without Git I/O."""
-    try:
-        expected_action, expected_reasons = _derive_action(
-            branch=state.branch,
-            head_sha=state.head_sha,
-            tree=state.tree,
-            operation=state.operation,
-            locks=state.locks,
-            default_base=state.default_base,
-            upstream=state.upstream,
-            failures=state.query_failures,
-        )
-    except (AttributeError, TypeError, ValueError) as exc:
-        return [f"repository-state evidence is malformed: {exc}"]
+def _is_nonnegative_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _validate_relation(
+    relation: object,
+    *,
+    name: str,
+    allow_none: bool,
+    query_failed: bool,
+) -> list[str]:
+    errors: list[str] = []
+    required = ("ref", "sha", "ahead", "behind", "status")
+    if not all(hasattr(relation, field) for field in required):
+        return [f"{name} relation is malformed"]
+    ref = relation.ref
+    sha = relation.sha
+    ahead = relation.ahead
+    behind = relation.behind
+    status = relation.status
+    if not isinstance(ref, str) or not ref:
+        errors.append(f"{name} relation ref is malformed")
+    if (
+        not isinstance(status, str)
+        or status not in RELATION_STATUSES
+        or (status == "none" and not allow_none)
+    ):
+        errors.append(f"{name} relation status is unsupported: {status!r}")
+        return errors
+    if status in {"ahead", "behind", "diverged", "equal"}:
+        if not isinstance(sha, str) or SHA_RE.fullmatch(sha) is None:
+            errors.append(f"{name} relation SHA is malformed")
+        if not _is_nonnegative_int(ahead) or not _is_nonnegative_int(behind):
+            errors.append(f"{name} relation counts are malformed")
+        else:
+            expected = (
+                "diverged"
+                if ahead and behind
+                else "ahead" if ahead else "behind" if behind else "equal"
+            )
+            if status != expected:
+                errors.append(f"{name} relation status contradicts counts")
+    elif status == "none":
+        if ref != "NONE" or any(value is not None for value in (sha, ahead, behind)):
+            errors.append(f"{name} none relation is contradictory")
+    elif status == "unknown":
+        if any(value is not None for value in (sha, ahead, behind)):
+            errors.append(f"{name} unknown relation is contradictory")
+        if not query_failed:
+            errors.append(f"{name} unknown relation lacks query failure evidence")
+    return errors
+
+
+def validate_repository_state_consistency(state: object) -> list[str]:
+    """Validate the full canonical evidence contract without Git or network I/O."""
+    required_fields = (
+        "schema_version",
+        "observed_at_utc",
+        "repository_root",
+        "worktree_root",
+        "git_dir",
+        "git_common_dir",
+        "linked_worktree",
+        "branch",
+        "head_sha",
+        "default_base",
+        "upstream",
+        "tree",
+        "operation",
+        "operation_markers",
+        "locks",
+        "remote_freshness",
+        "derived_action",
+        "hold_reasons",
+        "query_failures",
+        "duration_ms",
+    )
+    missing = [field for field in required_fields if not hasattr(state, field)]
+    if missing:
+        return [f"repository-state evidence is missing: {', '.join(missing)}"]
 
     errors: list[str] = []
+    if state.schema_version != SCHEMA_VERSION or isinstance(state.schema_version, bool):
+        errors.append(
+            f"repository-state schema is unsupported: {state.schema_version!r}"
+        )
+    if not isinstance(state.observed_at_utc, str):
+        errors.append("observed_at_utc is malformed")
+    else:
+        try:
+            observed = datetime.fromisoformat(
+                state.observed_at_utc.replace("Z", "+00:00")
+            )
+            if observed.tzinfo is None:
+                errors.append("observed_at_utc lacks timezone")
+        except ValueError:
+            errors.append("observed_at_utc is malformed")
+
+    path_fields = ("repository_root", "worktree_root", "git_dir", "git_common_dir")
+    for field in path_fields:
+        value = getattr(state, field)
+        if field == "repository_root" and (
+            not isinstance(value, str) or not value or not Path(value).is_absolute()
+        ):
+            errors.append(f"{field} is malformed")
+        elif value is not None and (
+            not isinstance(value, str) or not value or not Path(value).is_absolute()
+        ):
+            errors.append(f"{field} is malformed")
+    if state.linked_worktree is not None and not isinstance(
+        state.linked_worktree, bool
+    ):
+        errors.append("linked_worktree is malformed")
+    if isinstance(state.git_dir, str) and isinstance(state.git_common_dir, str):
+        expected_linked = state.git_dir != state.git_common_dir
+        if state.linked_worktree is not expected_linked:
+            errors.append("linked_worktree contradicts Git directory evidence")
+    elif state.linked_worktree is not None:
+        errors.append("linked_worktree lacks complete Git directory evidence")
+
+    if not isinstance(state.query_failures, list):
+        errors.append("query_failures is malformed")
+        query_failed = False
+    else:
+        query_failed = bool(state.query_failures)
+        for failure in state.query_failures:
+            if not all(
+                hasattr(failure, field) for field in ("command", "reason")
+            ) or not all(
+                isinstance(getattr(failure, field, None), str)
+                and bool(getattr(failure, field, None))
+                for field in ("command", "reason")
+            ):
+                errors.append("query failure evidence is malformed")
+                break
+    if not query_failed and any(
+        not isinstance(getattr(state, field), str)
+        for field in ("worktree_root", "git_dir", "git_common_dir")
+    ):
+        errors.append("successful state lacks required Git path evidence")
+
+    if (
+        not isinstance(state.branch, str)
+        or not state.branch
+        or any(char.isspace() for char in state.branch)
+    ):
+        errors.append("branch is malformed")
+    if state.branch == "UNKNOWN":
+        if state.head_sha is not None:
+            errors.append("UNKNOWN branch contradicts HEAD SHA")
+    elif (
+        not isinstance(state.head_sha, str) or SHA_RE.fullmatch(state.head_sha) is None
+    ):
+        errors.append("head_sha is malformed")
+
+    errors.extend(
+        _validate_relation(
+            state.default_base,
+            name="default_base",
+            allow_none=False,
+            query_failed=query_failed,
+        )
+    )
+    errors.extend(
+        _validate_relation(
+            state.upstream,
+            name="upstream",
+            allow_none=True,
+            query_failed=query_failed,
+        )
+    )
+
+    tree_fields = (
+        "staged_paths",
+        "modified_paths",
+        "untracked_paths",
+        "conflicted_paths",
+        "clean",
+        "dirty_count",
+    )
+    if not all(hasattr(state.tree, field) for field in tree_fields):
+        errors.append("tree evidence is malformed")
+    else:
+        path_groups = [
+            getattr(state.tree, field)
+            for field in (
+                "staged_paths",
+                "modified_paths",
+                "untracked_paths",
+                "conflicted_paths",
+            )
+        ]
+        if any(
+            not isinstance(group, list)
+            or any(not isinstance(path, str) or not path for path in group)
+            or len(group) != len(set(group))
+            for group in path_groups
+        ):
+            errors.append("tree path evidence is malformed")
+        else:
+            expected_count = len(set(path for group in path_groups for path in group))
+            if state.tree.dirty_count != expected_count:
+                errors.append("tree dirty_count contradicts paths")
+            if not isinstance(state.tree.clean, bool):
+                errors.append("tree clean flag is malformed")
+            elif state.tree.clean and expected_count:
+                errors.append("tree clean flag contradicts paths")
+            elif not state.tree.clean and not expected_count and not query_failed:
+                errors.append("tree dirty flag lacks paths or query failure")
+
+    if (
+        not isinstance(state.operation, str)
+        or state.operation not in OPERATION_STATUSES
+    ):
+        errors.append(f"operation is unsupported: {state.operation!r}")
+    if not isinstance(state.operation_markers, list) or any(
+        not isinstance(marker, str) or not marker for marker in state.operation_markers
+    ):
+        errors.append("operation_markers is malformed")
+    elif (state.operation == "none") != (not state.operation_markers):
+        errors.append("operation contradicts operation markers")
+    if not isinstance(state.locks, list) or any(
+        not isinstance(lock, str) or not lock for lock in state.locks
+    ):
+        errors.append("locks are malformed")
+    if (
+        not isinstance(state.remote_freshness, str)
+        or state.remote_freshness not in REMOTE_FRESHNESS_STATUSES
+    ):
+        errors.append(f"remote_freshness is unsupported: {state.remote_freshness!r}")
+    if (
+        not isinstance(state.derived_action, str)
+        or state.derived_action not in DERIVED_ACTIONS
+    ):
+        errors.append(f"derived_action is unsupported: {state.derived_action!r}")
+    if not isinstance(state.hold_reasons, list) or any(
+        not isinstance(reason, str) or not reason for reason in state.hold_reasons
+    ):
+        errors.append("hold_reasons are malformed")
+    if (
+        not isinstance(state.duration_ms, (int, float))
+        or isinstance(state.duration_ms, bool)
+        or state.duration_ms < 0
+    ):
+        errors.append("duration_ms is malformed")
+
+    if errors:
+        return errors
+    expected_action, expected_reasons = _derive_action(
+        branch=state.branch,
+        head_sha=state.head_sha,
+        tree=state.tree,
+        operation=state.operation,
+        locks=state.locks,
+        default_base=state.default_base,
+        upstream=state.upstream,
+        failures=state.query_failures,
+    )
     if state.derived_action != expected_action:
         errors.append(
             "derived_action contradicts canonical evidence: "

--- a/scripts/git_state.py
+++ b/scripts/git_state.py
@@ -13,13 +13,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
@@ -48,6 +49,11 @@ DERIVED_ACTIONS = frozenset(
     }
 )
 REMOTE_FRESHNESS_STATUSES = frozenset({"NOT_CHECKED"})
+# Local state is consumed immediately during session closeout. A small bounded
+# skew admits ordinary clock precision while preventing old or future evidence
+# from being upgraded to current authority.
+MAX_EVIDENCE_AGE = timedelta(minutes=5)
+MAX_FUTURE_SKEW = timedelta(seconds=5)
 
 
 @dataclass
@@ -383,6 +389,32 @@ def _is_nonnegative_int(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
+def _is_valid_git_refname(value: object, *, branch: bool = False) -> bool:
+    """Apply Git's ref-format constraints without invoking Git."""
+    if not isinstance(value, str) or not value or value == "@":
+        return False
+    if branch and value.startswith("-"):
+        return False
+    if (
+        value.startswith("/")
+        or value.endswith("/")
+        or value.endswith(".")
+        or "//" in value
+        or ".." in value
+        or "@{" in value
+    ):
+        return False
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        return False
+    if any(char in " ~^:?*[\\" for char in value):
+        return False
+    components = value.split("/")
+    return all(
+        component and not component.startswith(".") and not component.endswith(".lock")
+        for component in components
+    )
+
+
 def _validate_relation(
     relation: object,
     *,
@@ -399,8 +431,6 @@ def _validate_relation(
     ahead = relation.ahead
     behind = relation.behind
     status = relation.status
-    if not isinstance(ref, str) or not ref:
-        errors.append(f"{name} relation ref is malformed")
     if (
         not isinstance(status, str)
         or status not in RELATION_STATUSES
@@ -409,6 +439,8 @@ def _validate_relation(
         errors.append(f"{name} relation status is unsupported: {status!r}")
         return errors
     if status in {"ahead", "behind", "diverged", "equal"}:
+        if ref == "NONE" or not _is_valid_git_refname(ref):
+            errors.append(f"{name} relation ref is malformed")
         if not isinstance(sha, str) or SHA_RE.fullmatch(sha) is None:
             errors.append(f"{name} relation SHA is malformed")
         if not _is_nonnegative_int(ahead) or not _is_nonnegative_int(behind):
@@ -425,6 +457,8 @@ def _validate_relation(
         if ref != "NONE" or any(value is not None for value in (sha, ahead, behind)):
             errors.append(f"{name} none relation is contradictory")
     elif status == "unknown":
+        if ref != "NONE" and not _is_valid_git_refname(ref):
+            errors.append(f"{name} relation ref is malformed")
         if any(value is not None for value in (sha, ahead, behind)):
             errors.append(f"{name} unknown relation is contradictory")
         if not query_failed:
@@ -432,7 +466,9 @@ def _validate_relation(
     return errors
 
 
-def validate_repository_state_consistency(state: object) -> list[str]:
+def validate_repository_state_consistency(
+    state: object, *, now_utc: datetime | None = None
+) -> list[str]:
     """Validate the full canonical evidence contract without Git or network I/O."""
     required_fields = (
         "schema_version",
@@ -465,6 +501,7 @@ def validate_repository_state_consistency(state: object) -> list[str]:
         errors.append(
             f"repository-state schema is unsupported: {state.schema_version!r}"
         )
+    observed: datetime | None = None
     if not isinstance(state.observed_at_utc, str):
         errors.append("observed_at_utc is malformed")
     else:
@@ -474,20 +511,34 @@ def validate_repository_state_consistency(state: object) -> list[str]:
             )
             if observed.tzinfo is None:
                 errors.append("observed_at_utc lacks timezone")
+                observed = None
         except ValueError:
             errors.append("observed_at_utc is malformed")
+    current = now_utc or datetime.now(timezone.utc)
+    if not isinstance(current, datetime) or current.tzinfo is None:
+        errors.append("validation clock is malformed")
+    elif observed is not None:
+        current = current.astimezone(timezone.utc)
+        observed = observed.astimezone(timezone.utc)
+        if observed - current > MAX_FUTURE_SKEW:
+            errors.append("observed_at_utc is in the future")
+        elif current - observed > MAX_EVIDENCE_AGE:
+            errors.append("observed_at_utc is stale")
 
     path_fields = ("repository_root", "worktree_root", "git_dir", "git_common_dir")
-    for field in path_fields:
-        value = getattr(state, field)
-        if field == "repository_root" and (
+    for path_field in path_fields:
+        value = getattr(state, path_field)
+        if path_field == "repository_root" and (
             not isinstance(value, str) or not value or not Path(value).is_absolute()
         ):
-            errors.append(f"{field} is malformed")
+            errors.append(f"{path_field} is malformed")
         elif value is not None and (
             not isinstance(value, str) or not value or not Path(value).is_absolute()
         ):
-            errors.append(f"{field} is malformed")
+            errors.append(f"{path_field} is malformed")
+    if isinstance(state.repository_root, str) and isinstance(state.worktree_root, str):
+        if Path(state.repository_root) != Path(state.worktree_root):
+            errors.append("repository_root contradicts worktree_root")
     if state.linked_worktree is not None and not isinstance(
         state.linked_worktree, bool
     ):
@@ -496,6 +547,10 @@ def validate_repository_state_consistency(state: object) -> list[str]:
         expected_linked = state.git_dir != state.git_common_dir
         if state.linked_worktree is not expected_linked:
             errors.append("linked_worktree contradicts Git directory evidence")
+        if state.linked_worktree is True and Path(state.git_dir).parent != (
+            Path(state.git_common_dir) / "worktrees"
+        ):
+            errors.append("linked worktree Git directories are incoherent")
     elif state.linked_worktree is not None:
         errors.append("linked_worktree lacks complete Git directory evidence")
 
@@ -520,16 +575,16 @@ def validate_repository_state_consistency(state: object) -> list[str]:
     ):
         errors.append("successful state lacks required Git path evidence")
 
-    if (
-        not isinstance(state.branch, str)
-        or not state.branch
-        or any(char.isspace() for char in state.branch)
-    ):
+    if not isinstance(state.branch, str) or not state.branch:
         errors.append("branch is malformed")
     if state.branch == "UNKNOWN":
         if state.head_sha is not None:
             errors.append("UNKNOWN branch contradicts HEAD SHA")
-    elif (
+    elif state.branch != "DETACHED" and not _is_valid_git_refname(
+        state.branch, branch=True
+    ):
+        errors.append("branch is malformed")
+    if state.branch != "UNKNOWN" and (
         not isinstance(state.head_sha, str) or SHA_RE.fullmatch(state.head_sha) is None
     ):
         errors.append("head_sha is malformed")
@@ -621,6 +676,7 @@ def validate_repository_state_consistency(state: object) -> list[str]:
     if (
         not isinstance(state.duration_ms, (int, float))
         or isinstance(state.duration_ms, bool)
+        or not math.isfinite(state.duration_ms)
         or state.duration_ms < 0
     ):
         errors.append("duration_ms is malformed")

--- a/scripts/git_state.py
+++ b/scripts/git_state.py
@@ -391,9 +391,9 @@ def _is_nonnegative_int(value: object) -> bool:
 
 def _is_valid_git_refname(value: object, *, branch: bool = False) -> bool:
     """Apply Git's ref-format constraints without invoking Git."""
-    if not isinstance(value, str) or not value or value == "@":
+    if not isinstance(value, str) or not value or (not branch and value == "@"):
         return False
-    if branch and value.startswith("-"):
+    if branch and (value.startswith("-") or value == "HEAD"):
         return False
     if (
         value.startswith("/")

--- a/scripts/git_state.py
+++ b/scripts/git_state.py
@@ -357,6 +357,33 @@ def _derive_action(
     return reasons[0][0], [message for _action, message in reasons]
 
 
+def validate_repository_state_consistency(state: RepositoryState) -> list[str]:
+    """Recompute derived action/holds from supplied evidence without Git I/O."""
+    try:
+        expected_action, expected_reasons = _derive_action(
+            branch=state.branch,
+            head_sha=state.head_sha,
+            tree=state.tree,
+            operation=state.operation,
+            locks=state.locks,
+            default_base=state.default_base,
+            upstream=state.upstream,
+            failures=state.query_failures,
+        )
+    except (AttributeError, TypeError, ValueError) as exc:
+        return [f"repository-state evidence is malformed: {exc}"]
+
+    errors: list[str] = []
+    if state.derived_action != expected_action:
+        errors.append(
+            "derived_action contradicts canonical evidence: "
+            f"expected {expected_action}, got {state.derived_action}"
+        )
+    if state.hold_reasons != expected_reasons:
+        errors.append("hold_reasons contradict canonical evidence")
+    return errors
+
+
 def collect_repository_state(
     repo: Path | str = REPO_ROOT,
     *,

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3409,7 +3409,7 @@
     {
       "name": "git_handoff_receipt.py",
       "type": "python",
-      "size_lines": 581,
+      "size_lines": 573,
       "last_updated": "2026-08-15",
       "description": "Build and validate fail-closed task-to-Git handoff receipts.",
       "functions": [
@@ -3446,7 +3446,7 @@
         "SHA_RE",
         "SAFE_HOLD_NEXT_ACTIONS"
       ],
-      "content_hash": "8685e90d2ef8"
+      "content_hash": "97392ad102cb"
     },
     {
       "name": "git_state.py",
@@ -5520,5 +5520,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "98128a605a8612b2"
+  "content_hash": "794370ef5a651092"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3534,7 +3534,7 @@
         "REMOTE_FRESHNESS_STATUSES",
         "MAX_EVIDENCE_AGE"
       ],
-      "content_hash": "4d8581eb3500"
+      "content_hash": "3cbad0ae60d3"
     },
     {
       "name": "governance_health_score.py",
@@ -4408,7 +4408,7 @@
     {
       "name": "session.py",
       "type": "python",
-      "size_lines": 2456,
+      "size_lines": 2461,
       "last_updated": "2026-08-15",
       "description": "Unified session management CLI.",
       "functions": [
@@ -4524,7 +4524,7 @@
         "HANDOFF_DATE_RE",
         "COMMIT_HASH_RE"
       ],
-      "content_hash": "c5bf85c20a9c"
+      "content_hash": "8a951de8d836"
     },
     {
       "name": "session_store.py",
@@ -5538,5 +5538,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "db047dbf992b684a"
+  "content_hash": "3c741ce61e0e0c75"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -4505,7 +4505,7 @@
         "HANDOFF_DATE_RE",
         "COMMIT_HASH_RE"
       ],
-      "content_hash": "09c26e99cad8"
+      "content_hash": "8b29c36a9199"
     },
     {
       "name": "session_store.py",
@@ -5519,5 +5519,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "b37adb7217578d70"
+  "content_hash": "90283a25e364d051"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -1474,7 +1474,7 @@
     {
       "name": "check_codex_git_workflow.py",
       "type": "python",
-      "size_lines": 432,
+      "size_lines": 488,
       "last_updated": "2026-08-15",
       "description": "Guard the Codex-native Git/GitHub workflow contract.",
       "functions": [
@@ -1510,7 +1510,7 @@
         "DEPLOY_DOCS",
         "GUIDANCE_INDEX"
       ],
-      "content_hash": "71ae68233324"
+      "content_hash": "da05527345ad"
     },
     {
       "name": "check_doc_versions.py",
@@ -5520,5 +5520,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "794370ef5a651092"
+  "content_hash": "4b4d7cb693bd007e"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -1474,7 +1474,7 @@
     {
       "name": "check_codex_git_workflow.py",
       "type": "python",
-      "size_lines": 566,
+      "size_lines": 638,
       "last_updated": "2026-08-15",
       "description": "Guard the Codex-native Git/GitHub workflow contract.",
       "functions": [
@@ -1510,7 +1510,7 @@
         "DEPLOY_DOCS",
         "GUIDANCE_INDEX"
       ],
-      "content_hash": "086087bf8fee"
+      "content_hash": "480a59b69a6d"
     },
     {
       "name": "check_doc_versions.py",
@@ -3451,7 +3451,7 @@
     {
       "name": "git_state.py",
       "type": "python",
-      "size_lines": 685,
+      "size_lines": 948,
       "last_updated": "2026-08-15",
       "description": "Read-only, worktree-aware Git state authority.",
       "classes": [
@@ -3489,7 +3489,7 @@
       "functions": [
         {
           "name": "validate_repository_state_consistency",
-          "description": "Recompute derived action/holds from supplied evidence without Git I/O.",
+          "description": "Validate the full canonical evidence contract without Git or network I/O.",
           "params": [
             "state"
           ]
@@ -3526,9 +3526,14 @@
         "REPO_ROOT",
         "SCHEMA_VERSION",
         "DEFAULT_COMMAND_TIMEOUT_SECONDS",
-        "SIBLING_COMMAND_TIMEOUT_SECONDS"
+        "SIBLING_COMMAND_TIMEOUT_SECONDS",
+        "SHA_RE",
+        "RELATION_STATUSES",
+        "OPERATION_STATUSES",
+        "DERIVED_ACTIONS",
+        "REMOTE_FRESHNESS_STATUSES"
       ],
-      "content_hash": "15c15cb64c65"
+      "content_hash": "31931ac2ac57"
     },
     {
       "name": "governance_health_score.py",
@@ -4402,7 +4407,7 @@
     {
       "name": "session.py",
       "type": "python",
-      "size_lines": 2488,
+      "size_lines": 2456,
       "last_updated": "2026-08-15",
       "description": "Unified session management CLI.",
       "functions": [
@@ -4518,7 +4523,7 @@
         "HANDOFF_DATE_RE",
         "COMMIT_HASH_RE"
       ],
-      "content_hash": "8850582e1aa6"
+      "content_hash": "c5bf85c20a9c"
     },
     {
       "name": "session_store.py",
@@ -5532,5 +5537,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "e18abc3d37b9fd72"
+  "content_hash": "1e059a9c21fb6a84"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -1474,7 +1474,7 @@
     {
       "name": "check_codex_git_workflow.py",
       "type": "python",
-      "size_lines": 488,
+      "size_lines": 555,
       "last_updated": "2026-08-15",
       "description": "Guard the Codex-native Git/GitHub workflow contract.",
       "functions": [
@@ -1510,7 +1510,7 @@
         "DEPLOY_DOCS",
         "GUIDANCE_INDEX"
       ],
-      "content_hash": "da05527345ad"
+      "content_hash": "f62aa4b673e3"
     },
     {
       "name": "check_doc_versions.py",
@@ -4395,7 +4395,7 @@
     {
       "name": "session.py",
       "type": "python",
-      "size_lines": 2417,
+      "size_lines": 2466,
       "last_updated": "2026-08-15",
       "description": "Unified session management CLI.",
       "functions": [
@@ -4475,7 +4475,12 @@
           ]
         },
         {
-          "name": "get_uncommitted_changes"
+          "name": "get_closeout_git_evidence",
+          "description": "Return CLEAN, DIRTY, or UNKNOWN from the canonical Git-state authority."
+        },
+        {
+          "name": "report_closeout_git_evidence",
+          "description": "Print fail-closed closeout evidence; return true only for CLEAN."
         },
         {
           "name": "check_session_log_complete"
@@ -4485,13 +4490,6 @@
         },
         {
           "name": "get_changed_doc_folders"
-        },
-        {
-          "name": "update_folder_readmes",
-          "params": [
-            "folders",
-            "fix"
-          ]
         }
       ],
       "constants": [
@@ -4506,7 +4504,7 @@
         "HANDOFF_DATE_RE",
         "COMMIT_HASH_RE"
       ],
-      "content_hash": "8b29c36a9199"
+      "content_hash": "76f98cf223c6"
     },
     {
       "name": "session_store.py",
@@ -5520,5 +5518,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "4b4d7cb693bd007e"
+  "content_hash": "ea446ebe6eaf20ee"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3409,7 +3409,7 @@
     {
       "name": "git_handoff_receipt.py",
       "type": "python",
-      "size_lines": 454,
+      "size_lines": 555,
       "last_updated": "2026-08-15",
       "description": "Build and validate fail-closed task-to-Git handoff receipts.",
       "functions": [
@@ -3445,7 +3445,7 @@
         "MAX_EVIDENCE_AGE_SECONDS",
         "SHA_RE"
       ],
-      "content_hash": "c7720d3e142a"
+      "content_hash": "90d32be6f3e5"
     },
     {
       "name": "git_state.py",
@@ -5519,5 +5519,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "90283a25e364d051"
+  "content_hash": "c57139addba8b7c5"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3451,7 +3451,7 @@
     {
       "name": "git_state.py",
       "type": "python",
-      "size_lines": 948,
+      "size_lines": 1004,
       "last_updated": "2026-08-15",
       "description": "Read-only, worktree-aware Git state authority.",
       "classes": [
@@ -3531,9 +3531,10 @@
         "RELATION_STATUSES",
         "OPERATION_STATUSES",
         "DERIVED_ACTIONS",
-        "REMOTE_FRESHNESS_STATUSES"
+        "REMOTE_FRESHNESS_STATUSES",
+        "MAX_EVIDENCE_AGE"
       ],
-      "content_hash": "31931ac2ac57"
+      "content_hash": "4d8581eb3500"
     },
     {
       "name": "governance_health_score.py",
@@ -5537,5 +5538,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "1e059a9c21fb6a84"
+  "content_hash": "db047dbf992b684a"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3,7 +3,7 @@
   "type": "python-package",
   "description": "> Development, validation, discovery, release-preparation, and maintenance tools.",
   "last_updated": "2026-08-15",
-  "file_count": 109,
+  "file_count": 110,
   "files": [
     {
       "name": "README.md",
@@ -912,7 +912,7 @@
         "_coverage",
         "tasks"
       ],
-      "content_hash": "e72e30a4b4ba"
+      "content_hash": "509c9fc38593"
     },
     {
       "name": "batch_migrate_runner.py",
@@ -1474,10 +1474,26 @@
     {
       "name": "check_codex_git_workflow.py",
       "type": "python",
-      "size_lines": 298,
+      "size_lines": 402,
       "last_updated": "2026-08-15",
       "description": "Guard the Codex-native Git/GitHub workflow contract.",
       "functions": [
+        {
+          "name": "discover_guidance_surfaces",
+          "description": "Resolve live guidance from the maintained index, failing on ambiguity.",
+          "params": [
+            "repo_root",
+            "index_path"
+          ]
+        },
+        {
+          "name": "check_semantic_guidance",
+          "description": "Reject lifecycle contradictions across every indexed live surface.",
+          "params": [
+            "repo_root",
+            "index_path"
+          ]
+        },
         {
           "name": "main"
         }
@@ -1486,15 +1502,15 @@
         "REPO_ROOT",
         "CANONICAL",
         "GIT_STATE_AUTHORITY",
+        "HANDOFF_RECEIPT",
         "DISPOSITION_CLASSIFIER",
         "GIT_STATE_CONSUMERS",
         "GIT_STATE_COMPATIBILITY",
         "FAST_CHECKS",
         "DEPLOY_DOCS",
-        "RETIRED_PATHS",
-        "DISPOSITION_GUIDANCE"
+        "GUIDANCE_INDEX"
       ],
-      "content_hash": "31fc5eed5a46"
+      "content_hash": "9456903a9430"
     },
     {
       "name": "check_doc_versions.py",
@@ -3391,6 +3407,47 @@
       "content_hash": "47a4073cd002"
     },
     {
+      "name": "git_handoff_receipt.py",
+      "type": "python",
+      "size_lines": 454,
+      "last_updated": "2026-08-15",
+      "description": "Build and validate fail-closed task-to-Git handoff receipts.",
+      "functions": [
+        {
+          "name": "build_receipt",
+          "description": "Create one receipt. Missing or inconsistent facts become explicit holds."
+        },
+        {
+          "name": "validate_receipt",
+          "description": "Validate a stored receipt without upgrading unknown evidence to success.",
+          "params": [
+            "receipt"
+          ]
+        },
+        {
+          "name": "load_receipt",
+          "params": [
+            "path"
+          ]
+        },
+        {
+          "name": "main",
+          "params": [
+            "argv"
+          ]
+        }
+      ],
+      "constants": [
+        "SCHEMA_VERSION",
+        "RECEIPT_KIND",
+        "UNKNOWN",
+        "NOT_CHECKED",
+        "MAX_EVIDENCE_AGE_SECONDS",
+        "SHA_RE"
+      ],
+      "content_hash": "c7720d3e142a"
+    },
+    {
       "name": "git_state.py",
       "type": "python",
       "size_lines": 658,
@@ -4337,7 +4394,7 @@
     {
       "name": "session.py",
       "type": "python",
-      "size_lines": 2306,
+      "size_lines": 2417,
       "last_updated": "2026-08-15",
       "description": "Unified session management CLI.",
       "functions": [
@@ -4448,7 +4505,7 @@
         "HANDOFF_DATE_RE",
         "COMMIT_HASH_RE"
       ],
-      "content_hash": "cf690cae634e"
+      "content_hash": "09c26e99cad8"
     },
     {
       "name": "session_store.py",
@@ -5462,5 +5519,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "00cc8212e284953c"
+  "content_hash": "b37adb7217578d70"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -1474,7 +1474,7 @@
     {
       "name": "check_codex_git_workflow.py",
       "type": "python",
-      "size_lines": 402,
+      "size_lines": 432,
       "last_updated": "2026-08-15",
       "description": "Guard the Codex-native Git/GitHub workflow contract.",
       "functions": [
@@ -1510,7 +1510,7 @@
         "DEPLOY_DOCS",
         "GUIDANCE_INDEX"
       ],
-      "content_hash": "9456903a9430"
+      "content_hash": "71ae68233324"
     },
     {
       "name": "check_doc_versions.py",
@@ -3409,7 +3409,7 @@
     {
       "name": "git_handoff_receipt.py",
       "type": "python",
-      "size_lines": 555,
+      "size_lines": 581,
       "last_updated": "2026-08-15",
       "description": "Build and validate fail-closed task-to-Git handoff receipts.",
       "functions": [
@@ -3443,9 +3443,10 @@
         "UNKNOWN",
         "NOT_CHECKED",
         "MAX_EVIDENCE_AGE_SECONDS",
-        "SHA_RE"
+        "SHA_RE",
+        "SAFE_HOLD_NEXT_ACTIONS"
       ],
-      "content_hash": "90d32be6f3e5"
+      "content_hash": "8685e90d2ef8"
     },
     {
       "name": "git_state.py",
@@ -5519,5 +5520,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "c57139addba8b7c5"
+  "content_hash": "98128a605a8612b2"
 }

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -1474,7 +1474,7 @@
     {
       "name": "check_codex_git_workflow.py",
       "type": "python",
-      "size_lines": 555,
+      "size_lines": 566,
       "last_updated": "2026-08-15",
       "description": "Guard the Codex-native Git/GitHub workflow contract.",
       "functions": [
@@ -1510,7 +1510,7 @@
         "DEPLOY_DOCS",
         "GUIDANCE_INDEX"
       ],
-      "content_hash": "f62aa4b673e3"
+      "content_hash": "086087bf8fee"
     },
     {
       "name": "check_doc_versions.py",
@@ -3451,7 +3451,7 @@
     {
       "name": "git_state.py",
       "type": "python",
-      "size_lines": 658,
+      "size_lines": 685,
       "last_updated": "2026-08-15",
       "description": "Read-only, worktree-aware Git state authority.",
       "classes": [
@@ -3488,6 +3488,13 @@
       ],
       "functions": [
         {
+          "name": "validate_repository_state_consistency",
+          "description": "Recompute derived action/holds from supplied evidence without Git I/O.",
+          "params": [
+            "state"
+          ]
+        },
+        {
           "name": "collect_repository_state",
           "description": "Collect one local repository/worktree state without mutation or network.",
           "params": [
@@ -3521,7 +3528,7 @@
         "DEFAULT_COMMAND_TIMEOUT_SECONDS",
         "SIBLING_COMMAND_TIMEOUT_SECONDS"
       ],
-      "content_hash": "8a947cedc599"
+      "content_hash": "15c15cb64c65"
     },
     {
       "name": "governance_health_score.py",
@@ -4395,7 +4402,7 @@
     {
       "name": "session.py",
       "type": "python",
-      "size_lines": 2466,
+      "size_lines": 2488,
       "last_updated": "2026-08-15",
       "description": "Unified session management CLI.",
       "functions": [
@@ -4480,7 +4487,10 @@
         },
         {
           "name": "report_closeout_git_evidence",
-          "description": "Print fail-closed closeout evidence; return true only for CLEAN."
+          "description": "Print fail-closed closeout evidence; return true only for CLEAN.",
+          "params": [
+            "evidence"
+          ]
         },
         {
           "name": "check_session_log_complete"
@@ -4489,7 +4499,11 @@
           "name": "check_doc_links"
         },
         {
-          "name": "get_changed_doc_folders"
+          "name": "get_changed_doc_folders",
+          "description": "Derive current dirty doc folders only from canonical state evidence.",
+          "params": [
+            "evidence"
+          ]
         }
       ],
       "constants": [
@@ -4504,7 +4518,7 @@
         "HANDOFF_DATE_RE",
         "COMMIT_HASH_RE"
       ],
-      "content_hash": "76f98cf223c6"
+      "content_hash": "8850582e1aa6"
     },
     {
       "name": "session_store.py",
@@ -5518,5 +5532,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "ea446ebe6eaf20ee"
+  "content_hash": "e18abc3d37b9fd72"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -43,7 +43,7 @@
 | [check_circular_imports.py](check_circular_imports.py) | Circular Import Detector for the Python Structural Library | 5 | 1 | 464 |
 | [check_clause_coverage.py](check_clause_coverage.py) | IS 456 clause coverage gap detection. | 0 | 8 | 488 |
 | [check_cli_reference.py](check_cli_reference.py) | Ensure CLI reference includes required commands. | 0 | 1 | 48 |
-| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 402 |
+| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 432 |
 | [check_doc_versions.py](check_doc_versions.py) | Doc Version Drift Check — Validate no stale *library* versio | 0 | 2 | 72 |
 | [check_docker_config.py](check_docker_config.py) | Docker Configuration Validator. | 0 | 6 | 295 |
 | [check_docs.py](check_docs.py) | Unified documentation checker — consolidates 4 doc validatio | 0 | 6 | 675 |
@@ -81,7 +81,7 @@
 | [generate_docs_index.py](generate_docs_index.py) | Generate machine-readable JSON index of documentation. | 0 | 7 | 246 |
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
-| [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 555 |
+| [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 581 |
 | [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 4 | 658 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -43,7 +43,7 @@
 | [check_circular_imports.py](check_circular_imports.py) | Circular Import Detector for the Python Structural Library | 5 | 1 | 464 |
 | [check_clause_coverage.py](check_clause_coverage.py) | IS 456 clause coverage gap detection. | 0 | 8 | 488 |
 | [check_cli_reference.py](check_cli_reference.py) | Ensure CLI reference includes required commands. | 0 | 1 | 48 |
-| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 488 |
+| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 555 |
 | [check_doc_versions.py](check_doc_versions.py) | Doc Version Drift Check — Validate no stale *library* versio | 0 | 2 | 72 |
 | [check_docker_config.py](check_docker_config.py) | Docker Configuration Validator. | 0 | 6 | 295 |
 | [check_docs.py](check_docs.py) | Unified documentation checker — consolidates 4 doc validatio | 0 | 6 | 675 |
@@ -96,7 +96,7 @@
 | [release.py](release.py) | Unified release management CLI. | 0 | 10 | 1776 |
 | [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
-| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2417 |
+| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2466 |
 | [session_store.py](session_store.py) | JSON-based session state persistence for AI agent sessions. | 1 | 14 | 374 |
 | [skill_tiers.py](skill_tiers.py) | Skill tier classification and management for AI agents. | 1 | 11 | 485 |
 | [sync_numbers.py](sync_numbers.py) | Scan codebase and sync stale numbers across documentation fi | 2 | 11 | 502 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -96,7 +96,7 @@
 | [release.py](release.py) | Unified release management CLI. | 0 | 10 | 1776 |
 | [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
-| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2456 |
+| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2461 |
 | [session_store.py](session_store.py) | JSON-based session state persistence for AI agent sessions. | 1 | 14 | 374 |
 | [skill_tiers.py](skill_tiers.py) | Skill tier classification and management for AI agents. | 1 | 11 | 485 |
 | [sync_numbers.py](sync_numbers.py) | Scan codebase and sync stale numbers across documentation fi | 2 | 11 | 502 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -81,7 +81,7 @@
 | [generate_docs_index.py](generate_docs_index.py) | Generate machine-readable JSON index of documentation. | 0 | 7 | 246 |
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
-| [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 581 |
+| [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 573 |
 | [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 4 | 658 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -4,7 +4,7 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-15
-**Files:** 109
+**Files:** 110
 
 ## Config Files
 
@@ -43,7 +43,7 @@
 | [check_circular_imports.py](check_circular_imports.py) | Circular Import Detector for the Python Structural Library | 5 | 1 | 464 |
 | [check_clause_coverage.py](check_clause_coverage.py) | IS 456 clause coverage gap detection. | 0 | 8 | 488 |
 | [check_cli_reference.py](check_cli_reference.py) | Ensure CLI reference includes required commands. | 0 | 1 | 48 |
-| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 1 | 298 |
+| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 402 |
 | [check_doc_versions.py](check_doc_versions.py) | Doc Version Drift Check — Validate no stale *library* versio | 0 | 2 | 72 |
 | [check_docker_config.py](check_docker_config.py) | Docker Configuration Validator. | 0 | 6 | 295 |
 | [check_docs.py](check_docs.py) | Unified documentation checker — consolidates 4 doc validatio | 0 | 6 | 675 |
@@ -81,6 +81,7 @@
 | [generate_docs_index.py](generate_docs_index.py) | Generate machine-readable JSON index of documentation. | 0 | 7 | 246 |
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
+| [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 454 |
 | [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 4 | 658 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |
@@ -95,7 +96,7 @@
 | [release.py](release.py) | Unified release management CLI. | 0 | 10 | 1776 |
 | [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
-| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2306 |
+| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2417 |
 | [session_store.py](session_store.py) | JSON-based session state persistence for AI agent sessions. | 1 | 14 | 374 |
 | [skill_tiers.py](skill_tiers.py) | Skill tier classification and management for AI agents. | 1 | 11 | 485 |
 | [sync_numbers.py](sync_numbers.py) | Scan codebase and sync stale numbers across documentation fi | 2 | 11 | 502 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -81,7 +81,7 @@
 | [generate_docs_index.py](generate_docs_index.py) | Generate machine-readable JSON index of documentation. | 0 | 7 | 246 |
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
-| [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 454 |
+| [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 555 |
 | [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 4 | 658 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -82,7 +82,7 @@
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
 | [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 573 |
-| [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 5 | 948 |
+| [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 5 | 1004 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |
 | [migrate_react_component.py](migrate_react_component.py) | Migrate a React component to a new feature-grouped folder. | 0 | 9 | 475 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -43,7 +43,7 @@
 | [check_circular_imports.py](check_circular_imports.py) | Circular Import Detector for the Python Structural Library | 5 | 1 | 464 |
 | [check_clause_coverage.py](check_clause_coverage.py) | IS 456 clause coverage gap detection. | 0 | 8 | 488 |
 | [check_cli_reference.py](check_cli_reference.py) | Ensure CLI reference includes required commands. | 0 | 1 | 48 |
-| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 555 |
+| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 566 |
 | [check_doc_versions.py](check_doc_versions.py) | Doc Version Drift Check — Validate no stale *library* versio | 0 | 2 | 72 |
 | [check_docker_config.py](check_docker_config.py) | Docker Configuration Validator. | 0 | 6 | 295 |
 | [check_docs.py](check_docs.py) | Unified documentation checker — consolidates 4 doc validatio | 0 | 6 | 675 |
@@ -82,7 +82,7 @@
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
 | [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 573 |
-| [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 4 | 658 |
+| [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 5 | 685 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |
 | [migrate_react_component.py](migrate_react_component.py) | Migrate a React component to a new feature-grouped folder. | 0 | 9 | 475 |
@@ -96,7 +96,7 @@
 | [release.py](release.py) | Unified release management CLI. | 0 | 10 | 1776 |
 | [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
-| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2466 |
+| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2488 |
 | [session_store.py](session_store.py) | JSON-based session state persistence for AI agent sessions. | 1 | 14 | 374 |
 | [skill_tiers.py](skill_tiers.py) | Skill tier classification and management for AI agents. | 1 | 11 | 485 |
 | [sync_numbers.py](sync_numbers.py) | Scan codebase and sync stale numbers across documentation fi | 2 | 11 | 502 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -43,7 +43,7 @@
 | [check_circular_imports.py](check_circular_imports.py) | Circular Import Detector for the Python Structural Library | 5 | 1 | 464 |
 | [check_clause_coverage.py](check_clause_coverage.py) | IS 456 clause coverage gap detection. | 0 | 8 | 488 |
 | [check_cli_reference.py](check_cli_reference.py) | Ensure CLI reference includes required commands. | 0 | 1 | 48 |
-| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 432 |
+| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 488 |
 | [check_doc_versions.py](check_doc_versions.py) | Doc Version Drift Check — Validate no stale *library* versio | 0 | 2 | 72 |
 | [check_docker_config.py](check_docker_config.py) | Docker Configuration Validator. | 0 | 6 | 295 |
 | [check_docs.py](check_docs.py) | Unified documentation checker — consolidates 4 doc validatio | 0 | 6 | 675 |

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -43,7 +43,7 @@
 | [check_circular_imports.py](check_circular_imports.py) | Circular Import Detector for the Python Structural Library | 5 | 1 | 464 |
 | [check_clause_coverage.py](check_clause_coverage.py) | IS 456 clause coverage gap detection. | 0 | 8 | 488 |
 | [check_cli_reference.py](check_cli_reference.py) | Ensure CLI reference includes required commands. | 0 | 1 | 48 |
-| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 566 |
+| [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 638 |
 | [check_doc_versions.py](check_doc_versions.py) | Doc Version Drift Check — Validate no stale *library* versio | 0 | 2 | 72 |
 | [check_docker_config.py](check_docker_config.py) | Docker Configuration Validator. | 0 | 6 | 295 |
 | [check_docs.py](check_docs.py) | Unified documentation checker — consolidates 4 doc validatio | 0 | 6 | 675 |
@@ -82,7 +82,7 @@
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
 | [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 573 |
-| [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 5 | 685 |
+| [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 5 | 948 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
 | [migrate_python_module.py](migrate_python_module.py) | Migrate a Python module to a new location with import update | 0 | 8 | 516 |
 | [migrate_react_component.py](migrate_react_component.py) | Migrate a React component to a new feature-grouped folder. | 0 | 9 | 475 |
@@ -96,7 +96,7 @@
 | [release.py](release.py) | Unified release management CLI. | 0 | 10 | 1776 |
 | [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
-| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2488 |
+| [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2456 |
 | [session_store.py](session_store.py) | JSON-based session state persistence for AI agent sessions. | 1 | 14 | 374 |
 | [skill_tiers.py](skill_tiers.py) | Skill tier classification and management for AI agents. | 1 | 11 | 485 |
 | [sync_numbers.py](sync_numbers.py) | Scan codebase and sync stale numbers across documentation fi | 2 | 11 | 502 |

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -37,6 +37,7 @@ from git_state import (
     SCHEMA_VERSION as GIT_STATE_SCHEMA_VERSION,
     RepositoryState,
     collect_repository_state,
+    validate_repository_state_consistency,
 )
 from git_handoff_receipt import load_receipt, validate_receipt
 
@@ -808,13 +809,33 @@ def get_closeout_git_evidence() -> tuple[str, list[str], str]:
     except Exception as exc:
         return "UNKNOWN", [], f"Git-state authority raised: {exc}"
     if not all(
-        hasattr(state, field) for field in ("schema_version", "tree", "query_failures")
+        hasattr(state, field)
+        for field in (
+            "schema_version",
+            "tree",
+            "query_failures",
+            "derived_action",
+            "hold_reasons",
+        )
     ):
         return "UNKNOWN", [], "Git-state authority returned malformed evidence"
     if state.schema_version != GIT_STATE_SCHEMA_VERSION:
         return "UNKNOWN", [], f"Git-state schema is unknown: {state.schema_version}"
     if not isinstance(state.query_failures, list):
         return "UNKNOWN", [], "Git-state query-failure evidence is malformed"
+    if (
+        not isinstance(state.derived_action, str)
+        or not isinstance(state.hold_reasons, list)
+        or any(not isinstance(reason, str) for reason in state.hold_reasons)
+    ):
+        return "UNKNOWN", [], "Git-state action/hold evidence is malformed"
+    consistency_errors = validate_repository_state_consistency(state)
+    if consistency_errors:
+        return (
+            "UNKNOWN",
+            [],
+            "Git-state evidence contradicts: " + "; ".join(consistency_errors),
+        )
     if state.query_failures:
         if not all(
             hasattr(failure, "command") and hasattr(failure, "reason")
@@ -848,14 +869,20 @@ def get_closeout_git_evidence() -> tuple[str, list[str], str]:
     if not clean and not paths:
         return "UNKNOWN", [], "Git-state dirty flag has no path evidence"
     if clean:
+        if state.derived_action != "READY_LOCAL" or state.hold_reasons:
+            return "UNKNOWN", [], "Git-state clean/action/hold evidence contradicts"
         return "CLEAN", [], "Canonical Git-state tree is clean"
+    if state.derived_action != "HOLD_DIRTY" or not state.hold_reasons:
+        return "UNKNOWN", [], "Git-state dirty/action/hold evidence contradicts"
     return "DIRTY", paths, "Canonical Git-state tree contains changes"
 
 
-def report_closeout_git_evidence() -> bool:
+def report_closeout_git_evidence(
+    evidence: tuple[str, list[str], str] | None = None,
+) -> bool:
     """Print fail-closed closeout evidence; return true only for CLEAN."""
     print("📁 Uncommitted Changes:")
-    status, paths, reason = get_closeout_git_evidence()
+    status, paths, reason = evidence or get_closeout_git_evidence()
     if status == "UNKNOWN":
         print(f"  ⚠️  Git state UNKNOWN/hold: {reason}")
         return False
@@ -937,37 +964,27 @@ def check_doc_links() -> tuple[bool, str]:
         return True, f"Link check skipped: {e}"
 
 
-def get_changed_doc_folders() -> list[Path]:
-    try:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD~5", "HEAD"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
+def get_changed_doc_folders(
+    evidence: tuple[str, list[str], str],
+) -> tuple[str, list[Path], str]:
+    """Derive current dirty doc folders only from canonical state evidence."""
+    status, paths, reason = evidence
+    if status == "UNKNOWN":
+        return "UNKNOWN", [], reason
+    if status == "CLEAN":
+        return (
+            "UNKNOWN",
+            [],
+            "canonical state has no committed-diff path evidence; skipped",
         )
-        changed_files = (
-            result.stdout.strip().split("\n") if result.stdout.strip() else []
-        )
-        result2 = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
-        )
-        for line in result2.stdout.strip().split("\n"):
-            if line.strip():
-                parts = line.strip().split(maxsplit=1)
-                if len(parts) > 1:
-                    changed_files.append(parts[1])
-        doc_folders = set()
-        for f in changed_files:
-            if f.startswith("docs/") and f.endswith(".md"):
-                folder = Path(f).parent
-                if len(folder.parts) >= 2:
-                    doc_folders.add(REPO_ROOT / folder)
-        return list(doc_folders)
-    except Exception:
-        return []
+    doc_folders = {
+        REPO_ROOT / Path(path).parent
+        for path in paths
+        if path.startswith("docs/")
+        and path.endswith(".md")
+        and len(Path(path).parts) >= 2
+    }
+    return "OBSERVED", sorted(doc_folders), "canonical dirty paths inspected"
 
 
 def update_folder_readmes(folders: list[Path], fix: bool = False) -> int:
@@ -1029,7 +1046,8 @@ def cmd_end(args: argparse.Namespace) -> int:
     all_passed = True
 
     # 1. Uncommitted changes
-    if not report_closeout_git_evidence():
+    closeout_evidence = get_closeout_git_evidence()
+    if not report_closeout_git_evidence(closeout_evidence):
         all_passed = False
     print()
 
@@ -1101,8 +1119,12 @@ def cmd_end(args: argparse.Namespace) -> int:
 
     # 7. README updates
     print("📚 README Index Updates:")
-    changed_folders = get_changed_doc_folders()
-    if changed_folders:
+    folder_status, changed_folders, folder_reason = get_changed_doc_folders(
+        closeout_evidence
+    )
+    if folder_status == "UNKNOWN":
+        print(f"  ⏭️  Doc-folder set UNKNOWN: {folder_reason}")
+    elif changed_folders:
         print(f"  📂 {len(changed_folders)} folder(s) with changes detected")
         updated = update_folder_readmes(changed_folders, fix=args.fix)
         if args.fix and updated:
@@ -1110,7 +1132,7 @@ def cmd_end(args: argparse.Namespace) -> int:
         elif not args.fix:
             print("  ℹ️  Run with --fix to auto-update READMEs")
     else:
-        print("  ✅ No doc folder changes detected")
+        print("  ✅ No doc folders in canonical current changed paths")
     print()
 
     # 7. TASKS.md auto-archival

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -34,6 +34,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lib.utils import REPO_ROOT
 from _lib.output import StatusLine
 from git_state import RepositoryState, collect_repository_state
+from git_handoff_receipt import load_receipt, validate_receipt
 
 SESSION_LOG = REPO_ROOT / "docs" / "SESSION_LOG.md"
 TASKS_MD = REPO_ROOT / "docs" / "TASKS.md"
@@ -1018,7 +1019,29 @@ def cmd_end(args: argparse.Namespace) -> int:
         all_passed = False
     print()
 
-    # 5. Link check
+    # 5. Durable task-to-Git handoff receipt
+    print("🧾 Task-to-Git Handoff Receipt:")
+    try:
+        _date_str, latest_block = _latest_session_block(
+            SESSION_LOG.read_text(encoding="utf-8").splitlines()
+        )
+        receipt, receipt_path, receipt_errors = _resolve_git_receipt(
+            latest_block, args.git_receipt
+        )
+    except (OSError, ValueError) as exc:
+        receipt, receipt_path, receipt_errors = None, None, [str(exc)]
+    if receipt_errors:
+        for issue in receipt_errors:
+            print(f"  ⚠️  {issue}")
+        all_passed = False
+    else:
+        print(
+            f"  ✅ {receipt_path} | {receipt['local_state_receipt_hash']} | "
+            f"{receipt['receipt_status']}"
+        )
+    print()
+
+    # 6. Link check
     print("🔗 Doc Links:")
     passed, msg = check_doc_links()
     if passed:
@@ -1027,7 +1050,7 @@ def cmd_end(args: argparse.Namespace) -> int:
         print(f"  ⚠️  {msg}")
     print()
 
-    # 6. README updates
+    # 7. README updates
     print("📚 README Index Updates:")
     changed_folders = get_changed_doc_folders()
     if changed_folders:
@@ -1186,7 +1209,67 @@ def _parse_prs(block: list[str]) -> list[str]:
     return prs
 
 
-def _build_handoff_lines(date_str: str, block: list[str]) -> list[str]:
+def _parse_git_receipt_path(block: list[str]) -> str | None:
+    for line in block:
+        match = re.match(r"\*\*Git handoff receipt:\*\*\s+`?([^`\s]+)`?", line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _resolve_git_receipt(
+    block: list[str], explicit_path: Path | None = None
+) -> tuple[dict | None, str | None, list[str]]:
+    raw_path = str(explicit_path) if explicit_path else _parse_git_receipt_path(block)
+    if not raw_path:
+        return None, None, ["Missing task-to-Git handoff receipt"]
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    try:
+        resolved = path.resolve()
+        resolved.relative_to(REPO_ROOT.resolve())
+    except (OSError, ValueError):
+        return None, raw_path, ["Git handoff receipt must be inside the repository"]
+    try:
+        receipt = load_receipt(resolved)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return None, raw_path, [f"Git handoff receipt is malformed: {exc}"]
+    errors = validate_receipt(receipt)
+    if errors:
+        return receipt, raw_path, errors
+    return receipt, resolved.relative_to(REPO_ROOT).as_posix(), []
+
+
+def _git_handoff_lines(receipt: dict, relative_path: str) -> list[str]:
+    state = receipt["local"]["state"]
+    upstream = state["upstream"]
+    default_base = state["default_base"]
+    pr = receipt["pull_request"]
+    remote = receipt["remote"]
+    return [
+        f"- Git receipt: {relative_path} | {receipt['local_state_receipt_hash']} | "
+        f"{receipt['receipt_status']}",
+        f"- Git identity: {state['branch']}@{state['head_sha']} | "
+        f"upstream={upstream['ref']}@{upstream['sha'] or 'UNKNOWN'} | "
+        f"base={default_base['ref']}@{default_base['sha'] or 'UNKNOWN'} | "
+        f"tree={'clean' if state['tree']['clean'] else 'dirty'} | "
+        f"operation={state['operation']}",
+        f"- Hosted evidence: remote={remote['status']} | "
+        f"PR={pr['status']}#{pr.get('number', 'UNKNOWN')} | "
+        f"review={receipt['review']['status']} | "
+        f"retention={receipt['retention']['status']}",
+        f"- Next action: {receipt['authorization']['next_action']}",
+    ]
+
+
+def _build_handoff_lines(
+    date_str: str,
+    block: list[str],
+    *,
+    receipt: dict | None = None,
+    receipt_path: str | None = None,
+) -> list[str]:
     focus = _parse_focus(block)
     completed = _parse_completed(block)[:3]
     prs = _parse_prs(block)[:6]
@@ -1197,6 +1280,8 @@ def _build_handoff_lines(date_str: str, block: list[str]) -> list[str]:
         lines.append(f"- Completed: {'; '.join(completed)}")
     if prs:
         lines.append(f"- PRs: {', '.join(prs)}")
+    if receipt is not None and receipt_path is not None:
+        lines.extend(_git_handoff_lines(receipt, receipt_path))
     return lines
 
 
@@ -1234,7 +1319,11 @@ def _update_next_brief(handoff_lines: list[str]) -> None:
     NEXT_BRIEF.write_text(new_text.strip() + "\n", encoding="utf-8")
 
 
-def _do_handoff(*, preserve_current_same_day: bool = False) -> tuple[bool, str]:
+def _do_handoff(
+    *,
+    preserve_current_same_day: bool = False,
+    git_receipt: Path | None = None,
+) -> tuple[bool, str]:
     if not SESSION_LOG.exists():
         return False, "docs/SESSION_LOG.md not found"
     if not NEXT_BRIEF.exists():
@@ -1242,6 +1331,9 @@ def _do_handoff(*, preserve_current_same_day: bool = False) -> tuple[bool, str]:
     try:
         lines = SESSION_LOG.read_text(encoding="utf-8").splitlines()
         date_str, block = _latest_session_block(lines)
+        receipt, receipt_path, receipt_errors = _resolve_git_receipt(block, git_receipt)
+        if receipt_errors:
+            return False, "Git handoff receipt hold: " + ", ".join(receipt_errors)
         if preserve_current_same_day:
             current_brief = NEXT_BRIEF.read_text(encoding="utf-8")
             current_match = re.search(
@@ -1249,9 +1341,16 @@ def _do_handoff(*, preserve_current_same_day: bool = False) -> tuple[bool, str]:
                 current_brief,
             )
             current_block = current_match.group(1) if current_match else ""
-            if f"- Date: {date_str}" in current_block and "- Focus:" in current_block:
+            receipt_hash = receipt["local_state_receipt_hash"] if receipt else ""
+            if (
+                f"- Date: {date_str}" in current_block
+                and "- Focus:" in current_block
+                and receipt_hash in current_block
+            ):
                 return True, "Preserved current same-day handoff block"
-        handoff_lines = _build_handoff_lines(date_str, block)
+        handoff_lines = _build_handoff_lines(
+            date_str, block, receipt=receipt, receipt_path=receipt_path
+        )
         if not handoff_lines:
             return False, "Could not build handoff lines from SESSION_LOG.md"
         _update_next_brief(handoff_lines)
@@ -1261,7 +1360,7 @@ def _do_handoff(*, preserve_current_same_day: bool = False) -> tuple[bool, str]:
 
 
 def cmd_handoff(args: argparse.Namespace) -> int:
-    ok, msg = _do_handoff()
+    ok, msg = _do_handoff(git_receipt=args.git_receipt)
     print(msg)
     return 0 if ok else 1
 
@@ -2190,9 +2289,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_end.add_argument(
         "--agent", type=str, default=None, help="Agent name for cost logging"
     )
+    p_end.add_argument(
+        "--git-receipt",
+        type=Path,
+        help="Versioned task-to-Git handoff receipt (otherwise read from SESSION_LOG)",
+    )
 
     # handoff
-    sub.add_parser("handoff", help="Update next-session-brief.md from SESSION_LOG")
+    p_handoff = sub.add_parser(
+        "handoff", help="Update next-session-brief.md from SESSION_LOG"
+    )
+    p_handoff.add_argument(
+        "--git-receipt",
+        type=Path,
+        help="Versioned task-to-Git receipt to validate and embed",
+    )
 
     # check
     sub.add_parser("check", help="Validate session docs consistency")

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -1968,33 +1968,38 @@ def cmd_context(args: argparse.Namespace) -> int:
                 print(f"  {al}")
             print()
 
-    # 3. Git status summary
-    result = subprocess.run(
-        ["git", "status", "--porcelain"], capture_output=True, text=True, cwd=REPO_ROOT
-    )
-    changes = len([line for line in result.stdout.strip().split("\n") if line.strip()])
-    result2 = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        capture_output=True,
-        text=True,
-        cwd=REPO_ROOT,
-    )
-    branch = result2.stdout.strip()
-    result3 = subprocess.run(
-        ["git", "log", "-1", "--format=%h %s (%cr)"],
-        capture_output=True,
-        text=True,
-        cwd=REPO_ROOT,
-    )
-    last_commit = result3.stdout.strip()
-
+    # 3. Canonical Git-state summary
+    context_exit = 0
+    state = None
+    state_errors: list[str] = []
+    try:
+        state = collect_repository_state(REPO_ROOT)
+        state_errors = validate_repository_state_consistency(state)
+    except Exception as exc:
+        state_errors = [f"Git-state authority raised: {exc}"]
     print(f"{BOLD}🔀 Git:{NC}")
-    print(f"  Branch: {GREEN}{branch}{NC}")
-    print(f"  Last commit: {last_commit}")
-    if changes > 0:
-        print(f"  {YELLOW}Uncommitted changes: {changes} file(s){NC}")
+    if state is None or state_errors or state.query_failures:
+        context_exit = 1
+        detail = "; ".join(state_errors) or "required Git evidence is unknown"
+        print(f"  Branch: {YELLOW}UNKNOWN{NC}")
+        print(f"  HEAD: {YELLOW}UNKNOWN{NC}")
+        print(f"  Working tree: {YELLOW}UNKNOWN/hold ({detail}){NC}")
     else:
-        print(f"  Working tree: {DIM}clean{NC}")
+        print(f"  Branch: {GREEN}{state.branch}{NC}")
+        print(f"  HEAD: {state.head_sha or 'UNKNOWN'}")
+        if state.tree.dirty_count:
+            context_exit = 1
+            print(
+                f"  {YELLOW}Uncommitted changes: "
+                f"{state.tree.dirty_count} file(s){NC}"
+            )
+        elif state.derived_action != "READY_LOCAL":
+            context_exit = 1
+            print(
+                f"  Working tree: {YELLOW}UNKNOWN/hold " f"({state.derived_action}){NC}"
+            )
+        else:
+            print(f"  Working tree: {DIM}clean{NC}")
     print()
 
     # 4. Recent session log entries (last 3)
@@ -2021,7 +2026,7 @@ def cmd_context(args: argparse.Namespace) -> int:
     print(f"  {DIM}./run.sh test --changed{NC}   Test only changed files")
     print()
 
-    return 0
+    return context_exit
 
 
 # ─── CLI ─────────────────────────────────────────────────────────────────────

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -34,7 +34,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lib.utils import REPO_ROOT
 from _lib.output import StatusLine
 from git_state import (
-    SCHEMA_VERSION as GIT_STATE_SCHEMA_VERSION,
     RepositoryState,
     collect_repository_state,
     validate_repository_state_consistency,
@@ -808,49 +807,23 @@ def get_closeout_git_evidence() -> tuple[str, list[str], str]:
         state = collect_repository_state(REPO_ROOT)
     except Exception as exc:
         return "UNKNOWN", [], f"Git-state authority raised: {exc}"
-    if not all(
-        hasattr(state, field)
-        for field in (
-            "schema_version",
-            "tree",
-            "query_failures",
-            "derived_action",
-            "hold_reasons",
-        )
-    ):
-        return "UNKNOWN", [], "Git-state authority returned malformed evidence"
-    if state.schema_version != GIT_STATE_SCHEMA_VERSION:
-        return "UNKNOWN", [], f"Git-state schema is unknown: {state.schema_version}"
-    if not isinstance(state.query_failures, list):
-        return "UNKNOWN", [], "Git-state query-failure evidence is malformed"
-    if (
-        not isinstance(state.derived_action, str)
-        or not isinstance(state.hold_reasons, list)
-        or any(not isinstance(reason, str) for reason in state.hold_reasons)
-    ):
-        return "UNKNOWN", [], "Git-state action/hold evidence is malformed"
     consistency_errors = validate_repository_state_consistency(state)
     if consistency_errors:
         return (
             "UNKNOWN",
             [],
-            "Git-state evidence contradicts: " + "; ".join(consistency_errors),
+            "Git-state evidence is malformed or contradictory: "
+            + "; ".join(consistency_errors),
         )
     if state.query_failures:
-        if not all(
-            hasattr(failure, "command") and hasattr(failure, "reason")
-            for failure in state.query_failures
-        ):
-            return "UNKNOWN", [], "Git-state query-failure evidence is malformed"
         detail = "; ".join(
             f"{failure.command}: {failure.reason}" for failure in state.query_failures
         )
         return "UNKNOWN", [], f"Git-state query failed: {detail}"
 
     tree = state.tree
-    clean = getattr(tree, "clean", None)
     path_groups = [
-        getattr(tree, field, None)
+        getattr(tree, field)
         for field in (
             "staged_paths",
             "modified_paths",
@@ -858,22 +831,17 @@ def get_closeout_git_evidence() -> tuple[str, list[str], str]:
             "conflicted_paths",
         )
     ]
-    if not isinstance(clean, bool) or any(
-        not isinstance(group, list) or any(not isinstance(path, str) for path in group)
-        for group in path_groups
-    ):
-        return "UNKNOWN", [], "Git-state tree evidence is malformed"
     paths = sorted(set(path for group in path_groups for path in group))
-    if clean and paths:
-        return "UNKNOWN", [], "Git-state clean flag contradicts dirty paths"
-    if not clean and not paths:
-        return "UNKNOWN", [], "Git-state dirty flag has no path evidence"
-    if clean:
+    if tree.clean:
         if state.derived_action != "READY_LOCAL" or state.hold_reasons:
-            return "UNKNOWN", [], "Git-state clean/action/hold evidence contradicts"
+            return (
+                "UNKNOWN",
+                [],
+                f"Canonical Git state is held: {state.derived_action}",
+            )
         return "CLEAN", [], "Canonical Git-state tree is clean"
     if state.derived_action != "HOLD_DIRTY" or not state.hold_reasons:
-        return "UNKNOWN", [], "Git-state dirty/action/hold evidence contradicts"
+        return "UNKNOWN", [], f"Canonical Git state is held: {state.derived_action}"
     return "DIRTY", paths, "Canonical Git-state tree contains changes"
 
 

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -33,7 +33,11 @@ from typing import Optional
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lib.utils import REPO_ROOT
 from _lib.output import StatusLine
-from git_state import RepositoryState, collect_repository_state
+from git_state import (
+    SCHEMA_VERSION as GIT_STATE_SCHEMA_VERSION,
+    RepositoryState,
+    collect_repository_state,
+)
 from git_handoff_receipt import load_receipt, validate_receipt
 
 SESSION_LOG = REPO_ROOT / "docs" / "SESSION_LOG.md"
@@ -797,19 +801,73 @@ def cmd_usage(args: argparse.Namespace) -> int:
 # ─── End Session ─────────────────────────────────────────────────────────────
 
 
-def get_uncommitted_changes() -> list[str]:
+def get_closeout_git_evidence() -> tuple[str, list[str], str]:
+    """Return CLEAN, DIRTY, or UNKNOWN from the canonical Git-state authority."""
     try:
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
+        state = collect_repository_state(REPO_ROOT)
+    except Exception as exc:
+        return "UNKNOWN", [], f"Git-state authority raised: {exc}"
+    if not all(
+        hasattr(state, field) for field in ("schema_version", "tree", "query_failures")
+    ):
+        return "UNKNOWN", [], "Git-state authority returned malformed evidence"
+    if state.schema_version != GIT_STATE_SCHEMA_VERSION:
+        return "UNKNOWN", [], f"Git-state schema is unknown: {state.schema_version}"
+    if not isinstance(state.query_failures, list):
+        return "UNKNOWN", [], "Git-state query-failure evidence is malformed"
+    if state.query_failures:
+        if not all(
+            hasattr(failure, "command") and hasattr(failure, "reason")
+            for failure in state.query_failures
+        ):
+            return "UNKNOWN", [], "Git-state query-failure evidence is malformed"
+        detail = "; ".join(
+            f"{failure.command}: {failure.reason}" for failure in state.query_failures
         )
-        if not result.stdout.strip():
-            return []
-        return [line.strip() for line in result.stdout.strip().split("\n")]
-    except Exception:
-        return []
+        return "UNKNOWN", [], f"Git-state query failed: {detail}"
+
+    tree = state.tree
+    clean = getattr(tree, "clean", None)
+    path_groups = [
+        getattr(tree, field, None)
+        for field in (
+            "staged_paths",
+            "modified_paths",
+            "untracked_paths",
+            "conflicted_paths",
+        )
+    ]
+    if not isinstance(clean, bool) or any(
+        not isinstance(group, list) or any(not isinstance(path, str) for path in group)
+        for group in path_groups
+    ):
+        return "UNKNOWN", [], "Git-state tree evidence is malformed"
+    paths = sorted(set(path for group in path_groups for path in group))
+    if clean and paths:
+        return "UNKNOWN", [], "Git-state clean flag contradicts dirty paths"
+    if not clean and not paths:
+        return "UNKNOWN", [], "Git-state dirty flag has no path evidence"
+    if clean:
+        return "CLEAN", [], "Canonical Git-state tree is clean"
+    return "DIRTY", paths, "Canonical Git-state tree contains changes"
+
+
+def report_closeout_git_evidence() -> bool:
+    """Print fail-closed closeout evidence; return true only for CLEAN."""
+    print("📁 Uncommitted Changes:")
+    status, paths, reason = get_closeout_git_evidence()
+    if status == "UNKNOWN":
+        print(f"  ⚠️  Git state UNKNOWN/hold: {reason}")
+        return False
+    if status == "DIRTY":
+        print(f"  ⚠️  {len(paths)} uncommitted file(s):")
+        for path in paths[:5]:
+            print(f"     {path}")
+        if len(paths) > 5:
+            print(f"     ... and {len(paths) - 5} more")
+        return False
+    print("  ✅ Working tree clean (scripts/git_state.py)")
+    return True
 
 
 def check_session_log_complete() -> tuple[bool, list[str]]:
@@ -971,17 +1029,8 @@ def cmd_end(args: argparse.Namespace) -> int:
     all_passed = True
 
     # 1. Uncommitted changes
-    print("📁 Uncommitted Changes:")
-    uncommitted = get_uncommitted_changes()
-    if uncommitted:
-        print(f"  ⚠️  {len(uncommitted)} uncommitted file(s):")
-        for f in uncommitted[:5]:
-            print(f"     {f}")
-        if len(uncommitted) > 5:
-            print(f"     ... and {len(uncommitted) - 5} more")
+    if not report_closeout_git_evidence():
         all_passed = False
-    else:
-        print("  ✅ Working tree clean")
     print()
 
     # 2. Handoff brief update (if --fix)

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -1299,7 +1299,7 @@ def _update_next_brief(handoff_lines: list[str]) -> None:
     )
     if HANDOFF_START in text and HANDOFF_END in text:
         pattern = re.compile(
-            r"## Latest Handoff \(auto\)\n\n"
+            r"## Latest Handoff(?: \(auto\))?\n\n"
             + re.escape(HANDOFF_START)
             + r"[\s\S]*?"
             + re.escape(HANDOFF_END)


### PR DESCRIPTION
## Summary
- discover maintained live Git guidance deterministically and fail semantic contradictions closed
- add a versioned read-only task-to-Git handoff receipt using git_state.py as the sole local authority
- route receipt validation through session handoff/end and reconcile only GIT-7E truth surfaces

## Validation
- focused receipt/semantic/session regressions: 66 passed
- Codex-native semantic Git workflow: passed
- strict docs: 5/5; 1,107 links, zero broken
- quick gate: 10/10
- full gate: 30/30
- efficiency and session-end: passed
- protected refs/worktrees and detached dirty e54a: unchanged

## Audit boundary
Draft only. Do not mark ready or merge until the supervising orchestrator independently audits the unchanged exact base, head, and tree. No cleanup or deletion is authorized.