### PR TITLE
docs(planning): add INDIA-2 execution plan

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,64 @@
 
 ---
 
+## 2026-08-16 — Session: INDIA-2 One-Document Execution Plan
+
+**Agent:** Codex (`governance`, sole writer; no subagents)
+
+**Branch:** `codex/india-2-detailed-plan` from exact `origin/main` at
+`b3fed846210d3460cf4d6d6f326d2d6d6caf100d`
+
+**Git handoff receipt:** `docs/verification/india-2-plan-git-handoff-receipt.json`
+
+**Focus:** Consolidate all INDIA-2 work into one understandable, executable plan without starting calculation implementation.
+
+### Summary
+
+- Added one dedicated INDIA-2 execution plan covering the completed staircase,
+  next wall decision, deep beams, flat slabs/punching, four separate foundation
+  programs, validation cadence, and final exit criteria.
+- Added one reusable G0/A-D packet pattern while keeping family-specific
+  analysis models and exclusions separate.
+- Linked the parent Indian-code plan, task board, and next-session brief to the
+  detailed plan.
+- Kept `INDIA-2-WALL-G0` decision-only; no calculation, API, UI, release, or
+  cleanup work was activated.
+
+### Issues encountered
+
+- The parent completion document listed INDIA-2 families and status but did not
+  contain an executable family-by-family packet sequence in one place.
+- Foundation extensions could be misread as one generic footing enhancement
+  even though combined, strap, pile-cap, and raft systems require different
+  analysis models.
+
+### Root causes and resolutions
+
+- Root cause: the parent plan was intentionally concise and established the
+  umbrella hierarchy, leaving detailed execution spread across historical stair
+  evidence and future decision language. Resolution: add one subordinate
+  INDIA-2 execution authority with current truth, ordered family programs,
+  packet gates, exclusions, and completion criteria.
+- Root cause: shared concrete/material/detailing concepts can obscure the
+  distinct load-path and analysis decisions for each foundation system.
+  Resolution: require an independent G0, benchmark, pure-math workflow, public
+  contract, and cumulative gate for each foundation family.
+
+### Evidence
+
+- The lane started clean from exact current `origin/main`; Git-state authority
+  returned `READY_LOCAL` and runtime diagnosis returned `source_bound=true`.
+- The generated manifest remains the support-truth authority; the new document
+  changes planning only and preserves the completed stair boundary.
+- Focused documentation, manifest, index, link, and quick-gate evidence are
+  recorded at closeout.
+
+### Terminal issues
+
+- None encountered.
+
+---
+
 ## 2026-08-16 — Session: Indian-Code Completion Plan Reconciliation
 
 **Agent:** Codex (`governance`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -133,15 +133,17 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-2-WALL-G0 | Discuss and, if accepted, freeze one bounded Clause 32 wall case with exact source, benchmark, assumptions, and exclusions | repository owner + structural engineer | decision gate | P0 | 📋 READY FOR SCOPE DISCUSSION — implementation not activated |
+| INDIA-2-WALL-G0 | Discuss and, if accepted, freeze one bounded Clause 32 wall case using the [INDIA-2 execution plan](planning/india-2-remaining-is456-elements-plan.md) | repository owner + structural engineer | decision gate | P0 | 📋 READY FOR SCOPE DISCUSSION — implementation not activated |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 
 ## Backlog
 
 The version roadmap and historical backlog remain below. The canonical
 [Indian-code completion plan](planning/indian-code-completion-plan.md) defines
-INDIA-0 through INDIA-4. INDIA-0 and INDIA-1 are complete. The historical
-INDIA-2A-D packets form the completed `INDIA-2-STAIR` family, but umbrella
+INDIA-0 through INDIA-4, and the dedicated
+[INDIA-2 execution plan](planning/india-2-remaining-is456-elements-plan.md)
+defines the remaining family packets. INDIA-0 and INDIA-1 are complete. The
+historical INDIA-2A-D packets form the completed `INDIA-2-STAIR` family, but umbrella
 INDIA-2 remains in progress while wall, deep-beam, flat-slab/punching, and
 distinct foundation-system packets remain held.
 The v0.23.1a1 Alpha is published.
@@ -156,6 +158,7 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-2-PLAN | Consolidated INDIA-2 scope, family order, packet gates, exclusions, validation cadence, and completion criteria into one execution document | Main Agent + repository owner | ✅ DONE — INDIA-2-WALL-G0 remains the next decision; no engineering implementation activated |
 | INDIA-COMPLETION-PLAN | Reconciled the canonical INDIA-0 through INDIA-4 finish waves and mapped historical staircase receipts to INDIA-2-STAIR without renaming them | Main Agent + repository owner | ✅ DONE — next discussion is INDIA-2-WALL-G0; no calculation implementation activated |
 | INDIA-2-STAIR | Completed one bounded longitudinal straight-flight staircase family | Main Agent + structural engineer | ✅ DONE — historical INDIA-2A-D and INDIA-2-CUMULATIVE remain the immutable evidence names |
 | INDIA-2-CUMULATIVE | Ran the broad Python suite, full repository gate, manifest reconciliation, and cumulative essential review after A-D integration | Main Agent + reviewer | ✅ DONE — 5,950 Python tests and full 30/30 gate green; staircase remains one bounded L2 API workflow and qualified review remains separate |

--- a/docs/index.json
+++ b/docs/index.json
@@ -9,7 +9,7 @@
       "name": "README.md",
       "type": "documentation",
       "size_lines": 253,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "Docs Index (Start Here)",
       "description": "Guides, references, evidence, and contributor material for the structural-lib-is456 Python package and the React/FastAPI workbench.",
       "content_hash": "09e22d932251"
@@ -17,33 +17,33 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 6149,
+      "size_lines": 6207,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "65ee4e62f834"
+      "content_hash": "a43830e237a7"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 695,
+      "size_lines": 698,
       "last_updated": "2026-08-16",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "04b6d0e5d48f"
+      "content_hash": "6a6abe3d070e"
     },
     {
       "name": "WORKLOG.md",
       "type": "documentation",
       "size_lines": 354,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "> **One line per item. Compact. Append-only.** > Format: DATE | TASK-ID | what changed | commit",
       "content_hash": "99219f077170"
     },
     {
       "name": "docs-canonical.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "_comment",
         "_updated",
@@ -57,7 +57,7 @@
     {
       "name": "docs-index.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "version",
         "generated",
@@ -181,7 +181,7 @@
     {
       "name": "planning",
       "path": "planning/",
-      "file_count": 20
+      "file_count": 21
     },
     {
       "name": "publications",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 38,
+      "file_count": 40,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "dde75e62c9edc18c"
+  "content_hash": "100c1f4ce90a069d"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6149 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 695 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6207 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 698 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -43,9 +43,9 @@ Guides, references, evidence, and contributor material for the
 | [learning-foundations/](learning-foundations/) | 13 | These are NOT specific to this repo. They are universal concepts every developer |
 | [legal/](legal/) | 6 | Engineering certification templates and usage guidelines. |
 | [migration/](migration/) | 45 |  |
-| [planning/](planning/) | 20 |  |
+| [planning/](planning/) | 21 |  |
 | [publications/](publications/) | 11 | This directory contains blog posts, technical articles, and academic papers docu |
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 38 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 40 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -3,13 +3,13 @@
   "type": "documentation",
   "description": "",
   "last_updated": "2026-08-16",
-  "file_count": 18,
+  "file_count": 19,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 154,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "Planning",
       "description": "Internal planning documents and research notes. | Document | Purpose |",
       "content_hash": "56281c1a3fd2"
@@ -18,7 +18,7 @@
       "name": "adoption-trust-surface-plan.md",
       "type": "documentation",
       "size_lines": 380,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Make the released Alpha straightforward to evaluate from four perspectives: - a user can copy every public quick start and receive the documented result;",
       "content_hash": "ce4b11ed46d5"
     },
@@ -26,7 +26,7 @@
       "name": "compact-modernization-plan.md",
       "type": "documentation",
       "size_lines": 794,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Modernize the repository's CI, maintenance controls, and agent-facing workflow without changing the structural-engineering product outcome. The finished repository must have:",
       "content_hash": "b0efe5bf80fd"
     },
@@ -34,7 +34,7 @@
       "name": "democratization-vision.md",
       "type": "documentation",
       "size_lines": 273,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "> **\"What was not possible few years back, or only possible for big firms — now everyone can use them free.\"** This project is not just about building a structural engineering library. It's about **de",
       "content_hash": "248d22c61e51"
     },
@@ -42,7 +42,7 @@
       "name": "dependency-security-baseline.md",
       "type": "documentation",
       "size_lines": 69,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This record makes MAINT-003 reproducible. It separates confirmed vulnerabilities from transferred-environment residue and records every temporary exception.",
       "content_hash": "7870e2a5028a"
     },
@@ -50,7 +50,7 @@
       "name": "etabs-killer-masterplan.md",
       "type": "documentation",
       "size_lines": 2855,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "Project BHEEM: Open-Source Structural Design Software Masterplan",
       "description": "> **BHEEM** — **B**uilding **H**olistic **E**ngineering **E**nvironment with **M**achine-intelligence > An open-source, AI-native structural design platform that aims to surpass ETABS in usability, tr",
       "content_hash": "88e3dfd24f78"
@@ -59,17 +59,25 @@
       "name": "gpt-5-3-codex-spark-work-program.md",
       "type": "documentation",
       "size_lines": 614,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Use GPT-5.3-Codex-Spark as a high-throughput implementation lane for small, explicit, rapidly verifiable tasks. The program targets truthful documentation,",
       "content_hash": "4160ef25ca5e"
     },
     {
+      "name": "india-2-remaining-is456-elements-plan.md",
+      "type": "documentation",
+      "size_lines": 305,
+      "last_updated": "2026-08-16",
+      "description": "INDIA-2 finishes a practical, explicitly limited set of IS 456 reinforced concrete elements that are still missing from the library.",
+      "content_hash": "db399d9a9f4d"
+    },
+    {
       "name": "indian-code-completion-plan.md",
       "type": "documentation",
-      "size_lines": 125,
+      "size_lines": 129,
       "last_updated": "2026-08-16",
       "description": "This is the canonical finish plan for the repository's Indian-code program. It defines the meaning and order of INDIA-0 through INDIA-4 without claiming",
-      "content_hash": "d48559d90cb0"
+      "content_hash": "d8ad6701def2"
     },
     {
       "name": "is456-library-first-master-plan.md",
@@ -83,7 +91,7 @@
       "name": "is456-solid-slabs-master-plan.md",
       "type": "documentation",
       "size_lines": 1123,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "The next element program will complete a useful, evidence-backed solid-slab workflow under IS 456 without pretending to solve every slab system.",
       "content_hash": "bcd3ec19ce4d"
     },
@@ -100,7 +108,7 @@
       "name": "memory.md",
       "type": "documentation",
       "size_lines": 411,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "- Development resumed after a four-month pause and a Mac laptop → Mac Mini transfer. - Git history, reachable objects, sample data, package source, and ARM64 Python environment transferred intact.",
       "content_hash": "78a539f85b53"
     },
@@ -108,24 +116,24 @@
       "name": "next-phase-improvements-plan.md",
       "type": "documentation",
       "size_lines": 1445,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "> This document is a result of a full audit of the beam library, FastAPI layer, and React app. > Nothing here assumes — it traces every suggestion back to what already exists and what is missing.",
       "content_hash": "9be9935445ee"
     },
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 74,
+      "size_lines": 75,
       "last_updated": "2026-08-16",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-16",
-      "content_hash": "5ee4167eecd4"
+      "content_hash": "03ab4ccec99e"
     },
     {
       "name": "pre-release-checklist.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "Pre-Release Checklist",
       "description": "Release-ready source metadata: 0.23.1a1 Current public release: v0.23.1a1 Alpha",
       "content_hash": "aa14481f9a4b"
@@ -134,7 +142,7 @@
       "name": "professional-library-remediation-plan.md",
       "type": "documentation",
       "size_lines": 562,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "Professional Library Remediation Plan",
       "description": "This document is no longer the active implementation plan. T0 and R1-R8 are complete, and their findings, packet definitions, and verification remain here",
       "content_hash": "31095ffcf998"
@@ -143,7 +151,7 @@
       "name": "react-ux-improvement-plan.md",
       "type": "documentation",
       "size_lines": 709,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "> **Historical implementation record.** Execution status in this document is > superseded by",
       "content_hash": "706c92bd3f7a"
     },
@@ -151,11 +159,11 @@
       "name": "ui-experience-foundation-master-plan.md",
       "type": "documentation",
       "size_lines": 2408,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "The product will move from a collection of equally weighted pages to one compact, professional structural workbench.",
       "content_hash": "fc8042fee46a"
     }
   ],
   "subfolders": [],
-  "content_hash": "9ccf093e1339898d"
+  "content_hash": "c70a36458b61b47e"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -2,7 +2,7 @@
 
 **Type:** Documentation
 **Last Updated:** 2026-08-16
-**Files:** 18
+**Files:** 19
 
 ## Documentation Files
 
@@ -15,13 +15,14 @@
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
 | [etabs-killer-masterplan.md](etabs-killer-masterplan.md) | Project BHEEM: Open-Source Structural De | > **BHEEM** — **B**uilding **H**olistic **E**ngineering **E* | 2855 |
 | [gpt-5-3-codex-spark-work-program.md](gpt-5-3-codex-spark-work-program.md) |  | Use GPT-5.3-Codex-Spark as a high-throughput implementation  | 614 |
-| [indian-code-completion-plan.md](indian-code-completion-plan.md) |  | This is the canonical finish plan for the repository's India | 125 |
+| [india-2-remaining-is456-elements-plan.md](india-2-remaining-is456-elements-plan.md) |  | INDIA-2 finishes a practical, explicitly limited set of IS 4 | 305 |
+| [indian-code-completion-plan.md](indian-code-completion-plan.md) |  | This is the canonical finish plan for the repository's India | 129 |
 | [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1507 |
 | [is456-solid-slabs-master-plan.md](is456-solid-slabs-master-plan.md) |  | The next element program will complete a useful, evidence-ba | 1123 |
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 74 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 75 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/india-2-remaining-is456-elements-plan.md
+++ b/docs/planning/india-2-remaining-is456-elements-plan.md
@@ -1,0 +1,304 @@
+---
+task: INDIA-2-PLAN
+title: INDIA-2 Remaining Practical IS 456 Elements Plan
+status: active
+owner: Main Agent and repository owner
+created: 2026-08-16
+last_updated: 2026-08-16
+doc_type: spec
+---
+
+# INDIA-2 — Remaining Practical IS 456 Elements Plan
+
+## 1. The simple meaning
+
+INDIA-2 finishes a practical, explicitly limited set of IS 456 reinforced
+concrete elements that are still missing from the library.
+
+It does **not** mean “implement all of IS 456.” It means:
+
+1. choose one useful and benchmarkable case for each accepted family;
+2. implement and test pure calculation logic first;
+3. publish only the workflows that actually pass their evidence gates; and
+4. keep every alternate or unresolved case visibly unsupported.
+
+The bounded straight-flight staircase is already complete. The remaining work
+is walls, deep beams, flat slabs with column punching, and separately approved
+combined, strap, raft, and pile-cap foundation programs.
+
+## 2. Authority and truth sources
+
+This document is the single execution plan for INDIA-2. The parent
+[Indian-code completion plan](indian-code-completion-plan.md) controls the
+INDIA-0 through INDIA-4 wave hierarchy. The generated
+[Indian-code capability/coverage manifest](../verification/indian-code-capability-coverage.json)
+controls current support and registration truth. [TASKS.md](../TASKS.md)
+controls only the active and immediately next packet.
+
+Historical staircase task IDs, PRs, and evidence remain unchanged. The former
+`INDIA-2A` through `INDIA-2D` sequence is mapped here as the completed
+`INDIA-2-STAIR` family; it is not renamed or rerun.
+
+## 3. Current status
+
+| Family | Current truth | INDIA-2 treatment |
+|---|---|---|
+| Clause 32 walls | Not implemented | Next decision candidate |
+| Clause 33 stairs | One bounded longitudinal straight waist-slab flight supported | Complete; alternate stair systems remain held |
+| Clause 29 deep beams | Not implemented | Planned after the wall program |
+| Flat slabs and column punching | Not implemented | Planned after deep beams |
+| Combined footing | Not implemented | Separate foundation program |
+| Strap footing | Not implemented | Separate foundation program |
+| Pile cap | Not implemented | Separate foundation program |
+| Raft foundation | Not implemented | Separate foundation program |
+
+There is no progress percentage. A family is either supported within a written
+boundary, held with a written reason, or not implemented.
+
+## 4. Recommended execution order
+
+| Order | Program | Why it is placed here | State |
+|---:|---|---|---|
+| 1 | `INDIA-2-WALL` | Next clause-bounded practical element; establishes the new-family workflow | Ready for G0 discussion |
+| — | `INDIA-2-STAIR` | Already implemented and cumulatively gated | Complete |
+| 2 | `INDIA-2-DEEP` | Extends beam capability but requires its own geometry, action, and detailing boundary | Planned |
+| 3 | `INDIA-2-FLAT` | Requires panel analysis/distribution plus column punching; broader than the existing solid-slab route | Planned |
+| 4 | Foundation extensions | Each uses a different analysis model and must be activated separately | Planned, order provisional |
+| 5 | `INDIA-2-CLOSEOUT` | Reconcile truth, run final cumulative gates, and freeze the INDIA-2 evidence set | Pending |
+
+The provisional foundation order is combined footing, strap footing, pile cap,
+then raft. This is a planning recommendation, not activation. The owner may
+change that order after each preceding family is integrated and the next G0
+evidence is available.
+
+## 5. The packet pattern used for every new family
+
+Every family follows the same control sequence, although the engineering
+contents differ.
+
+### G0 — Scope and evidence decision
+
+No calculation code is written. The packet must end in `GO` or `HOLD` and must
+record:
+
+- governing standard edition and clause/table identifiers;
+- lawful source provenance without copying protected clause prose;
+- exactly one supported geometry, material, support, and loading model;
+- explicit units and required caller-supplied inputs;
+- one independent benchmark and justified tolerance;
+- unsafe and out-of-domain cases that must fail closed;
+- proposed pure-math, workflow, and publication packets;
+- explicit exclusions and capability wording.
+
+A missing source, ambiguous analysis model, or unsuitable benchmark produces a
+`HOLD`; it is not guessed around.
+
+### A — Types, geometry, and analysis contract
+
+- Add typed inputs/results with explicit units.
+- Define geometry eligibility and action assumptions.
+- Implement only pure deterministic math in the IS 456 layer.
+- Reject unsupported topology, invalid geometry, and missing required actions.
+- Prove the first independently checkable intermediate results.
+
+### B — Strength, serviceability, and detailing checks
+
+- Compose accepted actions into the bounded design/check workflow.
+- Preserve formula, limit, table/case, and source provenance in results.
+- Test governing safe, unsafe, boundary, and out-of-domain cases.
+- Compare final and important intermediate results with the accepted benchmark.
+- Return a truthful disposition such as pass, fail, review required, or held.
+
+### C — Public Python workflow
+
+- Publish one typed service workflow only after pure-math acceptance.
+- Keep calculation logic out of services and UI/IO layers.
+- Provide one executable example with units, assumptions, provenance, and
+  limitations.
+- Retain backward compatibility without adding duplicate calculation routes.
+
+### D — API, capability truth, and evidence
+
+- Add a thin FastAPI route only when a real consumer needs it.
+- Add React only through a separately accepted product scope; it is not an
+  automatic requirement for INDIA-2.
+- Update the runtime capability registry and generated Indian-code manifest.
+- Record benchmark evidence, fail-closed exclusions, tests, and exact Git/PR
+  identity.
+- Do not advertise adjacent cases that were not accepted in G0.
+
+The G0 decision may change the number or names of A-D packets when the family
+cannot be safely split this way. It must preserve the same evidence gates.
+
+## 6. Family-specific plan
+
+### 6.1 INDIA-2-WALL — Clause 32 wall program
+
+`INDIA-2-WALL-G0` must select exactly one practical reinforced-concrete wall
+case before code begins. The initial case to investigate is a regular braced
+wall strip under caller-supplied axial load and moments, subject to source and
+benchmark confirmation.
+
+The G0 decision must settle:
+
+- braced/unbraced and short/slender classification boundaries;
+- effective height/length assumptions and who supplies them;
+- minimum eccentricity and axial/moment interaction treatment;
+- reinforcement faces, minimum steel, spacing, and detailing scope;
+- strength and serviceability outputs;
+- benchmark source and tolerance.
+
+Initial exclusions are retaining walls, liquid-retaining walls, openings,
+irregular or flanged wall sections, global building stability, lateral-load
+analysis, seismic/shear-wall provisions, FEM, and IS 13920 detailing.
+
+Provisional packets:
+
+1. `INDIA-2-WALL-G0` — bounded case, sources, benchmark, GO/HOLD.
+2. `INDIA-2-WALL-A` — types, classification, geometry, and effective-dimension
+   contract.
+3. `INDIA-2-WALL-B` — bounded axial/flexural strength and detailing checks.
+4. `INDIA-2-WALL-C` — typed public Python workflow and benchmark example.
+5. `INDIA-2-WALL-D` — optional thin API, capability truth, and evidence freeze.
+6. `INDIA-2-WALL-CUMULATIVE` — family-level full gate after A-D integration.
+
+### 6.2 INDIA-2-STAIR — Clause 33 staircase program
+
+This family is complete. Its accepted case is one cast-in-situ longitudinal
+straight waist-slab flight with two collinear landing segments spanning between
+outer beam or wall supports. Historical `INDIA-2A` through `INDIA-2D` and
+`INDIA-2-CUMULATIVE` are its immutable evidence.
+
+Dog-legged, open-well, turning, bifurcated, spiral, cantilever, transverse,
+precast, and stringer-supported stairs remain held. INDIA-2 does not reopen
+them unless the owner activates a separate extension after the remaining
+families are considered.
+
+### 6.3 INDIA-2-DEEP — Clause 29 deep-beam program
+
+`INDIA-2-DEEP-G0` must choose one deep-beam geometry and loading model. The
+initial case to investigate is a simply supported solid rectangular deep beam
+with caller-supplied factored actions and no openings, subject to source and
+benchmark confirmation.
+
+The decision must settle:
+
+- deep-beam classification and effective-span/depth limits;
+- whether actions are caller-supplied or generated by a bounded analysis;
+- flexure, shear, bearing, anchorage, and web reinforcement scope;
+- load/support region assumptions and discontinuity treatment;
+- benchmark intermediate values and tolerance.
+
+Initial exclusions are openings, dapped ends, corbels, coupling beams, hollow
+sections, prestressing, cyclic/seismic design, generalized strut-and-tie
+modelling, nonlinear analysis, and FEM.
+
+Provisional packets are G0 decision; A geometry/classification/action contract;
+B strength and reinforcement checks; C public workflow; D capability/evidence;
+then one family cumulative gate.
+
+### 6.4 INDIA-2-FLAT — Flat slab and column-punching program
+
+This is broader than the existing beam/wall-supported solid-slab workflow and
+must not reuse its capability claim. `INDIA-2-FLAT-G0` must choose one regular
+gravity-load panel system and one punching-check boundary before code begins.
+
+The initial case to investigate is a regular interior rectangular panel without
+openings or lateral moment transfer, subject to source, applicability, and
+benchmark confirmation.
+
+The decision must settle:
+
+- analysis method eligibility and required panel regularity;
+- column strip, middle strip, support, drop, and column-head assumptions;
+- gravity-load moment distribution and design-strip outputs;
+- interior/edge/corner column scope;
+- critical punching perimeter, openings, moment transfer, and shear
+  reinforcement boundaries;
+- flexure, serviceability, detailing, and benchmark tolerances.
+
+Initial exclusions are irregular grids, transfer slabs, significant openings,
+unbounded lateral-load participation, equivalent-frame/FEM automation,
+post-tensioning, progressive collapse, seismic diaphragm design, and cases
+outside the selected column/panel topology.
+
+Provisional packets:
+
+1. G0 scope/source/benchmark decision.
+2. A panel geometry, eligibility, and strip definitions.
+3. B bounded gravity analysis and moment distribution.
+4. C flexure, serviceability, and detailing checks.
+5. D column-punching checks and fail-closed boundaries.
+6. E typed public workflow, capability truth, and evidence.
+7. One family cumulative gate after integration.
+
+### 6.5 Separate foundation programs
+
+The following are four separate programs, not one generic “foundation” route:
+
+| Program | G0 analysis decision that must be frozen | Initial exclusions |
+|---|---|---|
+| `INDIA-2-FOUNDATION-COMBINED` | Column/load arrangement, footing shape, soil-pressure model, rigidity, and action generation | More than the accepted column arrangement, biaxial/general soil interaction, settlement/FEM |
+| `INDIA-2-FOUNDATION-STRAP` | Two-footing/strap idealization, strap-soil interaction assumption, load path, and member actions | General combined mats, flexible-soil interaction, more than the accepted topology |
+| `INDIA-2-FOUNDATION-PILE-CAP` | One pile layout, pile-reaction input/model, cap action model, anchorage, and deep-region treatment | General pile groups, lateral piles, soil-pile interaction, dynamic or seismic analysis |
+| `INDIA-2-FOUNDATION-RAFT` | One bounded raft idealization, soil-pressure input/model, strip/panel action extraction, and settlement boundary | General plate/FEM soil-structure interaction, irregular rafts, basements, staged construction |
+
+Each program receives its own G0, pure-math packets, benchmark, public workflow,
+capability record, and cumulative gate. Shared material or detailing helpers do
+not justify sharing or guessing the analysis model.
+
+## 7. Validation and Git cadence
+
+For each implementation packet:
+
+- run focused formula, property, benchmark, unsafe, and out-of-domain tests;
+- run relevant architecture and duplication checks;
+- run `./run.sh check --quick` before commit;
+- require the normal hosted PR checks on the exact head;
+- merge only an unchanged reviewed head with required checks green.
+
+Run the expensive broad Python suite and 30-check repository gate once after a
+family's implementation packets are integrated. The final family's broad gate
+may also serve as `INDIA-2-CLOSEOUT` when no subsequent code or evidence change
+invalidates it. Run a broad gate earlier only when a confirmed repository-wide
+issue could change the result.
+
+Use one fresh `codex/<packet>` worktree per activated packet from verified
+current `main`. Preserve unrelated lanes. Branch, remote-ref, and worktree
+cleanup remain separate owner-authorized actions.
+
+## 8. INDIA-2 completion criteria
+
+The successful target is:
+
+- the accepted bounded wall, deep-beam, flat-slab/punching, and separately
+  activated foundation programs are implemented and independently benchmarked;
+- the existing staircase family remains supported without scope inflation;
+- every advertised workflow has explicit units, assumptions, provenance,
+  unsafe cases, and machine-visible exclusions;
+- every unimplemented or out-of-domain case is `HELD` or `NOT_IMPLEMENTED`,
+  with no contradictory or unknown status;
+- public Python/API behavior and generated capability truth agree;
+- family and final cumulative gates pass on exact integrated trees;
+- an INDIA-2 evidence index identifies source, benchmark, PR, test, and
+  integrated-tree receipts for every accepted family.
+
+An owner-approved `HOLD` may remove a blocked family from the current delivery
+scope, but it cannot be reported as implemented. The plan must then record the
+blocker, retained boundary, and reactivation condition before INDIA-2 is
+administratively closed.
+
+Qualified structural-engineering review, professional approval, stable release,
+package publication, IS 13920, IS 875, IS 1893, response-spectrum analysis, and
+FEM remain outside INDIA-2. They belong to INDIA-3, INDIA-4, or separately
+authorized programs.
+
+## 9. Exact next action
+
+Start with `INDIA-2-WALL-G0` as a decision-only packet. Its deliverable is one
+short GO/HOLD record that freezes the wall case, controlled source set,
+independent benchmark, units, assumptions, outputs, exclusions, downstream
+packet split, and acceptance commands.
+
+Do not write wall calculation code until that decision is reviewed and the
+owner activates the downstream packets.

--- a/docs/planning/indian-code-completion-plan.md
+++ b/docs/planning/indian-code-completion-plan.md
@@ -51,6 +51,10 @@ Every family starts with a decision packet that freezes one useful case, its
 source, independent benchmark, assumptions, and exclusions before calculation
 code is authorized.
 
+The complete packet sequence, family boundaries, and exit criteria are in the
+dedicated [INDIA-2 execution plan](india-2-remaining-is456-elements-plan.md).
+That document controls INDIA-2 execution within this parent wave.
+
 | Packet | Bounded objective | State and boundary |
 |---|---|---|
 | `INDIA-2-WALL` | IS 456 Clause 32 wall program | **Next decision candidate.** No implementation is activated by this plan update. |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,9 +4,9 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-16
-- Focus: Establish one durable INDIA-0 through INDIA-4 finish plan before any new calculation work begins.
-- Git receipt: docs/verification/india-completion-plan-git-handoff-receipt.json | sha256:5d5255d0098303e2ee2663d011cddad3cbdbba292eb013cd6640b37b207746a8 | HOLD
-- Git identity: codex/india-finish-plan-reconcile@ca65c165ba3abc23497f15ba5e305f2324b91191 | upstream=NONE@UNKNOWN | base=origin/main@62f4ba06b6287c1b74ddd41e7cdfefa71b08e515 | tree=dirty | operation=none
+- Focus: Consolidate all INDIA-2 work into one understandable, executable plan without starting calculation implementation.
+- Git receipt: docs/verification/india-2-plan-git-handoff-receipt.json | sha256:ecbc84c246e9f7e8bdaa19cac60ba0fa8ef12aea115bee9ddd1db077d5aa75f6 | HOLD
+- Git identity: codex/india-2-detailed-plan@b3fed846210d3460cf4d6d6f326d2d6d6caf100d | upstream=NONE@UNKNOWN | base=origin/main@b3fed846210d3460cf4d6d6f326d2d6d6caf100d | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: WAIT_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->
@@ -21,11 +21,12 @@
 
 ## Required Reading
 
-1. [Canonical Indian-code completion waves](indian-code-completion-plan.md)
-2. [Generated Indian-code manifest](../verification/indian-code-capability-coverage.json)
-3. [Current task board](../TASKS.md)
-4. [INDIA-2 staircase cumulative evidence](../verification/india-2-cumulative-gate-evidence.md)
-5. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
+1. [INDIA-2 remaining-elements execution plan](india-2-remaining-is456-elements-plan.md)
+2. [Canonical Indian-code completion waves](indian-code-completion-plan.md)
+3. [Generated Indian-code manifest](../verification/indian-code-capability-coverage.json)
+4. [Current task board](../TASKS.md)
+5. [INDIA-2 staircase cumulative evidence](../verification/india-2-cumulative-gate-evidence.md)
+6. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
 
 ## Start Boundary
 

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,12 +3,12 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-16",
-  "file_count": 36,
+  "file_count": 38,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -27,7 +27,7 @@
       "name": "README.md",
       "type": "documentation",
       "size_lines": 64,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "Verification",
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards. | Document | Description |",
       "content_hash": "4763d5ab8b48"
@@ -36,7 +36,7 @@
       "name": "alpha-0231-local-prepublication-rehearsal.md",
       "type": "documentation",
       "size_lines": 72,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "v0.23.1a1 Local Prepublication Rehearsal",
       "description": "not a CI artifact identity, tag, or publication approval | Artifact | Bytes | Members | SHA-256 |",
       "content_hash": "d6a173859f50"
@@ -45,7 +45,7 @@
       "name": "bundled-sample-boq-evidence.md",
       "type": "documentation",
       "size_lines": 58,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This is the reproducible software record for the bundled ETABS sample. It is not a bill approved for procurement or construction and is not professional",
       "content_hash": "78b84b5474bc"
     },
@@ -53,7 +53,7 @@
       "name": "column-pmm-benchmark.md",
       "type": "documentation",
       "size_lines": 107,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This record independently checks the experimental rectangular-column fiber kernel at an oblique neutral-axis orientation. It is a calculation benchmark,",
       "content_hash": "fcc6aaad58e3"
     },
@@ -61,7 +61,7 @@
       "name": "examples.md",
       "type": "documentation",
       "size_lines": 1550,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This document provides benchmark examples that engineers can use to verify the library's calculations against: - Hand calculations",
       "content_hash": "79cb3add7cbe"
     },
@@ -69,14 +69,14 @@
       "name": "external-cli-test.md",
       "type": "documentation",
       "size_lines": 98,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Purpose: capture a repeatable, human-run CLI test from a fresh user. Preferred: use the automated smoke script so the output is consistent and easy to share.",
       "content_hash": "a81223e8c701"
     },
     {
       "name": "footing-release-inclusion.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "record_id",
@@ -93,7 +93,7 @@
     {
       "name": "git-primary-session-log-reconcile-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -111,7 +111,7 @@
     {
       "name": "git-primary-session-log-reconcile-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -124,7 +124,7 @@
       "name": "india-1-cumulative-gate-evidence.md",
       "type": "documentation",
       "size_lines": 56,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "INDIA-1A through INDIA-1D are integrated on main as four independently gated packets:",
       "content_hash": "06bfd83e531d"
     },
@@ -132,7 +132,7 @@
       "name": "india-1a-beam-route-evidence.md",
       "type": "documentation",
       "size_lines": 85,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "design_flanged_beam_is456() composes one monolithic sagging T-beam case from already-factored supplied actions. It calculates the effective flange width,",
       "content_hash": "97194ff486b7"
     },
@@ -140,7 +140,7 @@
       "name": "india-1b-column-decision-evidence.md",
       "type": "documentation",
       "size_lines": 73,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "The stable IS 456 column decision remains bounded to solid rectangular tied sections. design_column_is456() and design_long_column_is456() accept one",
       "content_hash": "5ed855d6483f"
     },
@@ -148,7 +148,7 @@
       "name": "india-1c-isolated-footing-workflow-evidence.md",
       "type": "documentation",
       "size_lines": 53,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "INDIA-1C publishes the existing bounded concentric isolated-footing composition through structural_lib.services.api and the package root. No footing structural",
       "content_hash": "e6ec5ffc6d7b"
     },
@@ -156,7 +156,7 @@
       "name": "india-1d-slab-boundary-evidence.md",
       "type": "documentation",
       "size_lines": 71,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "INDIA-1D closes the decision boundary around already supported solid-slab serviceability, shear, and loading behavior. It does not add or promote new",
       "content_hash": "76b8e456fffe"
     },
@@ -164,14 +164,14 @@
       "name": "india-2-cumulative-gate-evidence.md",
       "type": "documentation",
       "size_lines": 71,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "INDIA-2A-D are integrated through exact origin/main 18da6c112e67af49d8adf32bf0babf65285e2cd4. The cumulative gate packet ran",
       "content_hash": "e72e21fb5707"
     },
     {
       "name": "india-2-cumulative-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -189,7 +189,7 @@
     {
       "name": "india-2-cumulative-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -199,10 +199,40 @@
       "content_hash": "aab91df123a3"
     },
     {
+      "name": "india-2-plan-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "32e20d5b8373"
+    },
+    {
+      "name": "india-2-plan-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "78d94af83e93"
+    },
+    {
       "name": "india-2a-staircase-scope-evidence.md",
       "type": "documentation",
       "size_lines": 111,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "activated INDIA-2A through INDIA-2D on 2026-08-15 by requesting that INDIA-2 be started and finished. This decision selects only the case below; it does not",
       "content_hash": "6d6defbea3ed"
     },
@@ -210,7 +240,7 @@
       "name": "india-2b-staircase-actions-evidence.md",
       "type": "documentation",
       "size_lines": 70,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "INDIA-2B implements only the typed geometry, concrete self-weight, and three-segment simply supported action contract selected by INDIA-2A. It adds no",
       "content_hash": "1f9680c591ed"
     },
@@ -218,14 +248,14 @@
       "name": "india-2c-staircase-design-evidence.md",
       "type": "documentation",
       "size_lines": 66,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "INDIA-2C composes the accepted INDIA-2B per-metre actions into one bounded waist-slab design check. It does not add public consumers or promote staircase",
       "content_hash": "ccbd767ff6fb"
     },
     {
       "name": "india-2d-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -243,7 +273,7 @@
     {
       "name": "india-2d-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -256,7 +286,7 @@
       "name": "india-2d-staircase-publication-evidence.md",
       "type": "documentation",
       "size_lines": 85,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "INDIA-2D publishes one typed Python service and one thin FastAPI transport for the bounded straight-flight staircase developed in INDIA-2A-C. It does not add",
       "content_hash": "be7ac2e157a6"
     },
@@ -293,7 +323,7 @@
     {
       "name": "indian-code-capability-coverage.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "manifest_id",
@@ -310,7 +340,7 @@
       "name": "indian-code-truth-baseline.md",
       "type": "documentation",
       "size_lines": 93,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "INDIA-0 Indian-Code Truth Baseline",
       "description": "was squash-merged as 0373de68; INDIA-1 packets now update the generated manifest from fresh integrated-main lanes",
       "content_hash": "e8d850af25d8"
@@ -319,7 +349,7 @@
       "name": "insights-verification-pack.md",
       "type": "documentation",
       "size_lines": 101,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This pack provides benchmark test cases for the insights module to ensure accuracy and prevent regressions. Tests are automatically run in CI on every PR. Run all insights benchmark tests:",
       "content_hash": "62116e5ed5fe"
     },
@@ -327,7 +357,7 @@
       "name": "is456-library-first-evidence.md",
       "type": "documentation",
       "size_lines": 169,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "IS 456 Library-First Evidence and Claim Crosswalk",
       "description": "| Source | SHA-256 | Pages | Use | |---|---|---:|---|",
       "content_hash": "3a47d498ba82"
@@ -335,7 +365,7 @@
     {
       "name": "is456-public-distribution-permission.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "record_id",
@@ -353,7 +383,7 @@
       "name": "is456-slab-evidence.md",
       "type": "documentation",
       "size_lines": 125,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "IS 456 Solid Slab Source and Benchmark Ledger",
       "description": "| ID | Identity | Permitted implementation use | State | |---|---|---|---|",
       "content_hash": "087b5c252695"
@@ -362,7 +392,7 @@
       "name": "pack.md",
       "type": "documentation",
       "size_lines": 56,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This repo’s unit tests validate correctness and edge cases, but they don’t always answer the question: **“did the numerical design outputs change?”** The **Verification Pack** is a small set of **pinn",
       "content_hash": "fa4fe75b3d05"
     },
@@ -370,7 +400,7 @@
       "name": "release-artifact-evidence-template.md",
       "type": "documentation",
       "size_lines": 38,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "Release Artifact Evidence Template",
       "description": "Complete this record from the CI run that built the exact candidate. | Field | Value |",
       "content_hash": "dd7652006f11"
@@ -379,7 +409,7 @@
       "name": "ui-experience-session-2-acceptance.md",
       "type": "documentation",
       "size_lines": 70,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This is the software acceptance record for UIX-001 P9-P15. It does not certify the formulas, approve a structural design, or authorize professional use.",
       "content_hash": "82dbbd6cae09"
     },
@@ -387,11 +417,11 @@
       "name": "validation-pack.md",
       "type": "documentation",
       "size_lines": 396,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This pack provides 5 benchmark beams and 3 benchmark columns with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trust",
       "content_hash": "63fd4822c78c"
     }
   ],
   "subfolders": [],
-  "content_hash": "e6494ef79e65782a"
+  "content_hash": "fbee75768764566b"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-16
-**Files:** 36
+**Files:** 38
 
 ## Config Files
 
@@ -14,6 +14,8 @@ Benchmark examples and verification packs for validating library calculations ag
 - [git-primary-session-log-reconcile-handoff-source-evidence.json](git-primary-session-log-reconcile-handoff-source-evidence.json)
 - [india-2-cumulative-git-handoff-receipt.json](india-2-cumulative-git-handoff-receipt.json)
 - [india-2-cumulative-git-handoff-source-evidence.json](india-2-cumulative-git-handoff-source-evidence.json)
+- [india-2-plan-git-handoff-receipt.json](india-2-plan-git-handoff-receipt.json)
+- [india-2-plan-git-handoff-source-evidence.json](india-2-plan-git-handoff-source-evidence.json)
 - [india-2d-git-handoff-receipt.json](india-2d-git-handoff-receipt.json)
 - [india-2d-git-handoff-source-evidence.json](india-2d-git-handoff-source-evidence.json)
 - [india-completion-plan-git-handoff-receipt.json](india-completion-plan-git-handoff-receipt.json)

--- a/docs/verification/india-2-plan-git-handoff-receipt.json
+++ b/docs/verification/india-2-plan-git-handoff-receipt.json
@@ -1,0 +1,168 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-15T18:42:31Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2-PLAN:user-request-prepare-one-document",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-15T18:42:31Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "IMPLEMENT_ENGINEERING_CALCULATION",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-detailed-plan",
+      "head_sha": "b3fed846210d3460cf4d6d6f326d2d6d6caf100d",
+      "task_id": "INDIA-2-PLAN"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "ecbc84c246e9f7e8bdaa19cac60ba0fa8ef12aea115bee9ddd1db077d5aa75f6",
+    "state": {
+      "branch": "codex/india-2-detailed-plan",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "b3fed846210d3460cf4d6d6f326d2d6d6caf100d",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 79.219,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-india-2-detailed-plan",
+      "head_sha": "b3fed846210d3460cf4d6d6f326d2d6d6caf100d",
+      "hold_reasons": [
+        "changed paths: 13"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-15T18:46:32.761786+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-detailed-plan",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 13,
+        "modified_paths": [
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/index.json",
+          "docs/planning/index.md",
+          "docs/planning/indian-code-completion-plan.md",
+          "docs/planning/next-session-brief.md",
+          "docs/verification/index.json",
+          "docs/verification/index.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/planning/india-2-remaining-is456-elements-plan.md",
+          "docs/verification/india-2-plan-git-handoff-receipt.json",
+          "docs/verification/india-2-plan-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-detailed-plan"
+    }
+  },
+  "local_state_receipt_hash": "sha256:ecbc84c246e9f7e8bdaa19cac60ba0fa8ef12aea115bee9ddd1db077d5aa75f6",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-15T18:46:32.761956+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-15T18:42:31Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/**",
+      "fastapi_app/**",
+      "react_app/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "docs/planning/india-2-remaining-is456-elements-plan.md",
+      "docs/planning/indian-code-completion-plan.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md",
+      "docs/SESSION_LOG.md",
+      "docs/verification/india-2-plan-git-handoff-source-evidence.json"
+    ],
+    "shared_paths": [
+      "docs/index.json",
+      "docs/index.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md"
+    ],
+    "task_id": "INDIA-2-PLAN"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-2-plan-git-handoff-source-evidence.json
+++ b/docs/verification/india-2-plan-git-handoff-source-evidence.json
@@ -1,0 +1,54 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-15T18:42:31Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2-PLAN:user-request-prepare-one-document",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-15T18:42:31Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "IMPLEMENT_ENGINEERING_CALCULATION",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-detailed-plan",
+      "head_sha": "b3fed846210d3460cf4d6d6f326d2d6d6caf100d",
+      "task_id": "INDIA-2-PLAN"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-15T18:42:31Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}


### PR DESCRIPTION
## What changed

- added one self-contained INDIA-2 execution plan covering walls, the completed stair family, deep beams, flat slabs/punching, and four separate foundation programs
- defined the shared G0/A-D evidence workflow plus family-specific questions, exclusions, and cumulative gates
- defined the INDIA-2 completion criteria and exact next action (`INDIA-2-WALL-G0`)
- linked the parent Indian-code plan, task board, and next-session brief to the detailed plan

## Why

The parent INDIA-0 through INDIA-4 plan established the hierarchy but intentionally kept INDIA-2 brief. The remaining family sequence, different analysis models, packet gates, and exit criteria now live in one understandable execution document.

## Scope boundary

Planning and documentation only. No wall, deep-beam, flat-slab, foundation, API, UI, release, or cleanup work is activated.

## Validation

- generated Indian-code manifest: current
- internal Markdown links: 1,144 checked, 0 broken
- targeted planning/verification/docs indexes: current
- `./run.sh check --quick`: 10/10 passed
- pre-commit hooks: passed