### PR TITLE
docs(git): add compact audited orchestrator workflow

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -24,6 +24,9 @@ receipt, Git reader, or second authority
 - Added the local-PASS-before-hosted-CI rule, one consolidated blocker packet,
   initial-plus-one-repair candidate ceiling, one full/hosted closeout, unchanged-
   head merge rule, timing labels, and retry/rework counters.
+- Corrected the consolidated audit finding so focused checks and the sole quick
+  gate precede the immutable candidate commit, while the full gate remains after
+  LOCAL PASS.
 - Embedded the minimal issue-record template in the canonical Git workflow and
   refreshed only already-maintained generated indexes after content freeze.
 - Preserved GIT-7E behavior and every protected worktree; no branch, worktree,
@@ -39,8 +42,11 @@ receipt, Git reader, or second authority
   diff/status checks on that line.
 - The primary checkout's clean local `main` was at `0fdb48ed`, while freshly
   fetched `origin/main` and this isolated worktree were at the required merged
-  base `6bcbd9d3`; treating the primary local ref as the integration base would
-  have violated the frozen exact-base contract.
+  base `6bcbd9d3`; treating that stale local ref as current would have violated
+  the frozen exact-base contract.
+- Independent audit rejected initial candidate `1f842b9d` because both workflow
+  authorities placed the quick gate after LOCAL PASS, conflicting with the
+  mandatory pre-commit quick gate in `AGENTS.md`.
 
 ### Root causes and resolutions
 
@@ -56,13 +62,23 @@ receipt, Git reader, or second authority
   `Python/tests/test_git_guidance_semantics.py`, and both pass on the frozen
   content. Proof: their direct focused runs. Recurrence control: discover
   maintained commands with `rg --files`/references before execution.
-- Root cause: the primary checkout contains a distinct local-main commit not
-  present on freshly fetched `origin/main`. Resolution: preserve that checkout
-  untouched and create this branch in the isolated clean worktree from the exact
-  fetched base requested by the orchestrator. Proof: candidate base/head/tree and
-  canonical `git_state.py --json --worktrees` receipts. Recurrence control:
-  compare fetched remote identity and tree with the frozen contract before any
-  writer mutation; stop if the required remote base differs.
+- Root cause: the primary checkout's local `main` had not advanced through the
+  seven commits already present on the required remote main; `0fdb48ed` is the
+  ancestor and merge-base of `6bcbd9d3`, not a distinct commit absent from remote
+  main. Resolution: preserve that checkout untouched and create this branch in
+  the isolated clean worktree from the exact fetched base requested by the
+  orchestrator. Proof: `git merge-base --is-ancestor` succeeds, merge-base is
+  `0fdb48ed`, and `git rev-list --left-right --count` reports `0 7`.
+  Recurrence control: compare fetched remote identity, ancestry, and tree with
+  the frozen contract before any writer mutation.
+- Root cause: the initial wording combined quick and full validation in the
+  post-audit final gate, overlooking the repository's mandatory pre-commit quick
+  gate. Resolution: both authorities now require content/index freeze, focused
+  checks, and the sole quick gate before committing the immutable local
+  candidate; only the full gate waits for LOCAL PASS. Proof: focused checks and
+  `./run.sh check --quick` pass before the repair commit. Recurrence control:
+  reconcile proposed stage order against mandatory `AGENTS.md` gates during
+  contract freeze.
 
 ## 2026-08-15 — Session: GIT-7E Semantic Guidance and Durable Handoff
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,65 @@
 
 ---
 
+## 2026-08-15 — Session: Compact Audited Orchestrator Workflow
+
+**Agent:** Codex (`doc-master`, sole writer/integration owner; no subagents)
+
+**Branch:** `codex/compact-orchestrator-workflow`, created from freshly fetched
+and verified `origin/main = 6bcbd9d3e082ea41bcba1d3858fcfa7deb77fa75`
+with tree `f1b38e17e932e8e84c06cca23061aec97351c699`
+
+**Focus:** Add the compact three-role, immutable-local-audit workflow to the two
+existing authorities without adding a workflow document, wrapper, checker,
+receipt, Git reader, or second authority
+
+### Summary
+
+- Added the orchestrator, single-writer, and independent-auditor boundaries and
+  the exact contract-freeze through post-merge stage gates.
+- Added the local-PASS-before-hosted-CI rule, one consolidated blocker packet,
+  initial-plus-one-repair candidate ceiling, one full/hosted closeout, unchanged-
+  head merge rule, timing labels, and retry/rework counters.
+- Embedded the minimal issue-record template in the canonical Git workflow and
+  refreshed only already-maintained generated indexes after content freeze.
+- Preserved GIT-7E behavior and every protected worktree; no branch, worktree,
+  receipt, script, or Git/GitHub authority was removed or replaced.
+
+### Issues encountered
+
+- A shell inventory command referenced the absent
+  `docs/git-automation/index.*` glob. Zsh stopped with `no matches found`, so the
+  remaining read-only commands on that line did not run.
+- The first semantic-check command guessed a retired/nonexistent
+  `scripts/check_git_guidance_semantics.py` path and stopped before the remaining
+  diff/status checks on that line.
+- The primary checkout's clean local `main` was at `0fdb48ed`, while freshly
+  fetched `origin/main` and this isolated worktree were at the required merged
+  base `6bcbd9d3`; treating the primary local ref as the integration base would
+  have violated the frozen exact-base contract.
+
+### Root causes and resolutions
+
+- Root cause: the inventory assumed every documentation folder had maintained
+  index topology. Resolution: use `rg --files` and explicit existing index paths;
+  do not create an index under `docs/git-automation`. Proof: the generator dry-
+  run targets only existing maintained projections and the focused index check
+  passes. Recurrence control: discover topology before composing generator or
+  shell-glob commands.
+- Root cause: the focused command was composed from the test module's topic
+  rather than the maintained executable inventory. Resolution: targeted search
+  identified `scripts/check_codex_git_workflow.py` plus
+  `Python/tests/test_git_guidance_semantics.py`, and both pass on the frozen
+  content. Proof: their direct focused runs. Recurrence control: discover
+  maintained commands with `rg --files`/references before execution.
+- Root cause: the primary checkout contains a distinct local-main commit not
+  present on freshly fetched `origin/main`. Resolution: preserve that checkout
+  untouched and create this branch in the isolated clean worktree from the exact
+  fetched base requested by the orchestrator. Proof: candidate base/head/tree and
+  canonical `git_state.py --json --worktrees` receipts. Recurrence control:
+  compare fetched remote identity and tree with the frozen contract before any
+  writer mutation; stop if the required remote base differs.
+
 ## 2026-08-15 — Session: GIT-7E Semantic Guidance and Durable Handoff
 
 **Agent:** Codex (`ops`, sole writer/integration owner; no subagents)

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -53,10 +53,12 @@ The stage gates are:
 1. **Contract freeze:** record the complete acceptance and schema/cross-field
    matrices, adversarial cases, maintained callers, non-goals, path ownership,
    focused commands, and evidence expected at closeout.
-2. **Focused implementation:** use focused checks while writing; freeze content
-   before the sole writer updates already-maintained generated projections.
-3. **Immutable local audit:** commit a clean local candidate and pause before
-   push. Give the auditor its exact base, head, tree, diff, and focused evidence.
+2. **Focused implementation:** use focused checks while writing. After content
+   freezes, the sole writer updates already-maintained generated projections,
+   reruns focused checks, and runs the sole quick gate.
+3. **Immutable local audit:** only then commit a clean local candidate and pause
+   before push. Give the auditor its exact base, head, tree, diff, focused
+   evidence, and quick-gate result.
 4. **Consolidated decision:** the auditor returns either `PASS <head> <tree>` or
    one deduplicated blocker list with reproduction, main-process impact, and
    required outcome after completing the whole matrix.
@@ -64,7 +66,7 @@ The stage gates are:
    consolidated repair candidate. A second rejection triggers contract/design
    re-planning; do not start another patch cycle.
 6. **Final local gate:** only after independent local PASS on the unchanged
-   head, run the quick gate and one final full gate.
+   head, run one final full gate.
 7. **Hosted closeout and merge:** push once, complete one hosted CI/review
    closeout, and immediately recheck the exact head/tree, base, required checks,
    reviews, unresolved threads, conflicts, and mergeability. Merge only the

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-13
+last_updated: 2026-08-15
 doc_type: guide
 complexity: intermediate
 tags: [git, github, codex, workflow]
@@ -34,6 +34,62 @@ feat|fix|docs|refactor|test|chore|ci(scope): description
 Do not add a repository script that automates this lifecycle. Validation scripts
 may inspect Git state, but they must not stage, commit, push, merge, reset,
 checkout, clean, stash, delete branches, or mutate GitHub state.
+
+## Compact audited integration
+
+Use three roles for work that needs independent acceptance:
+
+- the **orchestrator** freezes scope, non-goals, acceptance rows, maintained
+  callers, shared/generated owners, commands, timing labels, and the candidate
+  ceiling, then decides acceptance;
+- the **single writer** alone edits implementation, tests, receipts, shared
+  documents, session records, and generated indexes; and
+- the **independent auditor** stays read-only, derives falsification cases from
+  the frozen contract rather than writer fixtures, and audits one exact commit
+  and tree across every acceptance row before reporting.
+
+The stage gates are:
+
+1. **Contract freeze:** record the complete acceptance and schema/cross-field
+   matrices, adversarial cases, maintained callers, non-goals, path ownership,
+   focused commands, and evidence expected at closeout.
+2. **Focused implementation:** use focused checks while writing; freeze content
+   before the sole writer updates already-maintained generated projections.
+3. **Immutable local audit:** commit a clean local candidate and pause before
+   push. Give the auditor its exact base, head, tree, diff, and focused evidence.
+4. **Consolidated decision:** the auditor returns either `PASS <head> <tree>` or
+   one deduplicated blocker list with reproduction, main-process impact, and
+   required outcome after completing the whole matrix.
+5. **Candidate ceiling:** allow the initial candidate and at most one
+   consolidated repair candidate. A second rejection triggers contract/design
+   re-planning; do not start another patch cycle.
+6. **Final local gate:** only after independent local PASS on the unchanged
+   head, run the quick gate and one final full gate.
+7. **Hosted closeout and merge:** push once, complete one hosted CI/review
+   closeout, and immediately recheck the exact head/tree, base, required checks,
+   reviews, unresolved threads, conflicts, and mergeability. Merge only the
+   unchanged auditor-approved head; a changed head returns to local audit.
+8. **Post-merge verification:** refresh `main` without destructive cleanup and
+   verify the merge identity, reviewed-tree equivalence where relevant,
+   integrated checks, and task/handoff/receipt truth. Retain branches and
+   worktrees unless deletion is separately authorized.
+
+Do not claim a candidate is complete, final, ready, or merge-eligible before the
+independent PASS bound to its unchanged head and tree. Do not start hosted CI
+before that PASS.
+
+Record every material issue in the task-owned session entry with this minimal
+shape (use `unconfirmed` until the root cause is proved):
+
+```markdown
+### <issue title>
+- Symptom:
+- Main-process impact:
+- Confirmed root cause:  # or `unconfirmed`
+- Fix:
+- Proof:
+- Recurrence control:
+```
 
 ## Read-only Git state authority
 
@@ -93,10 +149,10 @@ numbers alone are not a durable Git receipt.
 
 ## Verification before publication
 
-- Run focused checks while editing.
-- Run `./run.sh check --quick` before the reviewed commit.
-- Run the full `./run.sh check` gate once at closeout for high-risk, merge, or
-  release work.
+- Follow the compact audited-integration gates above when independent acceptance
+  is required. Routine low-risk work still uses focused checks, then
+  `./run.sh check --quick` before publication and the full `./run.sh check` once
+  at closeout when its risk or release scope requires it.
 - Never bypass pre-commit hooks or required GitHub checks.
 - A green software gate is evidence about the software, not structural design
   approval or formula certification.

--- a/docs/guidelines/ai-token-efficiency.md
+++ b/docs/guidelines/ai-token-efficiency.md
@@ -157,13 +157,12 @@ controls:
 
 - one writer owns all mutable, shared, and generated surfaces;
 - freeze acceptance rows, maintained callers, and index scope before editing;
-- use focused gates during iteration and update maintained indexes once after
-  content freezes;
-- commit an immutable local candidate for a read-only independent audit and
-  return one consolidated blocker list only after the full audit matrix;
+- use focused gates during iteration; after content freezes, update maintained
+  indexes once, rerun focused checks, and run the sole quick gate;
+- only then commit an immutable local candidate for a read-only independent
+  audit and return one consolidated blocker list after the full audit matrix;
 - run no hosted CI before `PASS <head> <tree>` from that local audit;
-- after PASS, run the quick gate and one full gate at closeout, then push once
-  for one hosted run;
+- after PASS, run one full gate at closeout, then push once for one hosted run;
 - allow the initial candidate plus one consolidated repair candidate; a second
   rejection requires contract/design re-planning; and
 - if the audited head changes, invalidate the PASS rather than spending another

--- a/docs/guidelines/ai-token-efficiency.md
+++ b/docs/guidelines/ai-token-efficiency.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-10
+last_updated: 2026-08-15
 doc_type: guide
 ---
 
@@ -151,6 +151,31 @@ Then:
 5. Run `./run.sh check --quick` before committing.
 6. Run the full project or release gate once at closeout. Repeat only the failed
    portion unless the fix can affect other categories.
+
+For work requiring independent acceptance, use these stricter efficiency
+controls:
+
+- one writer owns all mutable, shared, and generated surfaces;
+- freeze acceptance rows, maintained callers, and index scope before editing;
+- use focused gates during iteration and update maintained indexes once after
+  content freezes;
+- commit an immutable local candidate for a read-only independent audit and
+  return one consolidated blocker list only after the full audit matrix;
+- run no hosted CI before `PASS <head> <tree>` from that local audit;
+- after PASS, run the quick gate and one full gate at closeout, then push once
+  for one hosted run;
+- allow the initial candidate plus one consolidated repair candidate; a second
+  rejection requires contract/design re-planning; and
+- if the audited head changes, invalidate the PASS rather than spending another
+  hosted run on unaudited work.
+
+Use non-overlapping timing labels: `contract/intake`, `writer implementation +
+focused verification`, `independent local audit`, `writer rework`, `final local
+closeout`, `hosted/network wait`, and `merge + post-merge verification`. Report
+their sum as `total wall time`; do not count idle or network time in another
+interval. At closeout report `candidate_heads`, `audit_rejections`,
+`repair_batches`, `focused_gate_retries`, `full_gate_runs`,
+`hosted_validation_runs`, `rework_minutes`, and `network_wait_minutes`.
 
 Safety-critical structural calculations still require independent reference
 validation. Token efficiency never replaces practicing-engineer review or the

--- a/docs/guidelines/index.json
+++ b/docs/guidelines/index.json
@@ -17,10 +17,10 @@
     {
       "name": "ai-token-efficiency.md",
       "type": "documentation",
-      "size_lines": 217,
+      "size_lines": 242,
       "last_updated": "2026-08-15",
       "description": "This is the canonical low-token operating policy for AI-assisted work in this repository. It controls avoidable context and agent fan-out without weakening",
-      "content_hash": "c9b5747bac10"
+      "content_hash": "31420d6c600c"
     },
     {
       "name": "api-design-guidelines.md",
@@ -140,5 +140,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "7096a108d9400caa"
+  "content_hash": "5488ed8b09bcaf39"
 }

--- a/docs/guidelines/index.json
+++ b/docs/guidelines/index.json
@@ -17,10 +17,10 @@
     {
       "name": "ai-token-efficiency.md",
       "type": "documentation",
-      "size_lines": 242,
+      "size_lines": 241,
       "last_updated": "2026-08-15",
       "description": "This is the canonical low-token operating policy for AI-assisted work in this repository. It controls avoidable context and agent fan-out without weakening",
-      "content_hash": "31420d6c600c"
+      "content_hash": "3f488ba304f9"
     },
     {
       "name": "api-design-guidelines.md",
@@ -140,5 +140,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "5488ed8b09bcaf39"
+  "content_hash": "fed1ed5c5ef2e933"
 }

--- a/docs/guidelines/index.md
+++ b/docs/guidelines/index.md
@@ -13,7 +13,7 @@
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Guidelines Index | Development standards and best practices for the structural  | 74 |
-| [ai-token-efficiency.md](ai-token-efficiency.md) |  | This is the canonical low-token operating policy for AI-assi | 242 |
+| [ai-token-efficiency.md](ai-token-efficiency.md) |  | This is the canonical low-token operating policy for AI-assi | 241 |
 | [api-design-guidelines.md](api-design-guidelines.md) |  | This document consolidates all Phase 1 and Phase 2 API resea | 2626 |
 | [api-evolution-standard.md](api-evolution-standard.md) |  | > **Standard for API versioning, deprecation, and backward c | 1691 |
 | [blog-writing-guide.md](blog-writing-guide.md) |  | | Audience | Tone | Example | |----------|------|---------| | 860 |

--- a/docs/guidelines/index.md
+++ b/docs/guidelines/index.md
@@ -13,7 +13,7 @@
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Guidelines Index | Development standards and best practices for the structural  | 74 |
-| [ai-token-efficiency.md](ai-token-efficiency.md) |  | This is the canonical low-token operating policy for AI-assi | 217 |
+| [ai-token-efficiency.md](ai-token-efficiency.md) |  | This is the canonical low-token operating policy for AI-assi | 242 |
 | [api-design-guidelines.md](api-design-guidelines.md) |  | This document consolidates all Phase 1 and Phase 2 API resea | 2626 |
 | [api-evolution-standard.md](api-evolution-standard.md) |  | > **Standard for API versioning, deprecation, and backward c | 1691 |
 | [blog-writing-guide.md](blog-writing-guide.md) |  | | Audience | Tone | Example | |----------|------|---------| | 860 |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4736,
+      "size_lines": 4795,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "912e7cadb897"
+      "content_hash": "d4038903cfbf"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "add306db2ec3e9c4"
+  "content_hash": "27a1a3eb34e847a2"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4795,
+      "size_lines": 4811,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "d4038903cfbf"
+      "content_hash": "7884afc17c9f"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "27a1a3eb34e847a2"
+  "content_hash": "f2700edac7822729"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4795 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4811 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4736 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4795 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 


### PR DESCRIPTION
## What changed

- document the compact orchestrator, single-writer, and independent-auditor workflow
- require immutable local audit before hosted CI, one consolidated repair batch, and unchanged-head merge protection
- align quick/full gate ordering with repository policy
- add compact issue, timing, and retry/rework reporting controls

## Why

GIT-7E exposed repeated candidate churn and hosted validation before independent local acceptance. This packet makes the efficient, fail-closed workflow explicit in the existing authorities without adding another workflow document or Git-state authority.

## Validation

- independent LOCAL PASS: `0690f74504b780f7920828a7ea0cd0e0dda4149c` / tree `8f38c8d40033010a011e9eb38c9519f3347d381c`
- focused semantic tests: 72 passed
- documentation checks: 5/5 passed
- internal links: 1,107 checked, zero broken
- quick gate: 10/10 passed before commit
- full gate: 30/30 passed after LOCAL PASS
