### PR TITLE
feat(is456): add bounded staircase design checks

### DIFF
--- a/Python/structural_lib/codes/is456/index.json
+++ b/Python/structural_lib/codes/is456/index.json
@@ -412,7 +412,7 @@
     {
       "name": "staircase",
       "path": "staircase/",
-      "file_count": 6,
+      "file_count": 7,
       "is_package": true
     }
   ],
@@ -438,5 +438,5 @@
     "list_clauses_by_category",
     "search_clauses"
   ],
-  "content_hash": "8182bc737b78e302"
+  "content_hash": "82f377cd63f28f9d"
 }

--- a/Python/structural_lib/codes/is456/index.md
+++ b/Python/structural_lib/codes/is456/index.md
@@ -57,4 +57,4 @@
 | [common/](common/) 📦 | 5 |  |
 | [footing/](footing/) 📦 | 10 |  |
 | [slab/](slab/) 📦 | 16 |  |
-| [staircase/](staircase/) 📦 | 6 |  |
+| [staircase/](staircase/) 📦 | 7 |  |

--- a/Python/structural_lib/codes/is456/staircase/__init__.py
+++ b/Python/structural_lib/codes/is456/staircase/__init__.py
@@ -6,6 +6,14 @@ from structural_lib.codes.is456.staircase.actions import (
     StraightFlightActionResult,
     analyze_straight_flight_actions,
 )
+from structural_lib.codes.is456.staircase.design import (
+    StaircaseDesignCheck,
+    StaircaseDesignStatus,
+    StaircaseServiceabilityStatus,
+    StraightFlightDesignInput,
+    StraightFlightDesignResult,
+    design_straight_flight_staircase,
+)
 from structural_lib.codes.is456.staircase.geometry import (
     StraightFlightGeometryResult,
     resolve_straight_flight_geometry,
@@ -23,11 +31,17 @@ __all__ = [
     "StairSpanDirection",
     "StairSupportCase",
     "StaircaseContractError",
+    "StaircaseDesignCheck",
+    "StaircaseDesignStatus",
+    "StaircaseServiceabilityStatus",
     "StraightFlightActionInput",
     "StraightFlightActionResult",
+    "StraightFlightDesignInput",
+    "StraightFlightDesignResult",
     "StraightFlightGeometryResult",
     "StraightFlightLoads",
     "StraightFlightStairGeometry",
     "analyze_straight_flight_actions",
+    "design_straight_flight_staircase",
     "resolve_straight_flight_geometry",
 ]

--- a/Python/structural_lib/codes/is456/staircase/design.py
+++ b/Python/structural_lib/codes/is456/staircase/design.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Structural design checks for the bounded straight-flight waist slab."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+
+from structural_lib.codes.is456 import materials
+from structural_lib.codes.is456.slab._flexure import (
+    calculate_ast_from_rectangular_stress_block,
+)
+from structural_lib.codes.is456.slab.shear import (
+    SlabShearInput,
+    SlabShearResult,
+    check_solid_slab_one_way_shear,
+)
+from structural_lib.codes.is456.staircase.actions import (
+    StraightFlightActionResult,
+    analyze_straight_flight_actions,
+)
+from structural_lib.codes.is456.staircase.models import (
+    StaircaseContractError,
+    positive_finite,
+)
+from structural_lib.codes.is456.traceability import clause
+
+__all__ = [
+    "StaircaseDesignCheck",
+    "StaircaseDesignStatus",
+    "StaircaseServiceabilityStatus",
+    "StraightFlightDesignInput",
+    "StraightFlightDesignResult",
+    "design_straight_flight_staircase",
+]
+
+
+_SUPPORTED_FY_N_PER_MM2 = (250.0, 415.0, 500.0)
+_SOURCE_REFS = (
+    "IS 456:2000 Cl. 23.2.1, 26.3.3, 26.5.2.1, 38.1, 40.1 and 40.2",
+    "IS 456:2000 Table 19 and Table 20",
+    "NPTEL-M9L20-EX9.1",
+)
+_LIMITATIONS = (
+    "HOLD: modification factors and direct deflection are not calculated.",
+    "HOLD: crack width, development-length layout, landing torsion, and automatic bar selection are not implemented.",
+    "HOLD: load generation, combinations, patterns, continuity, moment redistribution, and seismic behavior are not inferred.",
+    "REVIEW LIMITATION: software verification is not professional design approval.",
+)
+
+
+class StaircaseDesignStatus(StrEnum):
+    """Aggregate bounded design disposition."""
+
+    PASS = "PASS"  # nosec B105 - engineering disposition, not a credential
+    REVIEW_REQUIRED = "REVIEW_REQUIRED"
+    FAIL = "FAIL"
+
+
+class StaircaseServiceabilityStatus(StrEnum):
+    """Basic simply-supported L/d disposition without invented modifiers."""
+
+    BASIC_RATIO_SATISFIED = "basic_ratio_satisfied"
+    REVIEW_REQUIRED = "review_required"
+
+
+@dataclass(frozen=True)
+class StaircaseDesignCheck:
+    """One explicit comparison with retained units."""
+
+    check_id: str
+    actual: float
+    limit: float
+    unit: str
+    comparison: str
+    passed: bool
+
+
+@dataclass(frozen=True)
+class StraightFlightDesignInput:
+    """Accepted actions, material properties, depth, and supplied bars."""
+
+    actions: StraightFlightActionResult
+    effective_depth_mm: float
+    fck_n_per_mm2: float
+    fy_n_per_mm2: float
+    main_bar_diameter_mm: float
+    main_bar_spacing_mm: float
+    distribution_bar_diameter_mm: float
+    distribution_bar_spacing_mm: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.actions, StraightFlightActionResult):
+            raise StaircaseContractError("actions must be a StraightFlightActionResult")
+        for name, unit in (
+            ("effective_depth_mm", "mm"),
+            ("fck_n_per_mm2", "N/mm2"),
+            ("fy_n_per_mm2", "N/mm2"),
+            ("main_bar_diameter_mm", "mm"),
+            ("main_bar_spacing_mm", "mm"),
+            ("distribution_bar_diameter_mm", "mm"),
+            ("distribution_bar_spacing_mm", "mm"),
+        ):
+            object.__setattr__(
+                self,
+                name,
+                positive_finite(getattr(self, name), name, unit),
+            )
+        waist_thickness = self.actions.input.geometry.waist_thickness_mm
+        if self.effective_depth_mm >= waist_thickness:
+            raise StaircaseContractError(
+                "effective_depth_mm must be less than waist_thickness_mm"
+            )
+        if not 20.0 <= self.fck_n_per_mm2 <= 40.0:
+            raise StaircaseContractError(
+                "fck_n_per_mm2 must be within the combined flexure/shear domain of 20 to 40 N/mm2"
+            )
+        if not any(
+            abs(self.fy_n_per_mm2 - grade) < 0.5 for grade in _SUPPORTED_FY_N_PER_MM2
+        ):
+            raise StaircaseContractError(
+                "fy_n_per_mm2 must be one of 250, 415, or 500 N/mm2"
+            )
+
+
+@dataclass(frozen=True)
+class StraightFlightDesignResult:
+    """Strength, supplied-bar, shear, and basic serviceability evidence."""
+
+    input: StraightFlightDesignInput
+    design_strip_width_mm: float
+    factored_moment_knm_per_m: float
+    factored_shear_kn_per_m: float
+    limiting_moment_knm_per_m: float
+    ast_required_mm2_per_m: float | None
+    neutral_axis_depth_mm: float | None
+    minimum_reinforcement_mm2_per_m: float
+    main_reinforcement_required_mm2_per_m: float | None
+    main_reinforcement_provided_mm2_per_m: float
+    distribution_reinforcement_required_mm2_per_m: float
+    distribution_reinforcement_provided_mm2_per_m: float
+    maximum_bar_diameter_mm: float
+    maximum_main_bar_spacing_mm: float
+    maximum_distribution_bar_spacing_mm: float
+    shear: SlabShearResult
+    actual_span_to_depth_ratio: float
+    basic_span_to_depth_limit: float
+    serviceability_status: StaircaseServiceabilityStatus
+    governing_checks: tuple[StaircaseDesignCheck, ...]
+    status: StaircaseDesignStatus
+    source_refs: tuple[str, ...]
+    limitations: tuple[str, ...]
+    complete_engineering_design_approved: bool = False
+
+    @property
+    def is_strength_and_detailing_satisfied(self) -> bool:
+        """Return whether every non-serviceability comparison passed."""
+        return all(
+            check.passed
+            for check in self.governing_checks
+            if check.check_id != "INDIA-2C-LD-01"
+        )
+
+
+def _bar_area_mm2(diameter_mm: float) -> float:
+    return math.pi * diameter_mm * diameter_mm / 4.0
+
+
+def _minimum_reinforcement_ratio(fy_n_per_mm2: float) -> float:
+    if abs(fy_n_per_mm2 - 250.0) < 0.5:
+        return 0.0015
+    return 0.0012
+
+
+def _validate_action_integrity(actions: StraightFlightActionResult) -> None:
+    """Reject a forged or internally inconsistent action carrier."""
+    recomputed = analyze_straight_flight_actions(actions.input)
+    for field_name in (
+        "total_factored_load_kn",
+        "lower_support_reaction_kn",
+        "upper_support_reaction_kn",
+        "maximum_factored_shear_kn_per_m",
+        "maximum_factored_moment_knm_per_m",
+    ):
+        actual = getattr(actions, field_name)
+        expected = getattr(recomputed, field_name)
+        if not math.isclose(actual, expected, rel_tol=1e-12, abs_tol=1e-12):
+            raise StaircaseContractError(
+                f"actions.{field_name} is inconsistent with retained inputs"
+            )
+
+
+@clause("23.2.1", "26.3.3", "26.5.2.1", "38.1", "40.1", "40.2")
+def design_straight_flight_staircase(
+    design_input: StraightFlightDesignInput,
+) -> StraightFlightDesignResult:
+    """Check one metre of the accepted straight-flight waist-slab member."""
+    if not isinstance(design_input, StraightFlightDesignInput):
+        raise StaircaseContractError("design_input must be a StraightFlightDesignInput")
+    _validate_action_integrity(design_input.actions)
+
+    strip_width_mm = 1000.0
+    actions = design_input.actions
+    geometry = actions.input.geometry
+    moment_knm_per_m = actions.maximum_factored_moment_knm_per_m
+    shear_kn_per_m = actions.maximum_factored_shear_kn_per_m
+    xu_max_over_d = materials.get_xu_max_d(design_input.fy_n_per_mm2)
+    limiting_moment_knm = (
+        0.36
+        * xu_max_over_d
+        * (1.0 - 0.42 * xu_max_over_d)
+        * design_input.fck_n_per_mm2
+        * strip_width_mm
+        * design_input.effective_depth_mm
+        * design_input.effective_depth_mm
+        / 1_000_000.0
+    )
+    flexure_capacity_satisfied = moment_knm_per_m <= limiting_moment_knm
+    ast_required: float | None = None
+    neutral_axis_depth: float | None = None
+    if flexure_capacity_satisfied:
+        ast_required, neutral_axis_depth = calculate_ast_from_rectangular_stress_block(
+            b_mm=strip_width_mm,
+            d_mm=design_input.effective_depth_mm,
+            factored_moment_knm=moment_knm_per_m,
+            fck_n_per_mm2=design_input.fck_n_per_mm2,
+            fy_n_per_mm2=design_input.fy_n_per_mm2,
+        )
+
+    minimum_reinforcement = (
+        _minimum_reinforcement_ratio(design_input.fy_n_per_mm2)
+        * strip_width_mm
+        * geometry.waist_thickness_mm
+    )
+    main_required = (
+        max(ast_required, minimum_reinforcement) if ast_required is not None else None
+    )
+    main_provided = (
+        _bar_area_mm2(design_input.main_bar_diameter_mm)
+        * strip_width_mm
+        / design_input.main_bar_spacing_mm
+    )
+    distribution_provided = (
+        _bar_area_mm2(design_input.distribution_bar_diameter_mm)
+        * strip_width_mm
+        / design_input.distribution_bar_spacing_mm
+    )
+    maximum_bar_diameter = geometry.waist_thickness_mm / 8.0
+    maximum_main_spacing = min(3.0 * design_input.effective_depth_mm, 300.0)
+    maximum_distribution_spacing = min(5.0 * design_input.effective_depth_mm, 450.0)
+    shear_result = check_solid_slab_one_way_shear(
+        SlabShearInput(
+            factored_shear_kn=shear_kn_per_m,
+            strip_width_mm=strip_width_mm,
+            effective_depth_mm=design_input.effective_depth_mm,
+            overall_depth_mm=geometry.waist_thickness_mm,
+            fck_n_per_mm2=design_input.fck_n_per_mm2,
+            tension_reinforcement_mm2=main_provided,
+            uniformly_distributed_load_only=True,
+            beam_or_wall_supported=True,
+        )
+    )
+    actual_span_to_depth = (
+        actions.geometry.effective_span_mm / design_input.effective_depth_mm
+    )
+    basic_span_to_depth_limit = 20.0
+    serviceability_satisfied = actual_span_to_depth <= basic_span_to_depth_limit
+    serviceability_status = (
+        StaircaseServiceabilityStatus.BASIC_RATIO_SATISFIED
+        if serviceability_satisfied
+        else StaircaseServiceabilityStatus.REVIEW_REQUIRED
+    )
+
+    main_steel_satisfied = main_required is not None and main_provided >= main_required
+    checks = (
+        StaircaseDesignCheck(
+            "INDIA-2C-MU-01",
+            moment_knm_per_m,
+            limiting_moment_knm,
+            "kNm/m",
+            "<=",
+            flexure_capacity_satisfied,
+        ),
+        StaircaseDesignCheck(
+            "INDIA-2C-MAIN-STEEL-01",
+            main_provided,
+            main_required if main_required is not None else math.inf,
+            "mm2/m",
+            ">=",
+            main_steel_satisfied,
+        ),
+        StaircaseDesignCheck(
+            "INDIA-2C-DIST-STEEL-01",
+            distribution_provided,
+            minimum_reinforcement,
+            "mm2/m",
+            ">=",
+            distribution_provided >= minimum_reinforcement,
+        ),
+        StaircaseDesignCheck(
+            "INDIA-2C-MAIN-DIA-01",
+            design_input.main_bar_diameter_mm,
+            maximum_bar_diameter,
+            "mm",
+            "<=",
+            design_input.main_bar_diameter_mm <= maximum_bar_diameter,
+        ),
+        StaircaseDesignCheck(
+            "INDIA-2C-DIST-DIA-01",
+            design_input.distribution_bar_diameter_mm,
+            maximum_bar_diameter,
+            "mm",
+            "<=",
+            design_input.distribution_bar_diameter_mm <= maximum_bar_diameter,
+        ),
+        StaircaseDesignCheck(
+            "INDIA-2C-MAIN-SPACING-01",
+            design_input.main_bar_spacing_mm,
+            maximum_main_spacing,
+            "mm",
+            "<=",
+            design_input.main_bar_spacing_mm <= maximum_main_spacing,
+        ),
+        StaircaseDesignCheck(
+            "INDIA-2C-DIST-SPACING-01",
+            design_input.distribution_bar_spacing_mm,
+            maximum_distribution_spacing,
+            "mm",
+            "<=",
+            design_input.distribution_bar_spacing_mm <= maximum_distribution_spacing,
+        ),
+        StaircaseDesignCheck(
+            "INDIA-2C-SHEAR-01",
+            shear_result.tau_v_n_per_mm2,
+            shear_result.design_tau_c_n_per_mm2,
+            "N/mm2",
+            "<=",
+            shear_result.is_safe_without_shear_reinforcement,
+        ),
+        StaircaseDesignCheck(
+            "INDIA-2C-LD-01",
+            actual_span_to_depth,
+            basic_span_to_depth_limit,
+            "ratio",
+            "<=",
+            serviceability_satisfied,
+        ),
+    )
+    strength_and_detailing_satisfied = all(
+        check.passed for check in checks if check.check_id != "INDIA-2C-LD-01"
+    )
+    if not strength_and_detailing_satisfied:
+        status = StaircaseDesignStatus.FAIL
+    elif not serviceability_satisfied:
+        status = StaircaseDesignStatus.REVIEW_REQUIRED
+    else:
+        status = StaircaseDesignStatus.PASS
+
+    return StraightFlightDesignResult(
+        input=design_input,
+        design_strip_width_mm=strip_width_mm,
+        factored_moment_knm_per_m=moment_knm_per_m,
+        factored_shear_kn_per_m=shear_kn_per_m,
+        limiting_moment_knm_per_m=limiting_moment_knm,
+        ast_required_mm2_per_m=ast_required,
+        neutral_axis_depth_mm=neutral_axis_depth,
+        minimum_reinforcement_mm2_per_m=minimum_reinforcement,
+        main_reinforcement_required_mm2_per_m=main_required,
+        main_reinforcement_provided_mm2_per_m=main_provided,
+        distribution_reinforcement_required_mm2_per_m=minimum_reinforcement,
+        distribution_reinforcement_provided_mm2_per_m=distribution_provided,
+        maximum_bar_diameter_mm=maximum_bar_diameter,
+        maximum_main_bar_spacing_mm=maximum_main_spacing,
+        maximum_distribution_bar_spacing_mm=maximum_distribution_spacing,
+        shear=shear_result,
+        actual_span_to_depth_ratio=actual_span_to_depth,
+        basic_span_to_depth_limit=basic_span_to_depth_limit,
+        serviceability_status=serviceability_status,
+        governing_checks=checks,
+        status=status,
+        source_refs=_SOURCE_REFS,
+        limitations=_LIMITATIONS,
+    )

--- a/Python/structural_lib/codes/is456/staircase/index.json
+++ b/Python/structural_lib/codes/is456/staircase/index.json
@@ -3,15 +3,15 @@
   "type": "python-package",
   "description": "",
   "last_updated": "2026-08-15",
-  "file_count": 4,
+  "file_count": 5,
   "files": [
     {
       "name": "__init__.py",
       "type": "python",
-      "size_lines": 34,
+      "size_lines": 48,
       "last_updated": "2026-08-15",
       "description": "Bounded IS 456 straight-flight staircase geometry and actions.",
-      "content_hash": "bcabe16a3ac0"
+      "content_hash": "d7ce53933f24"
     },
     {
       "name": "actions.py",
@@ -38,6 +38,53 @@
         "_SOURCE_REFS"
       ],
       "content_hash": "a5500570cbb4"
+    },
+    {
+      "name": "design.py",
+      "type": "python",
+      "size_lines": 386,
+      "last_updated": "2026-08-15",
+      "description": "Structural design checks for the bounded straight-flight waist slab.",
+      "classes": [
+        {
+          "name": "StaircaseDesignStatus",
+          "description": "Aggregate bounded design disposition."
+        },
+        {
+          "name": "StaircaseServiceabilityStatus",
+          "description": "Basic simply-supported L/d disposition without invented modifiers."
+        },
+        {
+          "name": "StaircaseDesignCheck",
+          "description": "One explicit comparison with retained units."
+        },
+        {
+          "name": "StraightFlightDesignInput",
+          "description": "Accepted actions, material properties, depth, and supplied bars."
+        },
+        {
+          "name": "StraightFlightDesignResult",
+          "description": "Strength, supplied-bar, shear, and basic serviceability evidence.",
+          "public_methods": [
+            "is_strength_and_detailing_satisfied"
+          ]
+        }
+      ],
+      "functions": [
+        {
+          "name": "design_straight_flight_staircase",
+          "description": "Check one metre of the accepted straight-flight waist-slab member.",
+          "params": [
+            "design_input"
+          ]
+        }
+      ],
+      "constants": [
+        "_SUPPORTED_FY_N_PER_MM2",
+        "_SOURCE_REFS",
+        "_LIMITATIONS"
+      ],
+      "content_hash": "72c9b8e223cd"
     },
     {
       "name": "geometry.py",
@@ -126,13 +173,19 @@
     "StairSpanDirection",
     "StairSupportCase",
     "StaircaseContractError",
+    "StaircaseDesignCheck",
+    "StaircaseDesignStatus",
+    "StaircaseServiceabilityStatus",
     "StraightFlightActionInput",
     "StraightFlightActionResult",
+    "StraightFlightDesignInput",
+    "StraightFlightDesignResult",
     "StraightFlightGeometryResult",
     "StraightFlightLoads",
     "StraightFlightStairGeometry",
     "analyze_straight_flight_actions",
+    "design_straight_flight_staircase",
     "resolve_straight_flight_geometry"
   ],
-  "content_hash": "77b09fa017311510"
+  "content_hash": "9498a9ad228d1789"
 }

--- a/Python/structural_lib/codes/is456/staircase/index.md
+++ b/Python/structural_lib/codes/is456/staircase/index.md
@@ -2,26 +2,33 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-15
-**Files:** 4
+**Files:** 5
 
 ## Public API
 
 - `StairSpanDirection`
 - `StairSupportCase`
 - `StaircaseContractError`
+- `StaircaseDesignCheck`
+- `StaircaseDesignStatus`
+- `StaircaseServiceabilityStatus`
 - `StraightFlightActionInput`
 - `StraightFlightActionResult`
+- `StraightFlightDesignInput`
+- `StraightFlightDesignResult`
 - `StraightFlightGeometryResult`
 - `StraightFlightLoads`
 - `StraightFlightStairGeometry`
 - `analyze_straight_flight_actions`
+- `design_straight_flight_staircase`
 - `resolve_straight_flight_geometry`
 
 ## Python Files
 
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
-| [__init__.py](__init__.py) | Bounded IS 456 straight-flight staircase geometry and action | 0 | 0 | 34 |
+| [__init__.py](__init__.py) | Bounded IS 456 straight-flight staircase geometry and action | 0 | 0 | 48 |
 | [actions.py](actions.py) | Self-weight and three-segment actions for the INDIA-2 stairc | 1 | 1 | 216 |
+| [design.py](design.py) | Structural design checks for the bounded straight-flight wai | 5 | 1 | 386 |
 | [geometry.py](geometry.py) | Clause 33 geometry for the bounded straight-flight staircase | 1 | 1 | 62 |
 | [models.py](models.py) | Typed contracts for the bounded INDIA-2 straight-flight stai | 6 | 2 | 199 |

--- a/Python/tests/codes/is456/staircase/index.json
+++ b/Python/tests/codes/is456/staircase/index.json
@@ -3,7 +3,7 @@
   "type": "python-package",
   "description": "",
   "last_updated": "2026-08-15",
-  "file_count": 2,
+  "file_count": 3,
   "files": [
     {
       "name": "__init__.py",
@@ -12,6 +12,37 @@
       "last_updated": "2026-08-15",
       "description": "Focused staircase tests.",
       "content_hash": "c44590fc1fb3"
+    },
+    {
+      "name": "test_design.py",
+      "type": "python",
+      "size_lines": 136,
+      "last_updated": "2026-08-15",
+      "description": "INDIA-2C structural design benchmarks and dispositions.",
+      "functions": [
+        {
+          "name": "test_nptel_example_9_1_flexure_shear_and_reinforcement_benchmark"
+        },
+        {
+          "name": "test_nptel_example_requires_serviceability_review_without_invented_factor"
+        },
+        {
+          "name": "test_shorter_supported_member_can_pass_basic_span_depth_boundary"
+        },
+        {
+          "name": "test_insufficient_provided_main_steel_returns_fail"
+        },
+        {
+          "name": "test_singly_reinforced_capacity_exceedance_returns_fail_without_fake_ast"
+        },
+        {
+          "name": "test_effective_depth_outside_waist_fails_closed"
+        },
+        {
+          "name": "test_forged_action_result_fails_integrity_check"
+        }
+      ],
+      "content_hash": "b10ce2fa6706"
     },
     {
       "name": "test_geometry_actions.py",
@@ -54,5 +85,5 @@
   ],
   "subfolders": [],
   "has_init": true,
-  "content_hash": "f0478d8cdc76e135"
+  "content_hash": "1877a9d331eea9a0"
 }

--- a/Python/tests/codes/is456/staircase/index.md
+++ b/Python/tests/codes/is456/staircase/index.md
@@ -2,11 +2,12 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-15
-**Files:** 2
+**Files:** 3
 
 ## Python Files
 
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | Focused staircase tests. | 0 | 0 | 2 |
+| [test_design.py](test_design.py) | INDIA-2C structural design benchmarks and dispositions. | 0 | 7 | 136 |
 | [test_geometry_actions.py](test_geometry_actions.py) | INDIA-2B benchmark and fail-closed staircase action tests. | 0 | 8 | 132 |

--- a/Python/tests/codes/is456/staircase/test_design.py
+++ b/Python/tests/codes/is456/staircase/test_design.py
@@ -1,0 +1,135 @@
+"""INDIA-2C structural design benchmarks and dispositions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from structural_lib.codes.is456.staircase import (
+    StaircaseContractError,
+    StaircaseDesignStatus,
+    StaircaseServiceabilityStatus,
+    StraightFlightActionInput,
+    StraightFlightDesignInput,
+    StraightFlightLoads,
+    StraightFlightStairGeometry,
+    analyze_straight_flight_actions,
+    design_straight_flight_staircase,
+)
+
+
+def _actions(
+    *,
+    upper_landing_effective_length_mm: float = 1650.0,
+    ultimate_load_factor: float = 1.5,
+) -> object:
+    geometry = StraightFlightStairGeometry(
+        lower_landing_effective_length_mm=750.0,
+        going_mm=2700.0,
+        upper_landing_effective_length_mm=upper_landing_effective_length_mm,
+        flight_width_mm=1500.0,
+        riser_mm=160.0,
+        tread_mm=270.0,
+        waist_thickness_mm=250.0,
+        landing_thickness_mm=200.0,
+    )
+    loads = StraightFlightLoads(
+        lower_landing_superimposed_service_load_kn_per_m2=6.0,
+        flight_superimposed_service_load_kn_per_m2=6.0,
+        upper_landing_superimposed_service_load_kn_per_m2=6.0,
+        lower_landing_load_share=0.5,
+        upper_landing_load_share=1.0,
+        concrete_unit_weight_kn_per_m3=25.0,
+        ultimate_load_factor=ultimate_load_factor,
+        load_basis_reference="NPTEL-M9L20-EX9.1",
+    )
+    return analyze_straight_flight_actions(
+        StraightFlightActionInput(geometry=geometry, loads=loads)
+    )
+
+
+def _design_input(**overrides: object) -> StraightFlightDesignInput:
+    values: dict[str, object] = {
+        "actions": _actions(),
+        "effective_depth_mm": 224.0,
+        "fck_n_per_mm2": 20.0,
+        "fy_n_per_mm2": 415.0,
+        "main_bar_diameter_mm": 12.0,
+        "main_bar_spacing_mm": 120.0,
+        "distribution_bar_diameter_mm": 8.0,
+        "distribution_bar_spacing_mm": 160.0,
+    }
+    values.update(overrides)
+    return StraightFlightDesignInput(**values)  # type: ignore[arg-type]
+
+
+def test_nptel_example_9_1_flexure_shear_and_reinforcement_benchmark() -> None:
+    result = design_straight_flight_staircase(_design_input())
+
+    assert result.factored_moment_knm_per_m == pytest.approx(102.08 / 1.5, abs=0.04)
+    assert result.ast_required_mm2_per_m == pytest.approx(920.64, abs=2.0)
+    assert result.main_reinforcement_provided_mm2_per_m == pytest.approx(
+        942.48, abs=0.1
+    )
+    assert result.distribution_reinforcement_provided_mm2_per_m == pytest.approx(
+        314.16, abs=0.1
+    )
+    assert result.shear.tau_v_n_per_mm2 == pytest.approx(0.217, abs=0.002)
+    assert result.shear.is_safe_without_shear_reinforcement
+
+
+def test_nptel_example_requires_serviceability_review_without_invented_factor() -> None:
+    result = design_straight_flight_staircase(_design_input())
+
+    assert result.actual_span_to_depth_ratio == pytest.approx(5100.0 / 224.0)
+    assert result.serviceability_status is StaircaseServiceabilityStatus.REVIEW_REQUIRED
+    assert result.status is StaircaseDesignStatus.REVIEW_REQUIRED
+    assert result.is_strength_and_detailing_satisfied
+    assert not result.complete_engineering_design_approved
+
+
+def test_shorter_supported_member_can_pass_basic_span_depth_boundary() -> None:
+    actions = _actions(upper_landing_effective_length_mm=550.0)
+    result = design_straight_flight_staircase(_design_input(actions=actions))
+
+    assert result.actual_span_to_depth_ratio < 20.0
+    assert result.status is StaircaseDesignStatus.PASS
+
+
+def test_insufficient_provided_main_steel_returns_fail() -> None:
+    result = design_straight_flight_staircase(_design_input(main_bar_spacing_mm=300.0))
+    assert result.status is StaircaseDesignStatus.FAIL
+    main_check = next(
+        check
+        for check in result.governing_checks
+        if check.check_id == "INDIA-2C-MAIN-STEEL-01"
+    )
+    assert not main_check.passed
+
+
+def test_singly_reinforced_capacity_exceedance_returns_fail_without_fake_ast() -> None:
+    actions = _actions(ultimate_load_factor=5.0)
+    result = design_straight_flight_staircase(_design_input(actions=actions))
+
+    assert result.status is StaircaseDesignStatus.FAIL
+    assert result.ast_required_mm2_per_m is None
+    assert result.main_reinforcement_required_mm2_per_m is None
+
+
+def test_effective_depth_outside_waist_fails_closed() -> None:
+    with pytest.raises(StaircaseContractError, match="less than waist_thickness"):
+        _design_input(effective_depth_mm=250.0)
+
+
+def test_forged_action_result_fails_integrity_check() -> None:
+    actions = _actions()
+    assert hasattr(actions, "maximum_factored_moment_knm_per_m")
+    forged = replace(
+        actions,
+        maximum_factored_moment_knm_per_m=(
+            actions.maximum_factored_moment_knm_per_m + 1.0
+        ),
+    )
+    with pytest.raises(StaircaseContractError, match="inconsistent"):
+        design_straight_flight_staircase(_design_input(actions=forged))

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,58 @@
 
 ---
 
+## 2026-08-15 — Session: INDIA-2C Staircase Structural Design
+
+**Agent:** Codex (`structural-math`, sole writer; no subagents)
+
+**Branch:** `codex/india-2c-staircase-design` from integrated `origin/main` at
+`5bf8c0b50c62f144847e032ec436f6d0522acf8e`
+
+**Focus:** Compose accepted staircase actions into flexure, supplied-bar,
+ordinary-shear, and basic serviceability dispositions.
+
+### Summary
+
+- Verified PR #761 merge-tree identity and started a clean source-bound lane.
+- Added per-metre singly reinforced flexure and action-carrier integrity checks.
+- Reused the maintained solid-slab Table 19/20 shear provider and implemented
+  supplied main/distribution bar area, diameter, spacing, and minimum checks.
+- Kept serviceability fail-closed: L/d at or below 20 passes the basic boundary;
+  higher ratios require review rather than an invented modification factor.
+- Matched NPTEL Example 9.1 strength, reinforcement, and shear targets; unsafe
+  steel/capacity cases return `FAIL` and a shorter basic-L/d case returns `PASS`.
+
+### Issues encountered
+
+- The commit hook blocked on Bandit B105 at the public `PASS = "PASS"`
+  design-status enum member.
+
+### Root causes and resolutions
+
+- Bandit's hardcoded-password heuristic classifies assignments containing
+  `pass` as credential candidates, although this value is an engineering
+  disposition and not a secret. Added the narrow `# nosec B105` annotation
+  with that reason; the repeated commit hook passed Bandit.
+
+### Evidence
+
+- Fresh-lane Git state: `READY_LOCAL`; runtime diagnosis: `source_bound=true`.
+- Focused staircase suite after INDIA-2C: 17 passed.
+- Example 9.1: 921.196 mm2/m required versus 942.478 mm2/m supplied main
+  steel; 0.21756 N/mm2 nominal shear versus 0.48616 N/mm2 design capacity.
+- Example 9.1 aggregate status is `REVIEW_REQUIRED` solely because unmodified
+  L/d is 22.7679 versus the basic limit of 20.
+- Maintained mypy command: 199 source files pass.
+
+### Terminal issues
+
+- An inspection command used the guessed underscore filename
+  `indian_code_capability_manifest.json`; `rg --files docs/verification`
+  identified the maintained hyphenated file
+  `indian-code-capability-coverage.json`, which was then inspected directly.
+
+---
+
 ## 2026-08-15 — Session: INDIA-2B Staircase Geometry and Actions
 
 **Agent:** Codex (`structural-math`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-15 — INDIA-2B implements benchmarked staircase geometry/actions; INDIA-2C is next
+**Updated:** 2026-08-15 — INDIA-2C composes benchmarked staircase design dispositions; INDIA-2D is next
 
 ---
 
@@ -133,7 +133,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-2C | Compose flexure, provided-bar detailing, shear, and serviceability dispositions for the accepted staircase actions | Main Agent + structural math | focused implementation | P1 | 📋 READY AFTER INDIA-2B MERGE |
+| INDIA-2D | Publish the typed staircase Python service/facade and thin FastAPI route, then reconcile capability truth | Main Agent + API developer | focused implementation | P1 | 📋 READY AFTER INDIA-2C MERGE |
 | LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL QUALIFIED REVIEW |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 
@@ -155,6 +155,7 @@ held for the cumulative qualified review.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-2C | Composed accepted actions into singly reinforced flexure, supplied-bar detailing, ordinary shear, action-integrity, and basic span/depth dispositions | Main Agent + structural math | ✅ DONE — NPTEL Example 9.1 strength/detailing targets pass and truthfully return REVIEW_REQUIRED for unmodified L/d; unsafe cases return FAIL |
 | INDIA-2B | Implemented typed Clause 33 geometry, explicit concrete self-weight, and equilibrated three-segment actions for the accepted straight-flight case | Main Agent + structural math | ✅ DONE — NPTEL Example 9.1 geometry/load/action targets and fail-closed boundaries pass; capability remains HELD until INDIA-2D |
 | INDIA-2A | Selected and froze one longitudinal straight waist-slab flight with collinear landings against controlled Clause 33 sources and the IIT Kharagpur NPTEL Example 9.1 benchmark | Main Agent + structural engineer | ✅ GO — B-D owner-activated; alternate stairs, other families, IS 875/IS 1893, qualified review, and release remain held |
 | INDIA-1-CUMULATIVE | Ran broad Python, full repository, manifest reconciliation, and cumulative essential review after A-D integration | Main Agent + reviewer | ✅ DONE — PR #758 exact-head gate passed; 5,926 Python tests and full 30/30 gate green; reviewed tree squash-merged as `4e92f3d7` |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,11 +4,11 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-15
-- Focus: Complete INDIA-2B geometry/actions and launch INDIA-2C design from its integrated merge
-- Current branch: `codex/india-2b-staircase-actions`
-- Base: verified integrated `origin/main` at `1cd08b9cab20a34b9dad1806f500eef01a2f4739`
-- Next action: merge the unchanged INDIA-2B packet after required checks pass, then create a fresh `codex/india-2c-staircase-design` worktree from integrated `main`
-- Holds: structural design and capability promotion wait for later packets; alternate stairs, other held families, IS 875/IS 1893 generation, React, stable/engineering-use approval, release, and cleanup remain out of scope
+- Focus: Complete INDIA-2C structural design and launch INDIA-2D public workflow from its integrated merge
+- Current branch: `codex/india-2c-staircase-design`
+- Base: verified integrated `origin/main` at `5bf8c0b50c62f144847e032ec436f6d0522acf8e`
+- Next action: merge the unchanged INDIA-2C packet after required checks pass, then create a fresh `codex/india-2d-staircase-public` worktree from integrated `main`
+- Holds: public naming and capability promotion wait for INDIA-2D; alternate stairs, other held families, IS 875/IS 1893 generation, React, stable/engineering-use approval, release, and cleanup remain out of scope
 <!-- HANDOFF:END -->
 
 **Date:** 2026-08-15
@@ -16,7 +16,7 @@
 | Release state | Target |
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; INDIA-1 software and cumulative gates complete |
-| **Next** | INDIA-2C structural design after INDIA-2B integration; qualified review remains separate |
+| **Next** | INDIA-2D typed public workflow after INDIA-2C integration; qualified review remains separate |
 
 ## Required Reading
 

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-15",
-  "file_count": 25,
+  "file_count": 26,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -147,6 +147,14 @@
       "content_hash": "1f9680c591ed"
     },
     {
+      "name": "india-2c-staircase-design-evidence.md",
+      "type": "documentation",
+      "size_lines": 66,
+      "last_updated": "2026-08-15",
+      "description": "INDIA-2C composes the accepted INDIA-2B per-metre actions into one bounded waist-slab design check. It does not add public consumers or promote staircase",
+      "content_hash": "ccbd767ff6fb"
+    },
+    {
       "name": "indian-code-capability-coverage.json",
       "type": "config",
       "last_updated": "2026-08-15",
@@ -160,7 +168,7 @@
         "capability_summary",
         "standards"
       ],
-      "content_hash": "3fb66f059bc2"
+      "content_hash": "ae3bde140083"
     },
     {
       "name": "indian-code-truth-baseline.md",
@@ -249,5 +257,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "db6d2f451ad2cd43"
+  "content_hash": "e07a7c5c3d910470"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-15
-**Files:** 25
+**Files:** 26
 
 ## Config Files
 
@@ -30,6 +30,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [india-1d-slab-boundary-evidence.md](india-1d-slab-boundary-evidence.md) |  | INDIA-1D closes the decision boundary around already support | 71 |
 | [india-2a-staircase-scope-evidence.md](india-2a-staircase-scope-evidence.md) |  | activated INDIA-2A through INDIA-2D on 2026-08-15 by request | 111 |
 | [india-2b-staircase-actions-evidence.md](india-2b-staircase-actions-evidence.md) |  | INDIA-2B implements only the typed geometry, concrete self-w | 70 |
+| [india-2c-staircase-design-evidence.md](india-2c-staircase-design-evidence.md) |  | INDIA-2C composes the accepted INDIA-2B per-metre actions in | 66 |
 | [indian-code-truth-baseline.md](indian-code-truth-baseline.md) | INDIA-0 Indian-Code Truth Baseline | was squash-merged as 0373de68; INDIA-1 packets now update th | 93 |
 | [insights-verification-pack.md](insights-verification-pack.md) |  | This pack provides benchmark test cases for the insights mod | 101 |
 | [is456-library-first-evidence.md](is456-library-first-evidence.md) | IS 456 Library-First Evidence and Claim  | | Source | SHA-256 | Pages | Use | |---|---|---:|---| | 169 |

--- a/docs/verification/india-2c-staircase-design-evidence.md
+++ b/docs/verification/india-2c-staircase-design-evidence.md
@@ -1,0 +1,65 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-15
+doc_type: reference
+task: INDIA-2C
+---
+
+# INDIA-2C Staircase Structural-Design Evidence
+
+INDIA-2C composes the accepted INDIA-2B per-metre actions into one bounded
+waist-slab design check. It does not add public consumers or promote staircase
+capability from `HELD`.
+
+## Implemented calculation boundary
+
+`design_straight_flight_staircase()` checks:
+
+- singly reinforced rectangular flexure using the accepted IS 456 stress block;
+- minimum main and distribution reinforcement for the supplied steel grade;
+- caller-provided main/distribution bar areas, diameters, and spacings;
+- ordinary one-way concrete shear using the maintained Table 19/20 provider;
+- the basic simply supported effective-span/effective-depth limit of 20; and
+- integrity of the retained geometry/action carrier before design.
+
+The result is `PASS`, `REVIEW_REQUIRED`, or `FAIL`. It never invents a
+modification factor or treats software checks as professional approval.
+
+## Independent benchmark
+
+For `NPTEL-M9L20-EX9.1`, using M20 concrete, Fe415 steel, 224 mm effective
+depth, 12 mm main bars at 120 mm, and 8 mm distribution bars at 160 mm:
+
+| Quantity | Software | Published target |
+|---|---:|---:|
+| Factored moment | 68.0490 kNm/m | 102.08/1.5 = 68.0533 kNm/m |
+| Limiting moment | 138.4492 kNm/m | capacity must exceed demand |
+| Required main steel | 921.196 mm2/m | 920.64 mm2/m |
+| Provided main steel | 942.478 mm2/m | about 942 mm2/m |
+| Provided distribution steel | 314.159 mm2/m | about 314 mm2/m |
+| Nominal shear stress | 0.21756 N/mm2 | 0.217 N/mm2 |
+| Design concrete shear strength | 0.48616 N/mm2 | demand must be lower |
+| Basic span/depth ratio | 22.7679 | basic limit 20 |
+
+The required-steel difference is within the frozen 2 mm2/m tolerance because
+the published example reads a rounded percentage from SP 16, while the library
+solves the stress-block quadratic without table rounding.
+
+The example returns `REVIEW_REQUIRED`: flexure, supplied bars, and ordinary
+shear pass, but the unmodified basic L/d limit is exceeded. A shorter accepted
+member below L/d 20 returns `PASS`; insufficient main steel and singly
+reinforced capacity exceedance return `FAIL`.
+
+## Retained holds
+
+Modification factors, direct deflection, crack width, development-length
+layout, landing torsion, bar selection, continuity, concentrated actions,
+load generation/combinations, alternate stair systems, public service/FastAPI,
+React, qualified review, and release remain outside this packet.
+
+## Verification cadence
+
+This packet receives focused safe/review/fail/integrity tests, architecture and
+import checks, the quick gate, commit hooks, and hosted PR checks. Broad Python
+and the full repository gate remain deferred until INDIA-2D is integrated.

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -322,7 +322,8 @@
           "functions": [
             "structural_lib.codes.is456.beam.serviceability.check_deflection_span_depth",
             "structural_lib.codes.is456.beam.serviceability.get_long_term_deflection_factor",
-            "structural_lib.codes.is456.slab.serviceability.check_slab_span_depth_serviceability"
+            "structural_lib.codes.is456.slab.serviceability.check_slab_span_depth_serviceability",
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
           ]
         },
         {
@@ -561,7 +562,8 @@
           "registration_status": "REGISTERED",
           "functions": [
             "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
-            "structural_lib.codes.is456.slab.one_way_detailing.check_simply_supported_one_way_slab_detailing"
+            "structural_lib.codes.is456.slab.one_way_detailing.check_simply_supported_one_way_slab_detailing",
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
           ]
         },
         {
@@ -624,7 +626,8 @@
           "registration_status": "REGISTERED",
           "functions": [
             "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
-            "structural_lib.codes.is456.slab.one_way_detailing.check_simply_supported_one_way_slab_detailing"
+            "structural_lib.codes.is456.slab.one_way_detailing.check_simply_supported_one_way_slab_detailing",
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
           ]
         },
         {
@@ -958,7 +961,8 @@
             "structural_lib.codes.is456.column.pmm.pm_interaction_slice_for_layout",
             "structural_lib.codes.is456.slab.one_way.design_simply_supported_one_way_slab_flexure",
             "structural_lib.codes.is456.slab.one_way_continuous.design_continuous_one_way_slab_flexure",
-            "structural_lib.codes.is456.slab.two_way.design_supported_interior_two_way_slab_flexure"
+            "structural_lib.codes.is456.slab.two_way.design_supported_interior_two_way_slab_flexure",
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
           ]
         },
         {
@@ -1102,7 +1106,8 @@
           "functions": [
             "structural_lib.codes.is456.beam.shear.calculate_tv",
             "structural_lib.codes.is456.beam.shear.design_shear",
-            "structural_lib.codes.is456.slab.shear.check_solid_slab_one_way_shear"
+            "structural_lib.codes.is456.slab.shear.check_solid_slab_one_way_shear",
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
           ]
         },
         {
@@ -1115,7 +1120,8 @@
           "functions": [
             "structural_lib.codes.is456.beam.shear.design_shear",
             "structural_lib.codes.is456.slab.shear.check_solid_slab_one_way_shear",
-            "structural_lib.codes.is456.slab.two_way_complete.design_two_way_slab_panel"
+            "structural_lib.codes.is456.slab.two_way_complete.design_two_way_slab_panel",
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- compose accepted straight-flight actions into flexure, detailing, ordinary shear, and basic span-depth checks
- retain PASS, REVIEW_REQUIRED, and FAIL truth boundaries without inventing modification factors
- benchmark NPTEL Example 9.1 and preserve capability as HELD until the public workflow packet

## Validation
- focused staircase suite: 17 passed
- maintained mypy: 199 source files passed
- architecture/import checks: 0 violations
- quick gate: 10/10
- commit hooks: passed

## Holds
Alternate stairs, load generation, unresolved serviceability modifiers, qualified engineering review, release, and cleanup remain out of scope.