### PR TITLE
feat(is456): add staircase geometry and actions

### DIFF
--- a/Python/structural_lib/codes/is456/index.json
+++ b/Python/structural_lib/codes/is456/index.json
@@ -2,14 +2,14 @@
   "folder": "Python/structural_lib/codes/is456",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-12",
+  "last_updated": "2026-08-15",
   "file_count": 14,
   "files": [
     {
       "name": "__init__.py",
       "type": "python",
       "size_lines": 148,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "IS 456:2000 - Indian Standard for Plain and Reinforced Concrete.",
       "classes": [
         {
@@ -31,7 +31,7 @@
     {
       "name": "clauses.json",
       "type": "config",
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "$schema",
         "metadata",
@@ -45,8 +45,8 @@
     {
       "name": "compliance.py",
       "type": "python",
-      "size_lines": 549,
-      "last_updated": "2026-08-12",
+      "size_lines": 583,
+      "last_updated": "2026-08-15",
       "description": "Module: compliance",
       "functions": [
         {
@@ -65,13 +65,13 @@
           ]
         }
       ],
-      "content_hash": "f7e7b8ddd87c"
+      "content_hash": "084d68bf329d"
     },
     {
       "name": "detailing.py",
       "type": "python",
       "size_lines": 28,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Backward compatibility shim — detailing module moved to beam/ subpackage.",
       "content_hash": "c33bfd7dac60"
     },
@@ -79,7 +79,7 @@
       "name": "ductile.py",
       "type": "python",
       "size_lines": 30,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Backward compatibility shim — ductile module moved to codes/is13920/.",
       "content_hash": "bdd02d80e4da"
     },
@@ -87,7 +87,7 @@
       "name": "flexure.py",
       "type": "python",
       "size_lines": 28,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Backward compatibility shim — flexure module moved to beam/ subpackage.",
       "content_hash": "47488cbd8024"
     },
@@ -95,7 +95,7 @@
       "name": "load_analysis.py",
       "type": "python",
       "size_lines": 627,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Module:       load_analysis",
       "functions": [
         {
@@ -176,7 +176,7 @@
       "name": "materials.py",
       "type": "python",
       "size_lines": 128,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Module:       materials",
       "functions": [
         {
@@ -215,7 +215,7 @@
       "name": "serviceability.py",
       "type": "python",
       "size_lines": 37,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Backward compatibility shim — serviceability module moved to beam/ subpackage.",
       "content_hash": "090ff8893072"
     },
@@ -223,7 +223,7 @@
       "name": "shear.py",
       "type": "python",
       "size_lines": 28,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Backward compatibility shim — shear module moved to beam/ subpackage.",
       "content_hash": "9b97fb7e9292"
     },
@@ -231,7 +231,7 @@
       "name": "slenderness.py",
       "type": "python",
       "size_lines": 364,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Slenderness Check Module — IS 456:2000 Beam Lateral Stability",
       "classes": [
         {
@@ -280,7 +280,7 @@
       "name": "tables.py",
       "type": "python",
       "size_lines": 97,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Module:       tables",
       "functions": [
         {
@@ -309,7 +309,7 @@
       "name": "torsion.py",
       "type": "python",
       "size_lines": 29,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "Backward compatibility shim — torsion module moved to beam/ subpackage.",
       "content_hash": "93338352a274"
     },
@@ -317,7 +317,7 @@
       "name": "traceability.py",
       "type": "python",
       "size_lines": 350,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-15",
       "description": "IS 456 Traceability Module",
       "functions": [
         {
@@ -408,6 +408,12 @@
       "path": "slab/",
       "file_count": 16,
       "is_package": true
+    },
+    {
+      "name": "staircase",
+      "path": "staircase/",
+      "file_count": 6,
+      "is_package": true
     }
   ],
   "has_init": true,
@@ -432,5 +438,5 @@
     "list_clauses_by_category",
     "search_clauses"
   ],
-  "content_hash": "046c7ea40060e8db"
+  "content_hash": "8182bc737b78e302"
 }

--- a/Python/structural_lib/codes/is456/index.md
+++ b/Python/structural_lib/codes/is456/index.md
@@ -1,7 +1,7 @@
 # Is456
 
 **Type:** Python Package
-**Last Updated:** 2026-08-12
+**Last Updated:** 2026-08-15
 **Files:** 14
 
 ## Public API
@@ -35,7 +35,7 @@
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | IS 456:2000 - Indian Standard for Plain and Reinforced Concr | 1 | 0 | 148 |
-| [compliance.py](compliance.py) | Module: compliance | 0 | 3 | 549 |
+| [compliance.py](compliance.py) | Module: compliance | 0 | 3 | 583 |
 | [detailing.py](detailing.py) | Backward compatibility shim — detailing module moved to beam | 0 | 0 | 28 |
 | [ductile.py](ductile.py) | Backward compatibility shim — ductile module moved to codes/ | 0 | 0 | 30 |
 | [flexure.py](flexure.py) | Backward compatibility shim — flexure module moved to beam/  | 0 | 0 | 28 |
@@ -57,3 +57,4 @@
 | [common/](common/) 📦 | 5 |  |
 | [footing/](footing/) 📦 | 10 |  |
 | [slab/](slab/) 📦 | 16 |  |
+| [staircase/](staircase/) 📦 | 6 |  |

--- a/Python/structural_lib/codes/is456/staircase/__init__.py
+++ b/Python/structural_lib/codes/is456/staircase/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Bounded IS 456 straight-flight staircase geometry and actions."""
+
+from structural_lib.codes.is456.staircase.actions import (
+    StraightFlightActionResult,
+    analyze_straight_flight_actions,
+)
+from structural_lib.codes.is456.staircase.geometry import (
+    StraightFlightGeometryResult,
+    resolve_straight_flight_geometry,
+)
+from structural_lib.codes.is456.staircase.models import (
+    StaircaseContractError,
+    StairSpanDirection,
+    StairSupportCase,
+    StraightFlightActionInput,
+    StraightFlightLoads,
+    StraightFlightStairGeometry,
+)
+
+__all__ = [
+    "StairSpanDirection",
+    "StairSupportCase",
+    "StaircaseContractError",
+    "StraightFlightActionInput",
+    "StraightFlightActionResult",
+    "StraightFlightGeometryResult",
+    "StraightFlightLoads",
+    "StraightFlightStairGeometry",
+    "analyze_straight_flight_actions",
+    "resolve_straight_flight_geometry",
+]

--- a/Python/structural_lib/codes/is456/staircase/actions.py
+++ b/Python/structural_lib/codes/is456/staircase/actions.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Self-weight and three-segment actions for the INDIA-2 staircase case."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from structural_lib.codes.is456.staircase.geometry import (
+    StraightFlightGeometryResult,
+    resolve_straight_flight_geometry,
+)
+from structural_lib.codes.is456.staircase.models import (
+    StaircaseContractError,
+    StraightFlightActionInput,
+)
+from structural_lib.codes.is456.traceability import clause
+
+__all__ = ["StraightFlightActionResult", "analyze_straight_flight_actions"]
+
+
+_SOURCE_REFS = (
+    "IS 456:2000 Cl. 33.1-33.3",
+    "NPTEL-M9L20-EX9.1",
+    "ACTIONS: caller-supplied superimposed loads and load factor; no IS 875 generation",
+)
+
+
+@dataclass(frozen=True)
+class StraightFlightActionResult:
+    """Self-weight, piecewise loads, reactions, shear, and sagging moment."""
+
+    input: StraightFlightActionInput
+    geometry: StraightFlightGeometryResult
+    waist_self_weight_kn_per_m2: float
+    step_self_weight_kn_per_m2: float
+    landing_self_weight_kn_per_m2: float
+    flight_service_load_kn_per_m2: float
+    lower_landing_factored_load_kn_per_m2: float
+    flight_factored_load_kn_per_m2: float
+    upper_landing_factored_load_kn_per_m2: float
+    total_factored_load_kn: float
+    lower_support_reaction_kn: float
+    upper_support_reaction_kn: float
+    maximum_factored_shear_kn: float
+    maximum_factored_shear_kn_per_m: float
+    maximum_moment_location_mm: float
+    maximum_factored_moment_knm: float
+    maximum_factored_moment_knm_per_m: float
+    segment_boundary_moments_knm: tuple[float, float]
+    equilibrium_residual_kn: float
+    source_refs: tuple[str, ...]
+    load_generation_status: str = "not_generated_caller_supplied_actions"
+
+
+def _moment_at_m(
+    x_m: float,
+    lower_reaction_kn: float,
+    segment_lengths_m: tuple[float, float, float],
+    segment_line_loads_kn_per_m: tuple[float, float, float],
+) -> float:
+    """Return sagging moment at horizontal coordinate ``x_m`` in kNm."""
+    moment_knm = lower_reaction_kn * x_m
+    segment_start_m = 0.0
+    for length_m, line_load_kn_per_m in zip(
+        segment_lengths_m, segment_line_loads_kn_per_m, strict=True
+    ):
+        loaded_length_m = min(max(x_m - segment_start_m, 0.0), length_m)
+        if loaded_length_m > 0.0:
+            resultant_kn = line_load_kn_per_m * loaded_length_m
+            centroid_m = segment_start_m + loaded_length_m / 2.0
+            moment_knm -= resultant_kn * (x_m - centroid_m)
+        segment_start_m += length_m
+    return moment_knm
+
+
+@clause("33.1", "33.2", "33.3")
+def analyze_straight_flight_actions(
+    design_input: StraightFlightActionInput,
+) -> StraightFlightActionResult:
+    """Analyze three contiguous UDL segments over one simply supported span.
+
+    Concrete self-weight is calculated explicitly. Superimposed actions,
+    landing shares, and the ultimate factor remain caller-supplied provenance.
+    """
+    if not isinstance(design_input, StraightFlightActionInput):
+        raise StaircaseContractError("design_input must be a StraightFlightActionInput")
+    geometry = resolve_straight_flight_geometry(design_input.geometry)
+    raw_geometry = design_input.geometry
+    loads = design_input.loads
+    concrete_unit_weight = loads.concrete_unit_weight_kn_per_m3
+
+    waist_self_weight = (
+        concrete_unit_weight
+        * raw_geometry.waist_thickness_mm
+        / 1000.0
+        * geometry.slope_factor
+    )
+    step_self_weight = concrete_unit_weight * raw_geometry.riser_mm / 2000.0
+    landing_self_weight = (
+        concrete_unit_weight * raw_geometry.landing_thickness_mm / 1000.0
+    )
+    flight_service_load = (
+        waist_self_weight
+        + step_self_weight
+        + loads.flight_superimposed_service_load_kn_per_m2
+    )
+    lower_factored_load = (
+        (landing_self_weight + loads.lower_landing_superimposed_service_load_kn_per_m2)
+        * loads.lower_landing_load_share
+        * loads.ultimate_load_factor
+    )
+    flight_factored_load = flight_service_load * loads.ultimate_load_factor
+    upper_factored_load = (
+        (landing_self_weight + loads.upper_landing_superimposed_service_load_kn_per_m2)
+        * loads.upper_landing_load_share
+        * loads.ultimate_load_factor
+    )
+
+    segment_lengths_m = (
+        raw_geometry.lower_landing_effective_length_mm / 1000.0,
+        raw_geometry.going_mm / 1000.0,
+        raw_geometry.upper_landing_effective_length_mm / 1000.0,
+    )
+    width_m = raw_geometry.flight_width_mm / 1000.0
+    segment_line_loads: tuple[float, float, float] = (
+        lower_factored_load * width_m,
+        flight_factored_load * width_m,
+        upper_factored_load * width_m,
+    )
+    segment_resultants = tuple(
+        line_load * length
+        for line_load, length in zip(segment_line_loads, segment_lengths_m, strict=True)
+    )
+    total_span_m = geometry.effective_span_mm / 1000.0
+    total_factored_load = sum(segment_resultants)
+    moment_about_lower_knm = 0.0
+    segment_start_m = 0.0
+    for resultant_kn, length_m in zip(
+        segment_resultants, segment_lengths_m, strict=True
+    ):
+        moment_about_lower_knm += resultant_kn * (segment_start_m + length_m / 2.0)
+        segment_start_m += length_m
+    upper_reaction = moment_about_lower_knm / total_span_m
+    lower_reaction = total_factored_load - upper_reaction
+
+    cumulative_load_kn = 0.0
+    segment_start_m = 0.0
+    maximum_moment_location_m: float | None = None
+    for length_m, line_load_kn_per_m, resultant_kn in zip(
+        segment_lengths_m,
+        segment_line_loads,
+        segment_resultants,
+        strict=True,
+    ):
+        if cumulative_load_kn + resultant_kn >= lower_reaction:
+            maximum_moment_location_m = (
+                segment_start_m
+                + (lower_reaction - cumulative_load_kn) / line_load_kn_per_m
+            )
+            break
+        cumulative_load_kn += resultant_kn
+        segment_start_m += length_m
+    if maximum_moment_location_m is None:
+        raise StaircaseContractError(
+            "factored segment loads did not produce an internal zero-shear point"
+        )
+
+    maximum_moment = _moment_at_m(
+        maximum_moment_location_m,
+        lower_reaction,
+        segment_lengths_m,
+        segment_line_loads,
+    )
+    first_boundary_m = segment_lengths_m[0]
+    second_boundary_m = segment_lengths_m[0] + segment_lengths_m[1]
+    boundary_moments = (
+        _moment_at_m(
+            first_boundary_m,
+            lower_reaction,
+            segment_lengths_m,
+            segment_line_loads,
+        ),
+        _moment_at_m(
+            second_boundary_m,
+            lower_reaction,
+            segment_lengths_m,
+            segment_line_loads,
+        ),
+    )
+    maximum_shear = max(lower_reaction, upper_reaction)
+    equilibrium_residual = lower_reaction + upper_reaction - total_factored_load
+
+    return StraightFlightActionResult(
+        input=design_input,
+        geometry=geometry,
+        waist_self_weight_kn_per_m2=waist_self_weight,
+        step_self_weight_kn_per_m2=step_self_weight,
+        landing_self_weight_kn_per_m2=landing_self_weight,
+        flight_service_load_kn_per_m2=flight_service_load,
+        lower_landing_factored_load_kn_per_m2=lower_factored_load,
+        flight_factored_load_kn_per_m2=flight_factored_load,
+        upper_landing_factored_load_kn_per_m2=upper_factored_load,
+        total_factored_load_kn=total_factored_load,
+        lower_support_reaction_kn=lower_reaction,
+        upper_support_reaction_kn=upper_reaction,
+        maximum_factored_shear_kn=maximum_shear,
+        maximum_factored_shear_kn_per_m=maximum_shear / width_m,
+        maximum_moment_location_mm=maximum_moment_location_m * 1000.0,
+        maximum_factored_moment_knm=maximum_moment,
+        maximum_factored_moment_knm_per_m=maximum_moment / width_m,
+        segment_boundary_moments_knm=boundary_moments,
+        equilibrium_residual_kn=equilibrium_residual,
+        source_refs=_SOURCE_REFS + (loads.load_basis_reference,),
+    )

--- a/Python/structural_lib/codes/is456/staircase/geometry.py
+++ b/Python/structural_lib/codes/is456/staircase/geometry.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Clause 33 geometry for the bounded straight-flight staircase case."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from structural_lib.codes.is456.staircase.models import (
+    StaircaseContractError,
+    StraightFlightStairGeometry,
+)
+from structural_lib.codes.is456.traceability import clause
+
+__all__ = ["StraightFlightGeometryResult", "resolve_straight_flight_geometry"]
+
+
+_SOURCE_REFS = (
+    "IS 456:2000 Cl. 33.1(c) and Cl. 33.3",
+    "NPTEL-M9L20-EX9.1",
+)
+
+
+@dataclass(frozen=True)
+class StraightFlightGeometryResult:
+    """Resolved horizontal span and slope geometry with explicit mm units."""
+
+    input: StraightFlightStairGeometry
+    effective_span_mm: float
+    inclined_step_length_mm: float
+    slope_factor: float
+    slope_angle_degrees: float
+    inclined_going_length_mm: float
+    source_refs: tuple[str, ...]
+
+
+@clause("33.1", "33.3")
+def resolve_straight_flight_geometry(
+    geometry: StraightFlightStairGeometry,
+) -> StraightFlightGeometryResult:
+    """Resolve the frozen collinear-landing support and waist-depth geometry."""
+    if not isinstance(geometry, StraightFlightStairGeometry):
+        raise StaircaseContractError("geometry must be a StraightFlightStairGeometry")
+    inclined_step_length_mm = math.hypot(geometry.riser_mm, geometry.tread_mm)
+    slope_factor = inclined_step_length_mm / geometry.tread_mm
+    return StraightFlightGeometryResult(
+        input=geometry,
+        effective_span_mm=(
+            geometry.lower_landing_effective_length_mm
+            + geometry.going_mm
+            + geometry.upper_landing_effective_length_mm
+        ),
+        inclined_step_length_mm=inclined_step_length_mm,
+        slope_factor=slope_factor,
+        slope_angle_degrees=math.degrees(
+            math.atan2(geometry.riser_mm, geometry.tread_mm)
+        ),
+        inclined_going_length_mm=geometry.going_mm * slope_factor,
+        source_refs=_SOURCE_REFS,
+    )

--- a/Python/structural_lib/codes/is456/staircase/index.json
+++ b/Python/structural_lib/codes/is456/staircase/index.json
@@ -1,0 +1,138 @@
+{
+  "folder": "Python/structural_lib/codes/is456/staircase",
+  "type": "python-package",
+  "description": "",
+  "last_updated": "2026-08-15",
+  "file_count": 4,
+  "files": [
+    {
+      "name": "__init__.py",
+      "type": "python",
+      "size_lines": 34,
+      "last_updated": "2026-08-15",
+      "description": "Bounded IS 456 straight-flight staircase geometry and actions.",
+      "content_hash": "bcabe16a3ac0"
+    },
+    {
+      "name": "actions.py",
+      "type": "python",
+      "size_lines": 216,
+      "last_updated": "2026-08-15",
+      "description": "Self-weight and three-segment actions for the INDIA-2 staircase case.",
+      "classes": [
+        {
+          "name": "StraightFlightActionResult",
+          "description": "Self-weight, piecewise loads, reactions, shear, and sagging moment."
+        }
+      ],
+      "functions": [
+        {
+          "name": "analyze_straight_flight_actions",
+          "description": "Analyze three contiguous UDL segments over one simply supported span.",
+          "params": [
+            "design_input"
+          ]
+        }
+      ],
+      "constants": [
+        "_SOURCE_REFS"
+      ],
+      "content_hash": "a5500570cbb4"
+    },
+    {
+      "name": "geometry.py",
+      "type": "python",
+      "size_lines": 62,
+      "last_updated": "2026-08-15",
+      "description": "Clause 33 geometry for the bounded straight-flight staircase case.",
+      "classes": [
+        {
+          "name": "StraightFlightGeometryResult",
+          "description": "Resolved horizontal span and slope geometry with explicit mm units."
+        }
+      ],
+      "functions": [
+        {
+          "name": "resolve_straight_flight_geometry",
+          "description": "Resolve the frozen collinear-landing support and waist-depth geometry.",
+          "params": [
+            "geometry"
+          ]
+        }
+      ],
+      "constants": [
+        "_SOURCE_REFS"
+      ],
+      "content_hash": "52c7a78883b7"
+    },
+    {
+      "name": "models.py",
+      "type": "python",
+      "size_lines": 199,
+      "last_updated": "2026-08-15",
+      "description": "Typed contracts for the bounded INDIA-2 straight-flight staircase case.",
+      "classes": [
+        {
+          "name": "StaircaseContractError",
+          "description": "Raised when an input is outside the frozen INDIA-2 staircase scope."
+        },
+        {
+          "name": "StairSupportCase",
+          "description": "Support arrangements named at the boundary; only one is accepted."
+        },
+        {
+          "name": "StairSpanDirection",
+          "description": "Potential span directions; INDIA-2 accepts longitudinal behavior only."
+        },
+        {
+          "name": "StraightFlightStairGeometry",
+          "description": "Geometry for one longitudinal flight and two collinear landing segments."
+        },
+        {
+          "name": "StraightFlightLoads",
+          "description": "Caller load carriers plus explicit concrete self-weight inputs."
+        },
+        {
+          "name": "StraightFlightActionInput",
+          "description": "Accepted geometry and load carriers for the three-segment analysis."
+        }
+      ],
+      "functions": [
+        {
+          "name": "positive_finite",
+          "description": "Normalize a positive finite engineering input or fail closed.",
+          "params": [
+            "value",
+            "field_name",
+            "unit"
+          ]
+        },
+        {
+          "name": "nonnegative_finite",
+          "description": "Normalize a non-negative finite engineering input or fail closed.",
+          "params": [
+            "value",
+            "field_name",
+            "unit"
+          ]
+        }
+      ],
+      "content_hash": "6f5d652eb02e"
+    }
+  ],
+  "subfolders": [],
+  "has_init": true,
+  "public_api": [
+    "StairSpanDirection",
+    "StairSupportCase",
+    "StaircaseContractError",
+    "StraightFlightActionInput",
+    "StraightFlightActionResult",
+    "StraightFlightGeometryResult",
+    "StraightFlightLoads",
+    "StraightFlightStairGeometry",
+    "analyze_straight_flight_actions",
+    "resolve_straight_flight_geometry"
+  ],
+  "content_hash": "77b09fa017311510"
+}

--- a/Python/structural_lib/codes/is456/staircase/index.md
+++ b/Python/structural_lib/codes/is456/staircase/index.md
@@ -1,0 +1,27 @@
+# Staircase
+
+**Type:** Python Package
+**Last Updated:** 2026-08-15
+**Files:** 4
+
+## Public API
+
+- `StairSpanDirection`
+- `StairSupportCase`
+- `StaircaseContractError`
+- `StraightFlightActionInput`
+- `StraightFlightActionResult`
+- `StraightFlightGeometryResult`
+- `StraightFlightLoads`
+- `StraightFlightStairGeometry`
+- `analyze_straight_flight_actions`
+- `resolve_straight_flight_geometry`
+
+## Python Files
+
+| File | Description | Classes | Functions | Lines |
+|------|-------------|---------|-----------|-------|
+| [__init__.py](__init__.py) | Bounded IS 456 straight-flight staircase geometry and action | 0 | 0 | 34 |
+| [actions.py](actions.py) | Self-weight and three-segment actions for the INDIA-2 stairc | 1 | 1 | 216 |
+| [geometry.py](geometry.py) | Clause 33 geometry for the bounded straight-flight staircase | 1 | 1 | 62 |
+| [models.py](models.py) | Typed contracts for the bounded INDIA-2 straight-flight stai | 6 | 2 | 199 |

--- a/Python/structural_lib/codes/is456/staircase/models.py
+++ b/Python/structural_lib/codes/is456/staircase/models.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Typed contracts for the bounded INDIA-2 straight-flight staircase case."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from numbers import Real
+
+__all__ = [
+    "StairSpanDirection",
+    "StairSupportCase",
+    "StaircaseContractError",
+    "StraightFlightActionInput",
+    "StraightFlightLoads",
+    "StraightFlightStairGeometry",
+]
+
+
+class StaircaseContractError(ValueError):
+    """Raised when an input is outside the frozen INDIA-2 staircase scope."""
+
+
+class StairSupportCase(StrEnum):
+    """Support arrangements named at the boundary; only one is accepted."""
+
+    LANDINGS_SPAN_WITH_FLIGHT = "landings_span_with_flight"
+    BEAMS_AT_TOP_AND_BOTTOM_RISERS = "beams_at_top_and_bottom_risers"
+    STRINGER_SUPPORTED = "stringer_supported"
+
+
+class StairSpanDirection(StrEnum):
+    """Potential span directions; INDIA-2 accepts longitudinal behavior only."""
+
+    LONGITUDINAL = "longitudinal"
+    TRANSVERSE = "transverse"
+
+
+def positive_finite(value: float, field_name: str, unit: str) -> float:
+    """Normalize a positive finite engineering input or fail closed."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise StaircaseContractError(f"{field_name} must be a real value in {unit}")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0.0:
+        raise StaircaseContractError(
+            f"{field_name} must be finite and positive in {unit}"
+        )
+    return normalized
+
+
+def nonnegative_finite(value: float, field_name: str, unit: str) -> float:
+    """Normalize a non-negative finite engineering input or fail closed."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise StaircaseContractError(f"{field_name} must be a real value in {unit}")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized < 0.0:
+        raise StaircaseContractError(
+            f"{field_name} must be finite and non-negative in {unit}"
+        )
+    return normalized
+
+
+@dataclass(frozen=True)
+class StraightFlightStairGeometry:
+    """Geometry for one longitudinal flight and two collinear landing segments.
+
+    All dimensions are in mm. The three horizontal segment lengths run from
+    the lower outer support centre to the upper outer support centre.
+    """
+
+    lower_landing_effective_length_mm: float
+    going_mm: float
+    upper_landing_effective_length_mm: float
+    flight_width_mm: float
+    riser_mm: float
+    tread_mm: float
+    waist_thickness_mm: float
+    landing_thickness_mm: float
+    support_case: StairSupportCase = StairSupportCase.LANDINGS_SPAN_WITH_FLIGHT
+    span_direction: StairSpanDirection = StairSpanDirection.LONGITUDINAL
+    landings_collinear: bool = True
+    has_stringer_beams: bool = False
+    is_cast_in_situ_solid: bool = True
+
+    def __post_init__(self) -> None:
+        for name in (
+            "lower_landing_effective_length_mm",
+            "going_mm",
+            "upper_landing_effective_length_mm",
+            "flight_width_mm",
+            "riser_mm",
+            "tread_mm",
+            "waist_thickness_mm",
+            "landing_thickness_mm",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                positive_finite(getattr(self, name), name, "mm"),
+            )
+        if self.support_case is not StairSupportCase.LANDINGS_SPAN_WITH_FLIGHT:
+            raise StaircaseContractError(
+                "support_case must be landings_span_with_flight for INDIA-2"
+            )
+        if self.span_direction is not StairSpanDirection.LONGITUDINAL:
+            raise StaircaseContractError(
+                "span_direction must be longitudinal for INDIA-2"
+            )
+        if self.landings_collinear is not True:
+            raise StaircaseContractError(
+                "landings_collinear must be explicitly True for INDIA-2"
+            )
+        if self.has_stringer_beams is not False:
+            raise StaircaseContractError(
+                "has_stringer_beams must be explicitly False for INDIA-2"
+            )
+        if self.is_cast_in_situ_solid is not True:
+            raise StaircaseContractError(
+                "is_cast_in_situ_solid must be explicitly True for INDIA-2"
+            )
+
+
+@dataclass(frozen=True)
+class StraightFlightLoads:
+    """Caller load carriers plus explicit concrete self-weight inputs.
+
+    Superimposed actions are unfactored area loads on horizontal plan in kN/m2.
+    Landing shares are caller decisions; this type does not generate IS 875
+    actions or infer an open-well system.
+    """
+
+    lower_landing_superimposed_service_load_kn_per_m2: float
+    flight_superimposed_service_load_kn_per_m2: float
+    upper_landing_superimposed_service_load_kn_per_m2: float
+    lower_landing_load_share: float
+    upper_landing_load_share: float
+    concrete_unit_weight_kn_per_m3: float
+    ultimate_load_factor: float
+    load_basis_reference: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "lower_landing_superimposed_service_load_kn_per_m2",
+            "flight_superimposed_service_load_kn_per_m2",
+            "upper_landing_superimposed_service_load_kn_per_m2",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                nonnegative_finite(getattr(self, name), name, "kN/m2"),
+            )
+        for name in ("lower_landing_load_share", "upper_landing_load_share"):
+            share = positive_finite(getattr(self, name), name, "ratio")
+            if share > 1.0:
+                raise StaircaseContractError(f"{name} must not exceed 1.0")
+            object.__setattr__(self, name, share)
+        object.__setattr__(
+            self,
+            "concrete_unit_weight_kn_per_m3",
+            positive_finite(
+                self.concrete_unit_weight_kn_per_m3,
+                "concrete_unit_weight_kn_per_m3",
+                "kN/m3",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "ultimate_load_factor",
+            positive_finite(self.ultimate_load_factor, "ultimate_load_factor", "ratio"),
+        )
+        if (
+            not isinstance(self.load_basis_reference, str)
+            or not self.load_basis_reference.strip()
+        ):
+            raise StaircaseContractError(
+                "load_basis_reference must be a non-blank caller reference"
+            )
+        object.__setattr__(
+            self, "load_basis_reference", self.load_basis_reference.strip()
+        )
+
+
+@dataclass(frozen=True)
+class StraightFlightActionInput:
+    """Accepted geometry and load carriers for the three-segment analysis."""
+
+    geometry: StraightFlightStairGeometry
+    loads: StraightFlightLoads
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.geometry, StraightFlightStairGeometry):
+            raise StaircaseContractError(
+                "geometry must be a StraightFlightStairGeometry"
+            )
+        if not isinstance(self.loads, StraightFlightLoads):
+            raise StaircaseContractError("loads must be a StraightFlightLoads")

--- a/Python/tests/codes/is456/staircase/__init__.py
+++ b/Python/tests/codes/is456/staircase/__init__.py
@@ -1,0 +1,1 @@
+"""Focused staircase tests."""

--- a/Python/tests/codes/is456/staircase/index.json
+++ b/Python/tests/codes/is456/staircase/index.json
@@ -1,0 +1,58 @@
+{
+  "folder": "Python/tests/codes/is456/staircase",
+  "type": "python-package",
+  "description": "",
+  "last_updated": "2026-08-15",
+  "file_count": 2,
+  "files": [
+    {
+      "name": "__init__.py",
+      "type": "python",
+      "size_lines": 2,
+      "last_updated": "2026-08-15",
+      "description": "Focused staircase tests.",
+      "content_hash": "c44590fc1fb3"
+    },
+    {
+      "name": "test_geometry_actions.py",
+      "type": "python",
+      "size_lines": 132,
+      "last_updated": "2026-08-15",
+      "description": "INDIA-2B benchmark and fail-closed staircase action tests.",
+      "functions": [
+        {
+          "name": "test_nptel_example_9_1_geometry_and_load_benchmark"
+        },
+        {
+          "name": "test_nptel_example_9_1_piecewise_action_benchmark"
+        },
+        {
+          "name": "test_unrounded_actions_retain_full_width_and_per_metre_identity"
+        },
+        {
+          "name": "test_invalid_geometry_fails_closed",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_unsupported_span_and_support_models_fail_closed"
+        },
+        {
+          "name": "test_landing_share_above_one_fails_closed"
+        },
+        {
+          "name": "test_zero_superimposed_actions_preserve_positive_self_weight_analysis"
+        },
+        {
+          "name": "test_geometry_resolver_rejects_wrong_type"
+        }
+      ],
+      "content_hash": "6c9050ab62ce"
+    }
+  ],
+  "subfolders": [],
+  "has_init": true,
+  "content_hash": "f0478d8cdc76e135"
+}

--- a/Python/tests/codes/is456/staircase/index.md
+++ b/Python/tests/codes/is456/staircase/index.md
@@ -1,0 +1,12 @@
+# Staircase
+
+**Type:** Python Package
+**Last Updated:** 2026-08-15
+**Files:** 2
+
+## Python Files
+
+| File | Description | Classes | Functions | Lines |
+|------|-------------|---------|-----------|-------|
+| [__init__.py](__init__.py) | Focused staircase tests. | 0 | 0 | 2 |
+| [test_geometry_actions.py](test_geometry_actions.py) | INDIA-2B benchmark and fail-closed staircase action tests. | 0 | 8 | 132 |

--- a/Python/tests/codes/is456/staircase/test_geometry_actions.py
+++ b/Python/tests/codes/is456/staircase/test_geometry_actions.py
@@ -1,0 +1,131 @@
+"""INDIA-2B benchmark and fail-closed staircase action tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from structural_lib.codes.is456.staircase import (
+    StaircaseContractError,
+    StairSpanDirection,
+    StairSupportCase,
+    StraightFlightActionInput,
+    StraightFlightLoads,
+    StraightFlightStairGeometry,
+    analyze_straight_flight_actions,
+    resolve_straight_flight_geometry,
+)
+
+
+def _benchmark_geometry(**overrides: object) -> StraightFlightStairGeometry:
+    values: dict[str, object] = {
+        "lower_landing_effective_length_mm": 750.0,
+        "going_mm": 2700.0,
+        "upper_landing_effective_length_mm": 1650.0,
+        "flight_width_mm": 1500.0,
+        "riser_mm": 160.0,
+        "tread_mm": 270.0,
+        "waist_thickness_mm": 250.0,
+        "landing_thickness_mm": 200.0,
+    }
+    values.update(overrides)
+    return StraightFlightStairGeometry(**values)  # type: ignore[arg-type]
+
+
+def _benchmark_input(**load_overrides: object) -> StraightFlightActionInput:
+    values: dict[str, object] = {
+        "lower_landing_superimposed_service_load_kn_per_m2": 6.0,
+        "flight_superimposed_service_load_kn_per_m2": 6.0,
+        "upper_landing_superimposed_service_load_kn_per_m2": 6.0,
+        "lower_landing_load_share": 0.5,
+        "upper_landing_load_share": 1.0,
+        "concrete_unit_weight_kn_per_m3": 25.0,
+        "ultimate_load_factor": 1.5,
+        "load_basis_reference": "NPTEL-M9L20-EX9.1",
+    }
+    values.update(load_overrides)
+    return StraightFlightActionInput(
+        geometry=_benchmark_geometry(),
+        loads=StraightFlightLoads(**values),  # type: ignore[arg-type]
+    )
+
+
+def test_nptel_example_9_1_geometry_and_load_benchmark() -> None:
+    result = analyze_straight_flight_actions(_benchmark_input())
+
+    assert result.geometry.effective_span_mm == pytest.approx(5100.0)
+    assert result.geometry.inclined_step_length_mm == pytest.approx(313.85, abs=0.02)
+    assert result.geometry.slope_factor == pytest.approx(
+        math.hypot(160.0, 270.0) / 270.0
+    )
+    assert result.waist_self_weight_kn_per_m2 == pytest.approx(7.265, abs=0.002)
+    assert result.step_self_weight_kn_per_m2 == pytest.approx(2.0, abs=0.001)
+    assert result.flight_factored_load_kn_per_m2 == pytest.approx(22.9, abs=0.02)
+
+
+def test_nptel_example_9_1_piecewise_action_benchmark() -> None:
+    result = analyze_straight_flight_actions(_benchmark_input())
+
+    assert result.total_factored_load_kn == pytest.approx(142.86, abs=0.03)
+    assert result.lower_support_reaction_kn == pytest.approx(69.76, abs=0.03)
+    assert result.upper_support_reaction_kn == pytest.approx(73.10, abs=0.03)
+    assert result.maximum_moment_location_mm == pytest.approx(2510.0, abs=10.0)
+    assert result.maximum_factored_moment_knm == pytest.approx(102.08, abs=0.05)
+    assert result.segment_boundary_moments_knm[1] == pytest.approx(86.92, abs=0.05)
+    assert result.equilibrium_residual_kn == pytest.approx(0.0, abs=1e-12)
+
+
+def test_unrounded_actions_retain_full_width_and_per_metre_identity() -> None:
+    result = analyze_straight_flight_actions(_benchmark_input())
+
+    assert result.maximum_factored_moment_knm_per_m * 1.5 == pytest.approx(
+        result.maximum_factored_moment_knm
+    )
+    assert result.maximum_factored_shear_kn_per_m * 1.5 == pytest.approx(
+        result.maximum_factored_shear_kn
+    )
+    assert result.load_generation_status == "not_generated_caller_supplied_actions"
+    assert result.source_refs[-1] == "NPTEL-M9L20-EX9.1"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("tread_mm", 0.0), ("going_mm", -1.0), ("waist_thickness_mm", math.inf)),
+)
+def test_invalid_geometry_fails_closed(field: str, value: float) -> None:
+    with pytest.raises(StaircaseContractError, match=field):
+        _benchmark_geometry(**{field: value})
+
+
+def test_unsupported_span_and_support_models_fail_closed() -> None:
+    with pytest.raises(StaircaseContractError, match="span_direction"):
+        _benchmark_geometry(span_direction=StairSpanDirection.TRANSVERSE)
+    with pytest.raises(StaircaseContractError, match="support_case"):
+        _benchmark_geometry(
+            support_case=StairSupportCase.BEAMS_AT_TOP_AND_BOTTOM_RISERS
+        )
+    with pytest.raises(StaircaseContractError, match="has_stringer_beams"):
+        _benchmark_geometry(has_stringer_beams=True)
+
+
+def test_landing_share_above_one_fails_closed() -> None:
+    with pytest.raises(StaircaseContractError, match="must not exceed 1.0"):
+        _benchmark_input(lower_landing_load_share=1.01)
+
+
+def test_zero_superimposed_actions_preserve_positive_self_weight_analysis() -> None:
+    result = analyze_straight_flight_actions(
+        _benchmark_input(
+            lower_landing_superimposed_service_load_kn_per_m2=0.0,
+            flight_superimposed_service_load_kn_per_m2=0.0,
+            upper_landing_superimposed_service_load_kn_per_m2=0.0,
+        )
+    )
+    assert result.total_factored_load_kn > 0.0
+    assert result.maximum_factored_moment_knm > 0.0
+
+
+def test_geometry_resolver_rejects_wrong_type() -> None:
+    with pytest.raises(StaircaseContractError, match="StraightFlightStairGeometry"):
+        resolve_straight_flight_geometry(object())  # type: ignore[arg-type]

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,85 @@
 
 ---
 
+## 2026-08-15 — Session: INDIA-2B Staircase Geometry and Actions
+
+**Agent:** Codex (`structural-math`, sole writer; no subagents)
+
+**Branch:** `codex/india-2b-staircase-actions` from integrated `origin/main` at
+`1cd08b9cab20a34b9dad1806f500eef01a2f4739`
+
+**Focus:** Implement the frozen straight-flight geometry, self-weight, and
+three-segment action contract without adding design or public consumers.
+
+### Summary
+
+- Verified PR #760 merge-tree identity and started a clean source-bound lane.
+- Added typed, pure-math staircase geometry and load carriers with explicit
+  units, support/span flags, action provenance, and fail-closed exclusions.
+- Implemented explicit waist, step, and landing self-weight and a statically
+  determinate three-segment action solver with equilibrium evidence.
+- Matched the NPTEL Example 9.1 span, loads, reactions, zero-shear point,
+  maximum moment, and landing-boundary moment without rounding internals.
+- Added focused safe, boundary, invalid, and out-of-domain tests. Stair
+  capability remains held pending structural design and the public workflow.
+
+### Issues encountered
+
+- The first new-folder index dry-run targeted the staircase source folder
+  before that folder existed, so the generator correctly rejected the path.
+- The first Ruff pass found import-order drift in the new package export and
+  test module after Black formatting.
+- The deterministic Indian-code manifest became stale after the new Clause 33
+  decorators were added, and the generic element-completeness checker reported
+  zero staircase tests because it searches filenames rather than parent paths.
+- The first commit attempt failed mypy because a tuple comprehension inferred
+  the three segment line loads as variable-length `tuple[float, ...]`.
+- A manual mypy rerun from the repository root ignored `Python/pyproject.toml`
+  and surfaced 11 unrelated baseline typing errors.
+
+### Root causes and resolutions
+
+- A generator can preview new index files only after the owned folder topology
+  exists. Added the implementation files with `apply_patch`, reran dry-run with
+  `--allow-new-index`, and then generated the source and test indexes.
+- Black does not sort imports. Ran the maintained Ruff fixer on the two new
+  files, then repeated Black check, Ruff, and the focused test suite; all pass.
+- Clause registration is generated from live decorated functions. Regenerated
+  the manifest and verified that only Clauses 33.1-33.3 registration changed;
+  the staircase capability remains `HELD`. The completeness checker looks for
+  `test_*staircase*.py`, while the maintained test is nested at
+  `staircase/test_geometry_actions.py`; direct pytest evidence controls this
+  packet, and the checker must be reconciled with the completed vertical slice
+  during INDIA-2D rather than changing this pure-math packet's scope.
+- The action model always has exactly three frozen segments, but the tuple
+  comprehension erased that cardinality for static analysis. Replaced it with
+  an explicitly typed three-item tuple and reran mypy, focused tests, and the
+  commit hooks.
+- The maintained hook runs mypy from `Python/`, where its project configuration
+  applies. Repeated that exact command and verified all 198 source files pass;
+  the root-level output was not used as packet evidence.
+
+### Evidence
+
+- Fresh-lane Git state: `READY_LOCAL`; runtime diagnosis: `source_bound=true`.
+- Focused staircase suite: 10 passed.
+- Example 9.1 unrounded result: 142.85350 kN total load, 69.75472/73.09877 kN
+  reactions, 102.07350 kNm maximum moment, and zero equilibrium residual.
+- Unsupported support/span systems and invalid inputs fail closed.
+- Generated capability truth registers Clauses 33.1-33.3 while retaining the
+  stair family as `HELD` pending INDIA-2D.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: index dry-run rejected the not-yet-created
+  staircase folder -> created the scoped files, then dry-ran and generated both
+  new folder indexes with `--allow-new-index`.
+- ⚠️ TERMINAL ISSUE: manual mypy from the repository root did not load
+  `Python/pyproject.toml` -> repeated the maintained hook command from the
+  explicit `Python/` directory; 198 source files pass.
+
+---
+
 ## 2026-08-15 — Session: INDIA-2A Staircase Scope Foundation
 
 **Agent:** Codex (`structural-math`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-15 — INDIA-2A selected one bounded straight-flight staircase family; INDIA-2B is next
+**Updated:** 2026-08-15 — INDIA-2B implements benchmarked staircase geometry/actions; INDIA-2C is next
 
 ---
 
@@ -133,7 +133,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-2B | Implement typed geometry, self-weight, and three-segment actions for the accepted straight-flight staircase case | Main Agent + structural math | focused implementation | P1 | 📋 READY AFTER INDIA-2A MERGE |
+| INDIA-2C | Compose flexure, provided-bar detailing, shear, and serviceability dispositions for the accepted staircase actions | Main Agent + structural math | focused implementation | P1 | 📋 READY AFTER INDIA-2B MERGE |
 | LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL QUALIFIED REVIEW |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 
@@ -155,6 +155,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-2B | Implemented typed Clause 33 geometry, explicit concrete self-weight, and equilibrated three-segment actions for the accepted straight-flight case | Main Agent + structural math | ✅ DONE — NPTEL Example 9.1 geometry/load/action targets and fail-closed boundaries pass; capability remains HELD until INDIA-2D |
 | INDIA-2A | Selected and froze one longitudinal straight waist-slab flight with collinear landings against controlled Clause 33 sources and the IIT Kharagpur NPTEL Example 9.1 benchmark | Main Agent + structural engineer | ✅ GO — B-D owner-activated; alternate stairs, other families, IS 875/IS 1893, qualified review, and release remain held |
 | INDIA-1-CUMULATIVE | Ran broad Python, full repository, manifest reconciliation, and cumulative essential review after A-D integration | Main Agent + reviewer | ✅ DONE — PR #758 exact-head gate passed; 5,926 Python tests and full 30/30 gate green; reviewed tree squash-merged as `4e92f3d7` |
 | INDIA-1D | Closed solid-slab direct-deflection, crack-width, automatic-shear-reinforcement, and single-action load-envelope decisions with machine-visible holds | Main Agent | ✅ DONE — PR #757 exact-head gate passed; reviewed tree squash-merged as `ca55f22d` |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,11 +4,11 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: Complete INDIA-2A GO and launch INDIA-2B geometry/actions from its integrated merge
-- Current branch: `codex/india-2a-scope-foundation`
-- Base: verified integrated `origin/main` at `1fcbc6001d27ebfdc5f2a4644d405e50bdb862f7`
-- Next action: merge the unchanged INDIA-2A decision packet after required checks pass, then create a fresh `codex/india-2b-staircase-actions` worktree from integrated `main`
-- Holds: no calculation code before INDIA-2A integration; alternate stairs, other held families, IS 875/IS 1893 generation, React, stable/engineering-use approval, release, and cleanup remain out of scope
+- Focus: Complete INDIA-2B geometry/actions and launch INDIA-2C design from its integrated merge
+- Current branch: `codex/india-2b-staircase-actions`
+- Base: verified integrated `origin/main` at `1cd08b9cab20a34b9dad1806f500eef01a2f4739`
+- Next action: merge the unchanged INDIA-2B packet after required checks pass, then create a fresh `codex/india-2c-staircase-design` worktree from integrated `main`
+- Holds: structural design and capability promotion wait for later packets; alternate stairs, other held families, IS 875/IS 1893 generation, React, stable/engineering-use approval, release, and cleanup remain out of scope
 <!-- HANDOFF:END -->
 
 **Date:** 2026-08-15
@@ -16,7 +16,7 @@
 | Release state | Target |
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; INDIA-1 software and cumulative gates complete |
-| **Next** | INDIA-2B typed geometry/actions after INDIA-2A integration; qualified review remains separate |
+| **Next** | INDIA-2C structural design after INDIA-2B integration; qualified review remains separate |
 
 ## Required Reading
 

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-15",
-  "file_count": 24,
+  "file_count": 25,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -139,6 +139,14 @@
       "content_hash": "6d6defbea3ed"
     },
     {
+      "name": "india-2b-staircase-actions-evidence.md",
+      "type": "documentation",
+      "size_lines": 70,
+      "last_updated": "2026-08-15",
+      "description": "INDIA-2B implements only the typed geometry, concrete self-weight, and three-segment simply supported action contract selected by INDIA-2A. It adds no",
+      "content_hash": "1f9680c591ed"
+    },
+    {
       "name": "indian-code-capability-coverage.json",
       "type": "config",
       "last_updated": "2026-08-15",
@@ -152,7 +160,7 @@
         "capability_summary",
         "standards"
       ],
-      "content_hash": "ea7c0722948b"
+      "content_hash": "3fb66f059bc2"
     },
     {
       "name": "indian-code-truth-baseline.md",
@@ -241,5 +249,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "a74d2d90b9c0f5e1"
+  "content_hash": "db6d2f451ad2cd43"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-15
-**Files:** 24
+**Files:** 25
 
 ## Config Files
 
@@ -29,6 +29,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [india-1c-isolated-footing-workflow-evidence.md](india-1c-isolated-footing-workflow-evidence.md) |  | INDIA-1C publishes the existing bounded concentric isolated- | 53 |
 | [india-1d-slab-boundary-evidence.md](india-1d-slab-boundary-evidence.md) |  | INDIA-1D closes the decision boundary around already support | 71 |
 | [india-2a-staircase-scope-evidence.md](india-2a-staircase-scope-evidence.md) |  | activated INDIA-2A through INDIA-2D on 2026-08-15 by request | 111 |
+| [india-2b-staircase-actions-evidence.md](india-2b-staircase-actions-evidence.md) |  | INDIA-2B implements only the typed geometry, concrete self-w | 70 |
 | [indian-code-truth-baseline.md](indian-code-truth-baseline.md) | INDIA-0 Indian-Code Truth Baseline | was squash-merged as 0373de68; INDIA-1 packets now update th | 93 |
 | [insights-verification-pack.md](insights-verification-pack.md) |  | This pack provides benchmark test cases for the insights mod | 101 |
 | [is456-library-first-evidence.md](is456-library-first-evidence.md) | IS 456 Library-First Evidence and Claim  | | Source | SHA-256 | Pages | Use | |---|---|---:|---| | 169 |

--- a/docs/verification/india-2b-staircase-actions-evidence.md
+++ b/docs/verification/india-2b-staircase-actions-evidence.md
@@ -1,0 +1,69 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: reference
+task: INDIA-2B
+---
+
+# INDIA-2B Staircase Geometry and Action Evidence
+
+INDIA-2B implements only the typed geometry, concrete self-weight, and
+three-segment simply supported action contract selected by INDIA-2A. It adds no
+public service or FastAPI route and does not change the capability manifest from
+`HELD`.
+
+## Implemented calculation boundary
+
+`resolve_straight_flight_geometry()` accepts one cast-in-situ solid,
+longitudinally spanning, stringer-free waist slab with collinear landing
+segments. It resolves the Clause 33 horizontal effective span, inclined step
+length, slope factor, slope angle, and inclined going length.
+
+`analyze_straight_flight_actions()` calculates waist, step, and landing
+self-weight from explicit geometry and concrete unit weight. It consumes
+caller-supplied superimposed loads, landing shares, ultimate factor, and load
+basis. It then solves support reactions, maximum shear, the zero-shear location,
+maximum sagging moment, and per-metre design actions for three contiguous UDL
+segments.
+
+The calculation does not choose occupancy actions, infer IS 875 loads, generate
+load combinations, or analyse a non-collinear or indeterminate stair system.
+
+## Independent benchmark
+
+For `NPTEL-M9L20-EX9.1`, the unrounded software result is:
+
+| Quantity | Software | Published target |
+|---|---:|---:|
+| Effective span | 5100.0 mm | 5100 mm |
+| Inclined step length | 313.8471 mm | 313.85 mm |
+| Waist self-weight | 7.26498 kN/m2 | 7.265 kN/m2 |
+| Factored flight load | 22.89747 kN/m2 | 22.9 kN/m2 |
+| Total factored load | 142.85350 kN | 142.86 kN |
+| Lower reaction | 69.75472 kN | 69.76 kN |
+| Upper reaction | 73.09877 kN | 73.10 kN |
+| Zero-shear location | 2510.703 mm | 2510 mm |
+| Maximum sagging moment | 102.07350 kNm | 102.08 kNm |
+| Upper flight boundary moment | 86.92204 kNm | 86.92 kNm |
+| Equilibrium residual | 0.0 kN | 0 kN |
+
+The benchmark test retains published-rounding tolerances while also asserting
+the full-width/per-metre identity and exact reaction equilibrium.
+
+## Fail-closed evidence
+
+Focused tests reject zero, negative, or non-finite geometry; transverse span;
+beam-at-riser and stringer support models; and landing shares above one. Zero
+superimposed actions remain valid because explicit concrete self-weight still
+produces a physical positive action result.
+
+Alternate support cases, structural design, serviceability acceptance, public
+facades, FastAPI, React, capability promotion, qualified review, and release
+remain outside this packet.
+
+## Verification cadence
+
+This packet receives focused tests, architecture/import checks, the quick gate,
+commit hooks, and hosted PR checks. Broad Python and the full repository gate
+remain deferred until INDIA-2B through INDIA-2D are integrated.

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -255,10 +255,10 @@
       ],
       "registration_summary": {
         "known_references": 127,
-        "registered_known_references": 59,
-        "metadata_only_references": 68,
+        "registered_known_references": 62,
+        "metadata_only_references": 65,
         "registration_only_references": 0,
-        "registration_pct": 46.5
+        "registration_pct": 48.8
       },
       "references": [
         {
@@ -745,8 +745,11 @@
           "reference_type": "clause",
           "title": "Effective Span of Stairs",
           "category": "slabs",
-          "registration_status": "METADATA_ONLY",
-          "functions": []
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.staircase.actions.analyze_straight_flight_actions",
+            "structural_lib.codes.is456.staircase.geometry.resolve_straight_flight_geometry"
+          ]
         },
         {
           "reference_id": "IS456:2000:33.2",
@@ -754,8 +757,10 @@
           "reference_type": "clause",
           "title": "Distribution of Loading on Stairs",
           "category": "slabs",
-          "registration_status": "METADATA_ONLY",
-          "functions": []
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.staircase.actions.analyze_straight_flight_actions"
+          ]
         },
         {
           "reference_id": "IS456:2000:33.3",
@@ -763,8 +768,11 @@
           "reference_type": "clause",
           "title": "Depth of Section",
           "category": "slabs",
-          "registration_status": "METADATA_ONLY",
-          "functions": []
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.staircase.actions.analyze_straight_flight_actions",
+            "structural_lib.codes.is456.staircase.geometry.resolve_straight_flight_geometry"
+          ]
         },
         {
           "reference_id": "IS456:2000:34.1",


### PR DESCRIPTION
## Summary
- add typed Clause 33 straight-flight geometry and explicit-unit load contracts
- calculate waist, step, and landing self-weight without generating IS 875 actions
- solve the frozen three-segment simply supported reactions, shear, and sagging moment
- retain stair capability as HELD while registering executable Clause 33 traceability

## Benchmark
IIT Kharagpur NPTEL Example 9.1: 5.1 m span, 142.8535 kN total factored load, 69.7547/73.0988 kN reactions, and 102.0735 kNm maximum moment.

## Validation
- focused staircase tests: 10 passed
- mypy: 198 source files clean
- architecture: 0 violations
- imports: 0 broken
- Indian-code manifest and owned indexes: current
- quick repository gate: 10/10

## Boundaries
No structural design, public service/FastAPI route, React UI, IS 875 generation, capability promotion, release, or professional approval is included.