### PR TITLE
docs(planning): reconcile Indian-code completion waves

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,84 @@
 
 ---
 
+## 2026-08-16 — Session: Indian-Code Completion Plan Reconciliation
+
+**Agent:** Codex (`governance`, sole writer; no subagents)
+
+**Branch:** `codex/india-finish-plan-reconcile` from exact `origin/main` at
+`62f4ba06b6287c1b74ddd41e7cdfefa71b08e515`
+
+**Git handoff receipt:** `docs/verification/india-completion-plan-git-handoff-receipt.json`
+
+**Focus:** Establish one durable INDIA-0 through INDIA-4 finish plan before any new calculation work begins.
+
+### Summary
+
+- Added one canonical Indian-code completion plan that separates truth
+  baseline, existing-family closure, remaining IS 456 elements, companion
+  Indian codes, and final acceptance.
+- Preserved the historical INDIA-2A-D staircase task and evidence names while
+  mapping them to the completed `INDIA-2-STAIR` family inside umbrella INDIA-2.
+- Reconciled the task board, next-session brief, completed library-first plan,
+  and strategic blueprint around that hierarchy.
+- Set `INDIA-2-WALL-G0` as the next scope discussion only; no engineering
+  calculation, API, UI, release, or cleanup work was activated.
+
+### Issues encountered
+
+- Current planning called the completed bounded staircase program all of
+  `INDIA-2`, while the recovered finish plan used INDIA-2 for all remaining
+  practical IS 456 elements.
+- The strategic blueprint still classified every staircase as not implemented
+  after the bounded straight-flight workflow was merged.
+- The handoff scheduled cumulative qualified review immediately after the
+  staircase, conflicting with the recovered plan's INDIA-4 acceptance order.
+- The first generated handoff clipped the session focus at its Markdown line
+  break, leaving an incomplete sentence in the next-session brief.
+- Session closeout crossed midnight in India after the first commit, so the
+  August 15 entry and briefing date no longer satisfied the current-day check.
+
+### Root causes and resolutions
+
+- Root cause: a narrow implementation sequence reused the umbrella INDIA-2
+  label without a durable parent/family mapping. Resolution: preserve immutable
+  PR/evidence names and introduce `INDIA-2-STAIR` as their parent-family alias;
+  umbrella INDIA-2 remains in progress.
+- Root cause: the strategic blueprint is manually maintained and was not
+  updated when the generated manifest gained bounded staircase support.
+  Resolution: correct only the current-state table and link it to the canonical
+  generated manifest and wave plan.
+- Root cause: the prior handoff treated the staircase milestone boundary as the
+  end of the recovered Indian-code program. Resolution: keep packet-level
+  engineering/source checks, but place cumulative qualified review in INDIA-4
+  after accepted INDIA-2 and INDIA-3 scope is frozen.
+- Root cause: the handoff extractor reads the physical `**Focus:**` line rather
+  than joining wrapped Markdown continuation lines. Resolution: keep this
+  session's focus on one physical line and regenerate the handoff block.
+- Root cause: the session began immediately before the local date boundary and
+  the closeout checker intentionally matches the current local date. Resolution:
+  update only the current planning/session dates to August 16, bind the receipt
+  to the current local head, and rerun closeout before publication.
+
+### Evidence
+
+- The planning lane began clean from exact current `origin/main`; Git-state
+  authority returned `READY_LOCAL` and runtime diagnosis returned
+  `source_bound=true`.
+- Historical INDIA-2A-D rows, PR references, and evidence filenames are
+  unchanged; only the new parent-family mapping and future wave status changed.
+- Focused plan consistency, generated manifest, documentation, and quick-gate
+  evidence are recorded at closeout.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: `./run.sh session end --agent governance` reported that
+  the briefing and session log were not updated today after the local date
+  rolled from August 15 to August 16 -> updated only the current closeout dates,
+  regenerated the handoff receipt/indexes, and reran the check.
+
+---
+
 ## 2026-08-15 — Session: Primary Session-Log Reconciliation
 
 **Agent:** Codex (`ops`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-15 — INDIA-2 software and cumulative gates are complete; qualified review is next
+**Updated:** 2026-08-16 — umbrella finish plan reconciled; INDIA-2-STAIR is complete and INDIA-2 remains in progress
 
 ---
 
@@ -133,27 +133,31 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-IS456-FINAL-REVIEW | Perform the cumulative qualified review before any stable or engineering-use approval | qualified structural engineer | final gate | P0 | ⏸ DEFERRED UNTIL QUALIFIED REVIEW |
+| INDIA-2-WALL-G0 | Discuss and, if accepted, freeze one bounded Clause 32 wall case with exact source, benchmark, assumptions, and exclusions | repository owner + structural engineer | decision gate | P0 | 📋 READY FOR SCOPE DISCUSSION — implementation not activated |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 
 ## Backlog
 
-The version roadmap and historical backlog remain below. INDIA-0 provides the
-generated [Indian-code truth manifest](verification/indian-code-capability-coverage.json),
-and INDIA-1 closed limitations in the four already supported families. INDIA-2
-adds one bounded longitudinal straight-flight staircase workflow; alternate
-stair systems and every other held family remain outside the approved scope.
+The version roadmap and historical backlog remain below. The canonical
+[Indian-code completion plan](planning/indian-code-completion-plan.md) defines
+INDIA-0 through INDIA-4. INDIA-0 and INDIA-1 are complete. The historical
+INDIA-2A-D packets form the completed `INDIA-2-STAIR` family, but umbrella
+INDIA-2 remains in progress while wall, deep-beam, flat-slab/punching, and
+distinct foundation-system packets remain held.
 The v0.23.1a1 Alpha is published.
 UIX-001 P0-P15 is accepted: the revision-safe workbench, authoritative
 3D inspection, versioned capability catalogue, curated renderer, bounded
 development workflow, generated beam manifest, canonical routes, and integrated
-live acceptance are complete. Stable-release and engineering-use approval remain
-held for the cumulative qualified review.
+live acceptance are complete. INDIA-4 cumulative qualified review and separate
+owner authorization remain required before stable-release or engineering-use
+approval.
 
 ## Recently Done
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-COMPLETION-PLAN | Reconciled the canonical INDIA-0 through INDIA-4 finish waves and mapped historical staircase receipts to INDIA-2-STAIR without renaming them | Main Agent + repository owner | ✅ DONE — next discussion is INDIA-2-WALL-G0; no calculation implementation activated |
+| INDIA-2-STAIR | Completed one bounded longitudinal straight-flight staircase family | Main Agent + structural engineer | ✅ DONE — historical INDIA-2A-D and INDIA-2-CUMULATIVE remain the immutable evidence names |
 | INDIA-2-CUMULATIVE | Ran the broad Python suite, full repository gate, manifest reconciliation, and cumulative essential review after A-D integration | Main Agent + reviewer | ✅ DONE — 5,950 Python tests and full 30/30 gate green; staircase remains one bounded L2 API workflow and qualified review remains separate |
 | INDIA-2D | Published one typed Python/FastAPI straight-flight workflow and reconciled capability truth | Main Agent + API developer | ✅ DONE — public benchmark returns REVIEW_REQUIRED truthfully; unsafe and passing cases preserve FAIL/PASS boundaries; React remains excluded |
 | INDIA-2C | Composed accepted actions into singly reinforced flexure, supplied-bar detailing, ordinary shear, action-integrity, and basic span/depth dispositions | Main Agent + structural math | ✅ DONE — NPTEL Example 9.1 strength/detailing targets pass and truthfully return REVIEW_REQUIRED for unmodified L/d; unsafe cases return FAIL |

--- a/docs/index.json
+++ b/docs/index.json
@@ -2,7 +2,7 @@
   "folder": "docs",
   "type": "documentation",
   "description": "Guides, references, evidence, and contributor material for the",
-  "last_updated": "2026-08-15",
+  "last_updated": "2026-08-16",
   "file_count": 6,
   "files": [
     {
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 6071,
-      "last_updated": "2026-08-15",
+      "size_lines": 6149,
+      "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "33e23567eca5"
+      "content_hash": "65ee4e62f834"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 691,
-      "last_updated": "2026-08-15",
+      "size_lines": 695,
+      "last_updated": "2026-08-16",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "ee2e0c9969cb"
+      "content_hash": "04b6d0e5d48f"
     },
     {
       "name": "WORKLOG.md",
@@ -181,7 +181,7 @@
     {
       "name": "planning",
       "path": "planning/",
-      "file_count": 19
+      "file_count": 20
     },
     {
       "name": "publications",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 36,
+      "file_count": 38,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "14140c8570f15eb7"
+  "content_hash": "dde75e62c9edc18c"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 Guides, references, evidence, and contributor material for the
 
 **Type:** Documentation
-**Last Updated:** 2026-08-15
+**Last Updated:** 2026-08-16
 **Files:** 6
 
 ## Config Files
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6071 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 691 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6149 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 695 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -43,9 +43,9 @@ Guides, references, evidence, and contributor material for the
 | [learning-foundations/](learning-foundations/) | 13 | These are NOT specific to this repo. They are universal concepts every developer |
 | [legal/](legal/) | 6 | Engineering certification templates and usage guidelines. |
 | [migration/](migration/) | 45 |  |
-| [planning/](planning/) | 19 |  |
+| [planning/](planning/) | 20 |  |
 | [publications/](publications/) | 11 | This directory contains blog posts, technical articles, and academic papers docu |
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 36 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 38 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -2,8 +2,8 @@
   "folder": "docs/planning",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-15",
-  "file_count": 17,
+  "last_updated": "2026-08-16",
+  "file_count": 18,
   "files": [
     {
       "name": "README.md",
@@ -64,12 +64,20 @@
       "content_hash": "4160ef25ca5e"
     },
     {
+      "name": "indian-code-completion-plan.md",
+      "type": "documentation",
+      "size_lines": 125,
+      "last_updated": "2026-08-16",
+      "description": "This is the canonical finish plan for the repository's Indian-code program. It defines the meaning and order of INDIA-0 through INDIA-4 without claiming",
+      "content_hash": "d48559d90cb0"
+    },
+    {
       "name": "is456-library-first-master-plan.md",
       "type": "documentation",
-      "size_lines": 1500,
-      "last_updated": "2026-08-15",
+      "size_lines": 1507,
+      "last_updated": "2026-08-16",
       "description": "The Python package is the product. FastAPI, React, command-line workflows, reports, ETABS adapters, and future integrations are consumers of that product.",
-      "content_hash": "6578a824e80e"
+      "content_hash": "a4fd1d2c1971"
     },
     {
       "name": "is456-solid-slabs-master-plan.md",
@@ -82,11 +90,11 @@
     {
       "name": "library-expansion-blueprint-v5.md",
       "type": "documentation",
-      "size_lines": 1118,
-      "last_updated": "2026-08-15",
+      "size_lines": 1121,
+      "last_updated": "2026-08-16",
       "title": "Library Expansion Blueprint v5.0 — Multi-Code, Multi-Element",
       "description": "> Master plan for expanding structural_engineering_lib from single-code beam-only (IS 456) to multi-code (IS 456, ACI 318-19, EC2), multi-element (beam, column, slab, footing, wall, stair) with comple",
-      "content_hash": "cf6fe9e58706"
+      "content_hash": "c03aeee26b45"
     },
     {
       "name": "memory.md",
@@ -107,11 +115,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 68,
-      "last_updated": "2026-08-15",
+      "size_lines": 74,
+      "last_updated": "2026-08-16",
       "title": "Next Session Briefing",
-      "description": "<!-- HANDOFF:START --> - Date: 2026-08-15",
-      "content_hash": "871801126480"
+      "description": "<!-- HANDOFF:START --> - Date: 2026-08-16",
+      "content_hash": "5ee4167eecd4"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,5 +157,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "cbbf4b92e4c59d53"
+  "content_hash": "9ccf093e1339898d"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -1,8 +1,8 @@
 # Planning
 
 **Type:** Documentation
-**Last Updated:** 2026-08-15
-**Files:** 17
+**Last Updated:** 2026-08-16
+**Files:** 18
 
 ## Documentation Files
 
@@ -15,12 +15,13 @@
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
 | [etabs-killer-masterplan.md](etabs-killer-masterplan.md) | Project BHEEM: Open-Source Structural De | > **BHEEM** — **B**uilding **H**olistic **E**ngineering **E* | 2855 |
 | [gpt-5-3-codex-spark-work-program.md](gpt-5-3-codex-spark-work-program.md) |  | Use GPT-5.3-Codex-Spark as a high-throughput implementation  | 614 |
-| [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1500 |
+| [indian-code-completion-plan.md](indian-code-completion-plan.md) |  | This is the canonical finish plan for the repository's India | 125 |
+| [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1507 |
 | [is456-solid-slabs-master-plan.md](is456-solid-slabs-master-plan.md) |  | The next element program will complete a useful, evidence-ba | 1123 |
-| [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1118 |
+| [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-15 | 68 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 74 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/indian-code-completion-plan.md
+++ b/docs/planning/indian-code-completion-plan.md
@@ -1,0 +1,124 @@
+---
+task: INDIA-COMPLETION-PLAN
+title: Indian-Code Completion Waves
+status: active
+owner: Main Agent and repository owner
+created: 2026-08-15
+last_updated: 2026-08-16
+doc_type: spec
+---
+
+# Indian-Code Completion Waves
+
+## 1. Purpose and authority
+
+This is the canonical finish plan for the repository's Indian-code program.
+It defines the meaning and order of INDIA-0 through INDIA-4 without claiming
+that every provision of any standard will be implemented.
+
+The generated
+[Indian-code capability/coverage manifest](../verification/indian-code-capability-coverage.json)
+remains the authority for executable support and registration status.
+[TASKS.md](../TASKS.md) remains the short current-work board. The
+[library-first master plan](is456-library-first-master-plan.md) is the completed
+bounded-product milestone, and the
+[library expansion blueprint](library-expansion-blueprint-v5.md) remains the
+long-range architecture roadmap. Neither historical document overrides this
+wave order or the generated manifest.
+
+Historical PRs, evidence files, and task IDs are immutable receipts. In
+particular, the completed staircase packets named `INDIA-2A` through
+`INDIA-2D` are not renamed. This plan maps them to `INDIA-2-STAIR`, one
+completed family inside the larger INDIA-2 wave.
+
+## 2. Finish-line status
+
+| Wave | Outcome | Current state |
+|---|---|---|
+| INDIA-0 — Truth baseline | One generated, standard-namespaced capability/coverage manifest; repaired coverage consumers; reconciled status ledgers | **Complete** |
+| INDIA-1 — Existing-family closure | Close or explicitly hold limitations for beam, rectangular column, isolated footing, and solid slab | **Complete** |
+| INDIA-2 — Remaining practical IS 456 elements | Separately verify wall, stair, deep-beam, flat-slab/punching, and distinct foundation-system packets | **In progress** — bounded stair complete; other families remain held |
+| INDIA-3 — Companion Indian codes | Complete the bounded IS 13920 surface, then add IS 875 inputs before IS 1893 equivalent-static actions and Indian combinations | **Planned** |
+| INDIA-4 — Final acceptance | Run cumulative engineering, cross-layer, repository, and artifact acceptance for the explicitly supported subset | **Planned** |
+
+“Complete” means the bounded accepted scope and its explicit exclusions are
+closed. It does not mean whole-standard coverage, professional approval, or
+release authorization.
+
+## 3. INDIA-2 family packets
+
+Every family starts with a decision packet that freezes one useful case, its
+source, independent benchmark, assumptions, and exclusions before calculation
+code is authorized.
+
+| Packet | Bounded objective | State and boundary |
+|---|---|---|
+| `INDIA-2-WALL` | IS 456 Clause 32 wall program | **Next decision candidate.** No implementation is activated by this plan update. |
+| `INDIA-2-STAIR` | IS 456 Clause 33 longitudinal straight waist-slab flight with collinear landings | **Complete.** Historical `INDIA-2A`–`INDIA-2D` plus the cumulative gate are its evidence. Alternate stairs remain held. |
+| `INDIA-2-DEEP` | IS 456 Clause 29 deep-beam program | **Held pending its own decision packet.** |
+| `INDIA-2-FLAT` | Flat-slab and column-punching program | **Held pending its own decision packet.** |
+| `INDIA-2-FOUNDATION-COMBINED` | Combined-footing program | **Held; distinct analysis model required.** |
+| `INDIA-2-FOUNDATION-STRAP` | Strap-footing program | **Held; distinct analysis model required.** |
+| `INDIA-2-FOUNDATION-RAFT` | Raft-foundation program | **Held; distinct analysis model required.** |
+| `INDIA-2-FOUNDATION-PILE-CAP` | Pile-cap program | **Held; distinct analysis model required.** |
+
+The next discussion should decide whether `INDIA-2-WALL-G0` is the best next
+bounded packet and, if so, freeze its exact supported wall case. It must not
+silently expand into retaining walls, seismic wall design, building analysis,
+or foundation design.
+
+## 4. INDIA-3 companion-code order
+
+INDIA-3 is not another IS 456 element. It is the companion Indian-code wave:
+
+1. Finish and advertise the already bounded IS 13920 beam, column, and joint
+   checks without inflating registration into implementation.
+2. Add separately sourced and benchmarked IS 13920 wall provisions.
+3. Add separately sourced and benchmarked IS 13920 foundation provisions.
+4. Implement bounded IS 875 gravity and wind input programs.
+5. Only then implement IS 1893 equivalent-static seismic actions and the
+   accepted Indian load combinations that consume those inputs.
+
+Response-spectrum, dynamic, and FEM analysis are a separate analysis program.
+They are not implied by an equivalent-static or load-combination capability.
+
+## 5. INDIA-4 final acceptance
+
+After the accepted INDIA-2 and INDIA-3 scope is frozen, INDIA-4 performs:
+
+- source-to-result benchmark review for every advertised calculation packet;
+- cross-layer user-acceptance testing for supported Python, API, and UI paths;
+- the full repository gate and exact-artifact verification;
+- cumulative qualified structural-engineering review of the advertised subset.
+
+INDIA-4 does not authorize professional use or release. Stable-release,
+engineering-use, package publication, tag, GitHub Release, and professional
+approval remain separate owner-controlled decisions.
+
+## 6. Required contract for every calculation packet
+
+Before a packet can claim support, it must record all of the following:
+
+1. Governing standard edition, clause/table identifier, and source provenance.
+2. Explicit units plus supported geometry, material, support, and loading
+   assumptions.
+3. An independent benchmark and justified numerical tolerance.
+4. Governing unsafe cases and out-of-domain cases that fail closed.
+5. Pure-math acceptance before Python service, FastAPI, or React publication.
+6. Truthful capability wording and machine-visible exclusions.
+7. Focused tests, benchmark checks, architecture checks, and the quick gate for
+   the packet, followed by one cumulative full gate at the milestone boundary.
+
+The expensive broad Python and 30-check repository gates run once after a
+milestone's packets are integrated. Run them earlier only when a confirmed
+repository-wide issue could change the outcome.
+
+## 7. Claim boundaries
+
+- Generated registration or metadata is not proof of calculation capability.
+- Passing software tests is not qualified engineering review.
+- Qualified review is not release or professional-use authorization.
+- A completed bounded packet does not activate adjacent geometry, loads,
+  elements, companion codes, analysis systems, API, UI, or release work.
+- Unknown or unsupported cases must remain explicit holds, never inferred
+  support.

--- a/docs/planning/is456-library-first-master-plan.md
+++ b/docs/planning/is456-library-first-master-plan.md
@@ -1,10 +1,10 @@
 ---
 task: LIB-IS456-V1
 title: IS 456 Library-First Completion and PyPI Master Plan
-status: active
+status: completed
 owner: Main Agent and repository owner
 created: 2026-08-09
-last_updated: 2026-08-10
+last_updated: 2026-08-16
 doc_type: spec
 baseline_commit: d4eb9e9dda4a
 release_decision: v0.21.7 deferred
@@ -14,10 +14,10 @@ current_blocker: Qualified review before stable or engineering-use approval
 
 **Type:** Plan
 **Audience:** All Agents
-**Status:** C0-C4 Complete — v0.23.0 Alpha Released
+**Status:** Complete — bounded Alpha milestone released; successor program active
 **Importance:** Critical
 **Created:** 2026-08-09
-**Last Updated:** 2026-08-10
+**Last Updated:** 2026-08-16
 
 ---
 
@@ -61,6 +61,13 @@ library-first IS 456 lane activated by the owner. C0-C4 and the v0.23.0 Alpha
 release are complete. Qualified structural-engineering review is a cumulative
 final gate before stable/engineering-use approval, not a blocker for each
 development packet or Alpha release.
+
+The [Indian-code completion plan](indian-code-completion-plan.md) is the
+successor authority for INDIA-0 through INDIA-4. It preserves this program as a
+completed bounded milestone, maps the later staircase packets under
+`INDIA-2-STAIR`, and schedules cumulative qualified review in INDIA-4 after the
+accepted INDIA-2 and INDIA-3 scope is frozen. Historical packet and evidence
+names in this document remain unchanged.
 
 It narrows the immediate IS 456 execution order in
 `docs/planning/library-expansion-blueprint-v5.md`. It does not reverse that

--- a/docs/planning/library-expansion-blueprint-v5.md
+++ b/docs/planning/library-expansion-blueprint-v5.md
@@ -5,7 +5,7 @@
 **Status:** Future strategic roadmap; not active during bounded IS 456 closeout
 **Importance:** Critical
 **Created:** 2026-03-31
-**Last Updated:** 2026-08-15
+**Last Updated:** 2026-08-16
 **Supersedes:** [library-expansion-blueprint-v4.md](../_archive/planning-completed-2026-03/library-expansion-blueprint-v4.md) (IS 456-only)
 
 > Master plan for expanding structural_engineering_lib from single-code beam-only (IS 456) to multi-code (IS 456, ACI 318-19, EC2), multi-element (beam, column, slab, footing, wall, stair) with complete companion code support.
@@ -14,8 +14,10 @@
 > architecture blueprint, not a live status ledger. Current scope comes from
 > the generated
 > [Indian-code capability/coverage manifest](../verification/indian-code-capability-coverage.json)
-> and `docs/TASKS.md`. Historical task tables below are retained as design
-> context only where explicitly labelled; they must not override the manifest.
+> and `docs/TASKS.md`; current Indian-code wave order comes from the
+> [Indian-code completion plan](indian-code-completion-plan.md). Historical task
+> tables below are retained as design context only where explicitly labelled;
+> they must not override the manifest or current wave plan.
 
 ---
 
@@ -246,7 +248,8 @@ class DesignEnvelope:
 | Scope | Manifest status | Boundary |
 |-------|-----------------|----------|
 | Beam, rectangular column, isolated footing, solid slab | `SUPPORTED` / `IMPLEMENTED_BOUNDED` | Exact supported workflows and held cases come from the runtime IS 456 capability registry |
-| Walls, stairs, deep beams, flat slabs | `HELD` / `NOT_IMPLEMENTED` | Separate IS 456 programs required |
+| Staircase | `SUPPORTED` / `IMPLEMENTED_BOUNDED` | One longitudinal straight waist-slab flight is complete; alternate stair systems remain held |
+| Walls, deep beams, flat slabs | `HELD` / `NOT_IMPLEMENTED` | Separate IS 456 family programs required |
 | Combined/strap/raft/pile-cap foundations | `HELD` / `NOT_IMPLEMENTED` | Each requires a distinct analysis model |
 | IS 13920 beam, column and SCWB checks | `SUPPORTED` / `IMPLEMENTED_BOUNDED` | Does not claim complete seismic member/building design |
 | IS 13920 walls/foundations, IS 875, IS 1893 | `HELD` / `NOT_IMPLEMENTED` | Companion-code waves remain separate |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -3,38 +3,43 @@
 ## Latest Handoff (auto)
 
 <!-- HANDOFF:START -->
-- Date: 2026-08-15
-- Focus: Preserve the unique audit entry from stale dirty primary main before any INDIA-3 lane or destructive cleanup.
-- Git receipt: docs/verification/git-primary-session-log-reconcile-handoff-receipt.json | sha256:899b385ab0227bb7d5dbf3a19e72107cd09cb303c03f33f4394c1c5341e157db | HOLD
-- Git identity: codex/git-primary-session-log-reconcile@9d68f53e70dc088c3ee7034ca99d0ed1c418717a | upstream=origin/main@9d68f53e70dc088c3ee7034ca99d0ed1c418717a | base=origin/main@9d68f53e70dc088c3ee7034ca99d0ed1c418717a | tree=dirty | operation=none
+- Date: 2026-08-16
+- Focus: Establish one durable INDIA-0 through INDIA-4 finish plan before any new calculation work begins.
+- Git receipt: docs/verification/india-completion-plan-git-handoff-receipt.json | sha256:5d5255d0098303e2ee2663d011cddad3cbdbba292eb013cd6640b37b207746a8 | HOLD
+- Git identity: codex/india-finish-plan-reconcile@ca65c165ba3abc23497f15ba5e305f2324b91191 | upstream=NONE@UNKNOWN | base=origin/main@62f4ba06b6287c1b74ddd41e7cdfefa71b08e515 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: WAIT_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->
 
-**Date:** 2026-08-15
+**Date:** 2026-08-16
 
 | Release state | Target |
 |---|---|
-| **Current** | `v0.23.1a1` Alpha; INDIA-1 and INDIA-2 software and cumulative gates complete |
-| **Next** | Qualified structural-engineering review; no release or further stair scope is activated |
+| **Current** | `v0.23.1a1` Alpha; INDIA-0, INDIA-1, and the INDIA-2-STAIR family are complete |
+| **Program** | Umbrella INDIA-2 remains in progress; INDIA-3 and INDIA-4 remain planned |
+| **Next** | Discuss `INDIA-2-WALL-G0`; no wall implementation, release, or new stair scope is activated |
 
 ## Required Reading
 
-1. [INDIA-2 cumulative gate evidence](../verification/india-2-cumulative-gate-evidence.md)
-2. [INDIA-2D public-workflow evidence](../verification/india-2d-staircase-publication-evidence.md)
-3. [Generated Indian-code manifest](../verification/indian-code-capability-coverage.json)
-4. [Current task board](../TASKS.md)
+1. [Canonical Indian-code completion waves](indian-code-completion-plan.md)
+2. [Generated Indian-code manifest](../verification/indian-code-capability-coverage.json)
+3. [Current task board](../TASKS.md)
+4. [INDIA-2 staircase cumulative evidence](../verification/india-2-cumulative-gate-evidence.md)
 5. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
 
 ## Start Boundary
 
-INDIA-2A-D and the cumulative software gates are complete. Do not reopen those
-packets, add another stair topology, add React, or begin release work without a
-new owner-approved scope. The next engineering step is independent qualified
-review of the bounded workflow and its retained assumptions.
+The historical INDIA-2A-D packets and their cumulative software gate are the
+completed `INDIA-2-STAIR` family. Do not reopen them, add another stair topology,
+add React, or begin release work without a new owner-approved scope.
+
+The next conversation is a decision packet, not implementation: decide whether
+to start `INDIA-2-WALL-G0` and freeze exactly one practical Clause 32 wall case,
+its controlled source, independent benchmark, explicit units and assumptions,
+unsafe/out-of-domain cases, and retained exclusions.
 
 ```bash
-./run.sh session brief --agent structural-engineer
+./run.sh session brief --agent orchestrator
 ./run.sh session start
 ./scripts/python_runtime.sh --diagnose
 ./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
@@ -42,26 +47,27 @@ review of the bounded workflow and its retained assumptions.
 ```
 
 Require a clean fresh branch from verified current `origin/main` and
-`source_bound=true`. Preserve the dirty primary checkout, every unrelated
-worktree, and all INDIA-2 branches/worktrees until cleanup is explicitly
-authorized.
+`source_bound=true`. Preserve every unrelated worktree. Branch, remote-ref, or
+worktree cleanup remains a separate exact-target authorization.
 
-## Qualified-review boundary
+## INDIA-2-WALL-G0 decision exit
 
-The qualified reviewer should assess the accepted NPTEL benchmark, Clause 33
-geometry/action interpretation, flexure, supplied-bar and ordinary-shear checks,
-basic span/depth disposition, public provenance, and all retained holds. Record
-review findings separately from software-gate evidence.
+The decision packet ends with GO or HOLD. A GO must identify one supported wall
+case, governing standard edition and provisions, lawful source provenance, an
+independent benchmark with tolerance, calculation inputs/outputs, fail-closed
+boundaries, and the proposed pure-math implementation packets. A HOLD must state
+the missing evidence or unresolved scope decision. It must not add calculation
+code, API, UI, or public capability claims.
 
-Software completion does not grant professional approval, stable-release
-authorization, or engineering-use authorization. Any outcome-changing review
-finding must be resolved in a separately bounded packet and revalidated in
-proportion to the change.
+## Review and gate boundary
 
-## INDIA-2 Exit
+Each calculation packet still requires focused tests, benchmarks, architecture
+and PR checks, plus the quick gate. The expensive full Python and 30-check gate
+runs once at the milestone boundary unless an outcome-changing repository-wide
+issue appears earlier.
 
-INDIA-2 meets its software exit: the bounded stair family is executable,
-independently benchmarked, provenance-bearing, and truthfully limited; every
-other held family is unchanged; manifests contain no unknown status; and the
-cumulative gates pass. Qualified engineering review, professional approval,
-release authorization, and branch/worktree cleanup remain separate.
+Cumulative qualified structural-engineering review belongs to INDIA-4 after the
+accepted INDIA-2 and INDIA-3 scope is frozen. Packet-level source and engineering
+checks still occur before each implementation GO. Software completion does not
+grant professional approval, stable-release authorization, engineering-use
+authorization, or cleanup authority.

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -2,8 +2,8 @@
   "folder": "docs/verification",
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
-  "last_updated": "2026-08-15",
-  "file_count": 34,
+  "last_updated": "2026-08-16",
+  "file_count": 36,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -261,6 +261,36 @@
       "content_hash": "be7ac2e157a6"
     },
     {
+      "name": "india-completion-plan-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "505d57e0353e"
+    },
+    {
+      "name": "india-completion-plan-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "54d3a85d1687"
+    },
+    {
       "name": "indian-code-capability-coverage.json",
       "type": "config",
       "last_updated": "2026-08-15",
@@ -363,5 +393,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "63de9bea8940554f"
+  "content_hash": "e6494ef79e65782a"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -3,8 +3,8 @@
 Benchmark examples and verification packs for validating library calculations against IS 456 standards.
 
 **Type:** Documentation
-**Last Updated:** 2026-08-15
-**Files:** 34
+**Last Updated:** 2026-08-16
+**Files:** 36
 
 ## Config Files
 
@@ -16,6 +16,8 @@ Benchmark examples and verification packs for validating library calculations ag
 - [india-2-cumulative-git-handoff-source-evidence.json](india-2-cumulative-git-handoff-source-evidence.json)
 - [india-2d-git-handoff-receipt.json](india-2d-git-handoff-receipt.json)
 - [india-2d-git-handoff-source-evidence.json](india-2d-git-handoff-source-evidence.json)
+- [india-completion-plan-git-handoff-receipt.json](india-completion-plan-git-handoff-receipt.json)
+- [india-completion-plan-git-handoff-source-evidence.json](india-completion-plan-git-handoff-source-evidence.json)
 - [indian-code-capability-coverage.json](indian-code-capability-coverage.json)
 - [is456-public-distribution-permission.json](is456-public-distribution-permission.json)
 

--- a/docs/verification/india-completion-plan-git-handoff-receipt.json
+++ b/docs/verification/india-completion-plan-git-handoff-receipt.json
@@ -1,0 +1,166 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-15T18:27:48Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-COMPLETION:user-request-update-plans-first",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-15T18:27:48Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "IMPLEMENT_ENGINEERING_CALCULATION",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-finish-plan-reconcile",
+      "head_sha": "ca65c165ba3abc23497f15ba5e305f2324b91191",
+      "task_id": "INDIA-COMPLETION-PLAN"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "5d5255d0098303e2ee2663d011cddad3cbdbba292eb013cd6640b37b207746a8",
+    "state": {
+      "branch": "codex/india-finish-plan-reconcile",
+      "default_base": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "62f4ba06b6287c1b74ddd41e7cdfefa71b08e515",
+        "status": "ahead"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 83.856,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-india-finish-plan",
+      "head_sha": "ca65c165ba3abc23497f15ba5e305f2324b91191",
+      "hold_reasons": [
+        "changed paths: 11"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-15T18:34:30.167284+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-finish-plan",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 11,
+        "modified_paths": [
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/index.json",
+          "docs/planning/indian-code-completion-plan.md",
+          "docs/planning/is456-library-first-master-plan.md",
+          "docs/planning/library-expansion-blueprint-v5.md",
+          "docs/planning/next-session-brief.md",
+          "docs/verification/index.json",
+          "docs/verification/india-completion-plan-git-handoff-source-evidence.json"
+        ],
+        "staged_paths": [],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-finish-plan"
+    }
+  },
+  "local_state_receipt_hash": "sha256:5d5255d0098303e2ee2663d011cddad3cbdbba292eb013cd6640b37b207746a8",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-15T18:34:30.167424+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-15T18:27:48Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/**",
+      "fastapi_app/**",
+      "react_app/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "docs/planning/indian-code-completion-plan.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md",
+      "docs/planning/library-expansion-blueprint-v5.md",
+      "docs/planning/is456-library-first-master-plan.md",
+      "docs/SESSION_LOG.md",
+      "docs/verification/india-completion-plan-git-handoff-source-evidence.json"
+    ],
+    "shared_paths": [
+      "docs/index.json",
+      "docs/index.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md"
+    ],
+    "task_id": "INDIA-COMPLETION-PLAN"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-completion-plan-git-handoff-source-evidence.json
+++ b/docs/verification/india-completion-plan-git-handoff-source-evidence.json
@@ -1,0 +1,54 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-15T18:27:48Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-COMPLETION:user-request-update-plans-first",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-15T18:27:48Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "IMPLEMENT_ENGINEERING_CALCULATION",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-finish-plan-reconcile",
+      "head_sha": "ca65c165ba3abc23497f15ba5e305f2324b91191",
+      "task_id": "INDIA-COMPLETION-PLAN"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-15T18:27:48Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}


### PR DESCRIPTION
## What changed

- added one canonical INDIA-0 through INDIA-4 completion plan
- mapped the completed historical INDIA-2A-D staircase packets to `INDIA-2-STAIR` without renaming evidence
- marked umbrella INDIA-2 in progress, INDIA-3 as companion codes, and INDIA-4 as final acceptance
- updated the task board, next-session brief, completed library-first plan, strategic blueprint, indexes, and Git handoff/session evidence

## Why

The narrow staircase sequence reused the umbrella `INDIA-2` name, which made the task board incorrectly imply that all remaining practical IS 456 elements were complete and that cumulative qualified review was immediately next. The hierarchy now preserves historical receipts while restoring the intended finish waves.

## Scope boundary

This is planning and documentation only. `INDIA-2-WALL-G0` is ready for scope discussion, but no wall calculation, API, UI, release, or cleanup work is activated.

## Validation

- Indian-code generated manifest check: current
- internal Markdown links: 1,134 checked, 0 broken
- targeted planning/verification/docs indexes: current
- `./run.sh check --quick`: 10/10 passed
- pre-commit hooks: passed