### PR TITLE
feat(governance): establish Indian-code truth baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ UI/IO        → react_app/, fastapi_app/
 - **Session Persistence:** `scripts/session_store.py` — JSON session state in logs/sessions/
 - **Pipeline Resume:** `scripts/pipeline_state.py` — resumable 8-step task pipeline
 - **Hooks Framework:** `scripts/hooks/` — non-Git execution hooks such as `pre_route`
-- **Parity Dashboard:** `scripts/parity_dashboard.py` — IS 456 clause/endpoint/test coverage
+- **Parity Dashboard:** `scripts/parity_dashboard.py` — declared Indian-code capability plus endpoint/test/hook coverage
 - **Skill Tiers:** Core (task-eligible), Specialist (role-based), Experimental (explicit)
 
 ## Search Before Coding
@@ -185,7 +185,7 @@ grep -r "@router" fastapi_app/routers/ | head -30               # Existing API r
 ./run.sh release run 0.X.Y         # Bump version + release flow
 ./run.sh route "task description"   # Route task to best agent (NLP-based)
 ./run.sh tools [--list|--find|--agent] # Unified tool/script registry
-./run.sh parity                     # IS 456 clause/endpoint/test coverage dashboard
+./run.sh parity                     # Indian-code capability and cross-layer parity dashboard
 ./run.sh pipeline status TASK-XXX   # Check pipeline step for a task
 ./run.sh session compact            # Archive old SESSION_LOG entries (<50KB)
 ./run.sh efficiency check           # Validate low-token project controls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Core CANNOT import from Services or UI. Services CANNOT import from UI.
 - **Session Persistence:** `scripts/session_store.py` — JSON session state in logs/sessions/
 - **Pipeline Resume:** `scripts/pipeline_state.py` — resumable 8-step task pipeline
 - **Hooks Framework:** `scripts/hooks/` — non-Git execution hooks such as `pre_route`
-- **Parity Dashboard:** `scripts/parity_dashboard.py` — IS 456 clause/endpoint/test coverage
+- **Parity Dashboard:** `scripts/parity_dashboard.py` — declared Indian-code capability plus endpoint/test/hook coverage
 - **Skill Tiers:** Core (always), Specialist (role-based), Experimental (explicit)
 
 ## IMPORTANT: Search before coding
@@ -116,7 +116,7 @@ Key patterns: CSV import → `useCSVFileImport` | 3D geometry → `useBeamGeomet
 ./run.sh release run 0.X.Y         # Bump version + release flow
 ./run.sh route "task description"   # Route task to best agent (NLP-based)
 ./run.sh tools [--list|--find|--agent] # Unified tool/script registry
-./run.sh parity                     # IS 456 clause/endpoint/test coverage dashboard
+./run.sh parity                     # Indian-code capability and cross-layer parity dashboard
 ./run.sh pipeline status TASK-XXX   # Check pipeline step for a task
 ./run.sh session compact            # Archive old SESSION_LOG entries (<50KB)
 ./run.sh efficiency check           # Validate low-token project controls

--- a/Python/structural_lib/services/capabilities.py
+++ b/Python/structural_lib/services/capabilities.py
@@ -8,6 +8,8 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 __all__ = [
+    "IS456_STANDARD_ID",
+    "IS456_STANDARD_NAMESPACE",
     "IS456AdapterContract",
     "IS456Capability",
     "IS456FieldAlias",
@@ -21,6 +23,8 @@ __all__ = [
 ]
 
 CAPABILITY_SCHEMA_VERSION = "2.0"
+IS456_STANDARD_ID = "IS456"
+IS456_STANDARD_NAMESPACE = "IS456:2000"
 IS456_CODE_EDITION = "IS 456:2000"
 
 

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -3,7 +3,7 @@
   "type": "python-package",
   "description": "This document describes the test taxonomy and structure for the structural_engineering_lib test suite.",
   "last_updated": "2026-08-15",
-  "file_count": 67,
+  "file_count": 68,
   "files": [
     {
       "name": "README.md",
@@ -2546,6 +2546,38 @@
       "content_hash": "40ceabc73929"
     },
     {
+      "name": "test_indian_code_manifest.py",
+      "type": "python",
+      "size_lines": 140,
+      "last_updated": "2026-08-15",
+      "description": "INDIA-0 truth-manifest and reporting contract tests.",
+      "functions": [
+        {
+          "name": "test_committed_manifest_is_deterministic_and_current"
+        },
+        {
+          "name": "test_manifest_uses_closed_namespaced_statuses_without_unknowns"
+        },
+        {
+          "name": "test_is456_supported_families_are_generated_from_runtime_registry"
+        },
+        {
+          "name": "test_is456_and_is13920_registration_cannot_cross_match"
+        },
+        {
+          "name": "test_clause_checker_reports_registration_not_implementation"
+        },
+        {
+          "name": "test_parity_dashboard_consumes_declared_capability_families"
+        }
+      ],
+      "constants": [
+        "REPO_ROOT",
+        "SCRIPTS_ROOT"
+      ],
+      "content_hash": "03523611dd71"
+    },
+    {
       "name": "test_inputs.py",
       "type": "python",
       "size_lines": 464,
@@ -4672,5 +4704,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "8dcb6b97fa2d632a"
+  "content_hash": "3e6082ef5935ab72"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -4,7 +4,7 @@ This document describes the test taxonomy and structure for the structural_engin
 
 **Type:** Python Package
 **Last Updated:** 2026-08-15
-**Files:** 67
+**Files:** 68
 
 ## Documentation Files
 
@@ -53,6 +53,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 10 | 362 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 20 | 682 |
+| [test_indian_code_manifest.py](test_indian_code_manifest.py) | INDIA-0 truth-manifest and reporting contract tests. | 0 | 6 | 140 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
 | [test_is456_constants.py](test_is456_constants.py) | Tests for IS 456:2000 named design constants. | 1 | 0 | 163 |

--- a/Python/tests/test_indian_code_manifest.py
+++ b/Python/tests/test_indian_code_manifest.py
@@ -1,0 +1,135 @@
+"""INDIA-0 truth-manifest and reporting contract tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from structural_lib.services.capabilities import get_supported_is456_capabilities
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+if str(SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_ROOT))
+
+from _lib.indian_code_manifest import (  # noqa: E402
+    MANIFEST_PATH,
+    build_manifest,
+    render_manifest,
+)
+
+
+def _standard(manifest: dict, namespace: str) -> dict:
+    return next(
+        item for item in manifest["standards"] if item["namespace"] == namespace
+    )
+
+
+def _run_json(script: str, *arguments: str) -> dict:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPTS_ROOT / script), *arguments],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_committed_manifest_is_deterministic_and_current() -> None:
+    assert MANIFEST_PATH.read_text(encoding="utf-8") == render_manifest()
+
+
+def test_manifest_uses_closed_namespaced_statuses_without_unknowns() -> None:
+    manifest = build_manifest()
+    namespaces = [item["namespace"] for item in manifest["standards"]]
+    assert namespaces == ["IS456:2000", "IS13920:2016", "IS875", "IS1893"]
+    assert len(namespaces) == len(set(namespaces))
+
+    allowed_scope = set(manifest["status_vocabularies"]["scope_status"])
+    allowed_implementation = set(
+        manifest["status_vocabularies"]["implementation_status"]
+    )
+    allowed_registration = set(manifest["status_vocabularies"]["registration_status"])
+    for standard in manifest["standards"]:
+        for family in standard["capability_families"]:
+            assert family["scope_status"] in allowed_scope
+            assert family["implementation_status"] in allowed_implementation
+            assert family["qualified_review_required"] is True
+        for reference in standard["references"]:
+            assert reference["registration_status"] in allowed_registration
+
+    assert "UNKNOWN" not in render_manifest(manifest)
+
+
+def test_is456_supported_families_are_generated_from_runtime_registry() -> None:
+    manifest = build_manifest()
+    is456 = _standard(manifest, "IS456:2000")
+    generated_supported = {
+        item["family"]: item
+        for item in is456["capability_families"]
+        if item["scope_status"] == "SUPPORTED"
+    }
+    runtime = {item.element: item for item in get_supported_is456_capabilities()}
+
+    assert generated_supported.keys() == runtime.keys()
+    for family, capability in runtime.items():
+        assert generated_supported[family]["workflows"] == list(
+            capability.public_workflows
+        )
+        assert generated_supported[family]["limitations"] == list(capability.held_cases)
+
+    assert generated_supported["solid_slab"]["implementation_status"] == (
+        "IMPLEMENTED_BOUNDED"
+    )
+    flat_slab = next(
+        item for item in is456["capability_families"] if item["family"] == "flat_slab"
+    )
+    assert flat_slab["scope_status"] == "HELD"
+
+
+def test_is456_and_is13920_registration_cannot_cross_match() -> None:
+    manifest = build_manifest()
+    is456 = _standard(manifest, "IS456:2000")
+    is13920 = _standard(manifest, "IS13920:2016")
+
+    assert all(
+        item["reference_id"].startswith("IS456:2000:") for item in is456["references"]
+    )
+    assert all(
+        item["reference_id"].startswith("IS13920:2016:")
+        for item in is13920["references"]
+    )
+    assert is456["registration_summary"]["registration_only_references"] == 0
+    assert is13920["registration_summary"]["registration_only_references"] > 0
+    assert any(
+        item["reference"] == "7.4.8"
+        and item["registration_status"] == "REGISTRATION_ONLY"
+        for item in is13920["references"]
+    )
+
+
+def test_clause_checker_reports_registration_not_implementation() -> None:
+    report = _run_json("check_clause_coverage.py", "--standard", "IS13920", "--json")
+    assert report["report_kind"] == "STANDARD_REFERENCE_DECORATOR_REGISTRATION"
+    assert report["standards"][0]["namespace"] == "IS13920:2016"
+    assert "implemented" not in report["summary"]
+    assert "does not prove implementation" in report["claim_boundary"]
+
+
+def test_parity_dashboard_consumes_declared_capability_families() -> None:
+    report = _run_json("parity_dashboard.py", "--section", "capabilities", "--json")
+    section = report["sections"][0]
+    assert section["metric_kind"] == "DECLARED_CAPABILITY_FAMILY_COVERAGE"
+    assert section["supported"] == 7
+    assert section["held"] == 14
+    assert section["pct"] == 33
+    assert section["informational"] is True
+    assert report["overall_pct"] is None
+    assert "capability scope" in report["overall_scope"]
+    assert "not whole-standard completeness" in section["claim_boundary"]
+
+    default_report = _run_json("parity_dashboard.py", "--json")
+    assert default_report["overall_pct"] == 100

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,110 @@
 
 ---
 
+## 2026-08-15 — Session: INDIA-0 Draft PR Publication and INDIA-1 Handoff
+
+**Agent:** Codex (`ops`, sole writer; no subagents)
+
+**Branch:** `codex/india-0-truth-baseline`
+
+**Focus:** Validate the durable INDIA-0 handoff, commit and push only its owned
+paths, open draft PR #753 without waiting for CI, and replace the stale central
+handoff with a bounded INDIA-1 startup brief.
+
+### Summary
+
+- Revalidated the INDIA-0 receipt, 29-path ownership boundary, GitHub
+  authentication, clean operation state, and exact equality with freshly
+  fetched `origin/main = 96f193bd45a21f05698cf64de47808a2e5f82640`.
+- Committed only the receipt-owned INDIA-0 paths as
+  `cfe02b3d47b671097358cf2feff16ecd4319cf89`, pushed the feature branch
+  without rewriting history, and opened draft PR #753 against `main`.
+- Replaced the prior GIT-7E central handoff with the INDIA-0 integration
+  boundary and an executable INDIA-1 plan split into beam, column, isolated-
+  footing, and solid-slab closure packets.
+- Did not wait for hosted CI. Exact-head check review, ready transition, and
+  merge remain the next session's first task; release and cleanup are not
+  authorized.
+
+### Issues encountered
+
+- `git diff --cached --check` exposed three trailing-space violations in the
+  new truth-baseline document only after the previously untracked file was
+  staged.
+- The first commit attempt stopped because the Black pre-commit hook reformatted
+  the new manifest test file.
+- `gh pr view --head ...` failed because this installed GitHub CLI accepts the
+  branch as a positional argument rather than a `--head` flag.
+- The patch tool rejected a single request that deleted and recreated
+  `docs/planning/next-session-brief.md` at the same path.
+- The documentation metadata hook reported missing canonical metadata on the
+  newly added truth-baseline reference while operating in warning mode.
+- Verification-index regeneration again proposed current dates for 14 unchanged
+  evidence files in the linked worktree.
+
+### Root causes and resolutions
+
+- Root cause: Markdown hard-break spaces were present in an untracked file, so
+  the earlier tracked-only diff check could not inspect them. Resolution:
+  replace hard breaks with blank paragraphs, stage the file, and require the
+  cached diff check before commit. Evidence: `git diff --cached --check` and
+  the whitespace pre-commit hook passed.
+- Root cause: the test file had not been run through the repository's exact
+  Black formatting profile before staging. Resolution: accept the hook's
+  formatter-only edit, rerun all 15 focused manifest/capability/API tests,
+  restage only that path, and retry the commit. Evidence: 15 tests and every
+  commit hook passed.
+- Root cause: the command used the list-style PR filter on the view command.
+  Resolution: use `gh pr view codex/india-0-truth-baseline --json ...`.
+  Evidence: it returned draft PR #753 at the pushed implementation head.
+- Root cause: `apply_patch` permits only one operation per target path in a
+  request. Resolution: split the versioned central-handoff replacement into
+  one delete and one add patch, then validate its length, structure, and links.
+- Root cause: the initial reference header used a descriptive publication
+  sentence as `Status` instead of the repository's metadata vocabulary.
+  Resolution: add canonical type, audience, status, dates, and importance while
+  keeping hosted state in a separate evidence-boundary field.
+- Root cause: the index generator derives displayed dates from linked-worktree
+  filesystem mtimes rather than content history. Resolution: retain the genuine
+  truth-baseline hash/description update while restoring the 14 unchanged
+  evidence dates to their committed historical values. Evidence: the final
+  index diff contains no unrelated date drift and the focused index check
+  passes.
+
+### Verification
+
+- Durable pre-publication handoff validated as `INDIA-0 | HOLD`; the hold was
+  expected because it captured the uncommitted and unchecked hosted state.
+- Refreshed local base, `FETCH_HEAD`, and `origin/main` were identical before
+  commit; no PR already existed for the feature branch.
+- Pre-publication `./run.sh check --quick`: 10/10 passed.
+- Focused manifest, capability-semantic, and FastAPI capability tests: 15 passed
+  after Black's formatter-only change.
+- Commit hooks passed JSON, whitespace, Black, Ruff, mypy, Bandit, governance,
+  link, API-document, index, and session checks.
+- Draft PR #753 opened successfully; its first hosted check began running and
+  was intentionally not awaited in this session.
+
+### Remaining Git/PR handoff
+
+- Push the final documentation handoff commit to PR #753, then treat the live
+  PR head as authoritative rather than the implementation commit recorded
+  above.
+- In the next session, inspect the exact live head, base, tree, required checks,
+  mergeability, and unresolved review state. Mark ready and merge only if every
+  required gate passes for that unchanged head.
+- After merge, fetch and verify the integrated result, then start INDIA-1 in a
+  fresh isolated `codex/india-1-<packet>` lane from current `origin/main`.
+- Do not delete the feature branch/worktree, synchronize the preserved dirty
+  primary checkout, publish a release, or claim engineering approval.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: `gh pr view --head ...` is unsupported by the installed
+  CLI -> use the branch as the positional argument.
+- ⚠️ TERMINAL ISSUE: a same-path delete/add patch was rejected -> split it into
+  separate `apply_patch` operations.
+
 ## 2026-08-15 — Session: INDIA-0 Indian-Code Truth Baseline
 
 **Agent:** Codex (`orchestrator`, sole writer; one bounded read-only reviewer)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,145 @@
 
 ---
 
+## 2026-08-15 — Session: INDIA-0 Indian-Code Truth Baseline
+
+**Agent:** Codex (`orchestrator`, sole writer; one bounded read-only reviewer)
+
+**Branch:** `codex/india-0-truth-baseline`, created in an isolated worktree from
+freshly fetched and verified `origin/main = 96f193bd45a21f05698cf64de47808a2e5f82640`
+
+**Focus:** Create one deterministic, standard-namespaced Indian-code capability
+and decorator-registration manifest; repair both coverage consumers; reconcile
+current tasks, strategic planning, capability identity, and evidence ledgers.
+
+### Summary
+
+- Added a deterministic manifest covering `IS456:2000`, `IS13920:2016`,
+  `IS875`, and `IS1893` with closed supported/held, bounded/not-implemented,
+  and registered/metadata-only/registration-only status vocabularies.
+- Generated supported IS 456 families directly from the runtime capability
+  registry and retained its exact supported workflows, held cases, evidence
+  boundaries, and qualified-review requirement.
+- Replaced the dashboard's hand-maintained 17-item clause/file table with
+  declared capability-family status; the historical `88%` is no longer emitted.
+- Replaced the static-import clause checker with manifest consumption and
+  deterministic AST discovery. Reports are namespaced per standard and call the
+  metric decorator registration, not implementation or clause completeness.
+- Reconciled current `TASKS.md`, archived-in-place stale blueprint tables,
+  slab permission wording, maintained command descriptions, and only the
+  task-owned generated folder indexes.
+- Preserved the dirty, eight-commits-behind primary `main` checkout and its
+  earlier session-log edit without stash, reset, checkout, or copying it into
+  this lane.
+
+### Issues encountered
+
+- The primary checkout was `HOLD_MAIN`: local `main` was eight commits behind
+  verified `origin/main` and had one user-owned `docs/SESSION_LOG.md` edit.
+- The parity dashboard reported Clause 24 and Annex D as planned and classified
+  implementation only by the existence of a manually named file.
+- The clause checker called its output IS 456 coverage while its metadata set
+  contained 16 IS 13920 identifiers, its static imports omitted slab and footing
+  modules, and its registry projection discarded the decorator standard.
+- Legacy IS 13920 metadata does not match all 14 distinct decorator identifiers;
+  nine working registrations therefore have no matching metadata identity.
+- Index generation in a fresh linked worktree proposed current dates for
+  unchanged verification files because their worktree mtimes are new.
+- Independent review found that the truthful 33% supported-family planning
+  metric was still averaged into a 78% headline `Overall Parity Score`, treating
+  intentionally held families like failed cross-layer checks.
+- A single `apply_patch` request attempted to delete and recreate the clause
+  checker at the same path, which the patch tool rejected.
+- Initial session closeout reported a missing task-to-Git handoff receipt, so
+  prose alone did not satisfy the repository's newly merged GIT-7E handoff
+  contract.
+
+### Root causes and resolutions
+
+- Root cause: using a stale dirty integration anchor would mix prior evidence
+  with new implementation and start from superseded source. Resolution: fetched
+  and verified remote `main`, created a separate `codex/india-0-truth-baseline`
+  worktree at exact head `96f193bd`, and required `source_bound=true`. Evidence:
+  the initial task brief reported `READY_LOCAL`, equal to `origin/main`, and the
+  runtime diagnosis resolved imports to this worktree.
+- Root cause: capability status, decorator traceability, and professional
+  acceptance were collapsed into one manually maintained percentage.
+  Resolution: the generated manifest keeps these evidence classes separate and
+  carries explicit claim ceilings. Evidence: slab is `SUPPORTED` while flat
+  slab is `HELD`; every capability still requires qualified review; the parity
+  result is 7 supported and 14 held declared families, not an IS 456 clause
+  score.
+- Root cause: static runtime imports plus unnamespaced reference matching could
+  neither discover maintained modules nor prevent identical clause numbers in
+  different standards from colliding. Resolution: recursively scan the two
+  maintained code roots with AST, require literal references and a supported
+  standard name, namespace before aggregation, and make IS 875/IS 1893 holds
+  explicit. Evidence: IS 456 reports 59/127 known reference registrations with
+  zero registration-only identifiers; IS 13920 separately reports 5/16 known
+  plus nine registration-only identifiers.
+- Root cause: historic execution plans remained formatted as live status after
+  bounded slab, footing, and IS 13920 work landed. Resolution: update current
+  task rows, replace the blueprint's manual clause appendix with generated-tool
+  commands, and retain the historical footing D1 receipt unchanged as historical
+  evidence. Evidence: current task, blueprint, capability, and slab ledgers now
+  point to the generated manifest without elevating held scope.
+- Root cause: the index generator derives per-file dates from filesystem mtimes,
+  which change when a linked worktree is created. Resolution: retain new and
+  genuinely modified index entries while restoring unchanged per-file dates;
+  all three focused index checks pass. This prevents unrelated generated drift.
+- Root cause: the dashboard's existing composite included every section not
+  marked informational; the new declared-scope section initially omitted that
+  marker. Resolution: mark capability scope informational, exclude it from the
+  actionable composite, and state the exclusion in JSON and terminal output.
+  Evidence: the capability section remains 7 supported/14 held while the
+  separately labelled actionable cross-layer score excludes it.
+- Root cause: `apply_patch` does not allow two operations on the same path in one
+  patch. Resolution: split the delete and add into two patch calls. Evidence:
+  the replacement checker is executable and its Ruff/CLI tests pass.
+- Root cause: this task started after GIT-7E added a durable handoff contract,
+  while the initial INDIA-0 plan accounted only for the user-requested prose
+  Git/PR handoff. Resolution: create and validate
+  `docs/verification/INDIA-0-git-handoff.json` with the exact local dirty state,
+  path ownership, authorized next actions, retention decision, and explicit
+  remote/PR/review holds. The receipt grants no authority and prohibits merge,
+  deletion, ref retirement, and release.
+
+### Verification
+
+- `./scripts/python_runtime.sh --diagnose`: `source_bound=true`.
+- Manifest write/check and all task-owned maintained folder-index checks passed.
+- Ruff passed for the manifest, generator, both coverage consumers, capability
+  registry change, and focused tests.
+- INDIA-0, existing capability-semantic, and FastAPI capability tests: 15 passed.
+- Independent read-only reviewer reproduced both original contradictions, found
+  and rejected the first composite-score treatment, then confirmed the repaired
+  standard-namespace and evidence-boundary requirements.
+- Final `./run.sh check --quick`: 10/10 passed.
+- Final `./run.sh check`: 30/30 passed.
+
+### Remaining Git/PR handoff
+
+- Do not reuse or clean the primary `main` checkout; it still owns the earlier
+  uncommitted session audit record.
+- Validate and refresh `docs/verification/INDIA-0-git-handoff.json`; its expected
+  pre-publication status is `HOLD` for local dirty and unchecked hosted evidence.
+- Review and stage only the INDIA-0 paths from this isolated worktree, create a
+  conventional commit, push without rewriting history, and open a draft PR.
+- Record exact head/base/tree and hosted checks in the next session. Per owner
+  instruction, this session does not wait for CI.
+- Do not merge, release, delete a branch/worktree, or retire any historical lane
+  from this handoff. Release and cleanup remain separately authorized actions.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: one patch tried to delete and add the same file in a single
+  operation and was rejected -> split the deletion and creation into two
+  `apply_patch` calls; the resulting executable passes focused validation.
+- ⚠️ TERMINAL ISSUE: the final reviewer initially named nonexistent
+  `Python/tests/test_capabilities.py` -> it discovered and ran the maintained
+  `Python/tests/integration/test_capability_semantics.py` plus FastAPI capability
+  tests; the focused set passed 15/15.
+
 ## 2026-08-15 — Session: Compact Audited Orchestrator Workflow
 
 **Agent:** Codex (`doc-master`, sole writer/integration owner; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -153,7 +153,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
-| INDIA-0 | Reconciled supported and held Indian RC scope into one generated, standard-namespaced capability/registration manifest; repaired both coverage consumers | Main Agent | ✅ LOCALLY COMPLETE — focused contracts green; commit/push/draft PR and CI are intentionally left to the Git handoff |
+| INDIA-0 | Reconciled supported and held Indian RC scope into one generated, standard-namespaced capability/registration manifest; repaired both coverage consumers | Main Agent | 🚧 DRAFT PR #753 — local gates and review passed; hosted CI, exact-head review, and merge remain |
 | COLUMN-PMM-001 | Recovered and independently benchmarked the experimental rectangular-column P-Mx-My fiber surface | Main Agent | ✅ SOFTWARE COMPLETE — PR #738 merged; module remains experimental and outside the stable API |
 | ALPHA-0231-CANDIDATE | Published the exact 0.23.1a1 Alpha through exact-head CI, TestPyPI, production PyPI, and GitHub prerelease gates | Main Agent + ops | ✅ DONE — production run `31468341946`; exact public package UAT green |
 | IS456-SLAB-PRELAUNCH | Record and enforce source/licensing permission for public distribution of approved-scope normalized IS 456 data | Owner + Main Agent | ✅ DONE — owner confirmed 2026-08-11; canonical record, preflight, candidate, and publish-CI gates added |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -133,14 +133,16 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
+| INDIA-1 | Close or explicitly hold the remaining beam, rectangular-column, isolated-footing, and solid-slab workflow limitations recorded by the INDIA-0 manifest | Main Agent + structural engineer | multi-packet | P0 | 📋 READY AFTER INDIA-0 PUBLICATION |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 | LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL STABLE GATE |
 
 ## Backlog
 
-The version roadmap and historical backlog remain below. The owner-selected next
-program is [IS456-SLAB-001](planning/is456-solid-slabs-master-plan.md); broad
-multi-code infrastructure remains future work. The v0.23.1a1 Alpha is published.
+The version roadmap and historical backlog remain below. INDIA-0 now provides
+the generated [Indian-code truth manifest](verification/indian-code-capability-coverage.json);
+INDIA-1 is the next implementation wave after publication of this baseline.
+The v0.23.1a1 Alpha is published.
 UIX-001 P0-P15 is accepted: the revision-safe workbench, authoritative
 3D inspection, versioned capability catalogue, curated renderer, bounded
 development workflow, generated beam manifest, canonical routes, and integrated
@@ -151,6 +153,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-0 | Reconciled supported and held Indian RC scope into one generated, standard-namespaced capability/registration manifest; repaired both coverage consumers | Main Agent | ✅ LOCALLY COMPLETE — focused contracts green; commit/push/draft PR and CI are intentionally left to the Git handoff |
 | COLUMN-PMM-001 | Recovered and independently benchmarked the experimental rectangular-column P-Mx-My fiber surface | Main Agent | ✅ SOFTWARE COMPLETE — PR #738 merged; module remains experimental and outside the stable API |
 | ALPHA-0231-CANDIDATE | Published the exact 0.23.1a1 Alpha through exact-head CI, TestPyPI, production PyPI, and GitHub prerelease gates | Main Agent + ops | ✅ DONE — production run `31468341946`; exact public package UAT green |
 | IS456-SLAB-PRELAUNCH | Record and enforce source/licensing permission for public distribution of approved-scope normalized IS 456 data | Owner + Main Agent | ✅ DONE — owner confirmed 2026-08-11; canonical record, preflight, candidate, and publish-CI gates added |
@@ -356,7 +359,7 @@ We analyzed WHY each external audit finding was missed. Six patterns emerge:
 | **Undocumented API ergonomics** | EA-3, EA-5, EA-12, EA-13 | API grew incrementally without UX design review | API levels doc, build_detailing_input() factory, e2e examples | ✅ Fixed |
 | **Mixed API patterns** | EA-4, EA-14 | Features added fast without consistency enforcement | to_dict() added, task-oriented README | ✅ Fixed |
 | **Security in exception messages** | EA-17, EA-18, EA-20 | Error messages treated as debug output, CORS hardcoded | sanitize_error() utility, Settings-based CORS, RateLimitMiddleware | ✅ Fixed |
-| **Incomplete IS 456 coverage** | EA-21, EA-22, EA-23 | Code added without IS 456 clause coverage checklist | Clause audit list created, bearing_stress_enhancement(), SCWB check, D_mm param | ✅ Fixed |
+| **Incomplete IS 456 coverage** | EA-21, EA-22, EA-23 | Code added without a namespaced capability/traceability contract | INDIA-0 generated manifest separates supported scope, held scope, decorator registration, and qualified review | ✅ Reclassified; remaining work is explicit |
 
 ### Are We Protected Against Recurrence?
 
@@ -368,7 +371,7 @@ We analyzed WHY each external audit finding was missed. Six patterns emerge:
 | E2E pipeline test | ✅ Yes — test_full_pipeline_e2e.py (8 tests) | No gap |
 | RateLimitMiddleware on all endpoints | ✅ Yes — global middleware | No gap |
 | sanitize_error() for all routers | ⚠️ Partial — 2-4 HTTP-exposed ImportError leaks (38 total catch sites properly sanitized) | OL-08 above |
-| IS 456 clause checklist | ⚠️ Partial — @clause decorators exist but ~26 public IS 456 functions lack them (detailing: 11, common/: 8, footing/_common: 4, slenderness: 3; serviceability has full coverage) | IS-NEW-01, IS-NEW-02 |
+| Indian-code traceability | ⚠️ Explicit — INDIA-0 reports namespaced `REGISTERED`, `METADATA_ONLY`, and `REGISTRATION_ONLY` records separately from capability support; registration is not implementation evidence | Generated `indian-code-capability-coverage.json`; follow-on traceability packets only when they change supported workflow evidence |
 | Cross-field input validation | ✅ Yes — _validate_plausibility in common_api.py raises ValueError for d>D | ✅ Fixed (was UX-01) |
 | TestPyPI before prod publish | ❌ No — publish goes direct to PyPI | OL-10 above |
 | OWASP 2025 A03 (Supply Chain) | ⚠️ Partial — Trusted Publishers ✅, but no attestations/provenance | OL-03, OL-04 |
@@ -520,7 +523,7 @@ We analyzed WHY each external audit finding was missed. Six patterns emerge:
 | TASK-737 | Bounded one-way slab design umbrella | — | Cl 24.1–24.2 | ✅ DONE |
 | TASK-750 | Slab types + errors | `SolidRectangularSlabGeometry`, result records | — | ✅ DONE |
 | TASK-751 | Slab classification | `classify_solid_rectangular_slab()` | ly/lx ratio | ✅ DONE |
-| TASK-752 | General one-way coefficient tables | — | Table 12/13 | ⏸ OUT OF SCOPE |
+| TASK-752 | Bounded continuous one-way coefficient lookup | `design_continuous_one_way_slab_builtin_is456()` | Table 12/13 | ✅ DONE FOR DECLARED DOMAIN |
 | TASK-753 | Simply supported one-way design | `design_one_way_slab_is456()` | Cl 24.1–24.2 | ✅ DONE |
 | TASK-754 | Bounded slab detailing/serviceability | `check_one_way_slab_detailing()` | Cl 26.5 | ✅ DONE |
 
@@ -529,11 +532,11 @@ We analyzed WHY each external audit finding was missed. Six patterns emerge:
 | ID | Task | Function | IS 456 Clause | Status |
 |----|------|----------|---------------|--------|
 | TASK-738 | Bounded external-coefficient two-way flexure | — | Cl 24.3, Annex D | ✅ DONE |
-| TASK-760 | Built-in protected moment-coefficient lookup | — | Table 26 | ⏸ OUT OF SCOPE |
-| TASK-761 | Two-way shear coefficients | — | Table 27 | ⏸ OUT OF SCOPE |
+| TASK-760 | Built-in normalized moment-coefficient lookup/interpolation | `design_two_way_slab_panel_builtin_is456()` | Table 26 | ✅ DONE FOR DECLARED DOMAIN |
+| TASK-761 | Built-in simply-supported/free-corner coefficient route | `design_two_way_slab_panel_builtin_is456()` | Table 27 | ✅ DONE FOR DECLARED DOMAIN |
 | TASK-762 | Interior-panel bounded flexure | `design_two_way_slab_is456()` | Annex D-1 | ✅ DONE |
-| TASK-763 | Complete torsion reinforcement | — | Annex D-1.7/D-1.8 | ⏸ OUT OF SCOPE |
-| TASK-764 | Complete strip distribution | — | Annex D-1.2 | ⏸ OUT OF SCOPE |
+| TASK-763 | Bounded corner-torsion reinforcement disposition | complete two-way panel workflows | Annex D | ✅ DONE FOR DECLARED DOMAIN |
+| TASK-764 | Middle/edge strip distribution | complete two-way panel workflows | Annex D | ✅ DONE FOR DECLARED DOMAIN |
 | — | Flat slab with drop panels | — | IS 456 Cl 31 | ⏸ OUT OF SCOPE |
 
 ### Punching Shear (Shared — Slab + Footing)
@@ -548,7 +551,7 @@ We analyzed WHY each external audit finding was missed. Six patterns emerge:
 |----|------|--------|
 | TASK-780 | Bounded slab Python facade wiring | ✅ DONE |
 | TASK-781 | One-way slab FastAPI consumer | ✅ DONE FOR BOUNDED SCOPE |
-| TASK-782 | New slab React form + results panel | ⏸ OUT OF SCOPE |
+| TASK-782 | Revision-safe slab React workbench and review surface | ✅ DONE FOR DECLARED DOMAIN |
 
 ### Additional v0.23 Deliverables (from architecture doc §20.6)
 
@@ -616,7 +619,7 @@ We analyzed WHY each external audit finding was missed. Six patterns emerge:
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| — | IS 456 complete (beam + column + slab + footing) | @structural-math | 📋 |
+| — | INDIA-4 acceptance for the explicitly declared supported Indian RC subset; no whole-standard-complete claim | @structural-math + qualified structural engineer | 📋 |
 | — | ACI 318 beam + column | @structural-math | 📋 |
 | — | EC2 beam (basic) | @structural-math | 📋 |
 | — | CalculationProvenance on all results (§11) | @backend | 📋 |

--- a/docs/governance/maintenance-playbook.md
+++ b/docs/governance/maintenance-playbook.md
@@ -96,8 +96,11 @@ git branch --show-current
 # Full readiness audit
 ./run.sh audit
 
-# IS 456 clause coverage dashboard
+# Declared Indian-code capability and cross-layer dashboard
 ./run.sh parity
+
+# Standard-namespaced decorator registration (not implementation coverage)
+./run.sh coverage --summary
 
 # Element completeness check
 .venv/bin/python scripts/check_new_element_completeness.py

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4811,
+      "size_lines": 4950,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "7884afc17c9f"
+      "content_hash": "1a3c9a9250e4"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 677,
+      "size_lines": 680,
       "last_updated": "2026-08-15",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "49a8da2f8efe"
+      "content_hash": "56dff5fc2913"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 17,
+      "file_count": 20,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "f2700edac7822729"
+  "content_hash": "229f86641b5948e1"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4811 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 677 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4950 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 680 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 17 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 20 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -66,10 +66,10 @@
     {
       "name": "is456-library-first-master-plan.md",
       "type": "documentation",
-      "size_lines": 1497,
+      "size_lines": 1500,
       "last_updated": "2026-08-15",
       "description": "The Python package is the product. FastAPI, React, command-line workflows, reports, ETABS adapters, and future integrations are consumers of that product.",
-      "content_hash": "3c22c1017a09"
+      "content_hash": "2b56fd9cd0e7"
     },
     {
       "name": "is456-solid-slabs-master-plan.md",
@@ -82,11 +82,11 @@
     {
       "name": "library-expansion-blueprint-v5.md",
       "type": "documentation",
-      "size_lines": 1139,
+      "size_lines": 1118,
       "last_updated": "2026-08-15",
       "title": "Library Expansion Blueprint v5.0 — Multi-Code, Multi-Element",
       "description": "> Master plan for expanding structural_engineering_lib from single-code beam-only (IS 456) to multi-code (IS 456, ACI 318-19, EC2), multi-element (beam, column, slab, footing, wall, stair) with comple",
-      "content_hash": "ead8ebc9e2eb"
+      "content_hash": "cf6fe9e58706"
     },
     {
       "name": "memory.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "501eda91b4b8e5f6"
+  "content_hash": "052d684a52c04fce"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -107,11 +107,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 135,
+      "size_lines": 130,
       "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "c9028816a80e"
+      "content_hash": "5e8f62d0891a"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "052d684a52c04fce"
+  "content_hash": "552300ea8541f991"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -20,7 +20,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1118 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 135 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 130 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -15,9 +15,9 @@
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
 | [etabs-killer-masterplan.md](etabs-killer-masterplan.md) | Project BHEEM: Open-Source Structural De | > **BHEEM** — **B**uilding **H**olistic **E**ngineering **E* | 2855 |
 | [gpt-5-3-codex-spark-work-program.md](gpt-5-3-codex-spark-work-program.md) |  | Use GPT-5.3-Codex-Spark as a high-throughput implementation  | 614 |
-| [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1497 |
+| [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1500 |
 | [is456-solid-slabs-master-plan.md](is456-solid-slabs-master-plan.md) |  | The next element program will complete a useful, evidence-ba | 1123 |
-| [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1139 |
+| [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1118 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
 | [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 135 |

--- a/docs/planning/is456-library-first-master-plan.md
+++ b/docs/planning/is456-library-first-master-plan.md
@@ -763,6 +763,7 @@ publication until P12 resolves it.
 - `docs/reference/clause-map.md`
 - `docs/verification/`
 - `scripts/parity_dashboard.py`
+- `docs/verification/indian-code-capability-coverage.json`
 - `README.md`
 - `Python/README.md`
 
@@ -781,8 +782,10 @@ rg -n "@clause|Limitations|unsupported|NotImplemented" Python/structural_lib/cod
 rg --files Python/tests | rg "beam|column|footing|slab"
 ```
 
-**Acceptance:** matrix covers every public beam/column/footing route and records
-slab as planned; parity is not used as whole-code evidence.
+**Acceptance (reconciled by INDIA-0):** the generated manifest covers every
+declared supported and held family. Solid slabs are bounded supported scope;
+flat slabs remain held. Capability-family and decorator-registration metrics
+are not used as whole-code or engineering-approval evidence.
 
 **Return format:** capability -> source state -> benchmark state -> claim state
 -> limitations -> blocking packet. Report only confirmed outcome-changing gaps.

--- a/docs/planning/library-expansion-blueprint-v5.md
+++ b/docs/planning/library-expansion-blueprint-v5.md
@@ -5,18 +5,17 @@
 **Status:** Future strategic roadmap; not active during bounded IS 456 closeout
 **Importance:** Critical
 **Created:** 2026-03-31
-**Last Updated:** 2026-08-09
+**Last Updated:** 2026-08-15
 **Supersedes:** [library-expansion-blueprint-v4.md](../_archive/planning-completed-2026-03/library-expansion-blueprint-v4.md) (IS 456-only)
 
 > Master plan for expanding structural_engineering_lib from single-code beam-only (IS 456) to multi-code (IS 456, ACI 318-19, EC2), multi-element (beam, column, slab, footing, wall, stair) with complete companion code support.
 
-> **Execution note (2026-08-09):** Current work is governed by
-> [is456-library-first-master-plan.md](is456-library-first-master-plan.md).
-> Several current-state and Phase 1 tables below predate the implemented
-> bounded slab/footing/facade work and must not be used as task status. The
-> canonical current state is in `docs/TASKS.md`. Phase 2 multi-code work starts
-> only after the bounded milestone completes C0-C4 and the owner activates a
-> separate packet.
+> **Execution note (reconciled 2026-08-15):** This document is a strategic
+> architecture blueprint, not a live status ledger. Current scope comes from
+> the generated
+> [Indian-code capability/coverage manifest](../verification/indian-code-capability-coverage.json)
+> and `docs/TASKS.md`. Historical task tables below are retained as design
+> context only where explicitly labelled; they must not override the manifest.
 
 ---
 
@@ -214,7 +213,7 @@ class DesignEnvelope:
 | torsion.py | Cl 41.1–41.4 | ✅ Done | 533 | 6 |
 | detailing.py | Cl 26.2–26.5 | ✅ Done | 1189 | 16 |
 | serviceability.py | Cl 43.1–43.4 | ✅ Done | 1356 | 17 |
-| ductile.py | IS 13920 Cl 6 | ✅ Done (beam only) | — | — |
+| `codes/is13920/{beam,column,joint}.py` | Namespaced IS 13920 registrations | ✅ Bounded beam, column and SCWB checks | — | — |
 | materials.py | Cl 6.2, 38.1 | ✅ Done | — | — |
 | tables.py | Table 19, 20 | ✅ Done | — | — |
 | slenderness.py | Cl 23.3 | ✅ Done (beam only) | — | — |
@@ -232,32 +231,25 @@ class DesignEnvelope:
 | DetailingRules ABC | ✅ Exists | Not implemented by IS456Code |
 | CodeRegistry | ✅ Exists | **Dead code** — never called in production |
 | IS456Code class | ✅ Exists | Registered but doesn't implement ABCs |
-| @clause() decorator | ✅ Exists | IS 456-only, no code namespace |
-| clauses.json | ✅ Exists | IS 456 clauses, ~100 entries |
+| @clause() decorator | ✅ Exists | Decorators declare a standard; INDIA-0 discovers and namespaces them without treating registration as implementation |
+| Indian-code truth manifest | ✅ Generated | `IS456:2000`, `IS13920:2016`, `IS875`, and `IS1893`; closed supported/held and registration statuses |
+| clauses.json | ✅ Exists | Identifier/search metadata input; mixed legacy records are separated by namespace in the generated manifest |
 | Backward-compat shims | ✅ 46 exist | @deprecated decorator available in core/deprecation.py |
 | @deprecated decorator | ✅ Done | In core/deprecation.py (TASK-614) |
 | Code-specific input types | ❌ Missing | Only IS456 BeamInput exists |
 | DesignEnvelope result | ❌ Missing | Two parallel result hierarchies |
 | Unit conversion layer | ❌ Missing | No core/units.py |
-| Code discovery API | ❌ Missing | No list_codes(), get_capabilities() |
+| Code discovery API | ✅ Bounded IS 456 discovery | Public IS 456 capability contract exists; broader standard discovery is not claimed |
 
-### 3.3 NOT Implemented (IS 456)
+### 3.3 Reconciled bounded scope
 
-| Element | Clauses | Priority |
-|---------|---------|----------|
-| Column | Cl 25, 39, Annex E/G | ✅ COMPLETE — 14/14 tasks: classify, min_ecc, axial, uniaxial, biaxial, P-M curve, effective_length, helical, additional_moment, long_column, column_detailing, ductile_detailing (IS 13920). 500+ tests, SP:16 benchmarks ±0.1% |
-| One-way slab | Cl 24.1–24.2 | P1 |
-| Two-way slab | Cl 24.3, Annex D, Table 26 | P1 |
-| Footing | Cl 34, 31.6 | 🔄 5/7 done — bearing sizing, flexure, one-way shear, punching shear, bearing pressure done. Missing: dowel bars (TASK-655), FastAPI endpoint (TASK-656) |
-| Wall | Cl 32 | P2 |
-| Staircase | Cl 33 | P2 |
-| Deep beam | Cl 29 | P2 |
-| Flat slab | Cl 31.6 (punching) | P2 |
-| Enhanced shear near supports | Cl 40.3 | ✅ Done (TASK-712) |
-| Punching shear | Cl 31.6 | P1 |
-| Moment redistribution | Annex C | P2 |
-| Effective flange width (L-beam) | Cl 36.4.2 | P1 |
-| Continuous beam coefficients | Annex B | P2 |
+| Scope | Manifest status | Boundary |
+|-------|-----------------|----------|
+| Beam, rectangular column, isolated footing, solid slab | `SUPPORTED` / `IMPLEMENTED_BOUNDED` | Exact supported workflows and held cases come from the runtime IS 456 capability registry |
+| Walls, stairs, deep beams, flat slabs | `HELD` / `NOT_IMPLEMENTED` | Separate IS 456 programs required |
+| Combined/strap/raft/pile-cap foundations | `HELD` / `NOT_IMPLEMENTED` | Each requires a distinct analysis model |
+| IS 13920 beam, column and SCWB checks | `SUPPORTED` / `IMPLEMENTED_BOUNDED` | Does not claim complete seismic member/building design |
+| IS 13920 walls/foundations, IS 875, IS 1893 | `HELD` / `NOT_IMPLEMENTED` | Companion-code waves remain separate |
 
 ---
 
@@ -356,24 +348,24 @@ warnings.warn(
 - d'/d > threshold where compression steel doesn't yield
 - Non-standard column shapes (L, C, hollow) — Phase 5 only
 
-### 5.2 One-Way Slab Design (IS 456 Cl 24.1–24.2)
+### 5.2 One-Way Slab Design (IS 456 Cl 24.1–24.2) — bounded scope complete
 
-| # | Function | IS 456 Reference |
-|---|----------|-----------------|
-| 1 | `classify_slab()` | ly/lx ratio check |
-| 2 | `oneway_coefficients()` | Table 12/13 |
-| 3 | `design_oneway_slab()` | Cl 24.1–24.2 |
-| 4 | `slab_detailing()` | Cl 26.5 (min steel, max spacing) |
+| # | Current workflow area | IS 456 Reference | Status |
+|---|-----------------------|------------------|--------|
+| 1 | Solid-slab classification | ly/lx ratio check | ✅ Bounded |
+| 2 | Built-in continuous coefficients | Table 12/13 | ✅ Bounded lookup/interpolation |
+| 3 | Simply-supported and continuous one-way design | Cl 24.1–24.2 | ✅ Bounded |
+| 4 | Detailing, span/depth carrier and ordinary shear | Cl 26.5, 23.2.1, 40 | ✅ Bounded; direct deflection/crack width and shear reinforcement held |
 
-### 5.3 Two-Way Slab Design (IS 456 Cl 24.3, Annex D)
+### 5.3 Two-Way Slab Design (IS 456 Cl 24.3, Annex D) — bounded scope complete
 
-| # | Function | IS 456 Reference |
-|---|----------|-----------------|
-| 1 | `twoway_moment_coefficients()` | Table 26 (9 cases × αx, αy) |
-| 2 | `twoway_shear_coefficients()` | Table 27 |
-| 3 | `design_twoway_slab()` | Annex D-1 |
-| 4 | `torsion_reinforcement()` | Annex D-1.7/D-1.8 |
-| 5 | `strip_distribution()` | Annex D-1.2 (middle/edge strips) |
+| # | Current workflow area | IS 456 Reference | Status |
+|---|-----------------------|------------------|--------|
+| 1 | Restrained-panel moment coefficients | Table 26 | ✅ Bounded cases with no extrapolation |
+| 2 | Simply-supported/free-corner coefficients | Table 27 | ✅ Bounded cases |
+| 3 | Oriented two-way panel design | Annex D | ✅ Bounded |
+| 4 | Corner-torsion disposition | Annex D | ✅ Bounded topology |
+| 5 | Middle/edge strip distribution | Annex D | ✅ Bounded topology |
 
 **Edge Case:** ly/lx exactly = 2.0 — IS 456 says "may be designed as one-way" — library should default to two-way and document the choice.
 
@@ -385,7 +377,7 @@ warnings.warn(
 | 2 | `footing_flexure()` | Cl 34.2.1–34.2.3 | ✅ Done |
 | 3 | `footing_oneway_shear()` | Cl 34.2.4 (at d from face) | ✅ Done |
 | 4 | `footing_punching_shear()` | Cl 31.6 (at d/2 from face) | ✅ Done |
-| 5 | `footing_detailing()` | Cl 34.3 (rebar distribution) | 📋 |
+| 5 | `footing_detailing()` | Cl 34.3 (rebar distribution) | ✅ Done for declared isolated-footing scope |
 | 6 | `bearing_check()` | Cl 34.4 (σbr ≤ 0.45·fck·√(A1/A2)) | ✅ Done |
 
 **Edge Cases:**
@@ -437,9 +429,9 @@ class LoadCombination(ABC):
 
 ### 5.7 Phase 1 Success Criteria
 - [x] IS 456 column design: 14/14 tasks COMPLETE (classify, min_ecc, axial, uniaxial, biaxial, P-M curve, effective_length, additional_moment, helical, long_column, column_detailing, ductile_detailing (IS 13920)). 500+ column tests, SP:16 benchmarks passing ±0.1%
-- [ ] IS 456 one-way slab: 4 functions
-- [ ] IS 456 two-way slab: 5 functions with all 9 Table 26 cases
-- [ ] IS 456 footing: 6 functions including punching shear
+- [x] IS 456 one-way solid-slab bounded workflows
+- [x] IS 456 two-way solid-slab bounded workflows and accepted coefficient cases
+- [x] IS 456 isolated-footing bounded workflows including footing-specific punching
 - [x] Enhanced shear (Cl 40.3) implemented
 - [ ] New ABCs added to core/base.py
 - [ ] IS456Code implements all ABCs
@@ -1069,32 +1061,19 @@ Every IS 456 function must pass the 9-step pipeline from `/function-quality-pipe
 
 ## 16. Appendices
 
-### A. IS 456 Clause Coverage (Complete List)
+### A. Indian-code coverage reporting
 
-| Clause | Description | Status | Phase |
-|--------|-------------|--------|-------|
-| Cl 24.1–24.2 | One-way slab | ❌ | P1 |
-| Cl 24.3, Annex D | Two-way slab | ❌ | P1 |
-| Cl 25.1–25.4 | Column classification & eccentricity | ✅ Done | P1 |
-| Cl 26.2–26.5 | Detailing (beam) | ✅ | Done |
-| Cl 29 | Deep beams | ❌ | P5 |
-| Cl 31.6 | Punching shear | ❌ | P1 |
-| Cl 32 | Walls | ❌ | P5 |
-| Cl 33 | Stairs | ❌ | P5 |
-| Cl 34 | Footings | ❌ | P1 |
-| Cl 38.1–38.4 | Flexure (beam) | ✅ | Done |
-| Cl 39.1–39.7 | Column design | 🔄 Partial — 39.3/39.5/39.6 ✅, 39.4/39.7 ❌ | P1 |
-| Cl 40.1–40.5 | Shear (beam) | ✅ | Done |
-| Cl 40.3 | Enhanced shear near supports | ✅ Done | Done |
-| Cl 41 | Torsion | ✅ | Done |
-| Cl 43 | Serviceability | ✅ | Done |
-| Annex B | Continuous beam coefficients | ❌ | P2 |
-| Annex C | Moment redistribution | ❌ | P2 |
-| Annex D | Two-way slab coefficients | ❌ | P1 |
-| Annex E | Column effective length (stiffness method) | ❌ | P1 |
-| Annex G | P-M interaction | ✅ Done | P1 |
-| Table 26 | Two-way moment coefficients | ❌ | P1 |
-| Table 28 | Column effective length ratios | ✅ Done | P1 |
+The former hand-maintained clause table was archived in place by replacement
+because it contradicted implemented slab, footing, and column behavior. Use:
+
+```bash
+./scripts/python_runtime.sh scripts/check_clause_coverage.py --summary
+./scripts/python_runtime.sh scripts/parity_dashboard.py --section capabilities
+```
+
+The first command reports standard-namespaced decorator registration only. The
+second reports declared supported versus held capability families. Neither is a
+whole-standard-completeness score or professional approval.
 
 ### B. Seismic Detailing Comparison
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -1,134 +1,129 @@
 # Next Session Briefing
 
-## Latest Handoff (auto)
+## Latest Handoff
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: Add semantic coherence over deterministically discovered maintained
-- Git receipt: docs/research/git-governance/GIT-001-phase-7E-task-git-handoff.json | sha256:8ff1c88f16c39aa5ecb22d32916d199585bc6946ac87844d160ce04134132a97 | HOLD
-- Git identity: codex/git-7e-semantic-handoff@f7fcdb26a576399dd7b6462dc6e6132fa4798e2b | upstream=origin/codex/git-7e-semantic-handoff@942eddeca7ca225b62e8514826305e00d2322e48 | base=origin/main@b91838f594a04aff1d21c43bf6f87a64710b0748 | tree=clean | operation=none
-- Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
-- Next action: WAIT_FOR_EXACT_HEAD_AUDIT
+- Focus: Finish INDIA-0 exact-head integration, then start INDIA-1 existing-family closure from merged `main`
+- Draft PR: [#753](https://github.com/Pravin-surawase/structural_engineering_lib/pull/753)
+- Branch: `codex/india-0-truth-baseline`
+- Base: verified `origin/main` at `96f193bd45a21f05698cf64de47808a2e5f82640`
+- Implementation commit: `cfe02b3d47b671097358cf2feff16ecd4319cf89`
+- Next action: inspect the live PR head, required checks, mergeability, and review; merge only if the exact head is unchanged and all gates pass
+- Holds: no release, engineering-use approval, branch/worktree deletion, or historical-lane cleanup
 <!-- HANDOFF:END -->
 
-**Current release:** `v0.23.1a1` Alpha
+**Date:** 2026-08-15
 
-**Refreshed Git anchor:** `origin/main = b91838f594a04aff1d21c43bf6f87a64710b0748`
-
-**Task board:** [TASKS.md](../TASKS.md)
-
-| State | Target | Decision |
-|---|---|---|
-| **Complete** | GIT-7B, GIT-7C, and GIT-7D | State kernel, exact-head CI/server enforcement, targeted generation, and inspection-only disposition are integrated |
-| **Complete** | GIT-7D2 | PR #747 merged as `0a784de5`; closeout lessons PR #748 merged as `bf4065f0`; both reviewed/merge trees were equal |
-| **Complete** | Eight-branch retirement proposal | PR #750 squash-merged as `b91838f`; all eight exact targets remain `HOLD_UNKNOWN_OWNER` / `RETENTION_EVIDENCE_UNKNOWN` and no deletion is authorized |
-| **Next** | Retention decision | Owner must state `NO_RETENTION` or `RETAIN` for each exact SHA before any fresh classifier run or approval request |
-| **Current** | GIT-7E | Semantic live-guidance coherence and durable read-only task-to-Git handoff are being implemented; exact-head audit remains the ready/merge boundary |
-| **Owner decision** | Excel planning lane | Name an active owner/next action or separately authorize a complete retirement assessment |
-| **Separate maintenance** | Seven dependency PRs | Do not close or merge the existing Dependabot PRs in GIT-001 |
+| Release state | Target |
+|---|---|
+| **Current** | `v0.23.1a1` Alpha; qualified engineering review still required |
+| **Next** | Merge INDIA-0, then execute INDIA-1 as bounded existing-family packets |
 
 ## Required Reading
 
-1. [Eight-branch retirement proposal](../research/git-governance/GIT-001-eight-branch-retirement-authorization-proposal.md)
-2. [Machine-readable proposal receipt](../research/git-governance/GIT-001-eight-branch-retirement-authorization-proposal.json)
-3. [Classifier caller evidence](../research/git-governance/GIT-001-eight-branch-retirement-classifier-evidence.json)
-4. [Phase 7D cleanup reconciliation](../research/git-governance/GIT-001-phase-7D-cleanup-reconciliation.md)
-5. [GIT-001 research and phase ledger](../research/git-governance/GIT-001-README.md)
-6. [Phase 7D2 branch disposition](../research/git-governance/GIT-001-phase-7D2-branch-disposition.md)
-7. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
-8. [GIT-7D2 cleanup-audit case study](../git-automation/git-governance-case-study-git-7d2-cleanup-audit.md)
+1. [INDIA-0 truth baseline](../verification/indian-code-truth-baseline.md)
+2. [Generated Indian-code manifest](../verification/indian-code-capability-coverage.json)
+3. [Current task board](../TASKS.md)
+4. [IS 456 library-first plan](is456-library-first-master-plan.md)
+5. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
 
-## Start commands
+## Start Boundary
+
+Do not begin INDIA-1 implementation on the INDIA-0 branch. First inspect PR
+#753 live. If its exact head is unchanged, all required checks pass, there are
+no conflicts or unresolved blockers, and the reviewed tree is accepted, the
+owner has authorized the normal exact-head merge. Do not bypass checks.
+
+After merge, fetch `origin/main`, verify the merge result contains the INDIA-0
+manifest and tests, and create a fresh isolated `codex/india-1-<packet>` lane.
+Preserve the dirty primary checkout and all unrelated worktrees.
 
 ```bash
-./run.sh session brief --agent ops
+./run.sh session brief --agent structural-math
 ./run.sh session start
 ./scripts/python_runtime.sh --diagnose
 ./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
+./scripts/python_runtime.sh scripts/generate_indian_code_manifest.py --check
 ```
 
-Refresh and verify `origin/main` before relying on this handoff. Resume GIT-7E
-only from its exact receipt-bound branch/head, or create another fresh
-`codex/<task-slug>` lane from verified current main if that evidence is unknown.
-Do not extend, reset, rebase, merge into, or reconcile a preserved
-squash-diverged lane.
+Require `source_bound=true` before producing test or benchmark evidence.
 
-## Verified current Git facts
+## INDIA-1 Objective
 
-- PRs #744-#748 are merged at their exact reviewed heads with successful
-  `PR Gate`. Each reviewed-head tree equals its squash-result tree, and both
-  `PR Validation` and `Validate Documentation` passed after every merge.
-- GIT-7D1 is integrated through PR #746. GIT-7D2 is integrated through PRs
-  #747-#748. The old deletion-oriented route is absent; the classifier remains
-  local, inspection-only, fail-closed, and non-authorizing.
-- The clean primary `main` worktree remains at `0fdb48ed`, five commits behind
-  refreshed `origin/main = 670ea4be`. Synchronizing it is outside this packet.
-- Live proposal intake found 20 local `codex/*` branches and 16 worktrees after
-  the isolated proposal lane was created. Topology is evidence, not cleanup
-  authority; preserve concurrent task lanes without normalization.
-- Active ruleset `11390214` still requires a PR and strict `PR Gate`, protects
-  deletion/non-fast-forward, has no bypass actor, allows merge/squash, and
-  excludes rebase. Repository branch deletion after merge remains disabled.
-- The only pre-existing open PRs are Dependabot #683, #684, and #713-#717.
-  There are no open issues. None was changed by the audit.
+Close or explicitly retain every material limitation inside the already
+supported IS 456 beam, rectangular-column, isolated-footing, and solid-slab
+families. “Close” means an independently benchmarked, provenance-bearing,
+fail-closed supported route. “Retain” means the manifest and public capability
+wording clearly exclude the case and identify the analysis or evidence needed.
 
-## Preservation and disposition holds
+This wave does not add walls, stairs, deep beams, flat slabs, combined/strap/
+raft/pile-cap foundations, IS 875 load generation, or IS 1893 analysis. Those
+remain INDIA-2 or INDIA-3 work.
 
-- Detached `e54a` at `0fdb48ed` still has exactly one dirty path,
-  `docs/SESSION_LOG.md` (119 insertions, 7 deletions; patch ID `be157118`;
-  binary-diff SHA-256 begins `cf70f18f`). Preserve it byte-for-byte. Do not
-  attach, checkout, stage, copy, reset, stash, clean, or remove it.
-- `codex/git-governance-research` remains attached at local `65703736`, differs
-  from remote `51a8a57a`, and contains three locally unique patches. Preserve.
-- `codex/excel-product-planning` remains attached at `a0e115e1`, has no feature
-  remote or PR, and needs an owner decision. Git evidence cannot make it
-  deletion-ready.
-- `codex/release-preflight-alpha-policy` remains attached at local `5da9c66a`
-  while its remote is `20180a40`. Both are integrated, but the dual-head lane is
-  separate preserved evidence.
-- GIT-7B, GIT-7C1, GIT-7D1, GIT-7D2, GIT-7D2 lessons, Alpha closeout, and Alpha
-  integration branches remain attached worktree holds even where integration
-  evidence is complete.
-- Eight other local branches are unattached, remote-matching, main-reachable,
-  and linked to merged PRs with no open head/base dependency. Exact supplied
-  evidence still produced `HOLD_UNKNOWN_OWNER` with
-  `RETENTION_EVIDENCE_UNKNOWN` for every target because no authoritative exact-
-  SHA retention decision exists.
-- Proposal authority and autonomous orchestration do not imply `NO_RETENTION`.
-  Never translate merged/reachable evidence or routine Git authority into a
-  claim that historical evidence is unneeded.
+## Recommended Packet Sequence
 
-## GIT-7E exact boundary
+### INDIA-1A — Beam route closure
 
-GIT-7E must prove:
+- Inventory existing flanged-flexure, torsion, shear, detailing, deflection,
+  and crack-width math before adding code.
+- Decide and implement the smallest coherent combined flanged-beam route.
+- Propagate only explicit serviceability inputs supported by maintained math.
+- State load-envelope and torsion-redistribution exclusions fail-closed.
+- Do not claim hollow/box, deep, prestressed, or axially loaded beam support.
 
-1. every live indexed instruction rejects retired command and flag fixtures;
-2. archive/historical exclusions are explicit rather than accidental;
-3. branch, head, upstream, default base, tree, and operation identity survives
-   session handoff;
-4. remote, PR, reviewed-head, and required-check fields are exact or explicitly
-   unknown;
-5. task/transcript archive state is never represented as Git retention proof;
-6. aliases resolve maintained commands without permitting obsolete mutations.
+### INDIA-1B — Rectangular-column decision closure
 
-GIT-7E does not itself refresh remote state, mutate GitHub, change disposition logic,
-authorize cleanup/deletion, synchronize preserved lanes, modify GIT-7D1/7D2
-behavior, publish a release, or change product code. Implementation was
-authorized in the GIT-7E task delegation; ready/merge remains held for
-independent exact-head audit.
+- Reconfirm the supported symmetric/two-face rectangular reinforcement model.
+- Decide whether circular, asymmetric, and arbitrary multilayer layouts remain
+  held or need separate approved packets; do not silently broaden geometry.
+- Keep experimental PMM work outside the stable capability unless its separate
+  numerical and API acceptance gates are completed.
 
-## Destructive-action holds
+### INDIA-1C — Isolated-footing composed workflow
 
-- No branch, remote ref, or worktree deletion is authorized.
-- No prune, reset, rebase, stash/drop, clean, force push, or primary-main sync.
-- A future action needs a same-session refresh, complete identity-bound evidence,
-  `RETIREMENT_READY_PENDING_APPROVAL`, separate exact local/remote/worktree
-  authorization, immediate drift recheck, and post-action receipt.
+- Compose sizing, flexure, one-way shear, punching, bearing pressure, detailing,
+  and concentric load transfer into one reviewable supported workflow.
+- Add eccentric pressure only after documenting load reference, contact model,
+  units, kern/tension assumptions, and unsafe/out-of-domain behavior.
+- Keep combined, strap, raft, pile-cap, settlement, lateral stability, and soil-
+  structure interaction outside this packet.
 
-## Session closeout
+### INDIA-1D — Solid-slab serviceability and shear boundary
 
-Discover maintained tests/scripts with `rg --files`. Run focused checks, the
-semantic Git check, strict docs, quick gate, full gate once stable, session end,
-and `git diff --check`. Record every material issue with symptom/impact, root
-cause or explicit unconfirmed boundary, resolution, and proving evidence in the
-newest task-owned `docs/SESSION_LOG.md` entry.
+- Evaluate direct deflection and crack-width routes with explicit required
+  geometry, material, load-duration, reinforcement, and service-stress inputs.
+- Add automatic shear reinforcement only for a justified supported slab model;
+  otherwise retain the exclusion explicitly.
+- Define the load-envelope boundary. Concentrated loads, openings, irregular
+  panels, flat slabs, and FEM remain held unless separately approved.
+
+## Acceptance Per Packet
+
+- Governing edition, clause/table identifier, and source provenance are explicit.
+- Units, geometry, loading, topology, and support assumptions are explicit.
+- Pure math is accepted before service, FastAPI, or React expansion.
+- At least one independent benchmark has a justified tolerance.
+- Governing safe, unsafe, boundary, and out-of-domain cases are tested.
+- Unsupported inputs fail closed; capability wording matches executable behavior.
+- Focused tests pass while iterating; quick gate passes before every commit.
+- Run one full repository gate at each integrated INDIA-1 milestone.
+- Record material issues, confirmed root causes, resolutions, and evidence in
+  the newest task-owned `docs/SESSION_LOG.md` entry.
+
+## Git and Review Strategy
+
+Use one PR per coherent packet when packets are independently reviewable; do
+not keep all INDIA-1 work on a long-lived mega-branch. A named integration owner
+alone updates shared/generated surfaces such as the manifest, capability
+registry, `TASKS.md`, indexes, and session log. Read-only engineering review can
+run in parallel, but qualified structural-engineering review remains a distinct
+acceptance gate.
+
+## INDIA-1 Exit
+
+INDIA-1 is complete only when every original limitation is either supported by
+executable evidence or retained as an explicit hold, the generated manifest is
+current with no unknown status, focused and repository gates pass, and the
+cumulative engineering-review boundary is unchanged. Release remains separately
+owner-authorized.

--- a/docs/verification/INDIA-0-git-handoff.json
+++ b/docs/verification/INDIA-0-git-handoff.json
@@ -1,0 +1,199 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-15T14:26:04Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-0:user-request-2026-08-15",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "OPEN_DRAFT_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-15T14:26:04Z",
+    "prohibited_actions": [
+      "MERGE_WITHOUT_EXACT_HEAD_REVIEW",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "OPEN_DRAFT_PR"
+      ],
+      "branch": "codex/india-0-truth-baseline",
+      "head_sha": "96f193bd45a21f05698cf64de47808a2e5f82640",
+      "task_id": "INDIA-0"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "UNCOMMITTED_LOCAL_HANDOFF",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "462bbb4ebc7cfd6b159f434cee398532ce35b7fc5d1d6604aaa88afd78409481",
+    "state": {
+      "branch": "codex/india-0-truth-baseline",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "96f193bd45a21f05698cf64de47808a2e5f82640",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 89.512,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-india-0",
+      "head_sha": "96f193bd45a21f05698cf64de47808a2e5f82640",
+      "hold_reasons": [
+        "changed paths: 29"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-15T14:27:40.867810+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-0",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 29,
+        "modified_paths": [
+          "AGENTS.md",
+          "CLAUDE.md",
+          "Python/structural_lib/services/capabilities.py",
+          "Python/tests/index.json",
+          "Python/tests/index.md",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/governance/maintenance-playbook.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/index.json",
+          "docs/planning/index.md",
+          "docs/planning/is456-library-first-master-plan.md",
+          "docs/planning/library-expansion-blueprint-v5.md",
+          "docs/verification/index.json",
+          "docs/verification/index.md",
+          "docs/verification/is456-slab-evidence.md",
+          "run.sh",
+          "scripts/automation-map.json",
+          "scripts/check_clause_coverage.py",
+          "scripts/index.json",
+          "scripts/index.md",
+          "scripts/parity_dashboard.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "Python/tests/test_indian_code_manifest.py",
+          "docs/verification/INDIA-0-git-handoff.json",
+          "docs/verification/indian-code-capability-coverage.json",
+          "docs/verification/indian-code-truth-baseline.md",
+          "scripts/_lib/indian_code_manifest.py",
+          "scripts/generate_indian_code_manifest.py"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "96f193bd45a21f05698cf64de47808a2e5f82640",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-0"
+    }
+  },
+  "local_state_receipt_hash": "sha256:462bbb4ebc7cfd6b159f434cee398532ce35b7fc5d1d6604aaa88afd78409481",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-15T14:27:40.867998+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-15T14:26:04Z",
+    "owner": "repository owner and next Git/PR session",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "refs/**",
+      "docs/verification/footing-release-inclusion.json"
+    ],
+    "integration_owner": "Next Git/PR session agent",
+    "owned_paths": [
+      "Python/structural_lib/services/capabilities.py",
+      "Python/tests/test_indian_code_manifest.py",
+      "scripts/_lib/indian_code_manifest.py",
+      "scripts/generate_indian_code_manifest.py",
+      "scripts/check_clause_coverage.py",
+      "scripts/parity_dashboard.py",
+      "docs/verification/indian-code-capability-coverage.json",
+      "docs/verification/indian-code-truth-baseline.md",
+      "docs/verification/INDIA-0-git-handoff.json"
+    ],
+    "shared_paths": [
+      "AGENTS.md",
+      "CLAUDE.md",
+      "run.sh",
+      "scripts/automation-map.json",
+      "scripts/index.json",
+      "scripts/index.md",
+      "Python/tests/index.json",
+      "Python/tests/index.md",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/index.json",
+      "docs/index.md",
+      "docs/planning/is456-library-first-master-plan.md",
+      "docs/planning/library-expansion-blueprint-v5.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/governance/maintenance-playbook.md",
+      "docs/verification/is456-slab-evidence.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md"
+    ],
+    "task_id": "INDIA-0"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -2,9 +2,27 @@
   "folder": "docs/verification",
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
-  "last_updated": "2026-08-12",
-  "file_count": 15,
+  "last_updated": "2026-08-15",
+  "file_count": 18,
   "files": [
+    {
+      "name": "INDIA-0-git-handoff.json",
+      "type": "config",
+      "last_updated": "2026-08-15",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "e33f336515f1"
+    },
     {
       "name": "README.md",
       "type": "documentation",
@@ -73,6 +91,31 @@
       "content_hash": "e15f6ebeb790"
     },
     {
+      "name": "indian-code-capability-coverage.json",
+      "type": "config",
+      "last_updated": "2026-08-15",
+      "top_level_keys": [
+        "schema_version",
+        "manifest_id",
+        "last_reconciled",
+        "claim_boundaries",
+        "status_vocabularies",
+        "sources",
+        "capability_summary",
+        "standards"
+      ],
+      "content_hash": "4cecc72906d0"
+    },
+    {
+      "name": "indian-code-truth-baseline.md",
+      "type": "documentation",
+      "size_lines": 84,
+      "last_updated": "2026-08-15",
+      "title": "INDIA-0 Indian-Code Truth Baseline",
+      "description": "indian-code-capability-coverage.json structural-engineering review remains required before stable or engineering-use",
+      "content_hash": "e23ea7d47f12"
+    },
+    {
       "name": "insights-verification-pack.md",
       "type": "documentation",
       "size_lines": 101,
@@ -109,11 +152,11 @@
     {
       "name": "is456-slab-evidence.md",
       "type": "documentation",
-      "size_lines": 114,
-      "last_updated": "2026-08-12",
+      "size_lines": 115,
+      "last_updated": "2026-08-15",
       "title": "IS 456 Solid Slab Source and Benchmark Ledger",
       "description": "| ID | Identity | Permitted implementation use | State | |---|---|---|---|",
-      "content_hash": "c8ef17a438a0"
+      "content_hash": "fd3c5179fd1c"
     },
     {
       "name": "pack.md",
@@ -150,5 +193,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "a39b239ab3396604"
+  "content_hash": "b060696a630ed5fd"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -109,11 +109,11 @@
     {
       "name": "indian-code-truth-baseline.md",
       "type": "documentation",
-      "size_lines": 84,
+      "size_lines": 92,
       "last_updated": "2026-08-15",
       "title": "INDIA-0 Indian-Code Truth Baseline",
-      "description": "indian-code-capability-coverage.json structural-engineering review remains required before stable or engineering-use",
-      "content_hash": "e23ea7d47f12"
+      "description": "merge pending indian-code-capability-coverage.json",
+      "content_hash": "97b85669d0b9"
     },
     {
       "name": "insights-verification-pack.md",
@@ -193,5 +193,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "b060696a630ed5fd"
+  "content_hash": "bdfec0cc8d033a6f"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -23,7 +23,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [column-pmm-benchmark.md](column-pmm-benchmark.md) |  | This record independently checks the experimental rectangula | 107 |
 | [examples.md](examples.md) |  | This document provides benchmark examples that engineers can | 1550 |
 | [external-cli-test.md](external-cli-test.md) |  | Purpose: capture a repeatable, human-run CLI test from a fre | 98 |
-| [indian-code-truth-baseline.md](indian-code-truth-baseline.md) | INDIA-0 Indian-Code Truth Baseline | indian-code-capability-coverage.json structural-engineering  | 84 |
+| [indian-code-truth-baseline.md](indian-code-truth-baseline.md) | INDIA-0 Indian-Code Truth Baseline | merge pending indian-code-capability-coverage.json | 92 |
 | [insights-verification-pack.md](insights-verification-pack.md) |  | This pack provides benchmark test cases for the insights mod | 101 |
 | [is456-library-first-evidence.md](is456-library-first-evidence.md) | IS 456 Library-First Evidence and Claim  | | Source | SHA-256 | Pages | Use | |---|---|---:|---| | 169 |
 | [is456-slab-evidence.md](is456-slab-evidence.md) | IS 456 Solid Slab Source and Benchmark L | | ID | Identity | Permitted implementation use | State | |-- | 115 |

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -3,12 +3,14 @@
 Benchmark examples and verification packs for validating library calculations against IS 456 standards.
 
 **Type:** Documentation
-**Last Updated:** 2026-08-12
-**Files:** 15
+**Last Updated:** 2026-08-15
+**Files:** 18
 
 ## Config Files
 
+- [INDIA-0-git-handoff.json](INDIA-0-git-handoff.json)
 - [footing-release-inclusion.json](footing-release-inclusion.json)
+- [indian-code-capability-coverage.json](indian-code-capability-coverage.json)
 - [is456-public-distribution-permission.json](is456-public-distribution-permission.json)
 
 ## Documentation Files
@@ -21,9 +23,10 @@ Benchmark examples and verification packs for validating library calculations ag
 | [column-pmm-benchmark.md](column-pmm-benchmark.md) |  | This record independently checks the experimental rectangula | 107 |
 | [examples.md](examples.md) |  | This document provides benchmark examples that engineers can | 1550 |
 | [external-cli-test.md](external-cli-test.md) |  | Purpose: capture a repeatable, human-run CLI test from a fre | 98 |
+| [indian-code-truth-baseline.md](indian-code-truth-baseline.md) | INDIA-0 Indian-Code Truth Baseline | indian-code-capability-coverage.json structural-engineering  | 84 |
 | [insights-verification-pack.md](insights-verification-pack.md) |  | This pack provides benchmark test cases for the insights mod | 101 |
 | [is456-library-first-evidence.md](is456-library-first-evidence.md) | IS 456 Library-First Evidence and Claim  | | Source | SHA-256 | Pages | Use | |---|---|---:|---| | 169 |
-| [is456-slab-evidence.md](is456-slab-evidence.md) | IS 456 Solid Slab Source and Benchmark L | | ID | Identity | Permitted implementation use | State | |-- | 114 |
+| [is456-slab-evidence.md](is456-slab-evidence.md) | IS 456 Solid Slab Source and Benchmark L | | ID | Identity | Permitted implementation use | State | |-- | 115 |
 | [pack.md](pack.md) |  | This repo’s unit tests validate correctness and edge cases,  | 56 |
 | [release-artifact-evidence-template.md](release-artifact-evidence-template.md) | Release Artifact Evidence Template | Complete this record from the CI run that built the exact ca | 38 |
 | [ui-experience-session-2-acceptance.md](ui-experience-session-2-acceptance.md) |  | This is the software acceptance record for UIX-001 P9-P15. I | 70 |

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -1,0 +1,2034 @@
+{
+  "schema_version": "1.0",
+  "manifest_id": "INDIA-0-INDIAN-RC-TRUTH-BASELINE",
+  "last_reconciled": "2026-08-15",
+  "claim_boundaries": {
+    "capability_status": "Declared bounded software scope, not whole-standard completeness or engineering approval.",
+    "registration_status": "Decorator-to-identifier traceability only; it does not prove implementation, numerical verification, or provenance.",
+    "professional_review": "Qualified structural-engineering review remains required before stable or engineering-use approval."
+  },
+  "status_vocabularies": {
+    "scope_status": [
+      "SUPPORTED",
+      "HELD"
+    ],
+    "implementation_status": [
+      "IMPLEMENTED_BOUNDED",
+      "NOT_IMPLEMENTED"
+    ],
+    "registration_status": [
+      "REGISTERED",
+      "METADATA_ONLY",
+      "REGISTRATION_ONLY"
+    ]
+  },
+  "sources": [
+    "Python/structural_lib/services/capabilities.py",
+    "Python/structural_lib/codes/is456/clauses.json",
+    "Python/structural_lib/codes/is456/**/*.py",
+    "Python/structural_lib/codes/is13920/**/*.py"
+  ],
+  "capability_summary": {
+    "supported_families": 7,
+    "held_families": 14,
+    "total_declared_families": 21,
+    "supported_pct": 33.3
+  },
+  "standards": [
+    {
+      "standard_id": "IS456",
+      "namespace": "IS456:2000",
+      "edition": "2000",
+      "title": "Plain and reinforced concrete code of practice",
+      "source_root": "Python/structural_lib/codes/is456",
+      "status": "SUPPORTED_SUBSET",
+      "capability_summary": {
+        "supported_families": 4,
+        "held_families": 8,
+        "total_declared_families": 12,
+        "supported_pct": 33.3
+      },
+      "capability_families": [
+        {
+          "capability_id": "IS456:2000:beam",
+          "family": "beam",
+          "scope_status": "SUPPORTED",
+          "implementation_status": "IMPLEMENTED_BOUNDED",
+          "claim": "Ordinary solid rectangular beam primary design for flexure and shear, with optional IS 456 torsion within fck 15-40 N/mm2 and fy <= 500 N/mm2, plus maintained Level-A deflection and crack-width checks when their explicit inputs are supplied.",
+          "workflows": [
+            "design_beam_is456",
+            "check_beam_is456",
+            "detail_beam_is456"
+          ],
+          "limitations": [
+            "Flanged, hollow/box, deep, prestressed, or axially loaded torsion cases are excluded.",
+            "Compatibility-versus-equilibrium torsion redistribution decisions are excluded.",
+            "Beam check, detailing, batch, import, and other automation surfaces that do not accept Tu and serviceability inputs remain outside the combined route.",
+            "Serviceability is held unless span, support condition, crack geometry, and service strain or stress are explicitly supplied."
+          ],
+          "evidence": [
+            "docs/verification/is456-library-first-evidence.md"
+          ],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:column",
+          "family": "column",
+          "scope_status": "SUPPORTED",
+          "implementation_status": "IMPLEMENTED_BOUNDED",
+          "claim": "Rectangular columns with the declared symmetric/two-face reinforcement assumptions.",
+          "workflows": [
+            "design_column_is456",
+            "design_long_column_is456"
+          ],
+          "limitations": [
+            "Circular, asymmetric and arbitrary multilayer layouts are excluded."
+          ],
+          "evidence": [
+            "docs/verification/is456-library-first-evidence.md"
+          ],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:isolated_footing",
+          "family": "isolated_footing",
+          "scope_status": "SUPPORTED",
+          "implementation_status": "IMPLEMENTED_BOUNDED",
+          "claim": "Square/rectangular isolated footing checks, including bounded bearing pressure and concentric dowel transfer.",
+          "workflows": [
+            "size_footing",
+            "footing_flexure",
+            "footing_one_way_shear",
+            "footing_punching_shear",
+            "check_bearing_pressure",
+            "check_isolated_footing_load_transfer"
+          ],
+          "limitations": [
+            "Bearing-pressure results remain bounded checks requiring qualified review of the approved supporting-area basis and the complete footing design.",
+            "Combined, strap, raft, pile-cap, settlement and lateral stability design are excluded."
+          ],
+          "evidence": [
+            "docs/verification/footing-release-inclusion.json"
+          ],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:solid_slab",
+          "family": "solid_slab",
+          "scope_status": "SUPPORTED",
+          "implementation_status": "IMPLEMENTED_BOUNDED",
+          "claim": "Simply supported and coefficient-method continuous one-way solid strips; common oriented two-way beam/wall-supported panels with built-in bounded IS 456 coefficient lookup/interpolation or reviewed external coefficients, strip distribution, corner torsion, provided-bar checks, span/depth serviceability carriers, and ordinary one-way shear.",
+          "workflows": [
+            "design_one_way_slab_is456",
+            "design_complete_one_way_slab_is456",
+            "design_continuous_one_way_slab_is456",
+            "design_continuous_one_way_slab_builtin_is456",
+            "design_two_way_slab_is456",
+            "design_two_way_slab_panel_is456",
+            "design_two_way_slab_panel_builtin_is456"
+          ],
+          "limitations": [
+            "Direct deflection, crack width, concentrated loads, openings, irregular panels, load-envelope analysis and automatic slab shear reinforcement are excluded.",
+            "Flat/drop/ribbed slabs, column strips, column-supported punching and FEM require a separately approved extension."
+          ],
+          "evidence": [
+            "docs/verification/is456-slab-evidence.md"
+          ],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:wall",
+          "family": "wall",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "IS 456 wall design is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Clause 32 requires a separately verified program."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:stair",
+          "family": "stair",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "IS 456 stair design is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Clause 33 requires a separately verified program."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:deep_beam",
+          "family": "deep_beam",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "IS 456 deep-beam design is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Clause 29 requires a separately verified program."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:flat_slab",
+          "family": "flat_slab",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "Flat-slab and column-supported punching design are held.",
+          "workflows": [],
+          "limitations": [
+            "Column strips, drops, punching perimeters, openings, and moment transfer require a separate analysis program."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:combined_footing",
+          "family": "combined_footing",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "Combined-footing design is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "A distinct soil-pressure and structural analysis model is required."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:strap_footing",
+          "family": "strap_footing",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "Strap-footing design is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "A distinct analysis model is required."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:raft_foundation",
+          "family": "raft_foundation",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "Raft-foundation design is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Soil-structure interaction remains outside the supported subset."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS456:2000:pile_cap",
+          "family": "pile_cap",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "Pile-cap design is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Pile reactions and strut-and-tie behavior require a separate program."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        }
+      ],
+      "registration_summary": {
+        "known_references": 127,
+        "registered_known_references": 59,
+        "metadata_only_references": 68,
+        "registration_only_references": 0,
+        "registration_pct": 46.5
+      },
+      "references": [
+        {
+          "reference_id": "IS456:2000:21.1",
+          "reference": "21.1",
+          "reference_type": "clause",
+          "title": "Cover to Reinforcement",
+          "category": "durability",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:23.1",
+          "reference": "23.1",
+          "reference_type": "clause",
+          "title": "Effective Span",
+          "category": "analysis",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:23.1.1",
+          "reference": "23.1.1",
+          "reference_type": "clause",
+          "title": "Effective Span - Simply Supported",
+          "category": "analysis",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:23.1.2",
+          "reference": "23.1.2",
+          "reference_type": "clause",
+          "title": "Effective Span - Continuous",
+          "category": "analysis",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.flexure.calculate_effective_flange_width",
+            "structural_lib.codes.is456.beam.flexure.design_flanged_beam"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:23.2",
+          "reference": "23.2",
+          "reference_type": "clause",
+          "title": "Assumptions in Design for Flexure",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.serviceability.calculate_short_term_deflection",
+            "structural_lib.codes.is456.beam.serviceability.check_deflection_level_b"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:23.2.1",
+          "reference": "23.2.1",
+          "reference_type": "clause",
+          "title": "Slenderness Limits - Beams",
+          "category": "design_limits",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.serviceability.check_deflection_span_depth",
+            "structural_lib.codes.is456.beam.serviceability.get_long_term_deflection_factor",
+            "structural_lib.codes.is456.slab.serviceability.check_slab_span_depth_serviceability"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:24.1",
+          "reference": "24.1",
+          "reference_type": "clause",
+          "title": "Effective Span of Slabs",
+          "category": "slabs",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.slab.classification.classify_solid_rectangular_slab",
+            "structural_lib.codes.is456.slab.one_way.design_simply_supported_one_way_slab_flexure",
+            "structural_lib.codes.is456.slab.one_way_continuous.design_continuous_one_way_slab_flexure",
+            "structural_lib.codes.is456.slab.one_way_detailing.check_simply_supported_one_way_slab_detailing",
+            "structural_lib.codes.is456.slab.serviceability.check_slab_span_depth_serviceability",
+            "structural_lib.codes.is456.slab.two_way.design_supported_interior_two_way_slab_flexure"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:24.2",
+          "reference": "24.2",
+          "reference_type": "clause",
+          "title": "Slabs Continuous Over Supports",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:24.3",
+          "reference": "24.3",
+          "reference_type": "clause",
+          "title": "Slabs Spanning in Two Directions at Right Angles",
+          "category": "slabs",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.slab.classification.classify_solid_rectangular_slab"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:24.3.1",
+          "reference": "24.3.1",
+          "reference_type": "clause",
+          "title": "Reinforcement in Slabs — Minimum",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:24.3.2",
+          "reference": "24.3.2",
+          "reference_type": "clause",
+          "title": "Maximum Diameter of Bars in Slabs",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:24.4",
+          "reference": "24.4",
+          "reference_type": "clause",
+          "title": "Spacing of Reinforcement in Slabs",
+          "category": "slabs",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.slab.two_way.design_supported_interior_two_way_slab_flexure",
+            "structural_lib.codes.is456.slab.two_way_complete.design_two_way_slab_panel"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:25.1",
+          "reference": "25.1",
+          "reference_type": "clause",
+          "title": "General — Compression Members",
+          "category": "columns",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:25.1.1",
+          "reference": "25.1.1",
+          "reference_type": "clause",
+          "title": "Unsupported Length",
+          "category": "columns",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:25.1.2",
+          "reference": "25.1.2",
+          "reference_type": "clause",
+          "title": "Slenderness Limits for Columns",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.axial.classify_column"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:25.2",
+          "reference": "25.2",
+          "reference_type": "clause",
+          "title": "Effective Length of Compression Members",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.axial.effective_length"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:25.3",
+          "reference": "25.3",
+          "reference_type": "clause",
+          "title": "Short and Long Column Classification",
+          "category": "columns",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:25.4",
+          "reference": "25.4",
+          "reference_type": "clause",
+          "title": "Minimum Eccentricity",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.axial.min_eccentricity"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.2.1",
+          "reference": "26.2.1",
+          "reference_type": "clause",
+          "title": "Development Length of Bars",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.calculate_development_length",
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
+            "structural_lib.codes.is456.footing.load_transfer.check_isolated_footing_load_transfer"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.2.1.1",
+          "reference": "26.2.1.1",
+          "reference_type": "clause",
+          "title": "Design Bond Stress",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.get_bond_stress"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.2.2",
+          "reference": "26.2.2",
+          "reference_type": "clause",
+          "title": "Anchoring Reinforcement",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.calculate_standard_hook"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.2.2.1",
+          "reference": "26.2.2.1",
+          "reference_type": "clause",
+          "title": "Minimum Bend Radius",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.get_min_bend_radius"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.2.2.2",
+          "reference": "26.2.2.2",
+          "reference_type": "clause",
+          "title": "Stirrup Anchorage",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.calculate_stirrup_anchorage"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.2.3",
+          "reference": "26.2.3",
+          "reference_type": "clause",
+          "title": "Standard Hooks and Bends",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.calculate_anchorage_length"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.2.3.3",
+          "reference": "26.2.3.3",
+          "reference_type": "clause",
+          "title": "Anchorage at Simple Supports",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.check_anchorage_at_simple_support"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.2.5",
+          "reference": "26.2.5",
+          "reference_type": "clause",
+          "title": "Lap Splices",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.calculate_lap_length"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.3.2",
+          "reference": "26.3.2",
+          "reference_type": "clause",
+          "title": "Minimum Spacing of Reinforcement",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.3.3",
+          "reference": "26.3.3",
+          "reference_type": "clause",
+          "title": "Maximum Spacing of Reinforcement",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
+            "structural_lib.codes.is456.slab.one_way_detailing.check_simply_supported_one_way_slab_detailing"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.5.1.1",
+          "reference": "26.5.1.1",
+          "reference_type": "clause",
+          "title": "Minimum Shear Reinforcement",
+          "category": "shear",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:26.5.1.2",
+          "reference": "26.5.1.2",
+          "reference_type": "clause",
+          "title": "Stirrup Spacing",
+          "category": "shear",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:26.5.1.3",
+          "reference": "26.5.1.3",
+          "reference_type": "clause",
+          "title": "Side Face Reinforcement",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.detailing.check_side_face_reinforcement"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.5.1.5",
+          "reference": "26.5.1.5",
+          "reference_type": "clause",
+          "title": "Stirrup Legs",
+          "category": "shear",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.shear.design_shear"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.5.1.6",
+          "reference": "26.5.1.6",
+          "reference_type": "clause",
+          "title": "Bent-up Bars",
+          "category": "shear",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.shear.design_shear"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.5.2.1",
+          "reference": "26.5.2.1",
+          "reference_type": "clause",
+          "title": "Slab Reinforcement Detailing",
+          "category": "slabs",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
+            "structural_lib.codes.is456.slab.one_way_detailing.check_simply_supported_one_way_slab_detailing"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.5.3",
+          "reference": "26.5.3",
+          "reference_type": "clause",
+          "title": "Columns",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.detailing.create_column_detailing"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:26.5.3.1",
+          "reference": "26.5.3.1",
+          "reference_type": "clause",
+          "title": "Longitudinal Reinforcement in Columns",
+          "category": "columns",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:26.5.3.2",
+          "reference": "26.5.3.2",
+          "reference_type": "clause",
+          "title": "Transverse Reinforcement in Columns",
+          "category": "columns",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:31.6",
+          "reference": "31.6",
+          "reference_type": "clause",
+          "title": "Two-Way Shear (Punching Shear)",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:31.6.1",
+          "reference": "31.6.1",
+          "reference_type": "clause",
+          "title": "Critical Section for Punching Shear",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.punching_shear.footing_punching_shear"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:31.6.2",
+          "reference": "31.6.2",
+          "reference_type": "clause",
+          "title": "Nominal Shear Stress in Punching",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:31.6.3",
+          "reference": "31.6.3",
+          "reference_type": "clause",
+          "title": "Permissible Punching Shear Stress",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:32.1",
+          "reference": "32.1",
+          "reference_type": "clause",
+          "title": "Empirical Design Method for Walls",
+          "category": "walls",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:32.2",
+          "reference": "32.2",
+          "reference_type": "clause",
+          "title": "Design of Reinforced Concrete Walls",
+          "category": "walls",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:32.3",
+          "reference": "32.3",
+          "reference_type": "clause",
+          "title": "Eccentricity of Vertical Load on Walls",
+          "category": "walls",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:32.4",
+          "reference": "32.4",
+          "reference_type": "clause",
+          "title": "Reinforcement in Walls",
+          "category": "walls",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:32.5",
+          "reference": "32.5",
+          "reference_type": "clause",
+          "title": "Maximum Axial Load Capacity of Wall",
+          "category": "walls",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:33.1",
+          "reference": "33.1",
+          "reference_type": "clause",
+          "title": "Effective Span of Stairs",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:33.2",
+          "reference": "33.2",
+          "reference_type": "clause",
+          "title": "Distribution of Loading on Stairs",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:33.3",
+          "reference": "33.3",
+          "reference_type": "clause",
+          "title": "Depth of Section",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:34.1",
+          "reference": "34.1",
+          "reference_type": "clause",
+          "title": "General Requirements for Footings",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.bearing.size_footing"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.2",
+          "reference": "34.2",
+          "reference_type": "clause",
+          "title": "Moments and Forces",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:34.2.1",
+          "reference": "34.2.1",
+          "reference_type": "clause",
+          "title": "General — Footing Moment Computation",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:34.2.2",
+          "reference": "34.2.2",
+          "reference_type": "clause",
+          "title": "Critical Sections for Bending Moment in Footings",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:34.2.3",
+          "reference": "34.2.3",
+          "reference_type": "clause",
+          "title": "Bending Moment in Footings",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:34.2.3.1",
+          "reference": "34.2.3.1",
+          "reference_type": "clause",
+          "title": "Critical Section for Bending — Column Footings",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
+            "structural_lib.codes.is456.footing.flexure.footing_flexure"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.2.4",
+          "reference": "34.2.4",
+          "reference_type": "clause",
+          "title": "Shear in Footings",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:34.2.4.1",
+          "reference": "34.2.4.1",
+          "reference_type": "clause",
+          "title": "One-Way Shear in Footings — Unsupported Length",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
+            "structural_lib.codes.is456.footing.one_way_shear.footing_one_way_shear"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.3",
+          "reference": "34.3",
+          "reference_type": "clause",
+          "title": "Tensile Reinforcement in Footings",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.4",
+          "reference": "34.4",
+          "reference_type": "clause",
+          "title": "Transfer of Load at Base of Column",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.bearing.bearing_stress_enhancement",
+            "structural_lib.codes.is456.footing.bearing.check_bearing_pressure",
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
+            "structural_lib.codes.is456.footing.load_transfer.check_isolated_footing_load_transfer"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.4.1",
+          "reference": "34.4.1",
+          "reference_type": "clause",
+          "title": "Concrete Bearing Transfer",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.load_transfer.check_isolated_footing_load_transfer"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.4.2",
+          "reference": "34.4.2",
+          "reference_type": "clause",
+          "title": "Transfer Reinforcement Development",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.load_transfer.check_isolated_footing_load_transfer"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.4.3",
+          "reference": "34.4.3",
+          "reference_type": "clause",
+          "title": "Transfer Bar Arrangement",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.footing.load_transfer.check_isolated_footing_load_transfer"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.4.4",
+          "reference": "34.4.4",
+          "reference_type": "clause",
+          "title": "Large Column Bar Transfer Case",
+          "category": "footings",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:36.1",
+          "reference": "36.1",
+          "reference_type": "clause",
+          "title": "Limit State of Collapse - Flexure",
+          "category": "flexure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:36.4.2",
+          "reference": "36.4.2",
+          "reference_type": "clause",
+          "title": "Effective Width of Flange",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.flexure.calculate_effective_flange_width"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:38.1",
+          "reference": "38.1",
+          "reference_type": "clause",
+          "title": "Assumptions in Design",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.flexure.calculate_mu_lim",
+            "structural_lib.codes.is456.beam.flexure.calculate_mu_lim_flanged",
+            "structural_lib.codes.is456.beam.flexure.design_doubly_reinforced",
+            "structural_lib.codes.is456.beam.flexure.design_flanged_beam",
+            "structural_lib.codes.is456.beam.flexure.design_singly_reinforced",
+            "structural_lib.codes.is456.column.pmm.experimental_pmm_interaction_surface",
+            "structural_lib.codes.is456.column.pmm.pm_interaction_slice_for_layout",
+            "structural_lib.codes.is456.slab.one_way.design_simply_supported_one_way_slab_flexure",
+            "structural_lib.codes.is456.slab.one_way_continuous.design_continuous_one_way_slab_flexure",
+            "structural_lib.codes.is456.slab.two_way.design_supported_interior_two_way_slab_flexure"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:38.1.1",
+          "reference": "38.1.1",
+          "reference_type": "clause",
+          "title": "Neutral Axis Depth",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.flexure.calculate_mu_lim"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:38.1.2",
+          "reference": "38.1.2",
+          "reference_type": "clause",
+          "title": "Stress Block Parameters",
+          "category": "flexure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:38.2",
+          "reference": "38.2",
+          "reference_type": "clause",
+          "title": "Singly Reinforced Sections",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.flexure.calculate_ast_required",
+            "structural_lib.codes.is456.beam.flexure.design_doubly_reinforced",
+            "structural_lib.codes.is456.beam.flexure.design_singly_reinforced"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:38.3",
+          "reference": "38.3",
+          "reference_type": "clause",
+          "title": "Doubly Reinforced Sections",
+          "category": "flexure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:38.4",
+          "reference": "38.4",
+          "reference_type": "clause",
+          "title": "Flanged Beams",
+          "category": "flexure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:39.1",
+          "reference": "39.1",
+          "reference_type": "clause",
+          "title": "Minimum Eccentricity for Column Design",
+          "category": "columns",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:39.3",
+          "reference": "39.3",
+          "reference_type": "clause",
+          "title": "Short Axially Loaded Members in Compression",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.axial.short_axial_capacity",
+            "structural_lib.codes.is456.column.pmm.experimental_pmm_interaction_surface",
+            "structural_lib.codes.is456.column.pmm.pm_interaction_slice_for_layout"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:39.4",
+          "reference": "39.4",
+          "reference_type": "clause",
+          "title": "Compression Members with Helical Reinforcement",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.helical.check_helical_reinforcement"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:39.5",
+          "reference": "39.5",
+          "reference_type": "clause",
+          "title": "Members Subjected to Combined Axial Load and Uniaxial Bending",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.pmm.experimental_pmm_interaction_surface",
+            "structural_lib.codes.is456.column.pmm.pm_interaction_slice_for_layout",
+            "structural_lib.codes.is456.column.uniaxial.design_short_column_uniaxial",
+            "structural_lib.codes.is456.column.uniaxial.pm_interaction_curve"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:39.6",
+          "reference": "39.6",
+          "reference_type": "clause",
+          "title": "Members Subjected to Combined Axial Load and Biaxial Bending",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.biaxial.biaxial_bending_check"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:39.7",
+          "reference": "39.7",
+          "reference_type": "clause",
+          "title": "Slender Compression Members",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.long_column.design_long_column"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:39.7.1",
+          "reference": "39.7.1",
+          "reference_type": "clause",
+          "title": "Additional Moment in Slender Columns",
+          "category": "columns",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.column.slenderness.calculate_additional_moment"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:40.1",
+          "reference": "40.1",
+          "reference_type": "clause",
+          "title": "Limit State of Collapse: Shear",
+          "category": "shear",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.shear.calculate_tv",
+            "structural_lib.codes.is456.beam.shear.design_shear",
+            "structural_lib.codes.is456.slab.shear.check_solid_slab_one_way_shear"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:40.2",
+          "reference": "40.2",
+          "reference_type": "clause",
+          "title": "Design Shear Strength of Concrete",
+          "category": "shear",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.shear.design_shear",
+            "structural_lib.codes.is456.slab.shear.check_solid_slab_one_way_shear",
+            "structural_lib.codes.is456.slab.two_way_complete.design_two_way_slab_panel"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:40.3",
+          "reference": "40.3",
+          "reference_type": "clause",
+          "title": "Enhanced Shear Strength Near Supports",
+          "category": "shear",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.shear.enhanced_shear_strength"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:40.4",
+          "reference": "40.4",
+          "reference_type": "clause",
+          "title": "Shear Reinforcement Design",
+          "category": "shear",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.shear.design_shear"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:40.5.1",
+          "reference": "40.5.1",
+          "reference_type": "clause",
+          "title": "Maximum Shear Stress",
+          "category": "shear",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:41.1",
+          "reference": "41.1",
+          "reference_type": "clause",
+          "title": "General - Design for Torsion",
+          "category": "torsion",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.torsion.design_torsion"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:41.3",
+          "reference": "41.3",
+          "reference_type": "clause",
+          "title": "Critical Section for Torsion",
+          "category": "torsion",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.torsion.calculate_torsion_shear_stress",
+            "structural_lib.codes.is456.beam.torsion.design_torsion"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:41.3.1",
+          "reference": "41.3.1",
+          "reference_type": "clause",
+          "title": "Equivalent Shear",
+          "category": "torsion",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.torsion.calculate_equivalent_shear"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:41.4",
+          "reference": "41.4",
+          "reference_type": "clause",
+          "title": "Reinforcement for Torsion",
+          "category": "torsion",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.torsion.design_torsion"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:41.4.2",
+          "reference": "41.4.2",
+          "reference_type": "clause",
+          "title": "Longitudinal Reinforcement for Torsion",
+          "category": "torsion",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.torsion.calculate_equivalent_moment",
+            "structural_lib.codes.is456.beam.torsion.calculate_longitudinal_torsion_steel"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:41.4.3",
+          "reference": "41.4.3",
+          "reference_type": "clause",
+          "title": "Transverse Reinforcement for Torsion",
+          "category": "torsion",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.torsion.calculate_torsion_stirrup_area"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:43.1",
+          "reference": "43.1",
+          "reference_type": "clause",
+          "title": "Limit State of Serviceability: Deflection",
+          "category": "serviceability",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.serviceability.check_crack_width"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:43.2",
+          "reference": "43.2",
+          "reference_type": "clause",
+          "title": "Control of Deflection - Span/Depth Ratios",
+          "category": "serviceability",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:43.2.1",
+          "reference": "43.2.1",
+          "reference_type": "clause",
+          "title": "Modification Factors",
+          "category": "serviceability",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:43.3",
+          "reference": "43.3",
+          "reference_type": "clause",
+          "title": "Crack Control",
+          "category": "serviceability",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:43.4",
+          "reference": "43.4",
+          "reference_type": "clause",
+          "title": "Minimum Reinforcement",
+          "category": "detailing",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:5.1",
+          "reference": "5.1",
+          "reference_type": "clause",
+          "title": "Cement",
+          "category": "materials",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:5.2",
+          "reference": "5.2",
+          "reference_type": "clause",
+          "title": "Mineral Admixtures",
+          "category": "materials",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:5.3",
+          "reference": "5.3",
+          "reference_type": "clause",
+          "title": "Aggregates",
+          "category": "materials",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:5.4",
+          "reference": "5.4",
+          "reference_type": "clause",
+          "title": "Water",
+          "category": "materials",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:5.6",
+          "reference": "5.6",
+          "reference_type": "clause",
+          "title": "Reinforcement",
+          "category": "materials",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:6.1",
+          "reference": "6.1",
+          "reference_type": "clause",
+          "title": "Grades of Concrete",
+          "category": "materials",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:6.2",
+          "reference": "6.2",
+          "reference_type": "clause",
+          "title": "Properties of Concrete",
+          "category": "materials",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:6.2.2",
+          "reference": "6.2.2",
+          "reference_type": "clause",
+          "title": "Modulus of Elasticity",
+          "category": "materials",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:Annex E",
+          "reference": "Annex E",
+          "reference_type": "annexure",
+          "title": "Effective Length of Compression Members",
+          "category": "annexure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:Annex G",
+          "reference": "Annex G",
+          "reference_type": "annexure",
+          "title": "Moments of Resistance of Beams and Slabs",
+          "category": "annexure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1",
+          "reference": "AnnexD-1",
+          "reference_type": "clause",
+          "title": "Restrained Slabs — Moment Coefficients",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1.1",
+          "reference": "AnnexD-1.1",
+          "reference_type": "clause",
+          "title": "Conditions for Table 26 Coefficients",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1.2",
+          "reference": "AnnexD-1.2",
+          "reference_type": "clause",
+          "title": "Division into Middle and Edge Strips",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1.3",
+          "reference": "AnnexD-1.3",
+          "reference_type": "clause",
+          "title": "Maximum Moments in Middle Strip",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1.4",
+          "reference": "AnnexD-1.4",
+          "reference_type": "clause",
+          "title": "Moments in Edge Strips",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1.5",
+          "reference": "AnnexD-1.5",
+          "reference_type": "clause",
+          "title": "Negative Moments at Continuous Edge",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1.6",
+          "reference": "AnnexD-1.6",
+          "reference_type": "clause",
+          "title": "Negative Moments at Discontinuous Edge",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1.7",
+          "reference": "AnnexD-1.7",
+          "reference_type": "clause",
+          "title": "Torsion Reinforcement — Two Discontinuous Edges",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-1.8",
+          "reference": "AnnexD-1.8",
+          "reference_type": "clause",
+          "title": "Torsion Reinforcement — One Discontinuous Edge",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:AnnexD-2",
+          "reference": "AnnexD-2",
+          "reference_type": "clause",
+          "title": "Simply Supported Slabs Spanning in Two Directions",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:C-2",
+          "reference": "C-2",
+          "reference_type": "annexure",
+          "title": "Concrete Stress Block Parameters — Creep and Shrinkage",
+          "category": "serviceability",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.serviceability.calculate_cracked_moment_of_inertia",
+            "structural_lib.codes.is456.beam.serviceability.calculate_cracking_moment",
+            "structural_lib.codes.is456.beam.serviceability.calculate_creep_deflection",
+            "structural_lib.codes.is456.beam.serviceability.calculate_effective_moment_of_inertia",
+            "structural_lib.codes.is456.beam.serviceability.calculate_gross_moment_of_inertia",
+            "structural_lib.codes.is456.beam.serviceability.check_deflection_level_c",
+            "structural_lib.codes.is456.beam.serviceability.get_creep_coefficient"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:C-3",
+          "reference": "C-3",
+          "reference_type": "annexure",
+          "title": "Shrinkage",
+          "category": "serviceability",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.serviceability.calculate_shrinkage_curvature",
+            "structural_lib.codes.is456.beam.serviceability.calculate_shrinkage_deflection",
+            "structural_lib.codes.is456.beam.serviceability.check_deflection_level_c"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:Fig. 23",
+          "reference": "Fig. 23",
+          "reference_type": "figure",
+          "title": "Representative Stress-Strain Curve for Steel",
+          "category": "figure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.common.stress_blocks.steel_stress_from_strain_5point"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:Figure 3",
+          "reference": "Figure 3",
+          "reference_type": "figure",
+          "title": "Stress-Strain Curve for Concrete",
+          "category": "figure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:Figure 4",
+          "reference": "Figure 4",
+          "reference_type": "figure",
+          "title": "Modification Factor for Tension Reinforcement",
+          "category": "figure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:Figure 5",
+          "reference": "Figure 5",
+          "reference_type": "figure",
+          "title": "Modification Factor for Compression Reinforcement",
+          "category": "figure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:G-1.1",
+          "reference": "G-1.1",
+          "reference_type": "annexure",
+          "title": "Doubly Reinforced Rectangular Sections",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.flexure.design_doubly_reinforced"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:G-2.2",
+          "reference": "G-2.2",
+          "reference_type": "annexure",
+          "title": "Flanged Beams - Neutral Axis in Web",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.beam.flexure.calculate_mu_lim_flanged",
+            "structural_lib.codes.is456.beam.flexure.design_flanged_beam"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:Table 19",
+          "reference": "Table 19",
+          "reference_type": "table",
+          "title": "Design Shear Strength of Concrete",
+          "category": "table",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:Table 2",
+          "reference": "Table 2",
+          "reference_type": "table",
+          "title": "Grades of Concrete",
+          "category": "table",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:Table 20",
+          "reference": "Table 20",
+          "reference_type": "table",
+          "title": "Maximum Shear Stress",
+          "category": "table",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:Table 21",
+          "reference": "Table 21",
+          "reference_type": "table",
+          "title": "Design Bond Stress",
+          "category": "table",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:Table 23",
+          "reference": "Table 23",
+          "reference_type": "table",
+          "title": "Basic Span to Effective Depth Ratios",
+          "category": "table",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        }
+      ]
+    },
+    {
+      "standard_id": "IS13920",
+      "namespace": "IS13920:2016",
+      "edition": "2016",
+      "title": "Ductile detailing of reinforced concrete structures",
+      "source_root": "Python/structural_lib/codes/is13920",
+      "status": "SUPPORTED_SUBSET",
+      "capability_summary": {
+        "supported_families": 3,
+        "held_families": 2,
+        "total_declared_families": 5,
+        "supported_pct": 60.0
+      },
+      "capability_families": [
+        {
+          "capability_id": "IS13920:2016:beam_detailing_checks",
+          "family": "beam_detailing_checks",
+          "scope_status": "SUPPORTED",
+          "implementation_status": "IMPLEMENTED_BOUNDED",
+          "claim": "Bounded beam geometry, longitudinal-steel, and confinement-spacing checks exist.",
+          "workflows": [
+            "check_beam_ductility"
+          ],
+          "limitations": [
+            "This is a bounded detailing check, not a complete seismic design workflow."
+          ],
+          "evidence": [
+            "Python/structural_lib/codes/is13920/beam.py",
+            "Python/tests/property/test_ductile_hypothesis.py"
+          ],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS13920:2016:column_detailing_checks",
+          "family": "column_detailing_checks",
+          "scope_status": "SUPPORTED",
+          "implementation_status": "IMPLEMENTED_BOUNDED",
+          "claim": "Bounded column geometry and special-confinement checks exist.",
+          "workflows": [
+            "check_column_ductility_is13920"
+          ],
+          "limitations": [
+            "This is a bounded detailing check, not a complete seismic design workflow."
+          ],
+          "evidence": [
+            "Python/structural_lib/codes/is13920/column.py",
+            "Python/tests/codes/is13920/test_column.py"
+          ],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS13920:2016:beam_column_joint_scwb_check",
+          "family": "beam_column_joint_scwb_check",
+          "scope_status": "SUPPORTED",
+          "implementation_status": "IMPLEMENTED_BOUNDED",
+          "claim": "A pure-math strong-column weak-beam joint check exists.",
+          "workflows": [
+            "structural_lib.codes.is13920.joint.check_scwb"
+          ],
+          "limitations": [
+            "No complete joint design or public service workflow is claimed."
+          ],
+          "evidence": [
+            "Python/structural_lib/codes/is13920/joint.py",
+            "Python/tests/codes/is13920/test_joint.py"
+          ],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS13920:2016:wall_detailing",
+          "family": "wall_detailing",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "IS 13920 wall provisions are not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Wall and boundary-element provisions require a separate packet."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS13920:2016:foundation_detailing",
+          "family": "foundation_detailing",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "IS 13920 foundation provisions are not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Foundation capacity-design provisions require a separate packet."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        }
+      ],
+      "registration_summary": {
+        "known_references": 16,
+        "registered_known_references": 5,
+        "metadata_only_references": 11,
+        "registration_only_references": 9,
+        "registration_pct": 31.2
+      },
+      "references": [
+        {
+          "reference_id": "IS13920:2016:10.1",
+          "reference": "10.1",
+          "reference_type": "clause",
+          "title": "Foundation — General",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:5.1",
+          "reference": "5.1",
+          "reference_type": "clause",
+          "title": "General Requirements — IS 13920",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:6.1",
+          "reference": "6.1",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.beam.check_beam_ductility"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:6.1.1",
+          "reference": "6.1.1",
+          "reference_type": "clause",
+          "title": "Flexural Members — Dimensional Limits",
+          "category": "seismic",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is13920.beam.check_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:6.1.2",
+          "reference": "6.1.2",
+          "reference_type": "clause",
+          "title": "Flexural Members — Longitudinal Reinforcement",
+          "category": "seismic",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is13920.beam.check_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:6.2.1",
+          "reference": "6.2.1",
+          "reference_type": "clause",
+          "title": "Flexural Members — Shear Reinforcement",
+          "category": "seismic",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is13920.beam.check_beam_ductility",
+            "structural_lib.codes.is13920.beam.get_min_tension_steel_percentage"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:6.2.2",
+          "reference": "6.2.2",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.beam.check_beam_ductility",
+            "structural_lib.codes.is13920.beam.get_max_tension_steel_percentage"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:6.3",
+          "reference": "6.3",
+          "reference_type": "clause",
+          "title": "Lap Splices in Flexural Members",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:6.3.5",
+          "reference": "6.3.5",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.beam.calculate_confinement_spacing",
+            "structural_lib.codes.is13920.beam.check_beam_ductility"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:7.1",
+          "reference": "7.1",
+          "reference_type": "clause",
+          "title": "Columns — General Requirements",
+          "category": "seismic",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is13920.column.check_column_ductility"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:7.1.2",
+          "reference": "7.1.2",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.column.check_column_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:7.1.3",
+          "reference": "7.1.3",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.column.check_column_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:7.2",
+          "reference": "7.2",
+          "reference_type": "clause",
+          "title": "Columns — Longitudinal Reinforcement",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:7.2.1",
+          "reference": "7.2.1",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.column.check_column_ductility",
+            "structural_lib.codes.is13920.column.get_max_longitudinal_steel",
+            "structural_lib.codes.is13920.column.get_min_longitudinal_steel",
+            "structural_lib.codes.is13920.joint.check_scwb"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:7.3",
+          "reference": "7.3",
+          "reference_type": "clause",
+          "title": "Columns — Transverse Reinforcement",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:7.4",
+          "reference": "7.4",
+          "reference_type": "clause",
+          "title": "Columns — Special Confining Reinforcement Area",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:7.4.1",
+          "reference": "7.4.1",
+          "reference_type": "clause",
+          "title": "Area of Special Confining Reinforcement",
+          "category": "seismic",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is13920.column.calculate_confining_length",
+            "structural_lib.codes.is13920.column.check_column_ductility"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:7.4.6",
+          "reference": "7.4.6",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.column.calculate_special_confining_spacing",
+            "structural_lib.codes.is13920.column.check_column_ductility"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:7.4.7",
+          "reference": "7.4.7",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.column.calculate_ash_required",
+            "structural_lib.codes.is13920.column.check_column_ductility"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:7.4.8",
+          "reference": "7.4.8",
+          "reference_type": "clause",
+          "title": "",
+          "category": "unregistered_metadata",
+          "registration_status": "REGISTRATION_ONLY",
+          "functions": [
+            "structural_lib.codes.is13920.column.calculate_ash_required",
+            "structural_lib.codes.is13920.column.check_column_ductility"
+          ]
+        },
+        {
+          "reference_id": "IS13920:2016:8.1",
+          "reference": "8.1",
+          "reference_type": "clause",
+          "title": "Beam-Column Joint Requirements",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:9.1",
+          "reference": "9.1",
+          "reference_type": "clause",
+          "title": "Shear Walls — General",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:9.2",
+          "reference": "9.2",
+          "reference_type": "clause",
+          "title": "Design Shear Strength of Walls",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:9.3",
+          "reference": "9.3",
+          "reference_type": "clause",
+          "title": "Boundary Elements in Shear Walls",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS13920:2016:9.4",
+          "reference": "9.4",
+          "reference_type": "clause",
+          "title": "Shear Walls — Boundary Elements",
+          "category": "seismic",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        }
+      ]
+    },
+    {
+      "standard_id": "IS875",
+      "namespace": "IS875",
+      "edition": "SERIES_NOT_SELECTED",
+      "title": "Structural loading series",
+      "source_root": null,
+      "status": "HELD",
+      "capability_summary": {
+        "supported_families": 0,
+        "held_families": 2,
+        "total_declared_families": 2,
+        "supported_pct": 0.0
+      },
+      "capability_families": [
+        {
+          "capability_id": "IS875:gravity_load_generation",
+          "family": "gravity_load_generation",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "IS 875 gravity-load generation is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Applicable parts and editions must be selected before implementation."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS875:wind_load_generation",
+          "family": "wind_load_generation",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "IS 875 wind-load generation is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Wind inputs and pressure generation require a separate program."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        }
+      ],
+      "registration_summary": {
+        "known_references": 0,
+        "registered_known_references": 0,
+        "metadata_only_references": 0,
+        "registration_only_references": 0,
+        "registration_pct": null
+      },
+      "references": []
+    },
+    {
+      "standard_id": "IS1893",
+      "namespace": "IS1893",
+      "edition": "EDITION_NOT_SELECTED",
+      "title": "Earthquake-resistant design criteria",
+      "source_root": null,
+      "status": "HELD",
+      "capability_summary": {
+        "supported_families": 0,
+        "held_families": 2,
+        "total_declared_families": 2,
+        "supported_pct": 0.0
+      },
+      "capability_families": [
+        {
+          "capability_id": "IS1893:equivalent_static_seismic",
+          "family": "equivalent_static_seismic",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "IS 1893 equivalent-static force generation is not implemented.",
+          "workflows": [],
+          "limitations": [
+            "Edition, inputs, load combinations, and validation must be selected first."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        },
+        {
+          "capability_id": "IS1893:response_spectrum_analysis",
+          "family": "response_spectrum_analysis",
+          "scope_status": "HELD",
+          "implementation_status": "NOT_IMPLEMENTED",
+          "claim": "Response-spectrum and FEM analysis are not implemented.",
+          "workflows": [],
+          "limitations": [
+            "This remains a separate analysis program."
+          ],
+          "evidence": [],
+          "qualified_review_required": true
+        }
+      ],
+      "registration_summary": {
+        "known_references": 0,
+        "registered_known_references": 0,
+        "metadata_only_references": 0,
+        "registration_only_references": 0,
+        "registration_pct": null
+      },
+      "references": []
+    }
+  ]
+}

--- a/docs/verification/indian-code-truth-baseline.md
+++ b/docs/verification/indian-code-truth-baseline.md
@@ -1,6 +1,13 @@
 # INDIA-0 Indian-Code Truth Baseline
 
-**Status:** Locally complete; Git publication and CI handoff pending
+**Type:** Reference
+**Audience:** Developers
+**Status:** In Progress
+**Created:** 2026-08-15
+**Last Updated:** 2026-08-15
+**Importance:** Critical
+**Evidence boundary:** Draft PR #753 open; hosted CI, exact-head review, and
+merge pending
 
 **Manifest:**
 [`indian-code-capability-coverage.json`](indian-code-capability-coverage.json)
@@ -75,10 +82,9 @@ composite; intentionally held families are not failed parity checks.
 
 ## Remaining gates
 
-- The fail-closed Git handoff records `LOCAL_HOLD_DIRTY` plus unchecked
-  remote/PR/review evidence. The next Git/PR session must review the intended
-  path set, commit it, refresh exact-head evidence, push, and open a draft PR;
-  this session does not wait for CI.
+- The fail-closed Git handoff is the retained pre-publication receipt. Draft PR
+  #753 now carries the committed baseline; hosted CI, exact-head review, and
+  merge remain pending, and this session does not wait for CI.
 - INDIA-1 must use the manifest's held cases to close or retain limitations in
   the already supported beam, column, isolated-footing, and solid-slab families.
 - Release, stable approval, engineering-use approval, and branch/worktree

--- a/docs/verification/indian-code-truth-baseline.md
+++ b/docs/verification/indian-code-truth-baseline.md
@@ -1,0 +1,85 @@
+# INDIA-0 Indian-Code Truth Baseline
+
+**Status:** Locally complete; Git publication and CI handoff pending
+
+**Manifest:**
+[`indian-code-capability-coverage.json`](indian-code-capability-coverage.json)
+
+**Git handoff:** [`INDIA-0-git-handoff.json`](INDIA-0-git-handoff.json)
+**Claim ceiling:** Software scope and traceability evidence only; qualified
+structural-engineering review remains required before stable or engineering-use
+approval.
+
+## Purpose
+
+INDIA-0 replaces two incompatible measurements with one deterministic,
+standard-namespaced manifest:
+
+- capability families are either `SUPPORTED` or `HELD`;
+- implementation is either `IMPLEMENTED_BOUNDED` or `NOT_IMPLEMENTED`;
+- standard-reference decorators are `REGISTERED`, `METADATA_ONLY`, or
+  `REGISTRATION_ONLY`.
+
+Decorator registration is not implementation, numerical verification,
+provenance, or whole-standard completeness. No percentage in the manifest is a
+professional approval score.
+
+## Generated sources
+
+| Source | Role |
+|---|---|
+| `Python/structural_lib/services/capabilities.py` | Canonical supported IS 456 workflows and held boundaries |
+| `Python/structural_lib/codes/is456/clauses.json` | Distributable identifier/search metadata; legacy IS 13920 records are split into their own manifest namespace |
+| `Python/structural_lib/codes/is456/**/*.py` | Deterministically discovered IS 456 decorator registrations |
+| `Python/structural_lib/codes/is13920/**/*.py` | Deterministically discovered IS 13920 decorator registrations |
+
+The generator fails on a non-literal decorator reference or an unsupported
+standard name. The committed artifact is checked byte-for-byte against fresh
+generation.
+
+## Reconciled scope
+
+| Standard namespace | Supported | Held | Boundary |
+|---|---:|---:|---|
+| `IS456:2000` | 4 families | 8 families | Beam, rectangular column, isolated footing, and solid slab are bounded; other declared families remain held |
+| `IS13920:2016` | 3 check families | 2 families | Beam/column detailing and pure-math SCWB checks exist; complete seismic design is not claimed |
+| `IS875` | 0 | 2 families | Gravity and wind load generation are not implemented; editions/parts are not yet selected |
+| `IS1893` | 0 | 2 families | Equivalent-static and response-spectrum analysis are not implemented; editions are not yet selected |
+
+The IS 13920 reference registry also exposes registration-only identifiers.
+That is a traceability metadata gap, not a computational failure and not a
+reason to erase the working beam, column, or SCWB checks.
+
+## Root-cause corrections
+
+| Symptom | Confirmed root cause | Correction |
+|---|---|---|
+| Parity reported slabs and Annex D as planned | A hand-maintained 17-item table treated file existence as implementation | Dashboard now consumes declared capability families from the generated manifest |
+| “IS 456” clause report mixed IS 13920 entries and omitted slab/footing modules | Mixed metadata, a static module import list, and a registry projection that discarded the decorator standard | AST discovery scans maintained code roots and namespaces references before aggregation |
+| Strategic and task tables contradicted completed slab/footing work | Historical plans were retained as live-looking status tables | Current tables were reconciled or explicitly archived in place; the generated manifest is the status authority |
+
+## Reproduction
+
+```bash
+./scripts/python_runtime.sh scripts/generate_indian_code_manifest.py --check
+./scripts/python_runtime.sh scripts/check_clause_coverage.py --summary
+./scripts/python_runtime.sh scripts/parity_dashboard.py --section capabilities
+./scripts/python_runtime.sh -m pytest Python/tests/test_indian_code_manifest.py -q
+```
+
+The first command reports standard-namespaced decorator registration only. The
+second reports declared supported versus held capability families. Neither is a
+whole-standard-completeness score or professional approval. Declared capability
+scope is informational and excluded from the dashboard's actionable cross-layer
+composite; intentionally held families are not failed parity checks.
+
+## Remaining gates
+
+- The fail-closed Git handoff records `LOCAL_HOLD_DIRTY` plus unchecked
+  remote/PR/review evidence. The next Git/PR session must review the intended
+  path set, commit it, refresh exact-head evidence, push, and open a draft PR;
+  this session does not wait for CI.
+- INDIA-1 must use the manifest's held cases to close or retain limitations in
+  the already supported beam, column, isolated-footing, and solid-slab families.
+- Release, stable approval, engineering-use approval, and branch/worktree
+  retirement remain separately authorized actions.

--- a/docs/verification/is456-slab-evidence.md
+++ b/docs/verification/is456-slab-evidence.md
@@ -79,7 +79,7 @@ provenance; external coefficient carriers remain available.
   `10.688/12.825 kN m/m` with Table 12/13 provenance; editing its span made the
   result stale and disabled passport export. The oriented B04 two-way sample
   returned `18.600/13.888/11.656/8.680 kN m/m` with exact Table 26 provenance.
--- This evidence supports the bounded software behavior only. The normalized-data
+- This evidence supports the bounded software behavior only. The normalized-data
   public-distribution permission gate passed on 2026-08-11; each release still
   requires separate owner authorization, and project use still requires
   qualified structural-engineering review.
@@ -109,5 +109,6 @@ provenance; external coefficient carriers remain available.
   `7bb1512f`. After the explicitly authorized surgical restoration to the
   origin/main module-qualified annotations, the narrow manifest check and final
   full repository gate passed 30/30 without editing the generated manifest.
-- These are software and interface results only. The source/licensing pre-launch
-  gate and qualified structural-engineering review remain unchanged.
+- These are software and interface results only. Approved-scope normalized-data
+  distribution permission passed on 2026-08-11. Per-release owner authorization
+  and qualified structural-engineering review remain separate gates.

--- a/run.sh
+++ b/run.sh
@@ -829,8 +829,9 @@ _help_parity() {
     cat <<'EOF'
 Usage: ./run.sh parity [--json] [--missing] [--section <name>]
 
-Show cross-layer coverage for IS 456 clauses, public API functions, FastAPI
-endpoints/tests, and frontend API hooks.
+Show declared supported/held Indian-code capability families, public API
+exposure, FastAPI endpoint tests, and frontend API hooks. Capability percentages
+are planning indicators, not clause completeness or engineering approval.
 EOF
 }
 
@@ -914,8 +915,8 @@ _print_usage() {
     echo -e "  ${GREEN}task${NC}        Build a lane-safe task intake brief"
     echo -e "  ${GREEN}tools${NC}       Tool & script discovery (list, find,stats)"
     echo -e "  ${GREEN}pipeline${NC}    Pipeline state tracking (new, advance, show)"
-    echo -e "  ${GREEN}coverage${NC}    IS 456 clause coverage gap detection"
-    echo -e "  ${GREEN}parity${NC}      Cross-layer implementation/test parity dashboard"
+    echo -e "  ${GREEN}coverage${NC}    Namespaced decorator registration report"
+    echo -e "  ${GREEN}parity${NC}      Declared capability and cross-layer parity dashboard"
     echo -e "  ${GREEN}efficiency${NC}  Validate low-token agent and context controls"
     echo -e "  ${GREEN}model${NC}       Recommend a model and reasoning level for a task"
     echo -e "  ${GREEN}diagnose${NC}    Diagnose CI failures (--pr N, --local, --fix)"

--- a/scripts/_lib/indian_code_manifest.py
+++ b/scripts/_lib/indian_code_manifest.py
@@ -1,0 +1,460 @@
+"""Build the deterministic Indian-code capability and traceability manifest.
+
+Capability declarations and decorator registration are intentionally separate:
+neither file existence nor a ``@clause`` decorator proves engineering
+completeness, verification, or professional approval.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYTHON_ROOT = REPO_ROOT / "Python"
+MANIFEST_PATH = (
+    REPO_ROOT / "docs" / "verification" / "indian-code-capability-coverage.json"
+)
+SCHEMA_VERSION = "1.0"
+
+STANDARD_DEFINITIONS: tuple[dict[str, Any], ...] = (
+    {
+        "standard_id": "IS456",
+        "namespace": "IS456:2000",
+        "edition": "2000",
+        "title": "Plain and reinforced concrete code of practice",
+        "source_root": "Python/structural_lib/codes/is456",
+    },
+    {
+        "standard_id": "IS13920",
+        "namespace": "IS13920:2016",
+        "edition": "2016",
+        "title": "Ductile detailing of reinforced concrete structures",
+        "source_root": "Python/structural_lib/codes/is13920",
+    },
+    {
+        "standard_id": "IS875",
+        "namespace": "IS875",
+        "edition": "SERIES_NOT_SELECTED",
+        "title": "Structural loading series",
+        "source_root": None,
+    },
+    {
+        "standard_id": "IS1893",
+        "namespace": "IS1893",
+        "edition": "EDITION_NOT_SELECTED",
+        "title": "Earthquake-resistant design criteria",
+        "source_root": None,
+    },
+)
+
+_STANDARD_ALIASES = {
+    "IS 456": "IS456:2000",
+    "IS 456:2000": "IS456:2000",
+    "IS 13920": "IS13920:2016",
+    "IS 13920:2016": "IS13920:2016",
+}
+
+_IS456_EVIDENCE = {
+    "beam": ("docs/verification/is456-library-first-evidence.md",),
+    "column": ("docs/verification/is456-library-first-evidence.md",),
+    "isolated_footing": (
+        "docs/verification/footing-release-inclusion.json",
+    ),
+    "solid_slab": ("docs/verification/is456-slab-evidence.md",),
+}
+
+_HELD_FAMILIES: dict[str, tuple[dict[str, Any], ...]] = {
+    "IS456:2000": (
+        {
+            "family": "wall",
+            "claim": "IS 456 wall design is not implemented.",
+            "limitations": ["Clause 32 requires a separately verified program."],
+        },
+        {
+            "family": "stair",
+            "claim": "IS 456 stair design is not implemented.",
+            "limitations": ["Clause 33 requires a separately verified program."],
+        },
+        {
+            "family": "deep_beam",
+            "claim": "IS 456 deep-beam design is not implemented.",
+            "limitations": ["Clause 29 requires a separately verified program."],
+        },
+        {
+            "family": "flat_slab",
+            "claim": "Flat-slab and column-supported punching design are held.",
+            "limitations": [
+                "Column strips, drops, punching perimeters, openings, and moment transfer require a separate analysis program."
+            ],
+        },
+        {
+            "family": "combined_footing",
+            "claim": "Combined-footing design is not implemented.",
+            "limitations": ["A distinct soil-pressure and structural analysis model is required."],
+        },
+        {
+            "family": "strap_footing",
+            "claim": "Strap-footing design is not implemented.",
+            "limitations": ["A distinct analysis model is required."],
+        },
+        {
+            "family": "raft_foundation",
+            "claim": "Raft-foundation design is not implemented.",
+            "limitations": ["Soil-structure interaction remains outside the supported subset."],
+        },
+        {
+            "family": "pile_cap",
+            "claim": "Pile-cap design is not implemented.",
+            "limitations": ["Pile reactions and strut-and-tie behavior require a separate program."],
+        },
+    ),
+    "IS13920:2016": (
+        {
+            "family": "wall_detailing",
+            "claim": "IS 13920 wall provisions are not implemented.",
+            "limitations": ["Wall and boundary-element provisions require a separate packet."],
+        },
+        {
+            "family": "foundation_detailing",
+            "claim": "IS 13920 foundation provisions are not implemented.",
+            "limitations": ["Foundation capacity-design provisions require a separate packet."],
+        },
+    ),
+    "IS875": (
+        {
+            "family": "gravity_load_generation",
+            "claim": "IS 875 gravity-load generation is not implemented.",
+            "limitations": ["Applicable parts and editions must be selected before implementation."],
+        },
+        {
+            "family": "wind_load_generation",
+            "claim": "IS 875 wind-load generation is not implemented.",
+            "limitations": ["Wind inputs and pressure generation require a separate program."],
+        },
+    ),
+    "IS1893": (
+        {
+            "family": "equivalent_static_seismic",
+            "claim": "IS 1893 equivalent-static force generation is not implemented.",
+            "limitations": ["Edition, inputs, load combinations, and validation must be selected first."],
+        },
+        {
+            "family": "response_spectrum_analysis",
+            "claim": "Response-spectrum and FEM analysis are not implemented.",
+            "limitations": ["This remains a separate analysis program."],
+        },
+    ),
+}
+
+_IS13920_SUPPORTED: tuple[dict[str, Any], ...] = (
+    {
+        "family": "beam_detailing_checks",
+        "claim": "Bounded beam geometry, longitudinal-steel, and confinement-spacing checks exist.",
+        "workflows": ["check_beam_ductility"],
+        "limitations": ["This is a bounded detailing check, not a complete seismic design workflow."],
+        "evidence": [
+            "Python/structural_lib/codes/is13920/beam.py",
+            "Python/tests/property/test_ductile_hypothesis.py",
+        ],
+    },
+    {
+        "family": "column_detailing_checks",
+        "claim": "Bounded column geometry and special-confinement checks exist.",
+        "workflows": ["check_column_ductility_is13920"],
+        "limitations": ["This is a bounded detailing check, not a complete seismic design workflow."],
+        "evidence": [
+            "Python/structural_lib/codes/is13920/column.py",
+            "Python/tests/codes/is13920/test_column.py",
+        ],
+    },
+    {
+        "family": "beam_column_joint_scwb_check",
+        "claim": "A pure-math strong-column weak-beam joint check exists.",
+        "workflows": ["structural_lib.codes.is13920.joint.check_scwb"],
+        "limitations": ["No complete joint design or public service workflow is claimed."],
+        "evidence": [
+            "Python/structural_lib/codes/is13920/joint.py",
+            "Python/tests/codes/is13920/test_joint.py",
+        ],
+    },
+)
+
+
+def _supported_family(
+    namespace: str,
+    family: str,
+    claim: str,
+    workflows: list[str],
+    limitations: list[str],
+    evidence: list[str],
+) -> dict[str, Any]:
+    return {
+        "capability_id": f"{namespace}:{family}",
+        "family": family,
+        "scope_status": "SUPPORTED",
+        "implementation_status": "IMPLEMENTED_BOUNDED",
+        "claim": claim,
+        "workflows": workflows,
+        "limitations": limitations,
+        "evidence": evidence,
+        "qualified_review_required": True,
+    }
+
+
+def _held_family(namespace: str, definition: dict[str, Any]) -> dict[str, Any]:
+    family = definition["family"]
+    return {
+        "capability_id": f"{namespace}:{family}",
+        "family": family,
+        "scope_status": "HELD",
+        "implementation_status": "NOT_IMPLEMENTED",
+        "claim": definition["claim"],
+        "workflows": [],
+        "limitations": definition["limitations"],
+        "evidence": [],
+        "qualified_review_required": True,
+    }
+
+
+def _build_capability_families() -> dict[str, list[dict[str, Any]]]:
+    if str(PYTHON_ROOT) not in sys.path:
+        sys.path.insert(0, str(PYTHON_ROOT))
+
+    from structural_lib.services.capabilities import (  # noqa: PLC0415
+        IS456_STANDARD_NAMESPACE,
+        get_supported_is456_capabilities,
+    )
+
+    if IS456_STANDARD_NAMESPACE != "IS456:2000":
+        raise ValueError(
+            "Manifest namespace disagrees with the runtime IS 456 capability registry"
+        )
+    result: dict[str, list[dict[str, Any]]] = {item["namespace"]: [] for item in STANDARD_DEFINITIONS}
+    for capability in get_supported_is456_capabilities():
+        result["IS456:2000"].append(
+            _supported_family(
+                "IS456:2000",
+                capability.element,
+                capability.supported_case,
+                list(capability.public_workflows),
+                list(capability.held_cases),
+                list(_IS456_EVIDENCE[capability.element]),
+            )
+        )
+
+    for definition in _IS13920_SUPPORTED:
+        result["IS13920:2016"].append(
+            _supported_family(
+                "IS13920:2016",
+                definition["family"],
+                definition["claim"],
+                definition["workflows"],
+                definition["limitations"],
+                definition["evidence"],
+            )
+        )
+
+    for namespace, definitions in _HELD_FAMILIES.items():
+        result[namespace].extend(_held_family(namespace, item) for item in definitions)
+    return result
+
+
+def _decorator_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _discover_registrations() -> dict[str, dict[str, list[str]]]:
+    registrations: dict[str, dict[str, list[str]]] = {}
+    for definition in STANDARD_DEFINITIONS:
+        source_root = definition["source_root"]
+        if source_root is None:
+            continue
+        root = REPO_ROOT / source_root
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for decorator in node.decorator_list:
+                    if not isinstance(decorator, ast.Call) or _decorator_name(decorator.func) != "clause":
+                        continue
+                    standard = "IS 456"
+                    for keyword in decorator.keywords:
+                        if (
+                            keyword.arg == "standard"
+                            and isinstance(keyword.value, ast.Constant)
+                            and isinstance(keyword.value.value, str)
+                        ):
+                            standard = keyword.value.value
+                    namespace = _STANDARD_ALIASES.get(standard)
+                    if namespace is None:
+                        raise ValueError(f"Unsupported clause namespace {standard!r} in {path}")
+                    module = path.relative_to(PYTHON_ROOT).with_suffix("").as_posix().replace("/", ".")
+                    function = f"{module}.{node.name}"
+                    for argument in decorator.args:
+                        if not isinstance(argument, ast.Constant) or not isinstance(argument.value, str):
+                            raise ValueError(f"Non-literal clause reference in {path}:{node.lineno}")
+                        registrations.setdefault(namespace, {}).setdefault(argument.value, []).append(function)
+    return registrations
+
+
+def _load_reference_metadata() -> dict[str, dict[str, dict[str, Any]]]:
+    path = REPO_ROOT / "Python/structural_lib/codes/is456/clauses.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    result: dict[str, dict[str, dict[str, Any]]] = {
+        item["namespace"]: {} for item in STANDARD_DEFINITIONS
+    }
+
+    for reference, info in data.get("clauses", {}).items():
+        if reference.startswith("IS13920_"):
+            namespace = "IS13920:2016"
+            bare_reference = reference.removeprefix("IS13920_")
+        else:
+            namespace = "IS456:2000"
+            bare_reference = reference
+        result[namespace][bare_reference] = {
+            "reference_type": "clause",
+            "title": info.get("title", ""),
+            "category": info.get("category", "uncategorized"),
+        }
+
+    for group_name, reference_type in (
+        ("annexures", "annexure"),
+        ("tables", "table"),
+        ("figures", "figure"),
+    ):
+        for reference, info in data.get(group_name, {}).items():
+            result["IS456:2000"][reference] = {
+                "reference_type": reference_type,
+                "title": info.get("title", ""),
+                "category": info.get("category", reference_type),
+            }
+    return result
+
+
+def _reference_records(
+    namespace: str,
+    metadata: dict[str, dict[str, Any]],
+    registrations: dict[str, list[str]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    all_references = sorted(set(metadata) | set(registrations))
+    for reference in all_references:
+        known = reference in metadata
+        registered = reference in registrations
+        if known and registered:
+            status = "REGISTERED"
+        elif known:
+            status = "METADATA_ONLY"
+        else:
+            status = "REGISTRATION_ONLY"
+        info = metadata.get(reference, {})
+        records.append(
+            {
+                "reference_id": f"{namespace}:{reference}",
+                "reference": reference,
+                "reference_type": info.get("reference_type", "clause"),
+                "title": info.get("title", ""),
+                "category": info.get("category", "unregistered_metadata"),
+                "registration_status": status,
+                "functions": sorted(set(registrations.get(reference, []))),
+            }
+        )
+
+    known_count = len(metadata)
+    registered_known = len(set(metadata) & set(registrations))
+    summary = {
+        "known_references": known_count,
+        "registered_known_references": registered_known,
+        "metadata_only_references": len(set(metadata) - set(registrations)),
+        "registration_only_references": len(set(registrations) - set(metadata)),
+        "registration_pct": round(registered_known / known_count * 100, 1)
+        if known_count
+        else None,
+    }
+    return records, summary
+
+
+def build_manifest() -> dict[str, Any]:
+    """Return the canonical deterministic manifest as JSON-native data."""
+    capabilities = _build_capability_families()
+    registrations = _discover_registrations()
+    metadata = _load_reference_metadata()
+    standards: list[dict[str, Any]] = []
+
+    for definition in STANDARD_DEFINITIONS:
+        namespace = definition["namespace"]
+        families = capabilities[namespace]
+        references, registration_summary = _reference_records(
+            namespace,
+            metadata.get(namespace, {}),
+            registrations.get(namespace, {}),
+        )
+        supported = sum(item["scope_status"] == "SUPPORTED" for item in families)
+        held = sum(item["scope_status"] == "HELD" for item in families)
+        standards.append(
+            {
+                **definition,
+                "status": "SUPPORTED_SUBSET" if supported else "HELD",
+                "capability_summary": {
+                    "supported_families": supported,
+                    "held_families": held,
+                    "total_declared_families": len(families),
+                    "supported_pct": round(supported / len(families) * 100, 1)
+                    if families
+                    else 0.0,
+                },
+                "capability_families": families,
+                "registration_summary": registration_summary,
+                "references": references,
+            }
+        )
+
+    all_families = [family for standard in standards for family in standard["capability_families"]]
+    supported_total = sum(item["scope_status"] == "SUPPORTED" for item in all_families)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "manifest_id": "INDIA-0-INDIAN-RC-TRUTH-BASELINE",
+        "last_reconciled": "2026-08-15",
+        "claim_boundaries": {
+            "capability_status": "Declared bounded software scope, not whole-standard completeness or engineering approval.",
+            "registration_status": "Decorator-to-identifier traceability only; it does not prove implementation, numerical verification, or provenance.",
+            "professional_review": "Qualified structural-engineering review remains required before stable or engineering-use approval.",
+        },
+        "status_vocabularies": {
+            "scope_status": ["SUPPORTED", "HELD"],
+            "implementation_status": ["IMPLEMENTED_BOUNDED", "NOT_IMPLEMENTED"],
+            "registration_status": ["REGISTERED", "METADATA_ONLY", "REGISTRATION_ONLY"],
+        },
+        "sources": [
+            "Python/structural_lib/services/capabilities.py",
+            "Python/structural_lib/codes/is456/clauses.json",
+            "Python/structural_lib/codes/is456/**/*.py",
+            "Python/structural_lib/codes/is13920/**/*.py",
+        ],
+        "capability_summary": {
+            "supported_families": supported_total,
+            "held_families": len(all_families) - supported_total,
+            "total_declared_families": len(all_families),
+            "supported_pct": round(supported_total / len(all_families) * 100, 1),
+        },
+        "standards": standards,
+    }
+
+
+def render_manifest(manifest: dict[str, Any] | None = None) -> str:
+    """Serialize the manifest in its canonical committed form."""
+    return json.dumps(manifest or build_manifest(), indent=2, ensure_ascii=False) + "\n"
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
+    """Load the committed manifest used by reporting consumers."""
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -853,18 +853,24 @@
     "parity dashboard": {
       "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/parity_dashboard.py",
-      "description": "Cross-stack parity dashboard showing coverage across layers"
+      "description": "Declared Indian-code capability-family and cross-stack parity dashboard"
+    },
+    "generate indian code manifest": {
+      "group": "Quality",
+      "script": "./scripts/python_runtime.sh scripts/generate_indian_code_manifest.py --check",
+      "description": "Verify the generated standard-namespaced Indian-code capability and registration manifest"
     },
     "check clause coverage": {
       "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_clause_coverage.py",
-      "description": "IS 456 clause coverage gap detection — compares clauses.json against @clause() decorated functions",
+      "description": "Standard-namespaced decorator registration report; not implementation or engineering completeness",
       "options": {
-        "--gaps-only": "Show only unimplemented clauses",
+        "--gaps-only": "Show metadata-only and registration-only discrepancies",
+        "--standard X": "Select a standard id or namespace",
         "--category X": "Filter by category (e.g. flexure)",
         "--json": "Machine-readable output",
         "--summary": "Just totals",
-        "--implemented": "Show only implemented clauses"
+        "--registered": "Show only registered known references"
       }
     },
     "check function quality": {

--- a/scripts/check_clause_coverage.py
+++ b/scripts/check_clause_coverage.py
@@ -1,29 +1,17 @@
 #!/usr/bin/env python3
-"""IS 456 clause coverage gap detection.
+"""Report standard-namespaced clause/reference decorator registration.
 
-Scans clauses.json and compares against @clause() decorated functions
-to find unimplemented clauses.
-
-When to use: after changing IS 456 clause registrations or before a coverage review.
-
-This script:
-1. Loads all 119 defined clauses from clauses.json
-2. Imports all IS 456 modules to populate the @clause() registry
-3. Cross-references to identify coverage gaps
-4. Generates coverage reports by category
+This is a traceability report. Registration does not prove implementation,
+numerical verification, provenance, whole-standard coverage, or engineering
+approval. Capability scope is reported separately by ``parity_dashboard.py``.
 
 Usage:
     ./scripts/python_runtime.sh scripts/check_clause_coverage.py
+    ./scripts/python_runtime.sh scripts/check_clause_coverage.py --standard IS456
     ./scripts/python_runtime.sh scripts/check_clause_coverage.py --gaps-only
-    ./scripts/python_runtime.sh scripts/check_clause_coverage.py --category flexure
+    ./scripts/python_runtime.sh scripts/check_clause_coverage.py --registered
     ./scripts/python_runtime.sh scripts/check_clause_coverage.py --json
     ./scripts/python_runtime.sh scripts/check_clause_coverage.py --summary
-    ./scripts/python_runtime.sh scripts/check_clause_coverage.py --implemented
-
-Exit Codes:
-    0 - Success
-    1 - Error loading data
-    2 - Invalid arguments
 """
 
 from __future__ import annotations
@@ -32,456 +20,234 @@ import argparse
 import json
 import sys
 from collections import defaultdict
-from pathlib import Path
 from typing import Any
 
-# ---------------------------------------------------------------------------
-# Setup
-# ---------------------------------------------------------------------------
+from _lib.indian_code_manifest import load_manifest
 
-SCRIPT_DIR = Path(__file__).resolve().parent
-REPO_ROOT = SCRIPT_DIR.parent
-
-# Add Python/ to path for imports
-sys.path.insert(0, str(REPO_ROOT / "Python"))
-
-CLAUSES_JSON = (
-    REPO_ROOT / "Python" / "structural_lib" / "codes" / "is456" / "clauses.json"
-)
-
-# ANSI colors for terminal output
 COLOR_GREEN = "\033[92m"
 COLOR_YELLOW = "\033[93m"
-COLOR_RED = "\033[91m"
 COLOR_BLUE = "\033[94m"
 COLOR_RESET = "\033[0m"
 COLOR_BOLD = "\033[1m"
 
-# ---------------------------------------------------------------------------
-# Core Functions
-# ---------------------------------------------------------------------------
 
-
-def load_clauses_json() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-    """Load clauses.json and return (clauses, annexures, metadata).
-
-    Returns:
-        tuple: (clauses_dict, annexures_dict, metadata_dict)
-
-    Raises:
-        FileNotFoundError: If clauses.json doesn't exist
-        json.JSONDecodeError: If clauses.json is invalid
-    """
-    if not CLAUSES_JSON.exists():
-        raise FileNotFoundError(f"Clauses database not found: {CLAUSES_JSON}")
-
-    with open(CLAUSES_JSON, encoding="utf-8") as f:
-        data = json.load(f)
-
-    return (
-        data.get("clauses", {}),
-        data.get("annexures", {}),
-        data.get("metadata", {}),
-    )
-
-
-def get_implemented_clauses() -> dict[str, list[str]]:
-    """Import IS 456 modules to populate the clause registry.
-
-    Returns:
-        dict: Inverted registry mapping clause_ref -> [func_names]
-    """
-    import importlib
-    import warnings
-
-    # Suppress warnings during import
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-
-        # Import traceability module directly (avoids full structural_lib import)
-        traceability = importlib.import_module(
-            "structural_lib.codes.is456.traceability"
-        )
-
-        # Import all IS 456 modules to trigger @clause() decorators
-        # This populates _CLAUSE_REGISTRY in traceability.py
-        modules_to_import = [
-            # Top-level modules
-            "structural_lib.codes.is456.flexure",
-            "structural_lib.codes.is456.shear",
-            "structural_lib.codes.is456.detailing",
-            "structural_lib.codes.is456.torsion",
-            "structural_lib.codes.is456.serviceability",
-            "structural_lib.codes.is456.materials",
-            "structural_lib.codes.is456.slenderness",
-            "structural_lib.codes.is456.compliance",
-            # Beam submodules
-            "structural_lib.codes.is456.beam.flexure",
-            "structural_lib.codes.is456.beam.shear",
-            "structural_lib.codes.is456.beam.detailing",
-            "structural_lib.codes.is456.beam.serviceability",
-            "structural_lib.codes.is456.beam.torsion",
-            # Column submodules
-            "structural_lib.codes.is456.column.axial",
-            "structural_lib.codes.is456.column.uniaxial",
-            "structural_lib.codes.is456.column.biaxial",
-            "structural_lib.codes.is456.column.slenderness",
-        ]
-
-        for module_name in modules_to_import:
-            try:
-                importlib.import_module(module_name)
-            except (ImportError, AttributeError, KeyError):
-                # Module might not exist yet or have missing dependencies - that's OK
-                pass
-
-    # Get the registry: {func_qualname: [clause_refs]}
-    registry = traceability.get_all_registered_functions()
-
-    # Invert it: {clause_ref: [func_names]}
-    inverted: dict[str, list[str]] = defaultdict(list)
-    for func_name, clause_refs in registry.items():
-        for ref in clause_refs:
-            inverted[ref].append(func_name)
-
-    return dict(inverted)
-
-
-def build_coverage_matrix(
-    all_clauses: dict[str, Any],
-    annexures: dict[str, Any],
-    implemented: dict[str, list[str]],
+def _selected_standards(
+    manifest: dict[str, Any], selector: str | None
 ) -> list[dict[str, Any]]:
-    """Build coverage matrix: which clauses are implemented.
-
-    Args:
-        all_clauses: Dict of clause_id -> clause_info from clauses.json
-        annexures: Dict of annexure_id -> annexure_info from clauses.json
-        implemented: Dict of clause_ref -> [func_names]
-
-    Returns:
-        List of dicts with coverage info for each clause
-    """
-    results = []
-
-    # Process regular clauses
-    for clause_id, info in all_clauses.items():
-        functions = implemented.get(clause_id, [])
-        results.append(
-            {
-                "clause": clause_id,
-                "title": info.get("title", ""),
-                "category": info.get("category", "unknown"),
-                "section": info.get("section", ""),
-                "implemented": len(functions) > 0,
-                "functions": functions,
-                "type": "clause",
-            }
-        )
-
-    # Process annexures
-    for annex_id, info in annexures.items():
-        functions = implemented.get(annex_id, [])
-        # Check both with and without "Annex " prefix
-        if not functions and annex_id.startswith("G-"):
-            functions = implemented.get(f"Annex {annex_id}", [])
-        results.append(
-            {
-                "clause": f"Annex {annex_id}",
-                "title": info.get("title", ""),
-                "category": "annexure",
-                "section": info.get("section", "Annexures"),
-                "implemented": len(functions) > 0,
-                "functions": functions,
-                "type": "annexure",
-            }
-        )
-
-    return results
+    standards = manifest["standards"]
+    if selector is None:
+        return standards
+    normalized = selector.replace(" ", "").upper()
+    selected = [
+        standard
+        for standard in standards
+        if normalized
+        in {
+            standard["standard_id"].replace(" ", "").upper(),
+            standard["namespace"].replace(" ", "").upper(),
+        }
+    ]
+    if not selected:
+        available = ", ".join(item["namespace"] for item in standards)
+        raise ValueError(f"Unknown standard {selector!r}; available: {available}")
+    return selected
 
 
-def group_by_category(matrix: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
-    """Group coverage matrix by category.
-
-    Args:
-        matrix: Coverage matrix from build_coverage_matrix()
-
-    Returns:
-        Dict mapping category -> list of clause entries
-    """
-    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    for entry in matrix:
-        category = entry["category"]
-        grouped[category].append(entry)
-    return dict(grouped)
-
-
-# ---------------------------------------------------------------------------
-# Output Formatters
-# ---------------------------------------------------------------------------
-
-
-def format_summary(matrix: list[dict[str, Any]], metadata: dict[str, Any]) -> str:
-    """Format summary statistics only."""
-    total = len(matrix)
-    implemented = sum(1 for item in matrix if item["implemented"])
-    gaps = total - implemented
-    pct = round(implemented / total * 100, 1) if total > 0 else 0
-
-    return f"""{implemented}/{total} clauses implemented ({pct}%)
-Gaps: {gaps}"""
+def _filtered_references(
+    standard: dict[str, Any],
+    *,
+    discrepancies_only: bool = False,
+    registered_only: bool = False,
+    category: str | None = None,
+) -> list[dict[str, Any]]:
+    references = standard["references"]
+    if discrepancies_only:
+        references = [
+            item for item in references if item["registration_status"] != "REGISTERED"
+        ]
+    if registered_only:
+        references = [
+            item for item in references if item["registration_status"] == "REGISTERED"
+        ]
+    if category:
+        references = [item for item in references if item["category"] == category]
+    return references
 
 
-def format_json_output(matrix: list[dict[str, Any]], metadata: dict[str, Any]) -> str:
-    """Format full JSON output."""
-    total = len(matrix)
-    implemented = sum(1 for item in matrix if item["implemented"])
-
-    output = {
-        "metadata": metadata,
-        "summary": {
-            "total_clauses": total,
-            "implemented": implemented,
-            "gaps": total - implemented,
-            "coverage_pct": round(implemented / total * 100, 1) if total > 0 else 0,
-        },
-        "clauses": matrix,
+def _aggregate_summary(standards: list[dict[str, Any]]) -> dict[str, Any]:
+    known = sum(item["registration_summary"]["known_references"] for item in standards)
+    registered = sum(
+        item["registration_summary"]["registered_known_references"]
+        for item in standards
+    )
+    metadata_only = sum(
+        item["registration_summary"]["metadata_only_references"]
+        for item in standards
+    )
+    registration_only = sum(
+        item["registration_summary"]["registration_only_references"]
+        for item in standards
+    )
+    return {
+        "known_references": known,
+        "registered_known_references": registered,
+        "metadata_only_references": metadata_only,
+        "registration_only_references": registration_only,
+        "registration_pct": round(registered / known * 100, 1) if known else None,
     }
 
-    return json.dumps(output, indent=2, ensure_ascii=False)
 
-
-def format_detailed_report(
-    matrix: list[dict[str, Any]],
-    metadata: dict[str, Any],
-    gaps_only: bool = False,
-    implemented_only: bool = False,
-    filter_category: str | None = None,
-) -> str:
-    """Format detailed coverage report.
-
-    Args:
-        matrix: Coverage matrix
-        metadata: Metadata from clauses.json
-        gaps_only: Only show unimplemented clauses
-        implemented_only: Only show implemented clauses
-        filter_category: Filter by category (e.g., "flexure", "shear")
-
-    Returns:
-        Formatted report string
-    """
-    # Apply filters
-    filtered = matrix
-    if gaps_only:
-        filtered = [item for item in filtered if not item["implemented"]]
-    if implemented_only:
-        filtered = [item for item in filtered if item["implemented"]]
-    if filter_category:
-        filtered = [item for item in filtered if item["category"] == filter_category]
-
-    # Group by category
-    grouped = group_by_category(filtered)
-
-    # Calculate statistics
-    total = len(matrix)
-    implemented_count = sum(1 for item in matrix if item["implemented"])
-    gaps_count = total - implemented_count
-    pct = round(implemented_count / total * 100, 1) if total > 0 else 0
-
-    # Build report
-    lines = []
-    lines.append(f"{COLOR_BOLD}IS 456:2000 Clause Coverage Report{COLOR_RESET}")
-    lines.append("═" * 70)
-    lines.append(f"Total Clauses:     {total}")
-    lines.append(
-        f"Implemented:       {COLOR_GREEN}{implemented_count}{COLOR_RESET} ({pct}%)"
-    )
-    lines.append(
-        f"Gaps:              {COLOR_RED}{gaps_count}{COLOR_RESET} ({100 - pct}%)"
-    )
-    lines.append(f"Standard:          {metadata.get('title', 'IS 456:2000')}")
-    lines.append(f"Version:           {metadata.get('version', 'Unknown')}")
-    lines.append("")
-
-    # Show by category
-    lines.append(f"{COLOR_BOLD}Coverage by Category{COLOR_RESET}")
-    lines.append("─" * 70)
-
-    # Sort categories by coverage percentage (descending)
-    category_stats = []
-    for category in sorted(grouped.keys()):
-        items = grouped[category]
-        cat_total = len(items)
-        cat_impl = sum(1 for item in items if item["implemented"])
-        cat_pct = round(cat_impl / cat_total * 100) if cat_total > 0 else 0
-        category_stats.append((category, cat_impl, cat_total, cat_pct, items))
-
-    category_stats.sort(key=lambda x: x[3], reverse=True)
-
-    for category, cat_impl, cat_total, cat_pct, items in category_stats:
-        # Progress bar
-        bar_width = 16
-        filled = int(round(cat_pct / 100 * bar_width))
-        bar = "█" * filled + "░" * (bar_width - filled)
-
-        # Status emoji
-        if cat_pct == 100:
-            status = f"{COLOR_GREEN}✅{COLOR_RESET}"
-        elif cat_pct >= 50:
-            status = f"{COLOR_YELLOW}🟡{COLOR_RESET}"
-        else:
-            status = f"{COLOR_RED}🔴{COLOR_RESET}"
-
-        lines.append(
-            f"{category:15s} {cat_impl:3d}/{cat_total:<3d}  {bar}  {cat_pct:3d}%  {status}"
+def build_report(
+    manifest: dict[str, Any],
+    *,
+    standard_selector: str | None = None,
+    discrepancies_only: bool = False,
+    registered_only: bool = False,
+    category: str | None = None,
+) -> dict[str, Any]:
+    """Build the machine-readable registration report."""
+    standards = _selected_standards(manifest, standard_selector)
+    report_standards = []
+    for standard in standards:
+        report_standards.append(
+            {
+                "standard_id": standard["standard_id"],
+                "namespace": standard["namespace"],
+                "edition": standard["edition"],
+                "summary": standard["registration_summary"],
+                "references": _filtered_references(
+                    standard,
+                    discrepancies_only=discrepancies_only,
+                    registered_only=registered_only,
+                    category=category,
+                ),
+            }
         )
+    return {
+        "schema_version": manifest["schema_version"],
+        "report_kind": "STANDARD_REFERENCE_DECORATOR_REGISTRATION",
+        "claim_boundary": manifest["claim_boundaries"]["registration_status"],
+        "summary": _aggregate_summary(standards),
+        "standards": report_standards,
+    }
 
-        # Show gaps for this category if not 100%
-        if cat_pct < 100 and not implemented_only:
-            gaps = [item for item in items if not item["implemented"]]
-            if gaps and len(gaps) <= 5:  # Only show first 5 gaps
-                for gap in gaps[:5]:
-                    lines.append(
-                        f"  {COLOR_RED}Gap{COLOR_RESET}: {gap['clause']} — {gap['title']}"
-                    )
-            elif gaps:
-                lines.append(
-                    f"  {COLOR_RED}Gap{COLOR_RESET}: {len(gaps)} clauses unimplemented"
-                )
 
-    lines.append("")
-
-    # Show implemented clauses with functions (if not gaps_only)
-    if not gaps_only and implemented_only or (not gaps_only and not filter_category):
-        lines.append(f"{COLOR_BOLD}Implemented Clauses with Functions{COLOR_RESET}")
-        lines.append("─" * 70)
-
-        impl_items = [item for item in matrix if item["implemented"]]
-        # Sort by clause ID
-        impl_items.sort(key=lambda x: x["clause"])
-
-        for item in impl_items[:20]:  # Show first 20
-            funcs_str = ", ".join(item["functions"][:3])  # Show max 3 funcs
-            if len(item["functions"]) > 3:
-                funcs_str += f" (+{len(item['functions']) - 3} more)"
-            lines.append(f"{item['clause']:10s} → {funcs_str}")
-
-        if len(impl_items) > 20:
-            lines.append(f"\n... and {len(impl_items) - 20} more implemented clauses")
-
-    # Show gaps detail if requested
-    if gaps_only:
-        lines.append(f"{COLOR_BOLD}Unimplemented Clauses{COLOR_RESET}")
-        lines.append("─" * 70)
-
-        gaps = [item for item in filtered if not item["implemented"]]
-        gaps.sort(key=lambda x: (x["category"], x["clause"]))
-
-        current_category = None
-        for gap in gaps:
-            if gap["category"] != current_category:
-                current_category = gap["category"]
-                lines.append(f"\n{COLOR_BLUE}{current_category.upper()}{COLOR_RESET}")
-            lines.append(f"  {gap['clause']:10s} — {gap['title']}")
-
+def format_summary(report: dict[str, Any]) -> str:
+    """Format compact, explicitly bounded registration statistics."""
+    lines = [report["claim_boundary"]]
+    for standard in report["standards"]:
+        summary = standard["summary"]
+        pct = summary["registration_pct"]
+        pct_text = "not applicable" if pct is None else f"{pct}%"
+        lines.append(
+            f"{standard['namespace']}: "
+            f"{summary['registered_known_references']}/"
+            f"{summary['known_references']} known references registered ({pct_text}); "
+            f"metadata-only={summary['metadata_only_references']}; "
+            f"registration-only={summary['registration_only_references']}"
+        )
     return "\n".join(lines)
 
 
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
+def format_json_output(report: dict[str, Any]) -> str:
+    """Format the complete report as JSON."""
+    return json.dumps(report, indent=2, ensure_ascii=False)
+
+
+def _status_color(status: str) -> str:
+    if status == "REGISTERED":
+        return COLOR_GREEN
+    if status == "REGISTRATION_ONLY":
+        return COLOR_BLUE
+    return COLOR_YELLOW
+
+
+def format_detailed_report(report: dict[str, Any]) -> str:
+    """Format a detailed report without calling registrations implemented."""
+    lines = [
+        f"{COLOR_BOLD}Indian-code Reference Registration Report{COLOR_RESET}",
+        "═" * 78,
+        report["claim_boundary"],
+        "",
+    ]
+    for standard in report["standards"]:
+        summary = standard["summary"]
+        pct = summary["registration_pct"]
+        pct_text = "not applicable" if pct is None else f"{pct}%"
+        lines.extend(
+            [
+                f"{COLOR_BOLD}{standard['namespace']}{COLOR_RESET}",
+                f"Known references:       {summary['known_references']}",
+                f"Registered known:       {COLOR_GREEN}{summary['registered_known_references']}{COLOR_RESET} ({pct_text})",
+                f"Metadata only:          {COLOR_YELLOW}{summary['metadata_only_references']}{COLOR_RESET}",
+                f"Registration only:      {COLOR_BLUE}{summary['registration_only_references']}{COLOR_RESET}",
+            ]
+        )
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for reference in standard["references"]:
+            grouped[reference["category"]].append(reference)
+        for category in sorted(grouped):
+            lines.append(f"\n  {category}")
+            for reference in grouped[category]:
+                status = reference["registration_status"]
+                functions = ", ".join(reference["functions"][:2])
+                if len(reference["functions"]) > 2:
+                    functions += f" (+{len(reference['functions']) - 2} more)"
+                suffix = f" -> {functions}" if functions else ""
+                lines.append(
+                    f"    {_status_color(status)}{status:17s}{COLOR_RESET} "
+                    f"{reference['reference_id']}{suffix}"
+                )
+        lines.append("")
+    return "\n".join(lines).rstrip()
 
 
 def main() -> int:
-    """Main entry point."""
     parser = argparse.ArgumentParser(
-        description="IS 456 clause coverage gap detection",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  %(prog)s                          # Full detailed report
-  %(prog)s --gaps-only              # Only show unimplemented clauses
-  %(prog)s --implemented            # Only show implemented clauses
-  %(prog)s --category flexure       # Filter by category
-  %(prog)s --json                   # JSON output
-  %(prog)s --summary                # Summary stats only
-        """,
+        description="Standard-namespaced decorator registration report"
     )
-
-    parser.add_argument(
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument(
         "--gaps-only",
         action="store_true",
-        help="Only show unimplemented clauses",
+        help="Show metadata-only and registration-only discrepancies",
     )
-    parser.add_argument(
+    selection.add_argument(
+        "--registered",
+        action="store_true",
+        help="Show only registered known references",
+    )
+    selection.add_argument(
         "--implemented",
         action="store_true",
-        help="Only show implemented clauses",
+        help="Deprecated alias for --registered; registration is not implementation",
     )
-    parser.add_argument(
-        "--category",
-        type=str,
-        help="Filter by category (e.g., flexure, shear, columns)",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output in JSON format",
-    )
-    parser.add_argument(
-        "--summary",
-        action="store_true",
-        help="Show only summary statistics",
-    )
-
+    parser.add_argument("--standard", help="Standard id or namespace")
+    parser.add_argument("--category", help="Filter displayed references by category")
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    parser.add_argument("--summary", action="store_true", help="Show summary only")
     args = parser.parse_args()
 
-    # Validate arguments
-    if args.gaps_only and args.implemented:
-        print(
-            "Error: --gaps-only and --implemented are mutually exclusive",
-            file=sys.stderr,
-        )
-        return 2
-
     try:
-        # Load data
-        clauses, annexures, metadata = load_clauses_json()
-        implemented = get_implemented_clauses()
-
-        # Build coverage matrix
-        matrix = build_coverage_matrix(clauses, annexures, implemented)
-
-        # Generate output
-        if args.json:
-            print(format_json_output(matrix, metadata))
-        elif args.summary:
-            print(format_summary(matrix, metadata))
-        else:
-            report = format_detailed_report(
-                matrix,
-                metadata,
-                gaps_only=args.gaps_only,
-                implemented_only=args.implemented,
-                filter_category=args.category,
-            )
-            print(report)
-
-        return 0
-
-    except FileNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        report = build_report(
+            load_manifest(),
+            standard_selector=args.standard,
+            discrepancies_only=args.gaps_only,
+            registered_only=args.registered or args.implemented,
+            category=args.category,
+        )
+    except (OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         return 1
-    except json.JSONDecodeError as e:
-        print(f"Error parsing clauses.json: {e}", file=sys.stderr)
-        return 1
-    except Exception as e:
-        print(f"Unexpected error: {e}", file=sys.stderr)
-        import traceback
 
-        traceback.print_exc()
-        return 1
+    if args.json:
+        print(format_json_output(report))
+    elif args.summary:
+        print(format_summary(report))
+    else:
+        print(format_detailed_report(report))
+    return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/scripts/generate_indian_code_manifest.py
+++ b/scripts/generate_indian_code_manifest.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Generate or verify the INDIA-0 Indian-code truth manifest."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from _lib.indian_code_manifest import MANIFEST_PATH, render_manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate the standard-namespaced Indian-code capability and registration manifest"
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="Write the canonical manifest")
+    mode.add_argument("--check", action="store_true", help="Fail if the committed manifest is stale")
+    args = parser.parse_args()
+
+    rendered = render_manifest()
+    if args.write:
+        MANIFEST_PATH.write_text(rendered, encoding="utf-8")
+        print(f"Wrote {MANIFEST_PATH}")
+        return 0
+    if args.check:
+        if not MANIFEST_PATH.exists() or MANIFEST_PATH.read_text(encoding="utf-8") != rendered:
+            print(
+                "Indian-code manifest is stale; run "
+                "./scripts/python_runtime.sh scripts/generate_indian_code_manifest.py --write",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Indian-code manifest is current: {MANIFEST_PATH}")
+        return 0
+
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3,7 +3,7 @@
   "type": "python-package",
   "description": "> Development, validation, discovery, release-preparation, and maintenance tools.",
   "last_updated": "2026-08-15",
-  "file_count": 110,
+  "file_count": 111,
   "files": [
     {
       "name": "README.md",
@@ -912,7 +912,7 @@
         "_coverage",
         "tasks"
       ],
-      "content_hash": "509c9fc38593"
+      "content_hash": "f007b5052439"
     },
     {
       "name": "batch_migrate_runner.py",
@@ -1380,78 +1380,50 @@
     {
       "name": "check_clause_coverage.py",
       "type": "python",
-      "size_lines": 488,
+      "size_lines": 254,
       "last_updated": "2026-08-15",
-      "description": "IS 456 clause coverage gap detection.",
+      "description": "Report standard-namespaced clause/reference decorator registration.",
       "functions": [
         {
-          "name": "load_clauses_json",
-          "description": "Load clauses.json and return (clauses, annexures, metadata)."
-        },
-        {
-          "name": "get_implemented_clauses",
-          "description": "Import IS 456 modules to populate the clause registry."
-        },
-        {
-          "name": "build_coverage_matrix",
-          "description": "Build coverage matrix: which clauses are implemented.",
+          "name": "build_report",
+          "description": "Build the machine-readable registration report.",
           "params": [
-            "all_clauses",
-            "annexures",
-            "implemented"
-          ]
-        },
-        {
-          "name": "group_by_category",
-          "description": "Group coverage matrix by category.",
-          "params": [
-            "matrix"
+            "manifest"
           ]
         },
         {
           "name": "format_summary",
-          "description": "Format summary statistics only.",
+          "description": "Format compact, explicitly bounded registration statistics.",
           "params": [
-            "matrix",
-            "metadata"
+            "report"
           ]
         },
         {
           "name": "format_json_output",
-          "description": "Format full JSON output.",
+          "description": "Format the complete report as JSON.",
           "params": [
-            "matrix",
-            "metadata"
+            "report"
           ]
         },
         {
           "name": "format_detailed_report",
-          "description": "Format detailed coverage report.",
+          "description": "Format a detailed report without calling registrations implemented.",
           "params": [
-            "matrix",
-            "metadata",
-            "gaps_only",
-            "implemented_only",
-            "filter_category"
+            "report"
           ]
         },
         {
-          "name": "main",
-          "description": "Main entry point."
+          "name": "main"
         }
       ],
       "constants": [
-        "SCRIPT_DIR",
-        "REPO_ROOT",
-        "CLAUSES_JSON",
         "COLOR_GREEN",
         "COLOR_YELLOW",
-        "COLOR_RED",
         "COLOR_BLUE",
         "COLOR_RESET",
         "COLOR_BOLD"
       ],
-      "content_hash": "528bd8b95fd0"
+      "content_hash": "1f1586c50401"
     },
     {
       "name": "check_cli_reference.py",
@@ -3407,6 +3379,19 @@
       "content_hash": "47a4073cd002"
     },
     {
+      "name": "generate_indian_code_manifest.py",
+      "type": "python",
+      "size_lines": 43,
+      "last_updated": "2026-08-15",
+      "description": "Generate or verify the INDIA-0 Indian-code truth manifest.",
+      "functions": [
+        {
+          "name": "main"
+        }
+      ],
+      "content_hash": "3cc4c8550d72"
+    },
+    {
       "name": "git_handoff_receipt.py",
       "type": "python",
       "size_lines": 573,
@@ -3808,13 +3793,13 @@
     {
       "name": "parity_dashboard.py",
       "type": "python",
-      "size_lines": 519,
+      "size_lines": 466,
       "last_updated": "2026-08-15",
-      "description": "Parity Dashboard — coverage/parity across IS 456, API, endpoints, and React hooks.",
+      "description": "Parity dashboard across declared Indian-code scope and application layers.",
       "functions": [
         {
           "name": "check_clause_coverage",
-          "description": "Dimension 1: IS 456 clause coverage."
+          "description": "Dimension 1: declared Indian-code capability-family coverage."
         },
         {
           "name": "check_api_endpoint_coverage",
@@ -3839,14 +3824,13 @@
       "constants": [
         "SCRIPT_DIR",
         "REPO_ROOT",
-        "IS456_DIR",
         "API_PY",
         "ROUTERS_DIR",
         "FASTAPI_TESTS",
         "HOOKS_DIR",
         "LOCAL_ONLY_HOOKS"
       ],
-      "content_hash": "447d5ea2c617"
+      "content_hash": "d1c93075f774"
     },
     {
       "name": "pipeline_state.py",
@@ -5538,5 +5522,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "3c741ce61e0e0c75"
+  "content_hash": "73dac58404929a1f"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -4,7 +4,7 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-15
-**Files:** 110
+**Files:** 111
 
 ## Config Files
 
@@ -41,7 +41,7 @@
 | [check_architecture_boundaries.py](check_architecture_boundaries.py) | Architecture Boundary Linter. | 3 | 9 | 495 |
 | [check_bootstrap_freshness.py](check_bootstrap_freshness.py) | Check if bootstrap docs are stale compared to actual codebas | 0 | 4 | 290 |
 | [check_circular_imports.py](check_circular_imports.py) | Circular Import Detector for the Python Structural Library | 5 | 1 | 464 |
-| [check_clause_coverage.py](check_clause_coverage.py) | IS 456 clause coverage gap detection. | 0 | 8 | 488 |
+| [check_clause_coverage.py](check_clause_coverage.py) | Report standard-namespaced clause/reference decorator regist | 0 | 5 | 254 |
 | [check_cli_reference.py](check_cli_reference.py) | Ensure CLI reference includes required commands. | 0 | 1 | 48 |
 | [check_codex_git_workflow.py](check_codex_git_workflow.py) | Guard the Codex-native Git/GitHub workflow contract. | 0 | 3 | 638 |
 | [check_doc_versions.py](check_doc_versions.py) | Doc Version Drift Check — Validate no stale *library* versio | 0 | 2 | 72 |
@@ -81,6 +81,7 @@
 | [generate_docs_index.py](generate_docs_index.py) | Generate machine-readable JSON index of documentation. | 0 | 7 | 246 |
 | [generate_enhanced_index.py](generate_enhanced_index.py) | Generate enhanced index.json + index.md for ANY folder type. | 0 | 11 | 866 |
 | [generate_error_docs.py](generate_error_docs.py) | Generate docs/reference/error-codes.md from core/errors.py. | 0 | 4 | 139 |
+| [generate_indian_code_manifest.py](generate_indian_code_manifest.py) | Generate or verify the INDIA-0 Indian-code truth manifest. | 0 | 1 | 43 |
 | [git_handoff_receipt.py](git_handoff_receipt.py) | Build and validate fail-closed task-to-Git handoff receipts. | 0 | 4 | 573 |
 | [git_state.py](git_state.py) | Read-only, worktree-aware Git state authority. | 5 | 5 | 1004 |
 | [governance_health_score.py](governance_health_score.py) | Governance Health Score - TASK-289 | 3 | 1 | 515 |
@@ -88,7 +89,7 @@
 | [migrate_react_component.py](migrate_react_component.py) | Migrate a React component to a new feature-grouped folder. | 0 | 9 | 475 |
 | [model_picker.py](model_picker.py) | Recommend a supported model and reasoning effort for a repos | 1 | 2 | 305 |
 | [node_runtime.py](node_runtime.py) | Select and run the healthy Node.js major pinned by ``.nvmrc` | 0 | 4 | 205 |
-| [parity_dashboard.py](parity_dashboard.py) | Parity Dashboard — coverage/parity across IS 456, API, endpo | 0 | 6 | 519 |
+| [parity_dashboard.py](parity_dashboard.py) | Parity dashboard across declared Indian-code scope and appli | 0 | 6 | 466 |
 | [pipeline_state.py](pipeline_state.py) | Pipeline state tracking for multi-step agent workflows. | 2 | 17 | 868 |
 | [preflight.py](preflight.py) | Pre-flight check — catch common mistakes BEFORE they happen. | 0 | 9 | 203 |
 | [project_health.py](project_health.py) | Unified project health scanner with auto-fix capability. | 3 | 9 | 908 |

--- a/scripts/parity_dashboard.py
+++ b/scripts/parity_dashboard.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
-"""Parity Dashboard — coverage/parity across IS 456, API, endpoints, and React hooks.
+"""Parity dashboard across declared Indian-code scope and application layers.
 
-Scans actual source files to measure four parity dimensions:
-  1. IS 456 Clause Coverage — implemented vs known clauses
+Uses the generated INDIA-0 manifest and source scans for four dimensions:
+  1. Declared Indian-code capability families — supported vs explicitly held
   2. API → Endpoint Coverage — library functions with FastAPI routes
   3. Endpoint → Test Coverage — FastAPI endpoints with tests
   4. React Hook → API Coverage — hooks connected to API endpoints
+
+Capability-family percentages are planning indicators only. They are not
+clause coverage, whole-standard completeness, or engineering approval.
 
 When to use: after cross-layer API changes or before parity planning and release review.
 
 Usage:
     ./scripts/python_runtime.sh scripts/parity_dashboard.py
     ./scripts/python_runtime.sh scripts/parity_dashboard.py --json
-    ./scripts/python_runtime.sh scripts/parity_dashboard.py --section clauses
+    ./scripts/python_runtime.sh scripts/parity_dashboard.py --section capabilities
     ./scripts/python_runtime.sh scripts/parity_dashboard.py --missing
 """
 
@@ -27,94 +30,19 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from _lib.indian_code_manifest import load_manifest
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
-IS456_DIR = REPO_ROOT / "Python" / "structural_lib" / "codes" / "is456"
 API_PY = REPO_ROOT / "Python" / "structural_lib" / "services" / "api.py"
 ROUTERS_DIR = REPO_ROOT / "fastapi_app" / "routers"
 FASTAPI_TESTS = REPO_ROOT / "fastapi_app" / "tests"
 HOOKS_DIR = REPO_ROOT / "react_app" / "src" / "hooks"
 LOCAL_ONLY_HOOKS = {"useReducedMotion", "useWebGLContextLoss"}
-
-# ---------------------------------------------------------------------------
-# IS 456 Clause Reference
-# ---------------------------------------------------------------------------
-
-IS456_CLAUSES: dict[str, dict[str, str]] = {
-    "Cl 38.1": {
-        "desc": "Flexural design",
-        "status": "implemented",
-        "module": "flexure.py",
-    },
-    "Cl 40": {"desc": "Shear design", "status": "implemented", "module": "shear.py"},
-    "Cl 26.5.1": {
-        "desc": "Detailing - spacing",
-        "status": "implemented",
-        "module": "detailing.py",
-    },
-    "Cl 41": {"desc": "Torsion", "status": "implemented", "module": "torsion.py"},
-    "Cl 43": {
-        "desc": "Serviceability",
-        "status": "implemented",
-        "module": "serviceability.py",
-    },
-    "Cl 25.4": {
-        "desc": "Effective length columns",
-        "status": "implemented",
-        "module": "column/axial.py",
-    },
-    "Cl 39.3": {
-        "desc": "Short column axial",
-        "status": "implemented",
-        "module": "column/axial.py",
-    },
-    "Cl 39.5": {
-        "desc": "Uniaxial bending",
-        "status": "implemented",
-        "module": "column/uniaxial.py",
-    },
-    "Cl 39.6": {
-        "desc": "Biaxial bending",
-        "status": "implemented",
-        "module": "column/biaxial.py",
-    },
-    "Cl 39.7.1": {
-        "desc": "Additional moment slender",
-        "status": "implemented",
-        "module": "column/slenderness.py",
-    },
-    "Cl 24": {"desc": "Slab design", "status": "planned"},
-    "Annex D": {"desc": "Two-way slab coefficients", "status": "planned"},
-    "Cl 34": {
-        "desc": "Footing design",
-        "status": "implemented",
-        "module": "footing/bearing.py",
-    },
-    "Cl 31.6": {
-        "desc": "Punching shear",
-        "status": "implemented",
-        "module": "footing/punching_shear.py",
-    },
-    "Cl 42": {
-        "desc": "Development length",
-        "status": "implemented",
-        "module": "detailing.py",
-    },
-    "Cl 26.2": {
-        "desc": "Min reinforcement",
-        "status": "implemented",
-        "module": "detailing.py",
-    },
-    "Cl 23.2": {
-        "desc": "Deflection control",
-        "status": "implemented",
-        "module": "serviceability.py",
-    },
-}
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -205,38 +133,41 @@ def _scan_hooks(hooks_dir: Path) -> list[str]:
 
 
 def check_clause_coverage() -> dict[str, Any]:
-    """Dimension 1: IS 456 clause coverage."""
-    implemented = []
-    planned = []
-    verified: list[dict[str, Any]] = []
+    """Dimension 1: declared Indian-code capability-family coverage.
 
-    for clause, info in IS456_CLAUSES.items():
-        entry: dict[str, Any] = {
-            "clause": clause,
-            "desc": info["desc"],
-            "status": info["status"],
+    The historical function name remains as a compatibility shim for callers;
+    the returned metric is explicitly not clause coverage.
+    """
+    manifest = load_manifest()
+    summary = manifest["capability_summary"]
+    items = [
+        {
+            "capability_id": family["capability_id"],
+            "standard": standard["namespace"],
+            "family": family["family"],
+            "scope_status": family["scope_status"],
+            "implementation_status": family["implementation_status"],
+            "claim": family["claim"],
         }
-        if info["status"] == "implemented":
-            module_path = IS456_DIR / info.get("module", "")
-            entry["file_exists"] = module_path.is_file()
-            if module_path.is_file():
-                implemented.append(clause)
-            else:
-                entry["status"] = "missing_file"
-                planned.append(clause)
-        else:
-            planned.append(clause)
-        verified.append(entry)
-
-    total = len(IS456_CLAUSES)
-    impl_count = len(implemented)
+        for standard in manifest["standards"]
+        for family in standard["capability_families"]
+    ]
     return {
-        "name": "IS 456 Clause Coverage",
-        "implemented": impl_count,
-        "planned": len(planned),
-        "total": total,
-        "pct": round(impl_count / total * 100) if total else 0,
-        "items": verified,
+        "name": "Declared Indian-code Capability Families",
+        "metric_kind": "DECLARED_CAPABILITY_FAMILY_COVERAGE",
+        "claim_boundary": manifest["claim_boundaries"]["capability_status"],
+        "informational": True,
+        "gap_label": "Held (declared)",
+        "supported": summary["supported_families"],
+        "held": summary["held_families"],
+        "total": summary["total_declared_families"],
+        "pct": round(summary["supported_pct"]),
+        "items": items,
+        "missing_items": [
+            f"{item['capability_id']}: {item['claim']}"
+            for item in items
+            if item["scope_status"] == "HELD"
+        ],
     }
 
 
@@ -382,7 +313,10 @@ def _print_section(data: dict[str, Any], *, show_missing: bool = False) -> None:
     total = data["total"]
 
     # Determine numerator key
-    if "implemented" in data:
+    if "supported" in data:
+        num = data["supported"]
+        label1 = "Supported"
+    elif "implemented" in data:
         num = data["implemented"]
         label1 = "Implemented"
     elif "covered" in data:
@@ -399,13 +333,17 @@ def _print_section(data: dict[str, Any], *, show_missing: bool = False) -> None:
         label1 = "Done"
 
     gap = data.get(
-        "missing", data.get("planned", data.get("library_only", total - num))
+        "missing",
+        data.get("held", data.get("planned", data.get("library_only", total - num))),
     )
 
     print(f"  {name}")
     print("  \u2501" * 24)
     print(f"  {label1}:{num:>5}/{total}  ({pct}%)")
-    gap_label = data.get("gap_label", "Planned" if "planned" in data else "Missing")
+    gap_label = data.get(
+        "gap_label",
+        "Held" if "held" in data else "Planned" if "planned" in data else "Missing",
+    )
     print(f"  {gap_label}:{gap:>6}/{total}  ({100 - pct}%)")
     print(f"  {_progress_bar(pct / 100)}  {pct}%")
 
@@ -413,9 +351,11 @@ def _print_section(data: dict[str, Any], *, show_missing: bool = False) -> None:
         items = data.get("missing_items", [])
         if not items and "items" in data:
             items = [
-                f"{it['clause']}: {it['desc']}"
+                f"{it.get('clause', it.get('capability_id'))}: "
+                f"{it.get('desc', it.get('claim'))}"
                 for it in data["items"]
                 if it.get("status") != "implemented"
+                and it.get("scope_status") != "SUPPORTED"
             ]
         if items:
             print()
@@ -427,14 +367,14 @@ def _print_section(data: dict[str, Any], *, show_missing: bool = False) -> None:
     print()
 
 
-def _overall_score(sections: list[dict[str, Any]]) -> int:
+def _overall_score(sections: list[dict[str, Any]]) -> int | None:
     """Average actionable parity dimensions.
 
     Informational exposure metrics are displayed but do not lower the score.
     """
     actionable = [section for section in sections if not section.get("informational")]
     if not actionable:
-        return 0
+        return None
     total_pct = sum(s["pct"] for s in actionable)
     return round(total_pct / len(actionable))
 
@@ -448,7 +388,7 @@ def run_dashboard(
     """Run all parity checks and display results."""
 
     checks = {
-        "clauses": check_clause_coverage,
+        "capabilities": check_clause_coverage,
         "api": check_api_endpoint_coverage,
         "tests": check_endpoint_test_coverage,
         "hooks": check_hook_api_coverage,
@@ -456,6 +396,8 @@ def run_dashboard(
 
     if section_filter:
         key = section_filter.lower()
+        if key == "clauses":
+            key = "capabilities"
         if key not in checks:
             print(f"Unknown section: {key}. Available: {', '.join(checks.keys())}")
             return 1
@@ -469,6 +411,10 @@ def run_dashboard(
         output = {
             "sections": results,
             "overall_pct": _overall_score(results),
+            "overall_scope": (
+                "Actionable non-informational cross-layer sections only; "
+                "declared capability scope and public API exposure are excluded."
+            ),
         }
         print(json.dumps(output, indent=2))
         return 0
@@ -483,7 +429,8 @@ def run_dashboard(
 
     if len(results) > 1:
         score = _overall_score(results)
-        print(f"  Overall Parity Score: {score}%")
+        print(f"  Actionable Cross-Layer Score: {score}%")
+        print("  (Declared capability scope and API exposure are excluded.)")
     print("\u2501" * 45)
     print()
     return 0
@@ -501,7 +448,7 @@ def main() -> None:
         "--section",
         type=str,
         default=None,
-        help="Show single section: clauses, api, tests, hooks",
+        help="Show single section: capabilities, api, tests, hooks (clauses is a legacy alias)",
     )
     parser.add_argument(
         "--missing", action="store_true", help="Show only gaps/missing items"


### PR DESCRIPTION
## What changed

- add one generated, standard-namespaced Indian-code capability and registration manifest
- derive supported IS 456 families from the executable capability registry
- separate IS 456 and IS 13920 decorator registration
- repair the parity dashboard and clause-registration report
- reconcile stale task, blueprint, evidence, automation, and index records
- add deterministic manifest and consumer contract tests

## Why

The previous dashboard hard-coded slabs and Annex D as planned even though bounded slab workflows were implemented. The previous clause checker also mixed IS 13920 identifiers into an IS 456 report while discovering only IS 456 registrations. These independent status sources produced contradictory completion claims.

INDIA-0 establishes one fail-closed truth baseline before INDIA-1 extends or explicitly holds existing-family limitations.

## User and developer impact

Capability reporting now distinguishes:

- supported versus held software scope
- bounded implementation versus not implemented
- decorator registration versus metadata-only or registration-only references

These statuses are not whole-standard completeness or engineering approval. Qualified structural-engineering review remains required.

## Local verification

- focused manifest, capability, and FastAPI contracts: 15 passed
- quick repository gate: 10/10
- full repository gate: 30/30
- Ruff, mypy, Bandit, manifest freshness, generated indexes, and diff checks passed
- independent essential review: PASS
- linked-worktree runtime: source_bound=true

## Boundaries

- no release or engineering-use approval
- no expansion into INDIA-1 calculation work
- historical footing release receipt retained as point-in-time evidence
- CI and exact-head merge review remain pending
