### PR TITLE
feat(is456): add composed T-beam route

### DIFF
--- a/Python/structural_lib/__init__.py
+++ b/Python/structural_lib/__init__.py
@@ -65,6 +65,7 @@ from .services.api import (  # Audit & Verification; Input dataclasses; Calculat
     DetailingConfigInput,
     ETABSEnvelopeResult,
     ETABSForceRow,
+    FlangedBeamDesignResult,
     FootingBearingResult,
     FootingFlexureResult,
     FootingOneWayShearResult,
@@ -128,6 +129,7 @@ from .services.api import (  # Audit & Verification; Input dataclasses; Calculat
     design_complete_one_way_slab_is456,
     design_continuous_one_way_slab_builtin_is456,
     design_continuous_one_way_slab_is456,
+    design_flanged_beam_is456,
     design_from_input,
     design_long_column_is456,
     design_one_way_slab_is456,
@@ -237,6 +239,7 @@ __all__ = [
     "validate_design_results",
     # Core design functions
     "design_beam_is456",
+    "design_flanged_beam_is456",
     "check_beam_is456",
     "detail_beam_is456",
     "design_and_detail_beam_is456",
@@ -244,6 +247,7 @@ __all__ = [
     "ComplianceCaseResult",
     "ComplianceReport",
     "DesignAndDetailResult",
+    "FlangedBeamDesignResult",
     # Input dataclasses
     "BeamInput",
     "BeamGeometryInput",

--- a/Python/structural_lib/codes/is456/compliance.py
+++ b/Python/structural_lib/codes/is456/compliance.py
@@ -23,6 +23,7 @@ from enum import Enum
 from typing import Any
 
 from structural_lib.core.data_types import (
+    BeamType,
     ComplianceCaseResult,
     ComplianceReport,
     CrackWidthParams,
@@ -192,6 +193,11 @@ def check_compliance_case(
     tu_knm: float = 0.0,
     cover_mm: float | None = None,
     stirrup_dia_mm: float = 8.0,
+    # Optional flanged flexure selection.  Public callers should use the
+    # dedicated service wrapper rather than constructing these directly.
+    beam_type: BeamType = BeamType.RECTANGULAR,
+    bf_mm: float | None = None,
+    Df_mm: float | None = None,
 ) -> ComplianceCaseResult:
     """Run a single compliance case.
 
@@ -225,15 +231,39 @@ def check_compliance_case(
             "flexure and shear design."
         )
 
-    flex = flexure.design_doubly_reinforced(
-        b=b_mm,
-        d=d_mm,
-        d_dash=d_dash_mm,
-        d_total=D_mm,
-        mu_knm=design_mu_knm,
-        fck=fck_nmm2,
-        fy=fy_nmm2,
-    )
+    if beam_type == BeamType.RECTANGULAR:
+        flex = flexure.design_doubly_reinforced(
+            b=b_mm,
+            d=d_mm,
+            d_dash=d_dash_mm,
+            d_total=D_mm,
+            mu_knm=design_mu_knm,
+            fck=fck_nmm2,
+            fy=fy_nmm2,
+        )
+    elif beam_type in {BeamType.FLANGED_T, BeamType.FLANGED_L}:
+        if tu_knm > 0:
+            raise ValueError(
+                "FLANGED_TORSION_SCOPE_HOLD: the maintained torsion model is "
+                "limited to ordinary solid rectangular beams."
+            )
+        if bf_mm is None or Df_mm is None:
+            raise ValueError(
+                "bf_mm and Df_mm are required for a flanged compliance case."
+            )
+        flex = flexure.design_flanged_beam(
+            bw=b_mm,
+            bf=bf_mm,
+            d=d_mm,
+            Df=Df_mm,
+            d_total=D_mm,
+            mu_knm=design_mu_knm,
+            fck=fck_nmm2,
+            fy=fy_nmm2,
+            d_dash=d_dash_mm,
+        )
+    else:
+        raise ValueError(f"Unsupported beam_type: {beam_type!r}.")
 
     # Determine pt for shear table lookup.
     if pt_percent is None:
@@ -345,7 +375,11 @@ def check_compliance_case(
         remarks = remarks + " | " + " | ".join(assumptions)
 
     clause_refs = {
-        "flexure": "IS 456 Cl 38.1",
+        "flexure": (
+            "IS 456 Cl 38.1"
+            if beam_type == BeamType.RECTANGULAR
+            else "IS 456 Cl 23.1.2 and 38.1; Annex G"
+        ),
         "shear": "IS 456 Cl 40",
         "deflection": "IS 456 Cl 23.2",
         "crack_width": "IS 456 Cl 35.3.2",

--- a/Python/structural_lib/services/api.py
+++ b/Python/structural_lib/services/api.py
@@ -88,6 +88,7 @@ from structural_lib.services.beam_api import (  # noqa: F401
     compute_report,
     design_and_detail_beam_is456,
     design_beam_is456,
+    design_flanged_beam_is456,
     design_from_input,
     detail_beam_is456,
     enhanced_shear_strength_is456,
@@ -175,7 +176,10 @@ from structural_lib.visualization.geometry_3d import (  # noqa: F401
     compute_stirrup_positions,
 )
 
-from .api_results import DesignAndDetailResult  # noqa: F401
+from .api_results import (
+    DesignAndDetailResult,  # noqa: F401
+    FlangedBeamDesignResult,  # noqa: F401
+)
 from .audit import (  # noqa: F401
     AuditLogEntry,
     AuditTrail,
@@ -208,6 +212,8 @@ __all__ = [
     "CheckCodeReport",
     # Core design functions
     "design_beam_is456",
+    "design_flanged_beam_is456",
+    "FlangedBeamDesignResult",
     "check_beam_is456",
     "detail_beam_is456",
     "design_and_detail_beam_is456",

--- a/Python/structural_lib/services/api_results.py
+++ b/Python/structural_lib/services/api_results.py
@@ -14,7 +14,8 @@ Related:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from enum import Enum
 from typing import Any
 
 from structural_lib.core.result_base import BaseResult
@@ -22,6 +23,73 @@ from structural_lib.core.result_base import BaseResult
 # =============================================================================
 # Design and Detail Combined Result
 # =============================================================================
+
+
+@dataclass(frozen=True)
+class FlangedBeamDesignResult:
+    """Composed sagging T-beam design result for the bounded INDIA-1A route.
+
+    ``design`` contains the maintained flexure, web-shear, and optional
+    serviceability results.  The remaining fields preserve the section
+    geometry, load-case meaning, provenance, and explicit held boundaries that
+    distinguish this route from the ordinary rectangular beam workflow.
+    """
+
+    design: Any  # ComplianceCaseResult; Any avoids a service/core import cycle.
+    beam_type: str
+    moment_region: str
+    load_case_basis: str
+    bw_mm: float
+    bf_geometric_mm: float
+    bf_effective_mm: float
+    Df_mm: float
+    D_mm: float
+    d_mm: float
+    span_mm: float
+    source: str
+    clause_refs: dict[str, str]
+    assumptions: tuple[str, ...]
+    holds: tuple[str, ...]
+    is_ok: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serialization-ready result with explicit units."""
+
+        def _jsonable(value: Any) -> Any:
+            if isinstance(value, Enum):
+                return value.name
+            if isinstance(value, dict):
+                return {key: _jsonable(item) for key, item in value.items()}
+            if isinstance(value, (list, tuple)):
+                return [_jsonable(item) for item in value]
+            return value
+
+        return {
+            "design": _jsonable(asdict(self.design)),
+            "beam_type": self.beam_type,
+            "moment_region": self.moment_region,
+            "load_case_basis": self.load_case_basis,
+            "geometry": {
+                "bw_mm": self.bw_mm,
+                "bf_geometric_mm": self.bf_geometric_mm,
+                "bf_effective_mm": self.bf_effective_mm,
+                "Df_mm": self.Df_mm,
+                "D_mm": self.D_mm,
+                "d_mm": self.d_mm,
+                "span_mm": self.span_mm,
+            },
+            "explicit_units": {
+                "length": "mm",
+                "force": "kN",
+                "moment": "kN·m",
+                "stress": "N/mm²",
+            },
+            "source": self.source,
+            "clause_refs": dict(self.clause_refs),
+            "assumptions": list(self.assumptions),
+            "holds": list(self.holds),
+            "is_ok": self.is_ok,
+        }
 
 
 @dataclass

--- a/Python/structural_lib/services/beam_api.py
+++ b/Python/structural_lib/services/beam_api.py
@@ -15,10 +15,11 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from structural_lib.codes.is456 import compliance, slenderness
-from structural_lib.codes.is456.beam import detailing, serviceability
+from structural_lib.codes.is456.beam import detailing, flexure, serviceability
 from structural_lib.codes.is456.beam.shear import enhanced_shear_strength
 from structural_lib.codes.is13920 import beam as ductile
 from structural_lib.core.data_types import (
+    BeamType,
     ComplianceCaseResult,
     ComplianceReport,
     CrackWidthParams,
@@ -38,6 +39,7 @@ from .api_results import (
     CostOptimizationResult,
     DesignAndDetailResult,
     DesignSuggestionsResult,
+    FlangedBeamDesignResult,
     OptimalDesign,
     SmartAnalysisResult,
 )
@@ -1230,6 +1232,231 @@ def design_beam_is456(
         tu_knm=tu_knm,
         cover_mm=cover_mm,
         stirrup_dia_mm=stirrup_dia_mm,
+    )
+
+
+def design_flanged_beam_is456(
+    *,
+    units: str,
+    case_id: str = "CASE-1",
+    beam_type: str,
+    moment_region: str,
+    load_case_basis: str,
+    mu_knm: float,
+    vu_kn: float,
+    bw_mm: float,
+    D_mm: float,
+    d_mm: float,
+    span_mm: float,
+    flange_thickness_mm: float,
+    flange_overhang_left_mm: float,
+    flange_overhang_right_mm: float,
+    fck_nmm2: float,
+    fy_nmm2: float,
+    d_dash_mm: float = 50.0,
+    asv_mm2: float = 100.0,
+    pt_percent: float | None = None,
+    ast_mm2_for_shear: float | None = None,
+    deflection_params: DeflectionParams | None = None,
+    crack_width_params: CrackWidthParams | None = None,
+    tu_knm: float = 0.0,
+    torsion_redistribution_basis: str | None = None,
+) -> FlangedBeamDesignResult:
+    """Design one bounded sagging T-beam case per IS 456:2000.
+
+    The route composes maintained effective-flange-width, flanged-flexure,
+    web-shear, and optional Level-A serviceability calculations.  It consumes
+    already-factored actions; it does not generate or validate a load envelope.
+
+    Args:
+        units: IS 456 unit-system label.
+        case_id: Stable caller-provided case identity.
+        beam_type: Must be ``"T"`` for this benchmarked route.
+        moment_region: Must be ``"sagging"`` (flange in compression).
+        load_case_basis: ``"single_factored_case"`` or
+            ``"supplied_governing_envelope"``.
+        mu_knm: Supplied factored sagging bending moment (kN·m).
+        vu_kn: Supplied factored shear force (kN).
+        bw_mm: Web width (mm); also governs the shear-stress calculation.
+        D_mm: Overall beam depth (mm).
+        d_mm: Effective depth (mm).
+        span_mm: Effective span used for flange-width calculation (mm).
+        flange_thickness_mm: Compression flange thickness (mm).
+        flange_overhang_left_mm: Physical flange beyond the web, left (mm).
+        flange_overhang_right_mm: Physical flange beyond the web, right (mm).
+        fck_nmm2: Concrete characteristic strength (N/mm²).
+        fy_nmm2: Reinforcement yield strength (N/mm²).
+        d_dash_mm: Compression-steel depth (mm).
+        asv_mm2: Area of stirrup legs used by the shear design (mm²).
+        pt_percent: Optional tension-steel percentage for shear lookup (%).
+        ast_mm2_for_shear: Optional supplied tension steel for shear lookup (mm²).
+        deflection_params: Explicit maintained span/depth inputs, if evaluated.
+        crack_width_params: Explicit maintained Annex F inputs, if evaluated.
+        tu_knm: Must remain zero; flanged torsion is outside this route.
+        torsion_redistribution_basis: Must remain ``None``; compatibility versus
+            equilibrium redistribution is outside this route.
+
+    Returns:
+        A provenance-bearing composed result with explicit geometry and holds.
+
+    Supported boundary:
+        Monolithic T-beams in positive/sagging bending with both flange
+        overhangs present.  L-beams, hogging, hollow/box, deep, prestressed,
+        axially loaded, flanged-torsion, load-envelope generation, and composed
+        flanged detailing are excluded.
+    """
+
+    _require_is456_units(units)
+    numeric_inputs = (
+        ("mu_knm", mu_knm),
+        ("vu_kn", vu_kn),
+        ("bw_mm", bw_mm),
+        ("D_mm", D_mm),
+        ("d_mm", d_mm),
+        ("span_mm", span_mm),
+        ("flange_thickness_mm", flange_thickness_mm),
+        ("flange_overhang_left_mm", flange_overhang_left_mm),
+        ("flange_overhang_right_mm", flange_overhang_right_mm),
+        ("fck_nmm2", fck_nmm2),
+        ("fy_nmm2", fy_nmm2),
+        ("d_dash_mm", d_dash_mm),
+        ("asv_mm2", asv_mm2),
+        ("tu_knm", tu_knm),
+    )
+    for name, value in numeric_inputs:
+        _require_finite_real(name, value)
+
+    normalized_type = beam_type.strip().upper()
+    if normalized_type not in {"T", "FLANGED_T", "T_BEAM"}:
+        raise ValueError(
+            "FLANGED_SECTION_SCOPE_HOLD: INDIA-1A currently supports only "
+            "the independently benchmarked T-beam route; L-beams are held."
+        )
+    if moment_region.strip().lower() != "sagging":
+        raise ValueError(
+            "FLANGED_MOMENT_SCOPE_HOLD: the flange must be in compression; "
+            "hogging/flange-in-tension cases are held."
+        )
+    normalized_basis = load_case_basis.strip().lower()
+    allowed_bases = {"single_factored_case", "supplied_governing_envelope"}
+    if normalized_basis not in allowed_bases:
+        raise ValueError(
+            "LOAD_ENVELOPE_SCOPE_HOLD: provide already-factored actions as "
+            "single_factored_case or supplied_governing_envelope; this route "
+            "does not generate a load envelope."
+        )
+    if tu_knm != 0:
+        raise ValueError(
+            "FLANGED_TORSION_SCOPE_HOLD: the maintained torsion model is "
+            "limited to ordinary solid rectangular beams."
+        )
+    if torsion_redistribution_basis is not None:
+        raise ValueError(
+            "TORSION_REDISTRIBUTION_SCOPE_HOLD: compatibility-versus-equilibrium "
+            "torsion redistribution is outside this route."
+        )
+    if mu_knm < 0 or vu_kn < 0:
+        raise ValueError("mu_knm and vu_kn must be non-negative supplied actions.")
+    if flange_overhang_left_mm <= 0 or flange_overhang_right_mm <= 0:
+        raise ValueError(
+            "FLANGED_SECTION_SCOPE_HOLD: a T-beam requires positive flange "
+            "overhangs on both sides of the web."
+        )
+
+    _validate_plausibility(
+        fck_nmm2=fck_nmm2,
+        fy_nmm2=fy_nmm2,
+        b_mm=bw_mm,
+        d_mm=d_mm,
+        D_mm=D_mm,
+        mu_knm=mu_knm,
+        vu_kn=vu_kn,
+        d_dash_mm=d_dash_mm,
+        asv_mm2=asv_mm2,
+        pt_percent=pt_percent,
+        ast_mm2_for_shear=ast_mm2_for_shear,
+    )
+
+    if deflection_params is not None:
+        if float(deflection_params.get("span_mm", -1.0)) != float(span_mm):
+            raise ValueError(
+                "SERVICEABILITY_GEOMETRY_HOLD: deflection span_mm must match "
+                "the effective span used by the flanged route."
+            )
+        if float(deflection_params.get("d_mm", -1.0)) != float(d_mm):
+            raise ValueError(
+                "SERVICEABILITY_GEOMETRY_HOLD: deflection d_mm must match the "
+                "flanged-route effective depth."
+            )
+    if crack_width_params is not None:
+        if float(crack_width_params.get("h_mm", -1.0)) != float(D_mm):
+            raise ValueError(
+                "SERVICEABILITY_GEOMETRY_HOLD: crack-width h_mm must match "
+                "the flanged-route overall depth."
+            )
+
+    bf_geometric_mm = bw_mm + flange_overhang_left_mm + flange_overhang_right_mm
+    bf_effective_mm = flexure.calculate_effective_flange_width(
+        bw_mm=bw_mm,
+        span_mm=span_mm,
+        df_mm=flange_thickness_mm,
+        flange_overhang_left_mm=flange_overhang_left_mm,
+        flange_overhang_right_mm=flange_overhang_right_mm,
+        beam_type=BeamType.FLANGED_T,
+    )
+    design = compliance.check_compliance_case(
+        case_id=case_id,
+        mu_knm=mu_knm,
+        vu_kn=vu_kn,
+        b_mm=bw_mm,
+        D_mm=D_mm,
+        d_mm=d_mm,
+        fck_nmm2=fck_nmm2,
+        fy_nmm2=fy_nmm2,
+        d_dash_mm=d_dash_mm,
+        asv_mm2=asv_mm2,
+        pt_percent=pt_percent,
+        ast_mm2_for_shear=ast_mm2_for_shear,
+        deflection_params=deflection_params,
+        crack_width_params=crack_width_params,
+        beam_type=BeamType.FLANGED_T,
+        bf_mm=bf_effective_mm,
+        Df_mm=flange_thickness_mm,
+    )
+
+    return FlangedBeamDesignResult(
+        design=design,
+        beam_type="FLANGED_T",
+        moment_region="SAGGING",
+        load_case_basis=normalized_basis.upper(),
+        bw_mm=bw_mm,
+        bf_geometric_mm=bf_geometric_mm,
+        bf_effective_mm=bf_effective_mm,
+        Df_mm=flange_thickness_mm,
+        D_mm=D_mm,
+        d_mm=d_mm,
+        span_mm=span_mm,
+        source="IS 456:2000",
+        clause_refs={
+            "effective_flange_width": "IS 456 Cl 23.1.2",
+            "flexure": "IS 456 Cl 38.1 and Annex G",
+            "shear": "IS 456 Cl 40",
+            "deflection": "IS 456 Cl 23.2",
+            "crack_width": "IS 456 Annex F",
+        },
+        assumptions=(
+            "The supplied actions are already factored and are not generated by this workflow.",
+            "The flange is monolithic and in compression under sagging bending.",
+            "Shear stress and reinforcement are evaluated using the web width bw_mm.",
+        ),
+        holds=(
+            "Load-envelope generation and completeness validation are excluded.",
+            "L-beam and hogging/flange-in-tension flexure are excluded.",
+            "Flanged torsion and compatibility-versus-equilibrium redistribution are excluded.",
+            "Hollow/box, deep, prestressed, and axially loaded beams are excluded.",
+            "Composed flanged detailing is not included in this workflow.",
+        ),
+        is_ok=design.is_ok,
     )
 
 

--- a/Python/structural_lib/services/capabilities.py
+++ b/Python/structural_lib/services/capabilities.py
@@ -101,16 +101,25 @@ class IS456SemanticContract:
 _CAPABILITIES = (
     IS456Capability(
         element="beam",
-        public_workflows=("design_beam_is456", "check_beam_is456", "detail_beam_is456"),
+        public_workflows=(
+            "design_beam_is456",
+            "design_flanged_beam_is456",
+            "check_beam_is456",
+            "detail_beam_is456",
+        ),
         supported_case=(
             "Ordinary solid rectangular beam primary design for flexure and shear, "
             "with optional IS 456 torsion within fck 15-40 N/mm2 and fy <= 500 "
             "N/mm2, plus maintained Level-A deflection and crack-width checks when "
-            "their explicit inputs are supplied."
+            "their explicit inputs are supplied; and monolithic sagging T-beam "
+            "flexure with effective-flange-width calculation, web shear, and the "
+            "same explicit serviceability boundary."
         ),
         held_cases=(
-            "Flanged, hollow/box, deep, prestressed, or axially loaded torsion cases are excluded.",
+            "L-beam, hogging/flange-in-tension, flanged torsion, hollow/box, deep, prestressed, or axially loaded cases are excluded.",
             "Compatibility-versus-equilibrium torsion redistribution decisions are excluded.",
+            "Load-envelope generation and completeness validation are excluded; the flanged route accepts only declared supplied factored actions.",
+            "Composed flanged detailing remains excluded.",
             "Beam check, detailing, batch, import, and other automation surfaces that do not accept Tu and serviceability inputs remain outside the combined route.",
             "Serviceability is held unless span, support condition, crack geometry, and service strain or stress are explicitly supplied.",
         ),
@@ -260,6 +269,86 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
             limitations=(
                 "Optional torsion is limited to the ordinary solid rectangular route.",
                 "Serviceability requires explicit maintained inputs.",
+                "Qualified engineering review remains required.",
+            ),
+        ),
+        IS456WorkflowContract(
+            workflow="design_flanged_beam_is456",
+            element="beam",
+            fields=(
+                _field(
+                    "mu_knm",
+                    "supplied factored sagging moment",
+                    "kN m",
+                    True,
+                    "finite non-negative",
+                ),
+                _field(
+                    "vu_kn",
+                    "supplied factored shear force",
+                    "kN",
+                    True,
+                    "finite non-negative",
+                ),
+                _field("bw_mm", "web width", "mm", True, _MM),
+                _field("D_mm", "overall section depth", "mm", True, _MM),
+                _field("d_mm", "effective section depth", "mm", True, _MM),
+                _field("span_mm", "effective span", "mm", True, _MM),
+                _field(
+                    "flange_thickness_mm",
+                    "compression flange thickness",
+                    "mm",
+                    True,
+                    _MM,
+                ),
+                _field(
+                    "flange_overhang_left_mm",
+                    "left physical flange overhang",
+                    "mm",
+                    True,
+                    _MM,
+                ),
+                _field(
+                    "flange_overhang_right_mm",
+                    "right physical flange overhang",
+                    "mm",
+                    True,
+                    _MM,
+                ),
+                _field(
+                    "bf_effective_mm",
+                    "calculated effective flange width",
+                    "mm",
+                    True,
+                    _MM,
+                ),
+                _field("fck_nmm2", "concrete strength", "N/mm2", True, _N_PER_MM2),
+                _field("fy_nmm2", "steel strength", "N/mm2", True, _N_PER_MM2),
+                _field(
+                    "load_case_basis",
+                    "supplied action basis",
+                    "enumeration",
+                    True,
+                    "single factored case or supplied governing envelope",
+                ),
+                _field(
+                    "is_ok", "combined compliance outcome", "boolean", True, _BOOLEAN
+                ),
+            ),
+            statuses=(
+                IS456StatusContract(
+                    "is_ok",
+                    "The supported sagging T-beam flexure, web shear, and every enabled serviceability check pass.",
+                    (
+                        "Only supplied already-factored actions are evaluated.",
+                        "It is software evidence, not professional design approval.",
+                    ),
+                ),
+            ),
+            limitations=(
+                "Only the independently benchmarked monolithic sagging T-beam route is supported.",
+                "L-beam, hogging, flanged torsion, torsion redistribution, load-envelope generation, and composed detailing are held.",
+                "Serviceability requires explicit maintained inputs matching the section geometry.",
                 "Qualified engineering review remains required.",
             ),
         ),

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2548,7 +2548,7 @@
     {
       "name": "test_indian_code_manifest.py",
       "type": "python",
-      "size_lines": 140,
+      "size_lines": 136,
       "last_updated": "2026-08-15",
       "description": "INDIA-0 truth-manifest and reporting contract tests.",
       "functions": [
@@ -2575,7 +2575,7 @@
         "REPO_ROOT",
         "SCRIPTS_ROOT"
       ],
-      "content_hash": "03523611dd71"
+      "content_hash": "5830e3678613"
     },
     {
       "name": "test_inputs.py",
@@ -4675,7 +4675,7 @@
     {
       "name": "integration",
       "path": "integration/",
-      "file_count": 45,
+      "file_count": 46,
       "is_package": true
     },
     {
@@ -4704,5 +4704,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "3e6082ef5935ab72"
+  "content_hash": "b229c88f7c19298a"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -53,7 +53,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 10 | 362 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 20 | 682 |
-| [test_indian_code_manifest.py](test_indian_code_manifest.py) | INDIA-0 truth-manifest and reporting contract tests. | 0 | 6 | 140 |
+| [test_indian_code_manifest.py](test_indian_code_manifest.py) | INDIA-0 truth-manifest and reporting contract tests. | 0 | 6 | 136 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
 | [test_is456_constants.py](test_is456_constants.py) | Tests for IS 456:2000 named design constants. | 1 | 0 | 163 |
@@ -91,7 +91,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [data/](data/) | 5 |  |
 | [fixtures/](fixtures/) | 11 |  |
 | [helpers/](helpers/) 📦 | 2 |  |
-| [integration/](integration/) 📦 | 45 |  |
+| [integration/](integration/) 📦 | 46 |  |
 | [performance/](performance/) 📦 | 3 |  |
 | [property/](property/) 📦 | 9 |  |
 | [regression/](regression/) 📦 | 11 |  |

--- a/Python/tests/integration/test_flanged_beam_service.py
+++ b/Python/tests/integration/test_flanged_beam_service.py
@@ -1,0 +1,141 @@
+"""INDIA-1A composed T-beam service and boundary evidence."""
+
+from __future__ import annotations
+
+import pytest
+
+from structural_lib.services.api import design_flanged_beam_is456
+
+
+@pytest.fixture
+def benchmark_t_beam() -> dict[str, float | str]:
+    """Validation-pack B3 geometry with an explicit combined shear case."""
+    return {
+        "units": "IS456",
+        "beam_type": "T",
+        "moment_region": "sagging",
+        "load_case_basis": "single_factored_case",
+        "mu_knm": 200.0,
+        "vu_kn": 150.0,
+        "bw_mm": 300.0,
+        "D_mm": 550.0,
+        "d_mm": 500.0,
+        "span_mm": 6000.0,
+        "flange_thickness_mm": 150.0,
+        "flange_overhang_left_mm": 350.0,
+        "flange_overhang_right_mm": 350.0,
+        "fck_nmm2": 25.0,
+        "fy_nmm2": 500.0,
+    }
+
+
+def test_composed_t_beam_matches_b3_and_uses_web_for_shear(
+    benchmark_t_beam: dict[str, float | str],
+) -> None:
+    """B3 flexure is independently pinned; shear must use bw, not bf."""
+    result = design_flanged_beam_is456(**benchmark_t_beam)
+
+    assert result.is_ok is True
+    assert result.bf_geometric_mm == pytest.approx(1000.0)
+    assert result.bf_effective_mm == pytest.approx(1000.0)
+    assert result.design.flexure.Mu_lim == pytest.approx(835.038, abs=1.0)
+    assert result.design.flexure.Ast_required == pytest.approx(956.6, abs=10.0)
+    assert result.design.flexure.xu == pytest.approx(46.24, abs=1.0)
+    assert result.design.shear.tau_v == pytest.approx(1.0)
+    assert result.design.clause_refs["flexure"] == (
+        "IS 456 Cl 23.1.2 and 38.1; Annex G"
+    )
+    assert result.clause_refs["effective_flange_width"] == "IS 456 Cl 23.1.2"
+    assert "Load-envelope generation" in result.holds[0]
+    serialized = result.to_dict()
+    assert serialized["design"]["flexure"]["section_type"] == "UNDER_REINFORCED"
+    assert serialized["explicit_units"]["moment"] == "kN·m"
+
+
+def test_effective_flange_width_is_limited_by_span_and_flange_depth(
+    benchmark_t_beam: dict[str, float | str],
+) -> None:
+    result = design_flanged_beam_is456(
+        **{
+            **benchmark_t_beam,
+            "span_mm": 3000.0,
+            "flange_thickness_mm": 100.0,
+            "flange_overhang_left_mm": 1000.0,
+            "flange_overhang_right_mm": 1000.0,
+        }
+    )
+
+    assert result.bf_geometric_mm == pytest.approx(2300.0)
+    assert result.bf_effective_mm == pytest.approx(1400.0)
+
+
+def test_explicit_serviceability_inputs_are_composed_without_geometry_drift(
+    benchmark_t_beam: dict[str, float | str],
+) -> None:
+    result = design_flanged_beam_is456(
+        **benchmark_t_beam,
+        deflection_params={
+            "span_mm": 6000.0,
+            "d_mm": 500.0,
+            "support_condition": "simply_supported",
+        },
+        crack_width_params={
+            "exposure_class": "moderate",
+            "acr_mm": 40.0,
+            "cmin_mm": 25.0,
+            "h_mm": 550.0,
+            "x_mm": 150.0,
+            "fs_service_nmm2": 180.0,
+        },
+    )
+
+    assert result.design.deflection is not None
+    assert result.design.deflection.is_ok is True
+    assert result.design.crack_width is not None
+    assert result.design.crack_width.is_ok is True
+
+
+def test_unsafe_web_shear_fails_the_composed_result(
+    benchmark_t_beam: dict[str, float | str],
+) -> None:
+    result = design_flanged_beam_is456(**{**benchmark_t_beam, "vu_kn": 500.0})
+
+    assert result.is_ok is False
+    assert result.design.shear.is_safe is False
+    assert any(item.startswith("shear") for item in result.design.failed_checks)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"beam_type": "L"}, "FLANGED_SECTION_SCOPE_HOLD"),
+        ({"moment_region": "hogging"}, "FLANGED_MOMENT_SCOPE_HOLD"),
+        ({"load_case_basis": "generate_envelope"}, "LOAD_ENVELOPE_SCOPE_HOLD"),
+        ({"tu_knm": 5.0}, "FLANGED_TORSION_SCOPE_HOLD"),
+        (
+            {"torsion_redistribution_basis": "compatibility"},
+            "TORSION_REDISTRIBUTION_SCOPE_HOLD",
+        ),
+    ],
+)
+def test_out_of_scope_routes_fail_closed(
+    benchmark_t_beam: dict[str, float | str],
+    overrides: dict[str, float | str],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        design_flanged_beam_is456(**{**benchmark_t_beam, **overrides})
+
+
+def test_serviceability_geometry_mismatch_fails_closed(
+    benchmark_t_beam: dict[str, float | str],
+) -> None:
+    with pytest.raises(ValueError, match="SERVICEABILITY_GEOMETRY_HOLD"):
+        design_flanged_beam_is456(
+            **benchmark_t_beam,
+            deflection_params={
+                "span_mm": 5000.0,
+                "d_mm": 500.0,
+                "support_condition": "simply_supported",
+            },
+        )

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -117,6 +117,11 @@ broadening held beam cases.
 - Black check, Ruff, mypy, and Bandit passed on all changed Python paths.
 - Final repository gate passed 30/30 after the API manifest/documentation
   publication surfaces were corrected.
+- Owner set the remaining INDIA-1 validation cadence: focused benchmark/tests,
+  quick gate, commit hooks, and required hosted checks per packet; defer the
+  broad Python suite, full repository gate, manifest reconciliation, and
+  cumulative review until INDIA-1A through INDIA-1D are integrated, unless an
+  outcome-changing repository-wide issue requires an earlier run.
 
 ### Terminal issues
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,126 @@
 
 ---
 
+## 2026-08-15 — Session: PR #753 Integration and INDIA-1A Beam Closure
+
+**Agent:** Codex (`structural-math`, sole writer; no subagents)
+
+**Branches:** `codex/india-0-truth-baseline`, then fresh
+`codex/india-1a-beam-route-closure` from integrated `origin/main`
+
+**Focus:** Exact-head merge PR #753, verify the squash result, and close the
+smallest independently benchmarked sagging T-beam composition without
+broadening held beam cases.
+
+### Summary
+
+- Rechecked PR #753 at exact reviewed head `dd6c1f85`, with base `96f193bd`,
+  clean mergeability, no unresolved review threads, and passing required
+  `PR Gate`; marked it ready and squash-merged it as `0373de68`.
+- Verified the reviewed and integrated tree hashes are both
+  `f02f22b7526598a21ccbf34728e92572f71442e6`; the generated INDIA-0 manifest
+  and its regression test exist on integrated main.
+- Created the isolated `codex/india-1a-beam-route-closure` worktree from exact
+  integrated main, with a clean `READY_LOCAL` state and `source_bound=true`.
+- Added `design_flanged_beam_is456()` as a dedicated Python service composition
+  over maintained effective-width, flanged-flexure, web-shear, and explicit
+  serviceability math. The stable rectangular route is unchanged.
+- Published the route through both Python facades and the semantic capability
+  registry; regenerated the deterministic Indian-code manifest and recorded
+  source, benchmark, units, tolerances, assumptions, and held boundaries in
+  `india-1a-beam-route-evidence.md`.
+- Retained L-beams, hogging/flange-in-tension, flanged torsion and redistribution,
+  load-envelope generation, composed flanged detailing, hollow/box, deep,
+  prestressed, and axially loaded beams as explicit fail-closed holds.
+
+### Issues encountered
+
+- The first narrow Ruff pass stopped on import ordering after the new public
+  result/function symbols were added.
+- The first semantic-contract run found that the new function was exported by
+  `services.api` but not by the package top-level facade, and that `is_ok` was a
+  property rather than a dataclass field visible to contract introspection.
+- Regenerating the services folder index proposed hundreds of unrelated
+  linked-worktree date and previously omitted-file changes.
+- The broad Python suite found one release-workflow regression already present
+  on integrated main: `test_docs_workflow_is_build_only_until_pages_is_configured`
+  expects a `pull_request:` trigger that `deploy-docs.yml` no longer contains.
+- The first full repository gate stopped at 28/30 because the new facade symbols
+  were absent from the generated API manifest and public API/stability docs.
+- Regenerating the reference index proposed current linked-worktree dates for
+  every untouched reference file.
+- `./run.sh check --pre-commit` could not start because the selected shared
+  Python environment does not have the `pre-commit` package installed.
+
+### Root causes and resolutions
+
+- Root cause: Black does not sort imports and the new imports were inserted by
+  semantic location rather than Ruff order. Resolution: applied Ruff's
+  mechanical import fix and reran Black/Ruff. Evidence: the focused static pass
+  is green.
+- Root cause: capability validation requires every declared workflow to be the
+  same object from `structural_lib` and `services.api`, and recognizes serialized
+  dataclass fields rather than properties. Resolution: exported the function
+  and result class through the top-level facade and made `is_ok` an explicit
+  serialized field set from the composed compliance result. Evidence: all
+  capability-semantic and manifest tests pass.
+- Root cause: the index generator derives dates from fresh worktree mtimes and
+  the maintained services index predates several unrelated integrated files.
+  Resolution: after the required dry-run, restored the two services indexes to
+  byte-identical integrated-main content and retained only task-relevant test,
+  verification, planning, and root-doc indexes. Evidence: both services index
+  files have zero diff from `origin/main`; unrelated topology drift is absent.
+- Root cause: integrated `deploy-docs.yml` is push/manual only while the
+  unchanged release regression still encodes the earlier PR-trigger contract.
+  Resolution: classified it as an unrelated pre-existing release/CI mismatch
+  and did not alter workflow policy in a beam packet. Evidence: both the
+  workflow and test have zero diff from `origin/main`; the remaining 5,917
+  Python tests passed, with 3 skipped and 6 deselected.
+- Root cause: adding top-level public symbols requires regenerating
+  `docs/reference/api-manifest.json` and documenting them in both synchronized
+  API contract documents. Resolution: ran the maintained generator and added
+  the bounded signature/result/hold contract to `api.md` and
+  `api-stability.md`. Evidence: API-manifest check and the two formerly failed
+  repository checks pass on the final rerun.
+- Root cause: the reference index shares the linked-worktree mtime behavior.
+  Resolution: retained the generated folder date, new folder hash, and exact
+  `api-manifest.json`, `api-stability.md`, and `api.md` entries while restoring
+  every untouched entry from integrated main. Evidence: the final index diff
+  contains only those task-owned records.
+- Root cause: the worktree-bound runtime correctly selected the shared project
+  interpreter, but that environment lacks the optional `pre_commit` module.
+  Resolution: did not mutate dependencies; ran Black check, Ruff, mypy, and
+  Bandit directly against every changed Python source/test path, then retained
+  the normal commit hook as the final hook authority. Evidence: every direct
+  static/security command passed.
+
+### Verification
+
+- INDIA-0 merge boundary: exact head unchanged, required `PR Gate` passed,
+  mergeability `CLEAN`, no review/comment blockers, and reviewed/integrated tree
+  equality proved after squash merge.
+- Fresh INDIA-1A runtime: `source_bound=true`, `READY_LOCAL`, zero ahead/behind
+  from integrated `origin/main` at lane creation.
+- Accepted B3 T-beam benchmark: `bf,eff=1000 mm`, `Mu,lim=835.038 kN·m`,
+  `Ast=956.6 mm²`, `xu=46.24 mm`; the composed `150 kN` shear case returns
+  exactly `1.000 N/mm²` from `bw=300 mm` and `d=500 mm`.
+- Focused safe, unsafe, boundary, serviceability, and out-of-domain tests pass;
+  existing flanged-flexure and validation-pack regressions remain green.
+- Generated Indian-code manifest is current; capability and public-facade
+  semantic tests pass.
+- Broad Python suite: 5,917 passed, 3 skipped, 6 deselected, with one confirmed
+  pre-existing release-workflow assertion outside INDIA-1A scope.
+- Black check, Ruff, mypy, and Bandit passed on all changed Python paths.
+- Final repository gate passed 30/30 after the API manifest/documentation
+  publication surfaces were corrected.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: `./run.sh check --pre-commit` reported
+  `pre-commit not installed` in the selected shared environment -> ran the
+  maintained Black, Ruff, mypy, and Bandit modules directly; all passed, and
+  the normal Git commit hook remains the final hook execution path.
+
 ## 2026-08-15 — Session: INDIA-0 Draft PR Publication and INDIA-1 Handoff
 
 **Agent:** Codex (`ops`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-15 — PR #750 integrated the held retirement proposal at `b91838f`; GIT-7E semantic guidance and durable handoff implementation is active
+**Updated:** 2026-08-15 — PR #753 integrated the INDIA-0 truth baseline at `0373de68`; INDIA-1A sagging T-beam closure is active in a fresh lane
 
 ---
 
@@ -128,12 +128,14 @@
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
+| INDIA-1A | Close the beam-family gap with one benchmarked sagging T-beam flexure/web-shear/serviceability route and explicit retained boundaries | Main Agent | 🚧 SOFTWARE COMPLETE IN FRESH LANE — validation and publication closeout in progress |
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-1 | Close or explicitly hold the remaining beam, rectangular-column, isolated-footing, and solid-slab workflow limitations recorded by the INDIA-0 manifest | Main Agent + structural engineer | multi-packet | P0 | 📋 READY AFTER INDIA-0 PUBLICATION |
+| INDIA-1B | Close or retain rectangular-column geometry and reinforcement-layout decisions without promoting experimental PMM | Main Agent + structural engineer | one packet | P0 | 📋 READY AFTER INDIA-1A |
+| INDIA-1C/1D | Compose the isolated-footing workflow, then close solid-slab serviceability/shear boundaries | Main Agent + structural engineer | two packets | P0 | 📋 SEQUENCED AFTER INDIA-1B |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 | LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL STABLE GATE |
 
@@ -153,7 +155,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
-| INDIA-0 | Reconciled supported and held Indian RC scope into one generated, standard-namespaced capability/registration manifest; repaired both coverage consumers | Main Agent | 🚧 DRAFT PR #753 — local gates and review passed; hosted CI, exact-head review, and merge remain |
+| INDIA-0 | Reconciled supported and held Indian RC scope into one generated, standard-namespaced capability/registration manifest; repaired both coverage consumers | Main Agent | ✅ DONE — PR #753 exact-head gate passed; reviewed tree squash-merged as `0373de68` |
 | COLUMN-PMM-001 | Recovered and independently benchmarked the experimental rectangular-column P-Mx-My fiber surface | Main Agent | ✅ SOFTWARE COMPLETE — PR #738 merged; module remains experimental and outside the stable API |
 | ALPHA-0231-CANDIDATE | Published the exact 0.23.1a1 Alpha through exact-head CI, TestPyPI, production PyPI, and GitHub prerelease gates | Main Agent + ops | ✅ DONE — production run `31468341946`; exact public package UAT green |
 | IS456-SLAB-PRELAUNCH | Record and enforce source/licensing permission for public distribution of approved-scope normalized IS 456 data | Owner + Main Agent | ✅ DONE — owner confirmed 2026-08-11; canonical record, preflight, candidate, and publish-CI gates added |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -128,7 +128,7 @@
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
-| INDIA-1A | Close the beam-family gap with one benchmarked sagging T-beam flexure/web-shear/serviceability route and explicit retained boundaries | Main Agent | 🚧 SOFTWARE COMPLETE IN FRESH LANE — validation and publication closeout in progress |
+| INDIA-1A | Close the beam-family gap with one benchmarked sagging T-beam flexure/web-shear/serviceability route and explicit retained boundaries | Main Agent | 🚧 DRAFT PR #754 — software/benchmark evidence complete; exact-head hosted review pending |
 
 ## Up Next
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 5174,
+      "size_lines": 5179,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "3cb79b579dd7"
+      "content_hash": "d45a5f13ebdc"
     },
     {
       "name": "TASKS.md",
@@ -30,7 +30,7 @@
       "last_updated": "2026-08-15",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "d09d737639f7"
+      "content_hash": "20bd4b0b4368"
     },
     {
       "name": "WORKLOG.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "83e3571f33674646"
+  "content_hash": "de17e7b12bdaf5b2"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4950,
+      "size_lines": 5174,
       "last_updated": "2026-08-15",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "1a3c9a9250e4"
+      "content_hash": "3cb79b579dd7"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 680,
+      "size_lines": 682,
       "last_updated": "2026-08-15",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "56dff5fc2913"
+      "content_hash": "d09d737639f7"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 20,
+      "file_count": 21,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "229f86641b5948e1"
+  "content_hash": "83e3571f33674646"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4950 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 680 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 5174 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 682 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 20 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 21 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 5174 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 5179 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 682 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -69,7 +69,7 @@
       "size_lines": 1500,
       "last_updated": "2026-08-15",
       "description": "The Python package is the product. FastAPI, React, command-line workflows, reports, ETABS adapters, and future integrations are consumers of that product.",
-      "content_hash": "2b56fd9cd0e7"
+      "content_hash": "6578a824e80e"
     },
     {
       "name": "is456-solid-slabs-master-plan.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "552300ea8541f991"
+  "content_hash": "0ed7a0fe14930f68"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -107,11 +107,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 130,
+      "size_lines": 135,
       "last_updated": "2026-08-15",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "5e8f62d0891a"
+      "content_hash": "30fd0322d5fe"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +149,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "0ed7a0fe14930f68"
+  "content_hash": "700135b87df490a4"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -20,7 +20,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1118 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 130 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 135 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/is456-library-first-master-plan.md
+++ b/docs/planning/is456-library-first-master-plan.md
@@ -156,7 +156,7 @@ facts at packet start if the baseline commit changes.
 | Area | Current evidence | Program treatment |
 |---|---|---|
 | Architecture | Four-layer boundary scan reported 0 violations across 119 files; library import validation reported 0 broken internal imports | Preserve; rerun after cross-layer changes |
-| Beam | Flexure, shear, torsion, detailing, deflection/crack serviceability implemented | Capability and evidence closure audit; no broad redesign |
+| Beam | Rectangular combined route plus independently benchmarked sagging T-beam flexure/web-shear composition; explicit serviceability inputs supported | INDIA-1A retains L-beam, hogging, flanged torsion/redistribution, envelope generation, and flanged detailing as explicit holds |
 | Column | Axial, uniaxial, biaxial, slender/long, helical, and detailing modules implemented | Publish the supported-case boundary; close only outcome-changing gaps |
 | Footing | Isolated square/rectangular bearing, flexure, one-way shear, punching, and bearing enhancement implemented | Complete dowel/bearing-transfer slice; defer combined and other footing families |
 | Slab | No dedicated `codes/is456/slab/` package | New bounded element program: types/classification, one-way, then two-way |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,12 +4,12 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: Finish INDIA-0 exact-head integration, then start INDIA-1 existing-family closure from merged `main`
-- Draft PR: [#753](https://github.com/Pravin-surawase/structural_engineering_lib/pull/753)
-- Branch: `codex/india-0-truth-baseline`
-- Base: verified `origin/main` at `96f193bd45a21f05698cf64de47808a2e5f82640`
-- Implementation commit: `cfe02b3d47b671097358cf2feff16ecd4319cf89`
-- Next action: inspect the live PR head, required checks, mergeability, and review; merge only if the exact head is unchanged and all gates pass
+- Focus: Integrate INDIA-1A, then execute INDIA-1B through INDIA-1D with milestone-level gate efficiency
+- Draft PR: [#754](https://github.com/Pravin-surawase/structural_engineering_lib/pull/754)
+- Branch: `codex/india-1a-beam-route-closure`
+- Base: verified integrated `origin/main` at `0373de68ed6b29717da4200f3f9de05bb53f8cc5`
+- Implementation commit: `63d13bc6f35ecfd576fec731e95322d152a119fe`
+- Next action: inspect PR #754 at its live exact head; if required checks pass with no conflicts or blockers, mark ready, merge, verify integrated main, and start INDIA-1B from a fresh lane
 - Holds: no release, engineering-use approval, branch/worktree deletion, or historical-lane cleanup
 <!-- HANDOFF:END -->
 
@@ -18,7 +18,7 @@
 | Release state | Target |
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; qualified engineering review still required |
-| **Next** | Merge INDIA-0, then execute INDIA-1 as bounded existing-family packets |
+| **Next** | Integrate INDIA-1A, then execute INDIA-1B, 1C, and 1D as bounded packets |
 
 ## Required Reading
 
@@ -30,13 +30,13 @@
 
 ## Start Boundary
 
-Do not begin INDIA-1 implementation on the INDIA-0 branch. First inspect PR
-#753 live. If its exact head is unchanged, all required checks pass, there are
+Do not begin INDIA-1B implementation on the INDIA-1A branch. First inspect PR
+#754 live. If its exact head is unchanged, all required checks pass, there are
 no conflicts or unresolved blockers, and the reviewed tree is accepted, the
 owner has authorized the normal exact-head merge. Do not bypass checks.
 
-After merge, fetch `origin/main`, verify the merge result contains the INDIA-0
-manifest and tests, and create a fresh isolated `codex/india-1-<packet>` lane.
+After merge, fetch `origin/main`, verify the merge result contains the INDIA-1A
+service, manifest, and tests, and create a fresh isolated `codex/india-1b-<packet>` lane.
 Preserve the dirty primary checkout and all unrelated worktrees.
 
 ```bash
@@ -106,8 +106,13 @@ remain INDIA-2 or INDIA-3 work.
 - At least one independent benchmark has a justified tolerance.
 - Governing safe, unsafe, boundary, and out-of-domain cases are tested.
 - Unsupported inputs fail closed; capability wording matches executable behavior.
-- Focused tests pass while iterating; quick gate passes before every commit.
-- Run one full repository gate at each integrated INDIA-1 milestone.
+- Focused tests and the narrow benchmark pass while iterating; quick gate and
+  normal commit hooks remain the per-commit controls.
+- Required hosted PR checks remain mandatory for every packet and are not bypassed.
+- Run the broad Python suite, full repository gate, manifest reconciliation,
+  and cumulative review once after INDIA-1A through INDIA-1D are integrated.
+- Repeat a broad/full local gate earlier only when an outcome-changing failure
+  or repository-wide surface makes it necessary.
 - Record material issues, confirmed root causes, resolutions, and evidence in
   the newest task-owned `docs/SESSION_LOG.md` entry.
 

--- a/docs/reference/api-manifest.json
+++ b/docs/reference/api-manifest.json
@@ -1,8 +1,8 @@
 {
-  "generated": "2026-08-11",
+  "generated": "2026-08-15",
   "module": "structural_lib.api",
   "python": "3.11.15",
-  "count": 130,
+  "count": 132,
   "symbols": [
     {
       "name": "AuditLogEntry",
@@ -98,6 +98,11 @@
       "name": "ETABSForceRow",
       "kind": "class",
       "signature": "(story: 'str', beam_id: 'str', case_id: 'str', station: 'float', m3: 'float', v2: 'float', unique_name: 'str' = '', p: 'float' = 0.0) -> None"
+    },
+    {
+      "name": "FlangedBeamDesignResult",
+      "kind": "class",
+      "signature": "(design: 'Any', beam_type: 'str', moment_region: 'str', load_case_basis: 'str', bw_mm: 'float', bf_geometric_mm: 'float', bf_effective_mm: 'float', Df_mm: 'float', D_mm: 'float', d_mm: 'float', span_mm: 'float', source: 'str', clause_refs: 'dict[str, str]', assumptions: 'tuple[str, ...]', holds: 'tuple[str, ...]', is_ok: 'bool') -> None"
     },
     {
       "name": "FootingBearingResult",
@@ -468,6 +473,11 @@
       "name": "design_continuous_one_way_slab_is456",
       "kind": "function",
       "signature": "(*, short_effective_span_mm: 'float', long_effective_span_mm: 'float', thickness_mm: 'float', d_mm: 'float', factored_area_load_kn_per_m2: 'float', fck_n_per_mm2: 'float', fy_n_per_mm2: 'float', positive_moment_coefficient: 'float', negative_moment_coefficient: 'float', shear_coefficient: 'float', coefficient_source_reference: 'str', coefficient_source_is_approved: 'bool', qualified_coefficient_acceptance_reference: 'str', qualified_coefficient_acceptance_acknowledged: 'bool', number_of_spans: 'int', maximum_span_variation_percent: 'float', uniform_cross_section_acknowledged: 'bool', substantially_uniform_load_acknowledged: 'bool', redistribution_applied: 'bool', positive_bar_diameter_mm: 'float', positive_bar_spacing_mm: 'float', negative_bar_diameter_mm: 'float', negative_bar_spacing_mm: 'float', distribution_bar_diameter_mm: 'float', distribution_bar_spacing_mm: 'float', reviewed_base_span_depth_limit: 'float', reviewed_aggregate_modification_factor: 'float', serviceability_limit_source_reference: 'str', serviceability_limit_source_is_approved: 'bool', qualified_serviceability_acceptance_reference: 'str', qualified_serviceability_acceptance_acknowledged: 'bool', strip_width_mm: 'float' = 1000.0) -> 'ContinuousOneWaySlabDesignResult'"
+    },
+    {
+      "name": "design_flanged_beam_is456",
+      "kind": "function",
+      "signature": "(*, units: 'str', case_id: 'str' = 'CASE-1', beam_type: 'str', moment_region: 'str', load_case_basis: 'str', mu_knm: 'float', vu_kn: 'float', bw_mm: 'float', D_mm: 'float', d_mm: 'float', span_mm: 'float', flange_thickness_mm: 'float', flange_overhang_left_mm: 'float', flange_overhang_right_mm: 'float', fck_nmm2: 'float', fy_nmm2: 'float', d_dash_mm: 'float' = 50.0, asv_mm2: 'float' = 100.0, pt_percent: 'float | None' = None, ast_mm2_for_shear: 'float | None' = None, deflection_params: 'DeflectionParams | None' = None, crack_width_params: 'CrackWidthParams | None' = None, tu_knm: 'float' = 0.0, torsion_redistribution_basis: 'str | None' = None) -> 'FlangedBeamDesignResult'"
     },
     {
       "name": "design_from_input",

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -65,6 +65,12 @@ api.check_deflection_span_depth(span_mm, d_mm, support_condition, ...)
 api.check_crack_width(exposure_class, limit_mm, ...)
 api.check_compliance_report(cases, b_mm, D_mm, d_mm, fck_nmm2, fy_nmm2, ...)
 api.design_beam_is456(units, case_id, mu_knm, vu_kn, b_mm, D_mm, d_mm, ...)
+api.design_flanged_beam_is456(
+    units, case_id, beam_type, moment_region, load_case_basis,
+    mu_knm, vu_kn, bw_mm, D_mm, d_mm, span_mm, flange_thickness_mm,
+    flange_overhang_left_mm, flange_overhang_right_mm, ...
+)
+api.FlangedBeamDesignResult
 api.check_beam_is456(
     units, cases, b_mm, D_mm, d_mm, fck_nmm2, fy_nmm2, ...
 )

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -218,6 +218,54 @@ def design_beam_is456(
 ) -> ComplianceCaseResult
 ```
 
+### 1A.1A Bounded Sagging T-Beam (`design_flanged_beam_is456`)
+
+This dedicated route computes effective flange width from the declared span
+and physical flange geometry, then composes maintained flanged flexure,
+web-width shear, and optional explicit serviceability checks. It accepts
+already-factored supplied actions; it does not generate a load envelope.
+
+```python
+def design_flanged_beam_is456(
+    *,
+    units: str,
+    case_id: str = "CASE-1",
+    beam_type: str,                  # "T"
+    moment_region: str,              # "sagging"
+    load_case_basis: str,            # single_factored_case or supplied_governing_envelope
+    mu_knm: float,
+    vu_kn: float,
+    bw_mm: float,
+    D_mm: float,
+    d_mm: float,
+    span_mm: float,
+    flange_thickness_mm: float,
+    flange_overhang_left_mm: float,
+    flange_overhang_right_mm: float,
+    fck_nmm2: float,
+    fy_nmm2: float,
+    d_dash_mm: float = 50.0,
+    asv_mm2: float = 100.0,
+    pt_percent: float | None = None,
+    ast_mm2_for_shear: float | None = None,
+    deflection_params: dict | None = None,
+    crack_width_params: dict | None = None,
+    tu_knm: float = 0.0,
+    torsion_redistribution_basis: str | None = None,
+) -> FlangedBeamDesignResult
+```
+
+`api.FlangedBeamDesignResult` serializes the composed `design`, physical and
+effective section geometry, explicit units, source/clause identifiers,
+assumptions, held boundaries, and the combined `is_ok` outcome.
+
+The supported section is a monolithic T-beam in sagging bending with positive
+flange overhangs on both sides. L-beams, hogging/flange-in-tension, flanged
+torsion and redistribution, load-envelope generation, composed flanged
+detailing, hollow/box, deep, prestressed, and axially loaded beams fail closed
+or remain explicit holds. Qualified structural-engineering review is still
+required before stable or engineering use.
+
 ### 1A.2 Multi-Case Compliance (`check_beam_is456`)
 
 ```python
@@ -3934,6 +3982,25 @@ from structural_lib.services import api
 result = api.design_beam_is456(
     units="IS456", b_mm=300, D_mm=500, d_mm=450,
     fck_nmm2=25, fy_nmm2=500, mu_knm=150, vu_kn=100,
+)
+
+# Bounded sagging T-beam route from supplied factored actions
+t_beam = api.design_flanged_beam_is456(
+    units="IS456",
+    beam_type="T",
+    moment_region="sagging",
+    load_case_basis="single_factored_case",
+    mu_knm=200,
+    vu_kn=150,
+    bw_mm=300,
+    D_mm=550,
+    d_mm=500,
+    span_mm=6000,
+    flange_thickness_mm=150,
+    flange_overhang_left_mm=350,
+    flange_overhang_right_mm=350,
+    fck_nmm2=25,
+    fy_nmm2=500,
 )
 
 # Design + detailing in one call

--- a/docs/reference/index.json
+++ b/docs/reference/index.json
@@ -2,7 +2,7 @@
   "folder": "docs/reference",
   "type": "mixed",
   "description": "",
-  "last_updated": "2026-08-11",
+  "last_updated": "2026-08-15",
   "file_count": 30,
   "files": [
     {
@@ -49,7 +49,7 @@
     {
       "name": "api-manifest.json",
       "type": "config",
-      "last_updated": "2026-08-11",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "generated",
         "module",
@@ -57,23 +57,23 @@
         "count",
         "symbols"
       ],
-      "content_hash": "7145726e4150"
+      "content_hash": "934b0ea51f29"
     },
     {
       "name": "api-stability.md",
       "type": "documentation",
-      "size_lines": 663,
-      "last_updated": "2026-08-10",
+      "size_lines": 669,
+      "last_updated": "2026-08-15",
       "description": "> This document defines which parts of the library are safe to depend on and which may change. This library follows Semantic Versioning:",
-      "content_hash": "802492ba2ce0"
+      "content_hash": "d3efbd9a3958"
     },
     {
       "name": "api.md",
       "type": "documentation",
-      "size_lines": 3987,
-      "last_updated": "2026-08-10",
+      "size_lines": 4054,
+      "last_updated": "2026-08-15",
       "description": "geometry, loading, reinforcement, and evidence boundaries. The primary combined beam route covers rectangular flexure and shear (plus optional serviceability),",
-      "content_hash": "f121c4a9fbb2"
+      "content_hash": "f05f9af75859"
     },
     {
       "name": "automation-catalog.md",
@@ -261,5 +261,5 @@
       "file_count": 1760
     }
   ],
-  "content_hash": "e175ebf034b9813d"
+  "content_hash": "47bc070c07fa1ee3"
 }

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,7 @@
 # Reference
 
 **Type:** Mixed
-**Last Updated:** 2026-08-11
+**Last Updated:** 2026-08-15
 **Files:** 30
 
 ## Config Files
@@ -19,8 +19,8 @@
 | [README.md](README.md) | Reference Documentation | Comprehensive lookup documentation for APIs, formulas, contr | 81 |
 | [agent-automation-pitfalls.md](agent-automation-pitfalls.md) |  | <!-- lint-ignore-git --> > ⚠️ **Note:** This document includ | 634 |
 | [api-levels.md](api-levels.md) |  | structural_lib exposes three API levels. Pick the one that m | 117 |
-| [api-stability.md](api-stability.md) |  | > This document defines which parts of the library are safe  | 663 |
-| [api.md](api.md) |  | geometry, loading, reinforcement, and evidence boundaries. T | 3987 |
+| [api-stability.md](api-stability.md) |  | > This document defines which parts of the library are safe  | 669 |
+| [api.md](api.md) |  | geometry, loading, reinforcement, and evidence boundaries. T | 4054 |
 | [automation-catalog.md](automation-catalog.md) |  | The exhaustive machine-generated script inventory is scripts | 61 |
 | [bbs-dxf-contract.md](bbs-dxf-contract.md) |  | This document defines the stable contracts for Bar Bending S | 116 |
 | [beam-tool-manifest.md](beam-tool-manifest.md) |  | The generated beam tool manifest describes the one approved  | 32 |

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -121,7 +121,7 @@
       "last_updated": "2026-08-15",
       "title": "INDIA-0 Indian-Code Truth Baseline",
       "description": "was squash-merged as 0373de68; INDIA-1 packets now update the generated manifest from fresh integrated-main lanes",
-      "content_hash": "c971fcfa7633"
+      "content_hash": "e8d850af25d8"
     },
     {
       "name": "insights-verification-pack.md",
@@ -201,5 +201,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "cfa15ef705717afb"
+  "content_hash": "99f6903b00f392a9"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-15",
-  "file_count": 18,
+  "file_count": 19,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -27,7 +27,7 @@
       "name": "README.md",
       "type": "documentation",
       "size_lines": 64,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "title": "Verification",
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards. | Document | Description |",
       "content_hash": "4763d5ab8b48"
@@ -36,7 +36,7 @@
       "name": "alpha-0231-local-prepublication-rehearsal.md",
       "type": "documentation",
       "size_lines": 72,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "title": "v0.23.1a1 Local Prepublication Rehearsal",
       "description": "not a CI artifact identity, tag, or publication approval | Artifact | Bytes | Members | SHA-256 |",
       "content_hash": "d6a173859f50"
@@ -45,7 +45,7 @@
       "name": "bundled-sample-boq-evidence.md",
       "type": "documentation",
       "size_lines": 58,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This is the reproducible software record for the bundled ETABS sample. It is not a bill approved for procurement or construction and is not professional",
       "content_hash": "78b84b5474bc"
     },
@@ -53,7 +53,7 @@
       "name": "column-pmm-benchmark.md",
       "type": "documentation",
       "size_lines": 107,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This record independently checks the experimental rectangular-column fiber kernel at an oblique neutral-axis orientation. It is a calculation benchmark,",
       "content_hash": "fcc6aaad58e3"
     },
@@ -61,7 +61,7 @@
       "name": "examples.md",
       "type": "documentation",
       "size_lines": 1550,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This document provides benchmark examples that engineers can use to verify the library's calculations against: - Hand calculations",
       "content_hash": "79cb3add7cbe"
     },
@@ -69,14 +69,14 @@
       "name": "external-cli-test.md",
       "type": "documentation",
       "size_lines": 98,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Purpose: capture a repeatable, human-run CLI test from a fresh user. Preferred: use the automated smoke script so the output is consistent and easy to share.",
       "content_hash": "a81223e8c701"
     },
     {
       "name": "footing-release-inclusion.json",
       "type": "config",
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "schema_version",
         "record_id",
@@ -89,6 +89,14 @@
         "required_shared_markers"
       ],
       "content_hash": "e15f6ebeb790"
+    },
+    {
+      "name": "india-1a-beam-route-evidence.md",
+      "type": "documentation",
+      "size_lines": 85,
+      "last_updated": "2026-08-15",
+      "description": "design_flanged_beam_is456() composes one monolithic sagging T-beam case from already-factored supplied actions. It calculates the effective flange width,",
+      "content_hash": "97194ff486b7"
     },
     {
       "name": "indian-code-capability-coverage.json",
@@ -104,22 +112,22 @@
         "capability_summary",
         "standards"
       ],
-      "content_hash": "4cecc72906d0"
+      "content_hash": "a255bc11d6bf"
     },
     {
       "name": "indian-code-truth-baseline.md",
       "type": "documentation",
-      "size_lines": 92,
+      "size_lines": 93,
       "last_updated": "2026-08-15",
       "title": "INDIA-0 Indian-Code Truth Baseline",
-      "description": "merge pending indian-code-capability-coverage.json",
-      "content_hash": "97b85669d0b9"
+      "description": "was squash-merged as 0373de68; INDIA-1 packets now update the generated manifest from fresh integrated-main lanes",
+      "content_hash": "c971fcfa7633"
     },
     {
       "name": "insights-verification-pack.md",
       "type": "documentation",
       "size_lines": 101,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This pack provides benchmark test cases for the insights module to ensure accuracy and prevent regressions. Tests are automatically run in CI on every PR. Run all insights benchmark tests:",
       "content_hash": "62116e5ed5fe"
     },
@@ -127,7 +135,7 @@
       "name": "is456-library-first-evidence.md",
       "type": "documentation",
       "size_lines": 169,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "title": "IS 456 Library-First Evidence and Claim Crosswalk",
       "description": "| Source | SHA-256 | Pages | Use | |---|---|---:|---|",
       "content_hash": "3a47d498ba82"
@@ -135,7 +143,7 @@
     {
       "name": "is456-public-distribution-permission.json",
       "type": "config",
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "schema_version",
         "record_id",
@@ -162,7 +170,7 @@
       "name": "pack.md",
       "type": "documentation",
       "size_lines": 56,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This repo’s unit tests validate correctness and edge cases, but they don’t always answer the question: **“did the numerical design outputs change?”** The **Verification Pack** is a small set of **pinn",
       "content_hash": "fa4fe75b3d05"
     },
@@ -170,7 +178,7 @@
       "name": "release-artifact-evidence-template.md",
       "type": "documentation",
       "size_lines": 38,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "title": "Release Artifact Evidence Template",
       "description": "Complete this record from the CI run that built the exact candidate. | Field | Value |",
       "content_hash": "dd7652006f11"
@@ -179,7 +187,7 @@
       "name": "ui-experience-session-2-acceptance.md",
       "type": "documentation",
       "size_lines": 70,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This is the software acceptance record for UIX-001 P9-P15. It does not certify the formulas, approve a structural design, or authorize professional use.",
       "content_hash": "82dbbd6cae09"
     },
@@ -187,11 +195,11 @@
       "name": "validation-pack.md",
       "type": "documentation",
       "size_lines": 396,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "This pack provides 5 benchmark beams and 3 benchmark columns with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trust",
       "content_hash": "63fd4822c78c"
     }
   ],
   "subfolders": [],
-  "content_hash": "bdfec0cc8d033a6f"
+  "content_hash": "cfa15ef705717afb"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-15
-**Files:** 18
+**Files:** 19
 
 ## Config Files
 
@@ -23,7 +23,8 @@ Benchmark examples and verification packs for validating library calculations ag
 | [column-pmm-benchmark.md](column-pmm-benchmark.md) |  | This record independently checks the experimental rectangula | 107 |
 | [examples.md](examples.md) |  | This document provides benchmark examples that engineers can | 1550 |
 | [external-cli-test.md](external-cli-test.md) |  | Purpose: capture a repeatable, human-run CLI test from a fre | 98 |
-| [indian-code-truth-baseline.md](indian-code-truth-baseline.md) | INDIA-0 Indian-Code Truth Baseline | merge pending indian-code-capability-coverage.json | 92 |
+| [india-1a-beam-route-evidence.md](india-1a-beam-route-evidence.md) |  | design_flanged_beam_is456() composes one monolithic sagging  | 85 |
+| [indian-code-truth-baseline.md](indian-code-truth-baseline.md) | INDIA-0 Indian-Code Truth Baseline | was squash-merged as 0373de68; INDIA-1 packets now update th | 93 |
 | [insights-verification-pack.md](insights-verification-pack.md) |  | This pack provides benchmark test cases for the insights mod | 101 |
 | [is456-library-first-evidence.md](is456-library-first-evidence.md) | IS 456 Library-First Evidence and Claim  | | Source | SHA-256 | Pages | Use | |---|---|---:|---| | 169 |
 | [is456-slab-evidence.md](is456-slab-evidence.md) | IS 456 Solid Slab Source and Benchmark L | | ID | Identity | Permitted implementation use | State | |-- | 115 |

--- a/docs/verification/india-1a-beam-route-evidence.md
+++ b/docs/verification/india-1a-beam-route-evidence.md
@@ -1,0 +1,84 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: reference
+complexity: advanced
+tags: [is456, beam, flanged, verification, india-1]
+---
+
+# INDIA-1A Sagging T-Beam Route Evidence
+
+## Supported outcome
+
+`design_flanged_beam_is456()` composes one monolithic sagging T-beam case from
+already-factored supplied actions. It calculates the effective flange width,
+runs the maintained flanged-flexure design, evaluates shear using the web
+width, and optionally runs the maintained span/depth and crack-width checks
+when their complete geometry and service inputs are supplied.
+
+This is software verification evidence. It is not professional design approval;
+the cumulative qualified structural-engineering review remains required before
+stable or engineering-use approval.
+
+## Governing source and units
+
+| Result | IS 456:2000 reference | Input units | Output units |
+|---|---|---|---|
+| Effective flange width | Cl 23.1.2 | `bw`, span, flange thickness and overhangs in mm | mm |
+| Flanged flexure | Cl 38.1 and Annex G | geometry in mm, `Mu` in kN·m, strengths in N/mm² | steel in mm², capacity in kN·m |
+| Web shear | Cl 40 and Tables 19/20 | `Vu` in kN, `bw` and `d` in mm | stress in N/mm², spacing in mm |
+| Level-A deflection | Cl 23.2 | span and effective depth in mm | span/depth result |
+| Crack width | Annex F | explicit geometry in mm and strain or service stress | crack width in mm |
+
+The repository implements normalized formulas and identifiers without copying
+protected standard prose or page images.
+
+## Independent benchmark
+
+The accepted B3 benchmark in
+[`validation-pack.md`](validation-pack.md) supplies `bw=300 mm`, physical
+`bf=1000 mm`, `Df=150 mm`, `D=550 mm`, `d=500 mm`, `Mu=200 kN·m`, M25 and
+Fe500. With an effective span of `6000 mm` and `350 mm` overhang on each side:
+
+- physical flange width = `300 + 350 + 350 = 1000 mm`;
+- T-beam code limit = `300 + 6000/6 + 6(150) = 2200 mm`;
+- effective flange width = `min(1000, 2200) = 1000 mm`;
+- accepted flexure targets are `Mu,lim=835.04 kN·m`,
+  `Ast=956.6 mm²`, and `xu=46.24 mm`;
+- for the added `Vu=150 kN` combined-route check, nominal shear stress is
+  `150000/(300×500) = 1.000 N/mm²`, proving that shear uses the web width
+  rather than the effective flange width.
+
+The focused test allows the benchmark source precision: `±1 kN·m` for
+`Mu,lim`, `±10 mm²` for `Ast`, and `±1 mm` for `xu`; the web-shear identity
+uses floating-point approximation only.
+
+## Fail-closed boundary
+
+| Input or interpretation | Outcome |
+|---|---|
+| Monolithic T-beam, sagging, two positive flange overhangs | Supported |
+| Single supplied factored case | Supported |
+| Caller-supplied governing factored envelope result | Supported as supplied; envelope completeness is not validated |
+| Route asked to generate an envelope | `LOAD_ENVELOPE_SCOPE_HOLD` |
+| L-beam | `FLANGED_SECTION_SCOPE_HOLD` pending its own benchmark |
+| Hogging or flange in tension | `FLANGED_MOMENT_SCOPE_HOLD` |
+| Non-zero flanged torsion | `FLANGED_TORSION_SCOPE_HOLD` |
+| Compatibility/equilibrium redistribution selection | `TORSION_REDISTRIBUTION_SCOPE_HOLD` |
+| Serviceability geometry inconsistent with strength geometry | `SERVICEABILITY_GEOMETRY_HOLD` |
+| Hollow/box, deep, prestressed, axially loaded, or composed flanged detailing | Explicitly retained hold |
+
+## Verification commands
+
+```bash
+./scripts/python_runtime.sh --diagnose
+./scripts/python_runtime.sh -m pytest Python/tests/integration/test_flanged_beam_service.py -q
+./scripts/python_runtime.sh -m pytest Python/tests/integration/test_flanged_beam.py Python/tests/regression/test_verification_pack.py -q
+./scripts/python_runtime.sh -m pytest Python/tests/integration/test_capability_semantics.py Python/tests/test_indian_code_manifest.py -q
+./scripts/python_runtime.sh scripts/generate_indian_code_manifest.py --check
+```
+
+Safe benchmark, unsafe shear, effective-width boundary, explicit
+serviceability, geometry mismatch, L-beam, hogging, envelope-generation,
+flanged-torsion, and redistribution-hold cases are all covered.

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -54,15 +54,18 @@
           "family": "beam",
           "scope_status": "SUPPORTED",
           "implementation_status": "IMPLEMENTED_BOUNDED",
-          "claim": "Ordinary solid rectangular beam primary design for flexure and shear, with optional IS 456 torsion within fck 15-40 N/mm2 and fy <= 500 N/mm2, plus maintained Level-A deflection and crack-width checks when their explicit inputs are supplied.",
+          "claim": "Ordinary solid rectangular beam primary design for flexure and shear, with optional IS 456 torsion within fck 15-40 N/mm2 and fy <= 500 N/mm2, plus maintained Level-A deflection and crack-width checks when their explicit inputs are supplied; and monolithic sagging T-beam flexure with effective-flange-width calculation, web shear, and the same explicit serviceability boundary.",
           "workflows": [
             "design_beam_is456",
+            "design_flanged_beam_is456",
             "check_beam_is456",
             "detail_beam_is456"
           ],
           "limitations": [
-            "Flanged, hollow/box, deep, prestressed, or axially loaded torsion cases are excluded.",
+            "L-beam, hogging/flange-in-tension, flanged torsion, hollow/box, deep, prestressed, or axially loaded cases are excluded.",
             "Compatibility-versus-equilibrium torsion redistribution decisions are excluded.",
+            "Load-envelope generation and completeness validation are excluded; the flanged route accepts only declared supplied factored actions.",
+            "Composed flanged detailing remains excluded.",
             "Beam check, detailing, batch, import, and other automation surfaces that do not accept Tu and serviceability inputs remain outside the combined route.",
             "Serviceability is held unless span, support condition, crack geometry, and service strain or stress are explicitly supplied."
           ],

--- a/docs/verification/indian-code-truth-baseline.md
+++ b/docs/verification/indian-code-truth-baseline.md
@@ -2,7 +2,7 @@
 
 **Type:** Reference
 **Audience:** Developers
-**Status:** Active
+**Status:** Complete
 **Created:** 2026-08-15
 **Last Updated:** 2026-08-15
 **Importance:** Critical

--- a/docs/verification/indian-code-truth-baseline.md
+++ b/docs/verification/indian-code-truth-baseline.md
@@ -2,12 +2,13 @@
 
 **Type:** Reference
 **Audience:** Developers
-**Status:** In Progress
+**Status:** Active
 **Created:** 2026-08-15
 **Last Updated:** 2026-08-15
 **Importance:** Critical
-**Evidence boundary:** Draft PR #753 open; hosted CI, exact-head review, and
-merge pending
+**Evidence boundary:** PR #753 exact-head checks passed and the reviewed tree
+was squash-merged as `0373de68`; INDIA-1 packets now update the generated
+manifest from fresh integrated-main lanes
 
 **Manifest:**
 [`indian-code-capability-coverage.json`](indian-code-capability-coverage.json)
@@ -82,9 +83,9 @@ composite; intentionally held families are not failed parity checks.
 
 ## Remaining gates
 
-- The fail-closed Git handoff is the retained pre-publication receipt. Draft PR
-  #753 now carries the committed baseline; hosted CI, exact-head review, and
-  merge remain pending, and this session does not wait for CI.
+- The fail-closed Git handoff remains a retained pre-publication receipt. PR
+  #753 passed its exact-head gate and its reviewed tree equals the integrated
+  squash-result tree at `0373de68`.
 - INDIA-1 must use the manifest's held cases to close or retain limitations in
   the already supported beam, column, isolated-footing, and solid-slab families.
 - Release, stable approval, engineering-use approval, and branch/worktree


### PR DESCRIPTION
## What changed

- add `design_flanged_beam_is456()` as a dedicated composed sagging T-beam workflow
- calculate effective flange width from span and physical flange geometry
- reuse maintained flanged flexure, web-width shear, and explicit serviceability checks
- publish the result through both Python facades and the generated capability/API manifests
- add independent B3 benchmark evidence plus safe, unsafe, boundary, and fail-closed tests

## Why

INDIA-0 identified flanged-beam math that existed only as separate calculations. INDIA-1A closes the smallest coherent supported route without broadening geometry or analysis claims.

## Supported boundary

The route supports monolithic T-beams in sagging bending from declared supplied factored actions. L-beams, hogging/flange-in-tension, load-envelope generation, flanged torsion and redistribution, composed flanged detailing, hollow/box, deep, prestressed, and axially loaded beams remain explicit holds.

## Verification

- B3 benchmark: `bf,eff=1000 mm`, `Mu,lim=835.038 kN·m`, `Ast=956.6 mm²`, `xu=46.24 mm`
- focused beam/capability/manifest set: 51 passed
- broad Python suite: 5,917 passed, 3 skipped, 6 deselected; one unchanged integrated-main release-workflow assertion remains outside this beam packet
- Black, Ruff, mypy, and Bandit passed on changed Python paths
- `./run.sh check --quick`: 10/10
- `./run.sh check`: 30/30

Software verification is not professional design approval. The cumulative qualified structural-engineering review remains required before stable or engineering use.
