### PR TITLE
test(ci): reconcile cumulative INDIA-1 gates

### DIFF
--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -460,12 +460,18 @@ class TestPublishWorkflow:
         workflow = (REPO_ROOT / ".github" / "workflows" / "deploy-docs.yml").read_text(
             encoding="utf-8"
         )
+        pr_workflow = (
+            REPO_ROOT / ".github" / "workflows" / "fast-checks.yml"
+        ).read_text(encoding="utf-8")
         mkdocs = (REPO_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
 
         assert "mkdocs build --strict" in workflow
         assert "gh-deploy" not in workflow
         assert "contents: write" not in workflow
-        assert "pull_request:" in workflow
+        assert "pull_request:" not in workflow
+        assert "pull_request:" in pr_workflow
+        assert "name: Documentation Validation" in pr_workflow
+        assert "mkdocs build --strict" in pr_workflow
         assert "site_url:" not in mkdocs
 
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,72 @@
 
 ---
 
+## 2026-08-15 — Session: INDIA-1 Cumulative Integration Gates
+
+**Agent:** Codex (`reviewer`, sole writer; no subagents)
+
+**Branch:** `codex/india-1-cumulative-gates` from integrated `origin/main` at
+`ca55f22d3f8b6664e42ad41eb6d3ef9a0d1d96c3`
+
+**Focus:** Run the deferred broad Python, full repository, manifest, and
+cumulative essential-review gates after INDIA-1A through INDIA-1D integration.
+
+### Summary
+
+- Integrated INDIA-1D PR #757 only after exact head `9d7fe61d`, required hosted
+  `PR Gate`, clean mergeability, and zero review blockers were rechecked; squash
+  merge `ca55f22d` has the same tree as the reviewed head.
+- Created a fresh cumulative lane from exact integrated main and verified
+  `READY_LOCAL` with `source_bound=true`.
+- Reconciled the generated API and Indian-code capability manifests. The latter
+  contains 21 capability records, no unknown state, and reports beam, column,
+  isolated footing, and solid slab as bounded supported families.
+- Reviewed the integrated INDIA-1 code, public facade identities, benchmarks,
+  provenance, semantic holds, and result dispositions. No outcome-changing
+  calculation or public-claim defect was found.
+- Repaired one stale CI contract test discovered by the deferred broad suite;
+  no workflow policy or structural calculation changed.
+- Final broad Python and full repository gates pass. Qualified professional
+  review and any stable/engineering-use approval remain separate holds.
+
+### Issues encountered
+
+- The first broad Python run had one failure among 5,929 selected tests:
+  `test_docs_workflow_is_build_only_until_pages_is_configured` still required a
+  `pull_request:` trigger in `deploy-docs.yml`.
+- The broad folder-index audit reported 29 of 32 maintained indexes stale even
+  though the cumulative lane began from a clean integrated commit.
+
+### Root causes and resolutions
+
+- PR #745 (`729cc41b`) deliberately moved PR MkDocs evidence into the required
+  `Documentation Validation` job in `fast-checks.yml` and limited
+  `deploy-docs.yml` to relevant main pushes/manual dispatch, but the older
+  release regression from `176f5319` was not updated. Changed the test to verify
+  both halves of the current contract: no duplicated PR trigger in the main-only
+  workflow and strict PR docs validation in the consolidated workflow. The
+  focused regression and repeated broad suite pass.
+- `generate_enhanced_index.py` includes per-file `last_updated` values derived
+  from filesystem `st_mtime` inside its hash payload. Fresh linked worktrees
+  therefore make untouched folders look stale. This is a known generator-
+  signal problem, not INDIA-1 content drift; no 29-folder bulk rewrite was
+  introduced. Deterministic API and capability manifests were checked directly
+  and are current.
+
+### Evidence
+
+- First broad run: 5,925 passed, 3 skipped, 6 deselected, 1 stale CI-contract
+  failure.
+- Focused corrected CI regression: passed; Ruff and Black check passed.
+- Final broad Python run: 5,926 passed, 3 skipped, 6 deselected.
+- Full integrated repository gate: 30/30 passed.
+- Indian-code manifest: 21 capability records, zero unknown; the four INDIA-1
+  families are `SUPPORTED` / `IMPLEMENTED_BOUNDED`.
+- Cumulative essential review: no outcome-changing INDIA-1 finding; qualified
+  engineering review and release authorization remain ungranted.
+
+---
+
 ## 2026-08-15 — Session: INDIA-1D Solid-Slab Boundary Closure
 
 **Agent:** Codex (`structural-math`, sole writer; no subagents)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -32,6 +32,8 @@ cumulative essential-review gates after INDIA-1A through INDIA-1D integration.
   no workflow policy or structural calculation changed.
 - Final broad Python and full repository gates pass. Qualified professional
   review and any stable/engineering-use approval remain separate holds.
+- Published cumulative evidence commit `75089e8a` in draft PR #758; exact-head
+  hosted review remains the publication gate.
 
 ### Issues encountered
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -128,7 +128,7 @@
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
-| INDIA-1-CUMULATIVE | Run broad Python, full repository, manifest reconciliation, and cumulative essential review after A-D integration | Main Agent + reviewer | 🚧 SOFTWARE EVIDENCE COMPLETE — 5,926 Python tests and full 30/30 gate green; stale CI-contract repair publication pending |
+| INDIA-1-CUMULATIVE | Run broad Python, full repository, manifest reconciliation, and cumulative essential review after A-D integration | Main Agent + reviewer | 🚧 DRAFT PR #758 — 5,926 Python tests and full 30/30 gate green; exact-head hosted review pending |
 
 ## Up Next
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-15 — PR #753 integrated the INDIA-0 truth baseline at `0373de68`; INDIA-1A sagging T-beam closure is active in a fresh lane
+**Updated:** 2026-08-15 — INDIA-1A through INDIA-1D are integrated; cumulative software gates are green and qualified engineering review remains held
 
 ---
 
@@ -128,15 +128,14 @@
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
-| INDIA-1D | Close solid-slab serviceability, shear-reinforcement, and single-action load-envelope boundaries without promoting unvalidated slab math | Main Agent + structural engineer | 🚧 DRAFT PR #757 — focused 115 tests, architecture/import validation, and quick 10/10 green; exact-head hosted review pending |
+| INDIA-1-CUMULATIVE | Run broad Python, full repository, manifest reconciliation, and cumulative essential review after A-D integration | Main Agent + reviewer | 🚧 SOFTWARE EVIDENCE COMPLETE — 5,926 Python tests and full 30/30 gate green; stale CI-contract repair publication pending |
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-1-CUMULATIVE | Run broad Python, full repository, manifest reconciliation, and cumulative engineering review gates | Main Agent + qualified reviewer | milestone gate | P0 | 📋 SEQUENCED AFTER INDIA-1D INTEGRATION |
+| LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL QUALIFIED REVIEW |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
-| LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL STABLE GATE |
 
 ## Backlog
 
@@ -154,6 +153,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-1D | Closed solid-slab direct-deflection, crack-width, automatic-shear-reinforcement, and single-action load-envelope decisions with machine-visible holds | Main Agent | ✅ DONE — PR #757 exact-head gate passed; reviewed tree squash-merged as `ca55f22d` |
 | INDIA-1C | Published the bounded concentric isolated-footing composition with typed provenance, accepted benchmark, and explicit eccentric/other-foundation holds | Main Agent | ✅ DONE — PR #756 exact-head gate passed; reviewed tree squash-merged as `236ce646` |
 | INDIA-1B | Reconfirmed stable solid rectangular tied-column routes as a symmetric two-face reinforcement idealization and retained circular, arbitrary-layout, and experimental PMM cases | Main Agent | ✅ DONE — PR #755 exact-head gate passed; reviewed tree squash-merged as `f44452dd` |
 | INDIA-1A | Added a benchmarked monolithic sagging T-beam flexure/web-shear/explicit-serviceability composition with fail-closed retained boundaries | Main Agent | ✅ DONE — PR #754 exact-head gate passed; reviewed tree squash-merged as `3a7e162e` |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -5,10 +5,10 @@
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
 - Focus: Publish the cumulative INDIA-1 gate evidence and stale CI-contract repair
-- Draft PR: pending
+- Draft PR: [#758](https://github.com/Pravin-surawase/structural_engineering_lib/pull/758)
 - Branch: `codex/india-1-cumulative-gates`
 - Base: verified integrated `origin/main` at `ca55f22d3f8b6664e42ad41eb6d3ef9a0d1d96c3`
-- Implementation commit: pending
+- Implementation commit: `75089e8ad178d7d7ca8f7a5793cdf1f57c9ffbf4`
 - Next action: commit and publish the cumulative evidence packet; after its exact-head hosted gate passes, merge and verify integrated main. Keep stable/engineering-use approval held for qualified review and keep release authorization separate
 - Holds: no release, engineering-use approval, branch/worktree deletion, or historical-lane cleanup
 <!-- HANDOFF:END -->

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,12 +4,12 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: Publish INDIA-1D solid-slab boundary closure, then run the cumulative INDIA-1 gates
-- Draft PR: [#757](https://github.com/Pravin-surawase/structural_engineering_lib/pull/757)
-- Branch: `codex/india-1d-slab-boundary`
-- Base: verified integrated `origin/main` at `236ce6462543aa36df307a0a9b4ef463ac98d085`
-- Implementation commit: `782a4b79fd8cc19dce5a9a9fd0cada65ebc52673`
-- Next action: finish the narrow INDIA-1D gates, commit and publish the packet; after its exact-head hosted gate passes, merge and run the deferred broad Python, full repository, manifest reconciliation, and cumulative review gates on integrated A-D
+- Focus: Publish the cumulative INDIA-1 gate evidence and stale CI-contract repair
+- Draft PR: pending
+- Branch: `codex/india-1-cumulative-gates`
+- Base: verified integrated `origin/main` at `ca55f22d3f8b6664e42ad41eb6d3ef9a0d1d96c3`
+- Implementation commit: pending
+- Next action: commit and publish the cumulative evidence packet; after its exact-head hosted gate passes, merge and verify integrated main. Keep stable/engineering-use approval held for qualified review and keep release authorization separate
 - Holds: no release, engineering-use approval, branch/worktree deletion, or historical-lane cleanup
 <!-- HANDOFF:END -->
 
@@ -18,7 +18,7 @@
 | Release state | Target |
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; qualified engineering review still required |
-| **Next** | Publish INDIA-1D, then run the cumulative INDIA-1 gates on integrated A-D |
+| **Next** | Publish the cumulative INDIA-1 evidence; qualified review remains a separate gate |
 
 ## Required Reading
 
@@ -30,11 +30,12 @@
 
 ## Start Boundary
 
-INDIA-1A through INDIA-1C are integrated. Finish INDIA-1D only from its isolated
-branch. After its exact-head PR checks pass with no conflicts or blockers,
-merge normally, fetch `origin/main`, verify tree identity, and run the deferred
-cumulative gates from a fresh integrated lane. Preserve the dirty primary
-checkout and all unrelated worktrees; do not bypass checks.
+INDIA-1A through INDIA-1D are integrated. The deferred broad Python, full
+repository, deterministic manifest, and cumulative essential-review gates have
+run on a fresh integrated lane. Publish only the stale CI-contract repair and
+cumulative evidence from that lane. Preserve the dirty primary checkout and all
+unrelated worktrees; do not bypass checks or convert software evidence into
+qualified engineering or release approval.
 
 ```bash
 ./run.sh session brief --agent structural-math

--- a/docs/verification/india-1-cumulative-gate-evidence.md
+++ b/docs/verification/india-1-cumulative-gate-evidence.md
@@ -1,0 +1,55 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: reference
+task: INDIA-1-CUMULATIVE
+---
+
+# INDIA-1 Cumulative Gate Evidence
+
+INDIA-1A through INDIA-1D are integrated on main as four independently gated
+packets:
+
+| Packet | Reviewed head | Squash merge | Integrated outcome |
+|---|---|---|---|
+| INDIA-1A beam | `5df4e996` | `3a7e162e` | bounded sagging T-beam composition |
+| INDIA-1B column | `1f10778c` | `f44452dd` | symmetric two-face rectangular decision closure |
+| INDIA-1C footing | `03a50688` | `236ce646` | public concentric isolated-footing composition |
+| INDIA-1D slab | `9d7fe61d` | `ca55f22d` | serviceability, shear, and loading boundary closure |
+
+For every packet, the reviewed feature-head tree equals its integrated squash-
+merge tree. No branch, ref, or worktree cleanup was authorized or performed.
+
+## Deferred gates
+
+The first cumulative broad Python run exposed one stale CI-contract regression:
+the test still expected `deploy-docs.yml` to run on pull requests after PR #745
+moved strict MkDocs PR evidence into the required consolidated PR Validation
+workflow. The correction now verifies that `deploy-docs.yml` remains main/manual
+and build-only while `fast-checks.yml` owns strict pull-request documentation
+validation.
+
+After that root-cause repair:
+
+- broad Python: 5,926 passed, 3 skipped, 6 deselected;
+- full repository gate: 30/30 passed;
+- generated API manifest: current;
+- generated Indian-code manifest: current; and
+- capability state: 21 records, zero unknown, with beam, column, isolated
+  footing, and solid slab all `SUPPORTED` / `IMPLEMENTED_BOUNDED`.
+
+The folder-index audit reported 29 of 32 indexes stale because the generator's
+hash includes dates derived from linked-worktree filesystem mtimes. Those bulk
+changes do not represent INDIA-1 content drift and were not committed.
+
+## Cumulative review conclusion
+
+The integrated public facades, numerical benchmarks, provenance, units,
+supported cases, fail-closed holds, and serialized result boundaries are
+consistent. No outcome-changing INDIA-1 software or claim defect was found.
+
+This is software acceptance evidence only. Direct professional use, stable-
+capability approval, package publication, tagging, and GitHub Release creation
+remain outside this result. Qualified structural-engineering review and the
+per-release owner authorization are still required.


### PR DESCRIPTION
## Summary

- record the deferred cumulative INDIA-1 software gates after A-D integration
- repair the stale documentation-workflow regression exposed by the broad Python suite
- verify the current split contract: consolidated PR Validation owns strict pull-request MkDocs evidence; deploy-docs remains main/manual and build-only
- retain qualified engineering review and release authorization as separate holds

## Validation

- initial broad Python: 5,925 passed, 3 skipped, 6 deselected, 1 stale CI-contract failure
- corrected focused CI regression, Ruff, and Black: passed
- final broad Python: 5,926 passed, 3 skipped, 6 deselected
- full repository gate: 30/30 passed
- generated API and Indian-code manifests: current
- capability manifest: 21 records, zero unknown; four INDIA-1 families are bounded supported
- cumulative essential review: no outcome-changing INDIA-1 software or claim finding

## Index audit

The broad folder-index checker reports 29/32 stale because its hash includes per-file dates derived from linked-worktree filesystem mtimes. Those bulk changes are not INDIA-1 content drift and are intentionally not included.

## Holds

No stable/engineering-use approval, tag, package publication, GitHub Release, branch deletion, or worktree deletion is authorized.