### PR TITLE
feat(is456): close slab design boundaries

### DIFF
--- a/Python/structural_lib/codes/is456/slab/serviceability.py
+++ b/Python/structural_lib/codes/is456/slab/serviceability.py
@@ -73,6 +73,7 @@ class SlabServiceabilityResult:
     utilization: float
     status: SlabServiceabilityStatus
     direct_deflection_status: str
+    crack_width_status: str
     source_reference: str
     qualified_acceptance_reference: str
     verified_by_library: bool
@@ -104,7 +105,14 @@ def check_slab_span_depth_serviceability(
         reviewed_modified_span_depth_limit=limit,
         utilization=actual / limit,
         status=status,
-        direct_deflection_status="held_not_implemented",
+        direct_deflection_status=(
+            "held_requires_slab_specific_service_actions_load_duration_"
+            "reinforcement_and_effective_inertia_validation"
+        ),
+        crack_width_status=(
+            "held_requires_explicit_bar_geometry_cover_neutral_axis_and_"
+            "service_stress_or_strain_validation"
+        ),
         source_reference=design_input.limit_source_reference,
         qualified_acceptance_reference=(design_input.qualified_acceptance_reference),
         verified_by_library=False,

--- a/Python/structural_lib/services/capabilities.py
+++ b/Python/structural_lib/services/capabilities.py
@@ -188,7 +188,10 @@ _CAPABILITIES = (
             "serviceability carriers, and ordinary one-way shear."
         ),
         held_cases=(
-            "Direct deflection, crack width, concentrated loads, openings, irregular panels, load-envelope analysis and automatic slab shear reinforcement are excluded.",
+            "Direct deflection remains held until a slab-specific route validates explicit service-action combinations, load duration, reinforcement positions, cracking/effective inertia, creep and shrinkage against independent slab benchmarks.",
+            "Crack width remains held until explicit bar geometry, cover, neutral-axis depth, exposure limit and service steel stress or strain are validated for supported slab strips and panels.",
+            "Each public route consumes one caller-selected factored UDL or one declared coefficient-method action basis; concentrated loads, openings, irregular panels, load-combination/pattern generation and envelope analysis are excluded.",
+            "Ordinary one-way concrete shear is checked for beam/wall-supported UDL panels; when capacity is exceeded the result requires increased depth or separate engineering and never automatically designs slab shear reinforcement.",
             "Flat/drop/ribbed slabs, column strips, column-supported punching and FEM require a separately approved extension.",
         ),
         qualified_review_required=True,
@@ -760,7 +763,11 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
                     ("Qualified review remains required.",),
                 ),
             ),
-            limitations=("The route is a simply supported one-way slab strip.",),
+            limitations=(
+                "The route is a simply supported one-way slab strip and checks flexure plus supplied bars only.",
+                "Use the complete route for reviewed span/depth serviceability and ordinary concrete shear; direct deflection, crack width and automatic shear reinforcement remain held.",
+                "One caller-supplied factored UDL is consumed; load combinations, patterns, concentrated loads, openings and envelope generation are not performed.",
+            ),
         ),
         IS456WorkflowContract(
             workflow="design_two_way_slab_is456",
@@ -828,7 +835,8 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
                 ),
             ),
             limitations=(
-                "Reinforcement detailing, serviceability, shear/punching, load combinations/patterning, and other panel cases remain incomplete.",
+                "This compatibility route is flexure-only; reinforcement detailing, span/depth serviceability and ordinary shear require a complete panel route.",
+                "Direct deflection, crack width, automatic shear reinforcement, concentrated loads, openings and load-envelope generation remain held.",
             ),
         ),
         IS456WorkflowContract(
@@ -859,7 +867,10 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
                 ),
             ),
             limitations=(
-                "Direct deflection and automatic shear reinforcement are not implemented.",
+                "Only reviewed span/depth serviceability and ordinary concrete shear are evaluated.",
+                "Direct deflection and crack width require separately validated slab-specific service actions, duration, reinforcement/geometry and service-stress inputs.",
+                "Automatic slab shear reinforcement is not designed; increase depth or perform separate engineering when concrete capacity is exceeded.",
+                "One caller-supplied factored UDL is checked; load combinations, patterns, concentrated loads, openings and envelope generation are not performed.",
             ),
         ),
         IS456WorkflowContract(
@@ -897,6 +908,8 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
             ),
             limitations=(
                 "Requires at least three spans, no more than 15 percent span variation, a uniform section, substantially uniform load, and no redistribution.",
+                "Only reviewed span/depth serviceability and ordinary concrete shear are evaluated; direct deflection, crack width and automatic slab shear reinforcement remain held.",
+                "One declared coefficient-method action basis is checked; load-combination/pattern generation, concentrated loads, openings and envelope analysis are not performed.",
             ),
         ),
         IS456WorkflowContract(
@@ -936,6 +949,8 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
             ),
             limitations=(
                 "Requires at least three spans, no more than 15 percent span variation, a uniform section, substantially uniform load, and no redistribution.",
+                "Built-in action-location coefficients do not generate project load combinations or an envelope; the caller supplies the governing factored load components.",
+                "Only reviewed span/depth serviceability and ordinary concrete shear are evaluated; direct deflection, crack width and automatic slab shear reinforcement remain held.",
             ),
         ),
         IS456WorkflowContract(
@@ -973,6 +988,8 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
             ),
             limitations=(
                 "Flat slabs and column-supported punching are a separate held extension.",
+                "Only reviewed span/depth serviceability and ordinary concrete shear are evaluated; direct deflection, crack width and automatic slab shear reinforcement remain held.",
+                "One caller-supplied factored UDL and coefficient basis are checked; concentrated loads, openings and load-envelope generation are not performed.",
             ),
         ),
         IS456WorkflowContract(
@@ -1012,6 +1029,8 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
             ),
             limitations=(
                 "Flat slabs and column-supported punching are a separate held extension.",
+                "Built-in panel coefficients do not generate project load combinations or an envelope; one caller-supplied factored UDL is checked.",
+                "Direct deflection, crack width, automatic slab shear reinforcement, concentrated loads and openings remain held.",
             ),
         ),
     ),

--- a/Python/structural_lib/services/slab_api.py
+++ b/Python/structural_lib/services/slab_api.py
@@ -96,6 +96,9 @@ _COMPLETE_ONE_WAY_DETAILING_LIMITATIONS = (
     "HOLD: automatic slab shear reinforcement is not designed.",
     "REVIEW LIMITATION: qualified structural-engineering review remains required.",
 )
+_SINGLE_ACTION_LOAD_BOUNDARY = (
+    "not_generated_single_caller_supplied_factored_udl_or_coefficient_basis"
+)
 
 
 @dataclass(frozen=True)
@@ -104,6 +107,7 @@ class OneWaySlabDesignResult:
 
     flexure: OneWaySlabFlexureResult
     detailing: OneWaySlabDetailingResult
+    load_envelope_status: str = _SINGLE_ACTION_LOAD_BOUNDARY
 
     @property
     def is_detailing_adequate(self) -> bool:
@@ -120,6 +124,7 @@ class CompleteOneWaySlabDesignResult:
     serviceability: SlabServiceabilityResult
     punching_shear_disposition: str
     complete_engineering_design_approved: bool = False
+    load_envelope_status: str = _SINGLE_ACTION_LOAD_BOUNDARY
 
 
 @dataclass(frozen=True)
@@ -134,6 +139,7 @@ class ContinuousOneWaySlabDesignResult:
     serviceability: SlabServiceabilityResult
     punching_shear_disposition: str
     complete_engineering_design_approved: bool = False
+    load_envelope_status: str = _SINGLE_ACTION_LOAD_BOUNDARY
 
 
 @dataclass(frozen=True)
@@ -143,6 +149,7 @@ class TwoWaySlabPanelWorkflowResult:
     panel: TwoWayPanelDesignResult
     serviceability: SlabServiceabilityResult
     complete_engineering_design_approved: bool = False
+    load_envelope_status: str = _SINGLE_ACTION_LOAD_BOUNDARY
 
 
 def design_one_way_slab_is456(

--- a/Python/tests/integration/test_slab_boundary_closure.py
+++ b/Python/tests/integration/test_slab_boundary_closure.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Executable INDIA-1D slab serviceability, shear and load boundaries."""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import json
+
+import pytest
+
+from structural_lib.codes.is456.slab.shear import (
+    SlabShearInput,
+    SlabShearStatus,
+    check_solid_slab_one_way_shear,
+)
+from structural_lib.services import api
+
+
+def _complete_simply_supported(**overrides: object):
+    values: dict[str, object] = {
+        "short_effective_span_mm": 3000.0,
+        "long_effective_span_mm": 7500.0,
+        "thickness_mm": 150.0,
+        "d_mm": 125.0,
+        "factored_area_load_kn_per_m2": 10.0,
+        "fck_n_per_mm2": 20.0,
+        "fy_n_per_mm2": 415.0,
+        "main_bar_diameter_mm": 10.0,
+        "main_bar_spacing_mm": 250.0,
+        "distribution_bar_diameter_mm": 8.0,
+        "distribution_bar_spacing_mm": 250.0,
+        "reviewed_base_span_depth_limit": 20.0,
+        "reviewed_aggregate_modification_factor": 1.2,
+        "serviceability_limit_source_reference": "reviewed-limit:INDIA-1D",
+        "serviceability_limit_source_is_approved": True,
+        "qualified_serviceability_acceptance_reference": "review:INDIA-1D",
+        "qualified_serviceability_acceptance_acknowledged": True,
+    }
+    values.update(overrides)
+    return api.design_complete_one_way_slab_is456(**values)  # type: ignore[arg-type]
+
+
+def test_complete_route_serializes_explicit_retained_boundaries() -> None:
+    result = _complete_simply_supported()
+
+    assert result.serviceability.is_satisfied is True
+    assert result.serviceability.verified_by_library is False
+    assert result.serviceability.direct_deflection_status.startswith(
+        "held_requires_slab_specific_service_actions"
+    )
+    assert result.serviceability.crack_width_status.startswith(
+        "held_requires_explicit_bar_geometry"
+    )
+    assert result.shear.is_safe_without_shear_reinforcement is True
+    assert result.shear.shear_reinforcement_design_status == (
+        "not_automatically_designed"
+    )
+    assert result.load_envelope_status == (
+        "not_generated_single_caller_supplied_factored_udl_or_coefficient_basis"
+    )
+    json.dumps(dataclasses.asdict(result))
+
+
+def test_ordinary_shear_failure_never_claims_automatic_reinforcement() -> None:
+    result = check_solid_slab_one_way_shear(
+        SlabShearInput(
+            factored_shear_kn=100.0,
+            strip_width_mm=1000.0,
+            effective_depth_mm=115.0,
+            overall_depth_mm=140.0,
+            fck_n_per_mm2=20.0,
+            tension_reinforcement_mm2=300.0,
+            uniformly_distributed_load_only=True,
+            beam_or_wall_supported=True,
+        )
+    )
+
+    assert result.status in {
+        SlabShearStatus.INCREASE_DEPTH_OR_ENGINEER_REINFORCEMENT,
+        SlabShearStatus.EXCEEDS_MAXIMUM_SHEAR_STRESS,
+    }
+    assert result.is_safe_without_shear_reinforcement is False
+    assert result.shear_reinforcement_design_status == "not_automatically_designed"
+
+
+def test_public_slab_routes_have_no_hidden_load_or_geometry_envelope_inputs() -> None:
+    forbidden_fragments = (
+        "load_cases",
+        "load_envelope",
+        "concentrated",
+        "opening",
+        "service_load",
+    )
+    workflows = (
+        "design_one_way_slab_is456",
+        "design_complete_one_way_slab_is456",
+        "design_continuous_one_way_slab_is456",
+        "design_continuous_one_way_slab_builtin_is456",
+        "design_two_way_slab_is456",
+        "design_two_way_slab_panel_is456",
+        "design_two_way_slab_panel_builtin_is456",
+    )
+
+    for workflow in workflows:
+        parameters = inspect.signature(getattr(api, workflow)).parameters
+        assert not any(
+            fragment in parameter
+            for parameter in parameters
+            for fragment in forbidden_fragments
+        )
+
+    with pytest.raises(TypeError, match="concentrated_load_kn"):
+        _complete_simply_supported(concentrated_load_kn=25.0)
+
+
+def test_capability_and_semantic_contract_state_the_decision_ceiling() -> None:
+    slab = next(
+        item
+        for item in api.get_supported_is456_capabilities()
+        if item.element == "solid_slab"
+    )
+    holds = " ".join(slab.held_cases)
+
+    assert "slab-specific route" in holds
+    assert "service steel stress or strain" in holds
+    assert "one caller-selected factored UDL" in holds
+    assert "never automatically designs slab shear reinforcement" in holds
+
+    complete_workflows = {
+        "design_complete_one_way_slab_is456",
+        "design_continuous_one_way_slab_is456",
+        "design_continuous_one_way_slab_builtin_is456",
+        "design_two_way_slab_panel_is456",
+        "design_two_way_slab_panel_builtin_is456",
+    }
+    contracts = {
+        item.workflow: " ".join(item.limitations)
+        for item in api.get_supported_is456_semantic_contract().workflows
+        if item.workflow in complete_workflows
+    }
+    assert set(contracts) == complete_workflows
+    assert all("load" in limitations.lower() for limitations in contracts.values())
+    assert all(
+        "direct deflection" in limitations.lower() for limitations in contracts.values()
+    )
+    assert all("shear" in limitations.lower() for limitations in contracts.values())

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -37,6 +37,8 @@ load-action boundaries without promoting unvalidated slab calculations.
 - Kept the milestone gate cadence: focused slab/contract tests, architecture/
   import validation, quick gate, and hosted exact-head PR gate in this packet;
   broad Python and the full repository gate follow A-D integration.
+- Published implementation commit `782a4b79` in draft PR #757; exact-head hosted
+  review remains the publication gate.
 
 ### Issues encountered
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,75 @@
 
 ---
 
+## 2026-08-15 — Session: INDIA-1D Solid-Slab Boundary Closure
+
+**Agent:** Codex (`structural-math`, sole writer; no subagents)
+
+**Branch:** `codex/india-1d-slab-boundary` from integrated `origin/main` at
+`236ce6462543aa36df307a0a9b4ef463ac98d085`
+
+**Focus:** Close the supported solid-slab serviceability, ordinary-shear, and
+load-action boundaries without promoting unvalidated slab calculations.
+
+### Summary
+
+- Integrated INDIA-1C PR #756 only after exact head `03a50688`, required hosted
+  `PR Gate`, clean mergeability, and zero review blockers were rechecked; squash
+  merge `236ce646` has the same tree as the reviewed head.
+- Created a fresh isolated INDIA-1D lane from that integrated main and verified
+  `READY_LOCAL` with `source_bound=true`.
+- Retained reviewed span/depth serviceability and ordinary one-way concrete
+  shear for beam/wall-supported UDL panels as the supported ceiling.
+- Made direct-deflection and crack-width holds explicit in the serialized
+  serviceability carrier, including the slab-specific actions, duration,
+  reinforcement/geometry, effective-inertia and service-stress evidence needed
+  before either can be promoted.
+- Made the one-action loading boundary explicit in complete result carriers and
+  the semantic contract: routes consume one caller-selected factored UDL or one
+  declared coefficient-method action basis and do not generate project load
+  combinations, patterns, concentrated/opening effects, or envelopes.
+- Retained automatic slab shear reinforcement as held; an ordinary concrete-
+  capacity failure requires increased depth or separate engineering.
+- Kept the milestone gate cadence: focused slab/contract tests, architecture/
+  import validation, quick gate, and hosted exact-head PR gate in this packet;
+  broad Python and the full repository gate follow A-D integration.
+
+### Issues encountered
+
+- Repository inventory showed the intended holds already existed in prose and
+  nested shear state, but crack width and load-envelope disposition were not
+  explicit serialized result fields and the capability rationale was too
+  compressed to state the evidence needed for future promotion.
+- The first focused boundary run had one test-authoring error: it dereferenced
+  `.shear` on a low-level `SlabShearResult`. The same run also correctly found
+  the generated Indian-code manifest stale after capability edits.
+
+### Root causes and resolutions
+
+- Earlier slab completion work established the correct calculation ceiling but
+  did not give every retained decision a machine-visible result field. Added
+  `crack_width_status` and `load_envelope_status`, tightened every public slab
+  semantic limitation, and added focused public regression evidence without
+  changing structural formulas.
+- The failing assertion confused a composed result with the low-level shear
+  carrier. It now checks `SlabShearResult.status` directly. Regenerated both
+  capability and API manifests after their source contracts changed; the
+  repeated focused suite passed.
+
+### Evidence
+
+- Baseline slab, capability, and manifest suite before edits: 111 passed.
+- Focused slab, boundary, capability, and manifest suite after closure: 115
+  passed.
+- Boundary benchmark: span/depth 24.0/24.0, shear stress 0.12 N/mm2, concrete
+  shear capacity 0.4688283053 N/mm2, no automatic reinforcement, and explicit
+  single-action load-envelope disposition.
+- Architecture boundaries: 155 files, zero violations.
+- Structural-library imports: 194 files, 1061 imports, zero broken imports.
+- API documentation/manifest checks passed; quick repository gate: 10/10.
+
+---
+
 ## 2026-08-15 — Session: INDIA-1C Composed Isolated-Footing Workflow
 
 **Agent:** Codex (`structural-math`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -128,13 +128,13 @@
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
-| INDIA-1C | Publish and verify the bounded concentric isolated-footing composition while retaining eccentric and other-foundation cases | Main Agent + structural engineer | 🚧 DRAFT PR #756 — focused 215 tests, architecture/import validation, and quick 10/10 green; exact-head hosted review pending |
+| INDIA-1D | Close solid-slab serviceability, shear-reinforcement, and single-action load-envelope boundaries without promoting unvalidated slab math | Main Agent + structural engineer | 🚧 SOFTWARE COMPLETE — focused 115 tests, architecture/import validation, and quick 10/10 green; publication pending |
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-1D | Close solid-slab serviceability, shear, and load-envelope boundaries | Main Agent + structural engineer | one packet | P0 | 📋 SEQUENCED AFTER INDIA-1C |
+| INDIA-1-CUMULATIVE | Run broad Python, full repository, manifest reconciliation, and cumulative engineering review gates | Main Agent + qualified reviewer | milestone gate | P0 | 📋 SEQUENCED AFTER INDIA-1D INTEGRATION |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 | LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL STABLE GATE |
 
@@ -154,6 +154,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-1C | Published the bounded concentric isolated-footing composition with typed provenance, accepted benchmark, and explicit eccentric/other-foundation holds | Main Agent | ✅ DONE — PR #756 exact-head gate passed; reviewed tree squash-merged as `236ce646` |
 | INDIA-1B | Reconfirmed stable solid rectangular tied-column routes as a symmetric two-face reinforcement idealization and retained circular, arbitrary-layout, and experimental PMM cases | Main Agent | ✅ DONE — PR #755 exact-head gate passed; reviewed tree squash-merged as `f44452dd` |
 | INDIA-1A | Added a benchmarked monolithic sagging T-beam flexure/web-shear/explicit-serviceability composition with fail-closed retained boundaries | Main Agent | ✅ DONE — PR #754 exact-head gate passed; reviewed tree squash-merged as `3a7e162e` |
 | INDIA-0 | Reconciled supported and held Indian RC scope into one generated, standard-namespaced capability/registration manifest; repaired both coverage consumers | Main Agent | ✅ DONE — PR #753 exact-head gate passed; reviewed tree squash-merged as `0373de68` |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -128,7 +128,7 @@
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
-| INDIA-1D | Close solid-slab serviceability, shear-reinforcement, and single-action load-envelope boundaries without promoting unvalidated slab math | Main Agent + structural engineer | 🚧 SOFTWARE COMPLETE — focused 115 tests, architecture/import validation, and quick 10/10 green; publication pending |
+| INDIA-1D | Close solid-slab serviceability, shear-reinforcement, and single-action load-envelope boundaries without promoting unvalidated slab math | Main Agent + structural engineer | 🚧 DRAFT PR #757 — focused 115 tests, architecture/import validation, and quick 10/10 green; exact-head hosted review pending |
 
 ## Up Next
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -5,10 +5,10 @@
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
 - Focus: Publish INDIA-1D solid-slab boundary closure, then run the cumulative INDIA-1 gates
-- Draft PR: pending
+- Draft PR: [#757](https://github.com/Pravin-surawase/structural_engineering_lib/pull/757)
 - Branch: `codex/india-1d-slab-boundary`
 - Base: verified integrated `origin/main` at `236ce6462543aa36df307a0a9b4ef463ac98d085`
-- Implementation commit: pending
+- Implementation commit: `782a4b79fd8cc19dce5a9a9fd0cada65ebc52673`
 - Next action: finish the narrow INDIA-1D gates, commit and publish the packet; after its exact-head hosted gate passes, merge and run the deferred broad Python, full repository, manifest reconciliation, and cumulative review gates on integrated A-D
 - Holds: no release, engineering-use approval, branch/worktree deletion, or historical-lane cleanup
 <!-- HANDOFF:END -->

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,12 +4,12 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: Publish INDIA-1C composed concentric isolated-footing closure, then start INDIA-1D with milestone-level gate efficiency
-- Draft PR: [#756](https://github.com/Pravin-surawase/structural_engineering_lib/pull/756)
-- Branch: `codex/india-1c-isolated-footing-workflow`
-- Base: verified integrated `origin/main` at `f44452ddc6b0bdf837f59a97917af8cf9d61c1dd`
-- Implementation commit: `42157f291ec49ee33a5640490055dfe141c1fcae`
-- Next action: commit and publish the verified INDIA-1C packet; after its exact-head required checks pass with no conflicts or blockers, merge, verify integrated main, and start INDIA-1D from a fresh lane
+- Focus: Publish INDIA-1D solid-slab boundary closure, then run the cumulative INDIA-1 gates
+- Draft PR: pending
+- Branch: `codex/india-1d-slab-boundary`
+- Base: verified integrated `origin/main` at `236ce6462543aa36df307a0a9b4ef463ac98d085`
+- Implementation commit: pending
+- Next action: finish the narrow INDIA-1D gates, commit and publish the packet; after its exact-head hosted gate passes, merge and run the deferred broad Python, full repository, manifest reconciliation, and cumulative review gates on integrated A-D
 - Holds: no release, engineering-use approval, branch/worktree deletion, or historical-lane cleanup
 <!-- HANDOFF:END -->
 
@@ -18,7 +18,7 @@
 | Release state | Target |
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; qualified engineering review still required |
-| **Next** | Publish INDIA-1C, then execute INDIA-1D as the final bounded packet before cumulative gates |
+| **Next** | Publish INDIA-1D, then run the cumulative INDIA-1 gates on integrated A-D |
 
 ## Required Reading
 
@@ -30,11 +30,11 @@
 
 ## Start Boundary
 
-INDIA-1A and INDIA-1B are integrated. Finish INDIA-1C only from its isolated
+INDIA-1A through INDIA-1C are integrated. Finish INDIA-1D only from its isolated
 branch. After its exact-head PR checks pass with no conflicts or blockers,
-merge normally, fetch `origin/main`, verify tree identity, and create a fresh
-isolated `codex/india-1d-<packet>` lane. Preserve the dirty primary checkout and
-all unrelated worktrees; do not bypass checks.
+merge normally, fetch `origin/main`, verify tree identity, and run the deferred
+cumulative gates from a fresh integrated lane. Preserve the dirty primary
+checkout and all unrelated worktrees; do not bypass checks.
 
 ```bash
 ./run.sh session brief --agent structural-math

--- a/docs/reference/api-manifest.json
+++ b/docs/reference/api-manifest.json
@@ -62,7 +62,7 @@
     {
       "name": "CompleteOneWaySlabDesignResult",
       "kind": "class",
-      "signature": "(reinforcement: 'OneWaySlabDesignResult', shear: 'SlabShearResult', serviceability: 'SlabServiceabilityResult', punching_shear_disposition: 'str', complete_engineering_design_approved: 'bool' = False) -> None"
+      "signature": "(reinforcement: 'OneWaySlabDesignResult', shear: 'SlabShearResult', serviceability: 'SlabServiceabilityResult', punching_shear_disposition: 'str', complete_engineering_design_approved: 'bool' = False, load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
     },
     {
       "name": "ConcentricIsolatedFootingInput",
@@ -77,7 +77,7 @@
     {
       "name": "ContinuousOneWaySlabDesignResult",
       "kind": "class",
-      "signature": "(flexure: 'ContinuousOneWaySlabResult', positive_reinforcement: 'SlabReinforcementRegionResult', negative_reinforcement: 'SlabReinforcementRegionResult', distribution_reinforcement: 'SlabReinforcementRegionResult', shear: 'SlabShearResult', serviceability: 'SlabServiceabilityResult', punching_shear_disposition: 'str', complete_engineering_design_approved: 'bool' = False) -> None"
+      "signature": "(flexure: 'ContinuousOneWaySlabResult', positive_reinforcement: 'SlabReinforcementRegionResult', negative_reinforcement: 'SlabReinforcementRegionResult', distribution_reinforcement: 'SlabReinforcementRegionResult', shear: 'SlabShearResult', serviceability: 'SlabServiceabilityResult', punching_shear_disposition: 'str', complete_engineering_design_approved: 'bool' = False, load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
     },
     {
       "name": "CostProfile",
@@ -202,7 +202,7 @@
     {
       "name": "OneWaySlabDesignResult",
       "kind": "class",
-      "signature": "(flexure: 'OneWaySlabFlexureResult', detailing: 'OneWaySlabDetailingResult') -> None"
+      "signature": "(flexure: 'OneWaySlabFlexureResult', detailing: 'OneWaySlabDetailingResult', load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
     },
     {
       "name": "ParetoCandidate",
@@ -252,7 +252,7 @@
     {
       "name": "TwoWaySlabPanelWorkflowResult",
       "kind": "class",
-      "signature": "(panel: 'TwoWayPanelDesignResult', serviceability: 'SlabServiceabilityResult', complete_engineering_design_approved: 'bool' = False) -> None"
+      "signature": "(panel: 'TwoWayPanelDesignResult', serviceability: 'SlabServiceabilityResult', complete_engineering_design_approved: 'bool' = False, load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
     },
     {
       "name": "ValidationReport",

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -553,6 +553,14 @@ loading, other foundation systems, settlement/soil-structure interaction,
 lateral/uplift/global-overturning checks, and arbitrary geometry are outside the
 contract.
 
+Complete slab workflow results expose only reviewed span/depth serviceability
+and ordinary one-way concrete shear for beam/wall-supported UDL panels. Their
+serviceability carrier explicitly holds direct deflection and crack width, and
+their shear carrier never claims automatic reinforcement design. Each result's
+`load_envelope_status` records that one caller-selected factored UDL or declared
+coefficient-method action basis was checked; project load combinations,
+patterns, concentrated/opening effects, and envelopes are not generated.
+
 The compatibility two-way route retains its documented interior-panel
 configuration with caller-supplied, qualified coefficients. The complete
 development-preview routes add common oriented beam/wall-supported panels,
@@ -683,6 +691,7 @@ If you find a breaking change:
 
 ## Changelog
 
+- **2026-08-15**: Closed solid-slab serviceability, shear-reinforcement, and single-action load-envelope boundaries without promoting unvalidated slab math
 - **2026-08-15**: Published the bounded concentric isolated-footing composition through the canonical services and package-root APIs
 - **2026-04-04**: Added Column Design API (stable) and Footing Design API (experimental) for v0.21.0
 - **2026-04-06**: Version references updated to v0.21.5 (test coverage & regression prevention release)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -72,8 +72,19 @@ case from the declared physical edges and corner restraint, uses exact tabulated
 points or adjacent linear interpolation, and rejects extrapolation. External
 coefficient carriers remain available and never claim library verification.
 All complete routes return provenance, provided-bar checks, ordinary one-way
-shear and strict reviewed span/depth serviceability evidence. Flat slabs,
-column-supported punching and direct-deflection calculation remain held.
+concrete-shear and strict reviewed span/depth serviceability evidence. The
+serviceability carrier explicitly reports direct deflection and crack width as
+held pending slab-specific service-action, duration, reinforcement/geometry,
+effective-inertia and service-stress validation. If concrete shear capacity is
+exceeded, the result requires increased depth or separate engineering; it never
+automatically designs slab shear reinforcement.
+
+Every slab call consumes one caller-selected factored UDL or one declared
+coefficient-method action basis. Built-in coefficient lookup does not generate
+project load combinations, load patterns, concentrated/opening effects, or an
+envelope. Complete workflow results serialize this boundary in
+`load_envelope_status`. Flat slabs, column-supported punching, openings,
+concentrated loads, irregular panels, and FEM remain held.
 
 Supported-case discovery is available through
 `api.get_supported_is456_capabilities`. CLI and REST consumers use

--- a/docs/verification/india-1d-slab-boundary-evidence.md
+++ b/docs/verification/india-1d-slab-boundary-evidence.md
@@ -1,0 +1,70 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: reference
+task: INDIA-1D
+---
+
+# INDIA-1D Solid-Slab Boundary Evidence
+
+INDIA-1D closes the decision boundary around already supported solid-slab
+serviceability, shear, and loading behavior. It does not add or promote new
+structural formulas.
+
+## Supported outcome
+
+The complete simply supported, continuous one-way, and common two-way
+beam/wall-supported workflows retain:
+
+- reviewed span/depth serviceability with explicit source and qualified-
+  acceptance references;
+- ordinary one-way concrete shear using the maintained Table 19/20 lookup and
+  solid-slab depth factor;
+- supplied reinforcement and topology checks appropriate to each route; and
+- one caller-selected factored UDL or declared coefficient-method action basis
+  per call.
+
+The result carriers now serialize the ceiling. `SlabServiceabilityResult`
+identifies both direct deflection and crack width as held, while complete
+workflow results expose `load_envelope_status`. `SlabShearResult` already
+reports `not_automatically_designed` for shear reinforcement regardless of its
+concrete-capacity disposition.
+
+## Boundary benchmark
+
+The focused public test uses the accepted simply supported one-way strip with a
+3000 mm effective span, 150 mm overall depth, 125 mm effective depth, 10 kN/m2
+factored UDL, M20 concrete, Fe415 steel, and supplied 10 mm main bars at 250 mm.
+It verifies:
+
+- actual and reviewed modified span/depth ratios: 24.0, utilization 1.0;
+- nominal shear stress: 0.12 N/mm2;
+- design concrete shear capacity: 0.4688283053 N/mm2;
+- concrete-capacity status: `concrete_capacity_satisfied`;
+- automatic shear reinforcement: `not_automatically_designed`; and
+- JSON serialization of the serviceability, shear, and load-envelope holds.
+
+A separate focused failure case verifies that exceeding ordinary concrete shear
+capacity never changes the automatic-reinforcement disposition into a design
+claim.
+
+## Retained boundaries
+
+Direct deflection needs a separately accepted slab contract with explicit
+service actions/combinations, load duration, reinforcement positions, cracking
+and effective inertia, creep and shrinkage, plus independent slab benchmarks.
+Crack width needs explicit bar geometry, cover, neutral-axis depth, exposure
+limit, and service steel stress or strain validated for the supported slab
+domain. Beam serviceability utilities are not promoted as slab-qualified by
+analogy.
+
+Automatic slab shear reinforcement remains held: a failed ordinary shear check
+requires increased depth or separate engineering. Concentrated loads, openings,
+irregular panels, project load-combination/pattern generation, and envelope
+analysis remain excluded from every public slab signature. Flat/drop/ribbed and
+column-supported slabs, punching, and FEM remain separate extensions.
+
+This packet receives focused tests, architecture/import validation, the quick
+repository gate, and required hosted PR checks. Broad Python and the full
+repository gate run once after INDIA-1A through INDIA-1D are integrated.

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -137,7 +137,10 @@
             "design_two_way_slab_panel_builtin_is456"
           ],
           "limitations": [
-            "Direct deflection, crack width, concentrated loads, openings, irregular panels, load-envelope analysis and automatic slab shear reinforcement are excluded.",
+            "Direct deflection remains held until a slab-specific route validates explicit service-action combinations, load duration, reinforcement positions, cracking/effective inertia, creep and shrinkage against independent slab benchmarks.",
+            "Crack width remains held until explicit bar geometry, cover, neutral-axis depth, exposure limit and service steel stress or strain are validated for supported slab strips and panels.",
+            "Each public route consumes one caller-selected factored UDL or one declared coefficient-method action basis; concentrated loads, openings, irregular panels, load-combination/pattern generation and envelope analysis are excluded.",
+            "Ordinary one-way concrete shear is checked for beam/wall-supported UDL panels; when capacity is exceeded the result requires increased depth or separate engineering and never automatically designs slab shear reinforcement.",
             "Flat/drop/ribbed slabs, column strips, column-supported punching and FEM require a separately approved extension."
           ],
           "evidence": [

--- a/docs/verification/is456-slab-evidence.md
+++ b/docs/verification/is456-slab-evidence.md
@@ -5,7 +5,7 @@
 **Status:** Internal implementation evidence; qualified review required
 **Importance:** Critical
 **Created:** 2026-08-10
-**Last Updated:** 2026-08-11
+**Last Updated:** 2026-08-15
 
 ## Source lock
 
@@ -57,8 +57,18 @@ provenance; external coefficient carriers remain available.
   page images, and unrelated standard content remain excluded.
 - Unequal-span or unequal-load continuous analysis beyond the accepted
   coefficient-method domain is unsupported; no elastic envelope is inferred.
-- Direct deflection, crack-width calculation, concentrated loads, openings,
-  irregular panels, and automatic slab shear reinforcement are held.
+- Direct deflection remains held until a slab-specific route validates explicit
+  service actions and combinations, load duration, reinforcement positions,
+  cracking/effective inertia, creep and shrinkage against independent slab
+  benchmarks. Crack width likewise requires validated explicit bar geometry,
+  cover, neutral-axis depth, exposure limit, and service steel stress or strain.
+- Each public route consumes one caller-selected factored UDL or one declared
+  coefficient-method action basis. Built-in coefficient resolution does not
+  generate project load combinations, patterns, concentrated/opening effects,
+  or an envelope.
+- Ordinary one-way concrete shear is checked for the beam/wall-supported UDL
+  domain. A capacity failure requires increased depth or separate engineering;
+  automatic slab shear reinforcement design remains held.
 - Punching shear is not applicable to the supported beam/wall-supported UDL
   solid-panel routes. Column-supported and flat-slab punching is a separate held
   extension.


### PR DESCRIPTION
## Summary

- close solid-slab serviceability, ordinary-shear, and single-action loading boundaries without adding structural formulas
- serialize explicit direct-deflection, crack-width, and load-envelope holds
- retain ordinary concrete shear while ensuring a failed capacity check never claims automatic slab shear-reinforcement design
- tighten capability/semantic contracts and add focused public regression evidence

## Validation

- focused slab, boundary, capability, and manifest suites: 115 passed
- architecture boundaries: 155 files, 0 violations
- structural-library imports: 194 files, 0 broken imports
- API docs and generated manifests: current
- `./run.sh check --quick`: 10/10 passed
- commit hooks: passed

## Gate cadence

This is the final INDIA-1 packet. Required hosted PR checks remain mandatory for this exact head. After integration, the deferred broad Python suite, full repository gate, manifest reconciliation, and cumulative review run once on integrated INDIA-1A through INDIA-1D.

## Retained boundaries

Direct deflection and crack width need separately validated slab-specific service inputs and independent benchmarks. Automatic slab shear reinforcement, concentrated loads, openings, irregular panels, project load-combination/pattern generation, and envelope analysis remain held. No release or engineering-use approval is requested.