### PR TITLE
feat(is456): check wall reinforcement

### DIFF
--- a/Python/structural_lib/codes/is456/index.json
+++ b/Python/structural_lib/codes/is456/index.json
@@ -418,7 +418,7 @@
     {
       "name": "wall",
       "path": "wall/",
-      "file_count": 5,
+      "file_count": 6,
       "is_package": true
     }
   ],
@@ -444,5 +444,5 @@
     "list_clauses_by_category",
     "search_clauses"
   ],
-  "content_hash": "357825be6a397942"
+  "content_hash": "cde6adc5424a1a92"
 }

--- a/Python/structural_lib/codes/is456/index.md
+++ b/Python/structural_lib/codes/is456/index.md
@@ -58,4 +58,4 @@
 | [footing/](footing/) 📦 | 10 |  |
 | [slab/](slab/) 📦 | 16 |  |
 | [staircase/](staircase/) 📦 | 7 |  |
-| [wall/](wall/) 📦 | 5 |  |
+| [wall/](wall/) 📦 | 6 |  |

--- a/Python/structural_lib/codes/is456/wall/__init__.py
+++ b/Python/structural_lib/codes/is456/wall/__init__.py
@@ -13,7 +13,14 @@ from structural_lib.codes.is456.wall.models import (
     BracedWallGeometry,
     WallAxialStatus,
     WallContractError,
+    WallReinforcementInput,
+    WallReinforcementKind,
     WallRotationRestraint,
+)
+from structural_lib.codes.is456.wall.reinforcement import (
+    WallDirectionalReinforcementResult,
+    WallReinforcementResult,
+    check_wall_minimum_reinforcement,
 )
 
 __all__ = [
@@ -23,7 +30,12 @@ __all__ = [
     "BracedWallGeometryResult",
     "WallAxialStatus",
     "WallContractError",
+    "WallDirectionalReinforcementResult",
+    "WallReinforcementInput",
+    "WallReinforcementKind",
+    "WallReinforcementResult",
     "WallRotationRestraint",
     "check_braced_wall_axial_capacity",
+    "check_wall_minimum_reinforcement",
     "resolve_braced_wall_geometry",
 ]

--- a/Python/structural_lib/codes/is456/wall/index.json
+++ b/Python/structural_lib/codes/is456/wall/index.json
@@ -3,15 +3,15 @@
   "type": "python-package",
   "description": "",
   "last_updated": "2026-08-16",
-  "file_count": 3,
+  "file_count": 4,
   "files": [
     {
       "name": "__init__.py",
       "type": "python",
-      "size_lines": 30,
+      "size_lines": 42,
       "last_updated": "2026-08-16",
       "description": "Bounded IS 456 Clause 32 braced-wall geometry and axial capacity.",
-      "content_hash": "12bba3fa2494"
+      "content_hash": "91a214437b91"
     },
     {
       "name": "axial.py",
@@ -53,7 +53,7 @@
     {
       "name": "models.py",
       "type": "python",
-      "size_lines": 177,
+      "size_lines": 247,
       "last_updated": "2026-08-16",
       "description": "Typed contracts for the bounded INDIA-2 Clause 32 braced-wall case.",
       "classes": [
@@ -70,12 +70,20 @@
           "description": "Strength disposition for the accepted empirical axial check."
         },
         {
+          "name": "WallReinforcementKind",
+          "description": "Clause 32.5 material categories for minimum wall reinforcement."
+        },
+        {
           "name": "BracedWallGeometry",
           "description": "Caller-confirmed geometry and bracing basis for one wall strip."
         },
         {
           "name": "BracedWallAxialInput",
           "description": "Geometry, material, and caller-supplied factored axial compression."
+        },
+        {
+          "name": "WallReinforcementInput",
+          "description": "Caller-provided one-grid vertical and horizontal wall reinforcement."
         }
       ],
       "functions": [
@@ -98,7 +106,43 @@
           ]
         }
       ],
-      "content_hash": "5679ba76bce7"
+      "content_hash": "c72587dc8941"
+    },
+    {
+      "name": "reinforcement.py",
+      "type": "python",
+      "size_lines": 162,
+      "last_updated": "2026-08-16",
+      "description": "Clause 32.5 minimum reinforcement checks for the bounded wall case.",
+      "classes": [
+        {
+          "name": "WallDirectionalReinforcementResult",
+          "description": "Required and caller-provided reinforcement for one wall direction.",
+          "public_methods": [
+            "status"
+          ]
+        },
+        {
+          "name": "WallReinforcementResult",
+          "description": "Clause 32.5 one-grid minimum-reinforcement disposition.",
+          "public_methods": [
+            "status"
+          ]
+        }
+      ],
+      "functions": [
+        {
+          "name": "check_wall_minimum_reinforcement",
+          "description": "Check caller-provided wall steel against Clause 32.5 minimums.",
+          "params": [
+            "reinforcement_input"
+          ]
+        }
+      ],
+      "constants": [
+        "_SOURCE_REFS"
+      ],
+      "content_hash": "3343059c72f8"
     }
   ],
   "subfolders": [],
@@ -110,9 +154,14 @@
     "BracedWallGeometryResult",
     "WallAxialStatus",
     "WallContractError",
+    "WallDirectionalReinforcementResult",
+    "WallReinforcementInput",
+    "WallReinforcementKind",
+    "WallReinforcementResult",
     "WallRotationRestraint",
     "check_braced_wall_axial_capacity",
+    "check_wall_minimum_reinforcement",
     "resolve_braced_wall_geometry"
   ],
-  "content_hash": "d3491de5268fbedc"
+  "content_hash": "b68ccbbff894c74d"
 }

--- a/Python/structural_lib/codes/is456/wall/index.md
+++ b/Python/structural_lib/codes/is456/wall/index.md
@@ -2,7 +2,7 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-16
-**Files:** 3
+**Files:** 4
 
 ## Public API
 
@@ -12,14 +12,20 @@
 - `BracedWallGeometryResult`
 - `WallAxialStatus`
 - `WallContractError`
+- `WallDirectionalReinforcementResult`
+- `WallReinforcementInput`
+- `WallReinforcementKind`
+- `WallReinforcementResult`
 - `WallRotationRestraint`
 - `check_braced_wall_axial_capacity`
+- `check_wall_minimum_reinforcement`
 - `resolve_braced_wall_geometry`
 
 ## Python Files
 
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
-| [__init__.py](__init__.py) | Bounded IS 456 Clause 32 braced-wall geometry and axial capa | 0 | 0 | 30 |
+| [__init__.py](__init__.py) | Bounded IS 456 Clause 32 braced-wall geometry and axial capa | 0 | 0 | 42 |
 | [axial.py](axial.py) | Clause 32.2 geometry and empirical axial capacity for braced | 2 | 2 | 160 |
-| [models.py](models.py) | Typed contracts for the bounded INDIA-2 Clause 32 braced-wal | 5 | 2 | 177 |
+| [models.py](models.py) | Typed contracts for the bounded INDIA-2 Clause 32 braced-wal | 7 | 2 | 247 |
+| [reinforcement.py](reinforcement.py) | Clause 32.5 minimum reinforcement checks for the bounded wal | 2 | 1 | 162 |

--- a/Python/structural_lib/codes/is456/wall/models.py
+++ b/Python/structural_lib/codes/is456/wall/models.py
@@ -14,6 +14,8 @@ __all__ = [
     "BracedWallGeometry",
     "WallAxialStatus",
     "WallContractError",
+    "WallReinforcementInput",
+    "WallReinforcementKind",
     "WallRotationRestraint",
 ]
 
@@ -34,6 +36,14 @@ class WallAxialStatus(StrEnum):
 
     PASS = "PASS"  # nosec B105
     FAIL = "FAIL"
+
+
+class WallReinforcementKind(StrEnum):
+    """Clause 32.5 material categories for minimum wall reinforcement."""
+
+    DEFORMED_415_OR_GREATER = "deformed_415_or_greater"
+    OTHER_BARS = "other_bars"
+    WELDED_WIRE_FABRIC = "welded_wire_fabric"
 
 
 def positive_finite(value: float, field_name: str, unit: str) -> float:
@@ -173,4 +183,64 @@ class BracedWallAxialInput:
             )
         object.__setattr__(
             self, "action_basis_reference", self.action_basis_reference.strip()
+        )
+
+
+@dataclass(frozen=True)
+class WallReinforcementInput:
+    """Caller-provided one-grid vertical and horizontal wall reinforcement.
+
+    Bar diameters and spacings are in mm. The accepted wall geometry limits the
+    packet to a single reinforcement grid; this contract checks provided steel
+    and never selects bars.
+    """
+
+    geometry: BracedWallGeometry
+    reinforcement_kind: WallReinforcementKind
+    vertical_bar_diameter_mm: float
+    vertical_bar_spacing_mm: float
+    horizontal_bar_diameter_mm: float
+    horizontal_bar_spacing_mm: float
+    reinforcement_basis_reference: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.geometry, BracedWallGeometry):
+            raise WallContractError("geometry must be a BracedWallGeometry")
+        if not isinstance(self.reinforcement_kind, WallReinforcementKind):
+            raise WallContractError(
+                "reinforcement_kind must be a WallReinforcementKind"
+            )
+        for name in (
+            "vertical_bar_diameter_mm",
+            "vertical_bar_spacing_mm",
+            "horizontal_bar_diameter_mm",
+            "horizontal_bar_spacing_mm",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                positive_finite(getattr(self, name), name, "mm"),
+            )
+        if self.reinforcement_kind in {
+            WallReinforcementKind.DEFORMED_415_OR_GREATER,
+            WallReinforcementKind.WELDED_WIRE_FABRIC,
+        } and (
+            self.vertical_bar_diameter_mm > 16.0
+            or self.horizontal_bar_diameter_mm > 16.0
+        ):
+            raise WallContractError(
+                "bar diameter must not exceed 16 mm for the selected Clause "
+                "32.5 minimum-ratio category"
+            )
+        if (
+            not isinstance(self.reinforcement_basis_reference, str)
+            or not self.reinforcement_basis_reference.strip()
+        ):
+            raise WallContractError(
+                "reinforcement_basis_reference must be a non-blank caller reference"
+            )
+        object.__setattr__(
+            self,
+            "reinforcement_basis_reference",
+            self.reinforcement_basis_reference.strip(),
         )

--- a/Python/structural_lib/codes/is456/wall/reinforcement.py
+++ b/Python/structural_lib/codes/is456/wall/reinforcement.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Clause 32.5 minimum reinforcement checks for the bounded wall case."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from structural_lib.codes.is456.traceability import clause
+from structural_lib.codes.is456.wall.models import (
+    WallAxialStatus,
+    WallContractError,
+    WallReinforcementInput,
+    WallReinforcementKind,
+)
+
+__all__ = [
+    "WallDirectionalReinforcementResult",
+    "WallReinforcementResult",
+    "check_wall_minimum_reinforcement",
+]
+
+
+_SOURCE_REFS = (
+    "IS 456:2000 Cl. 32.5-32.5.2",
+    "IS456-2000-A6",
+)
+
+
+@dataclass(frozen=True)
+class WallDirectionalReinforcementResult:
+    """Required and caller-provided reinforcement for one wall direction."""
+
+    minimum_ratio: float
+    required_area_mm2_per_m: float
+    provided_area_mm2_per_m: float
+    provided_ratio: float
+    maximum_spacing_mm: float
+    provided_spacing_mm: float
+    area_status: WallAxialStatus
+    spacing_status: WallAxialStatus
+
+    @property
+    def status(self) -> WallAxialStatus:
+        """Return PASS only when both area and spacing checks pass."""
+        if (
+            self.area_status is WallAxialStatus.PASS
+            and self.spacing_status is WallAxialStatus.PASS
+        ):
+            return WallAxialStatus.PASS
+        return WallAxialStatus.FAIL
+
+
+@dataclass(frozen=True)
+class WallReinforcementResult:
+    """Clause 32.5 one-grid minimum-reinforcement disposition."""
+
+    input: WallReinforcementInput
+    vertical: WallDirectionalReinforcementResult
+    horizontal: WallDirectionalReinforcementResult
+    transverse_enclosure_required: bool
+    source_refs: tuple[str, ...]
+
+    @property
+    def status(self) -> WallAxialStatus:
+        """Return PASS only when both reinforcement directions pass."""
+        if (
+            self.vertical.status is WallAxialStatus.PASS
+            and self.horizontal.status is WallAxialStatus.PASS
+            and not self.transverse_enclosure_required
+        ):
+            return WallAxialStatus.PASS
+        return WallAxialStatus.FAIL
+
+
+def _provided_area_mm2_per_m(diameter_mm: float, spacing_mm: float) -> float:
+    return math.pi * diameter_mm**2 / 4.0 * 1000.0 / spacing_mm
+
+
+def _direction_result(
+    *,
+    minimum_ratio: float,
+    wall_thickness_mm: float,
+    bar_diameter_mm: float,
+    bar_spacing_mm: float,
+) -> WallDirectionalReinforcementResult:
+    gross_area_mm2_per_m = wall_thickness_mm * 1000.0
+    required_area_mm2_per_m = minimum_ratio * gross_area_mm2_per_m
+    provided_area_mm2_per_m = _provided_area_mm2_per_m(
+        bar_diameter_mm,
+        bar_spacing_mm,
+    )
+    provided_ratio = provided_area_mm2_per_m / gross_area_mm2_per_m
+    maximum_spacing_mm = min(3.0 * wall_thickness_mm, 450.0)
+    return WallDirectionalReinforcementResult(
+        minimum_ratio=minimum_ratio,
+        required_area_mm2_per_m=required_area_mm2_per_m,
+        provided_area_mm2_per_m=provided_area_mm2_per_m,
+        provided_ratio=provided_ratio,
+        maximum_spacing_mm=maximum_spacing_mm,
+        provided_spacing_mm=bar_spacing_mm,
+        area_status=(
+            WallAxialStatus.PASS
+            if provided_area_mm2_per_m >= required_area_mm2_per_m
+            else WallAxialStatus.FAIL
+        ),
+        spacing_status=(
+            WallAxialStatus.PASS
+            if bar_spacing_mm <= maximum_spacing_mm
+            else WallAxialStatus.FAIL
+        ),
+    )
+
+
+@clause("32.5", "32.5.1", "32.5.2")
+def check_wall_minimum_reinforcement(
+    reinforcement_input: WallReinforcementInput,
+) -> WallReinforcementResult:
+    """Check caller-provided wall steel against Clause 32.5 minimums.
+
+    The geometry contract already excludes walls thicker than 200 mm, for which
+    Clause 32.5.1 requires two reinforcement grids. If the provided vertical
+    ratio exceeds 0.01, this bounded route fails closed because the Clause
+    32.5.2 transverse-enclosure exception no longer applies automatically.
+    """
+    if not isinstance(reinforcement_input, WallReinforcementInput):
+        raise WallContractError("reinforcement_input must be a WallReinforcementInput")
+
+    if reinforcement_input.reinforcement_kind in {
+        WallReinforcementKind.DEFORMED_415_OR_GREATER,
+        WallReinforcementKind.WELDED_WIRE_FABRIC,
+    }:
+        vertical_minimum_ratio = 0.0012
+        horizontal_minimum_ratio = 0.0020
+    else:
+        vertical_minimum_ratio = 0.0015
+        horizontal_minimum_ratio = 0.0025
+
+    thickness_mm = reinforcement_input.geometry.wall_thickness_mm
+    vertical = _direction_result(
+        minimum_ratio=vertical_minimum_ratio,
+        wall_thickness_mm=thickness_mm,
+        bar_diameter_mm=reinforcement_input.vertical_bar_diameter_mm,
+        bar_spacing_mm=reinforcement_input.vertical_bar_spacing_mm,
+    )
+    horizontal = _direction_result(
+        minimum_ratio=horizontal_minimum_ratio,
+        wall_thickness_mm=thickness_mm,
+        bar_diameter_mm=reinforcement_input.horizontal_bar_diameter_mm,
+        bar_spacing_mm=reinforcement_input.horizontal_bar_spacing_mm,
+    )
+    transverse_enclosure_required = vertical.provided_ratio > 0.01
+
+    return WallReinforcementResult(
+        input=reinforcement_input,
+        vertical=vertical,
+        horizontal=horizontal,
+        transverse_enclosure_required=transverse_enclosure_required,
+        source_refs=_SOURCE_REFS + (reinforcement_input.reinforcement_basis_reference,),
+    )

--- a/Python/tests/codes/is456/index.json
+++ b/Python/tests/codes/is456/index.json
@@ -34,10 +34,10 @@
     {
       "name": "wall",
       "path": "wall/",
-      "file_count": 4,
+      "file_count": 5,
       "is_package": true
     }
   ],
   "has_init": true,
-  "content_hash": "5a10f85b061f901b"
+  "content_hash": "c48fab64113dbe81"
 }

--- a/Python/tests/codes/is456/index.md
+++ b/Python/tests/codes/is456/index.md
@@ -17,4 +17,4 @@
 | [column/](column/) 📦 | 7 |  |
 | [slab/](slab/) | 7 |  |
 | [staircase/](staircase/) 📦 | 5 |  |
-| [wall/](wall/) 📦 | 4 |  |
+| [wall/](wall/) 📦 | 5 |  |

--- a/Python/tests/codes/is456/wall/index.json
+++ b/Python/tests/codes/is456/wall/index.json
@@ -3,7 +3,7 @@
   "type": "python-package",
   "description": "",
   "last_updated": "2026-08-16",
-  "file_count": 2,
+  "file_count": 3,
   "files": [
     {
       "name": "__init__.py",
@@ -65,9 +65,55 @@
         }
       ],
       "content_hash": "3617ec4a1232"
+    },
+    {
+      "name": "test_reinforcement.py",
+      "type": "python",
+      "size_lines": 192,
+      "last_updated": "2026-08-16",
+      "description": "INDIA-2-WALL-B Clause 32.5 reinforcement-check tests.",
+      "functions": [
+        {
+          "name": "test_frozen_benchmark_minimum_reinforcement_passes"
+        },
+        {
+          "name": "test_material_category_selects_exact_minimum_ratios",
+          "params": [
+            "kind",
+            "vertical_ratio",
+            "horizontal_ratio"
+          ]
+        },
+        {
+          "name": "test_maximum_spacing_uses_three_times_thickness_or_450"
+        },
+        {
+          "name": "test_inadequate_area_and_excess_spacing_return_fail"
+        },
+        {
+          "name": "test_vertical_ratio_above_one_percent_requires_held_enclosure_route"
+        },
+        {
+          "name": "test_invalid_bar_geometry_fails_closed",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_sixteen_millimetre_category_limit_is_enforced"
+        },
+        {
+          "name": "test_wrong_type_and_blank_reference_fail_closed"
+        },
+        {
+          "name": "test_clause_and_source_provenance_is_machine_visible"
+        }
+      ],
+      "content_hash": "eb7b6888eb67"
     }
   ],
   "subfolders": [],
   "has_init": true,
-  "content_hash": "47aa2edc35034d79"
+  "content_hash": "54a0d53dd98555bc"
 }

--- a/Python/tests/codes/is456/wall/index.md
+++ b/Python/tests/codes/is456/wall/index.md
@@ -2,7 +2,7 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-16
-**Files:** 2
+**Files:** 3
 
 ## Python Files
 
@@ -10,3 +10,4 @@
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | Focused tests for the bounded IS 456 Clause 32 wall package. | 0 | 0 | 2 |
 | [test_axial.py](test_axial.py) | INDIA-2-WALL-A benchmark and fail-closed axial-kernel tests. | 0 | 12 | 203 |
+| [test_reinforcement.py](test_reinforcement.py) | INDIA-2-WALL-B Clause 32.5 reinforcement-check tests. | 0 | 9 | 192 |

--- a/Python/tests/codes/is456/wall/test_reinforcement.py
+++ b/Python/tests/codes/is456/wall/test_reinforcement.py
@@ -1,0 +1,191 @@
+"""INDIA-2-WALL-B Clause 32.5 reinforcement-check tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from structural_lib.codes.is456.traceability import get_clause_refs
+from structural_lib.codes.is456.wall import (
+    BracedWallGeometry,
+    WallAxialStatus,
+    WallContractError,
+    WallReinforcementInput,
+    WallReinforcementKind,
+    WallRotationRestraint,
+    check_wall_minimum_reinforcement,
+)
+
+
+def _geometry(**overrides: object) -> BracedWallGeometry:
+    values: dict[str, object] = {
+        "unsupported_height_mm": 3000.0,
+        "lateral_restraint_spacing_mm": 4000.0,
+        "wall_length_mm": 4000.0,
+        "wall_thickness_mm": 150.0,
+        "rotation_restraint": WallRotationRestraint.RESTRAINED_BOTH_ENDS,
+        "bracing_elements_in_two_directions": True,
+        "lateral_forces_resisted_by_bracing_system": True,
+        "diaphragm_transfer_confirmed": True,
+        "lateral_connection_capacity_confirmed": True,
+        "bracing_basis_reference": "INDIA-2-WALL-HAND-01-BRACING",
+    }
+    values.update(overrides)
+    return BracedWallGeometry(**values)  # type: ignore[arg-type]
+
+
+def _reinforcement(**overrides: object) -> WallReinforcementInput:
+    values: dict[str, object] = {
+        "geometry": _geometry(),
+        "reinforcement_kind": WallReinforcementKind.DEFORMED_415_OR_GREATER,
+        "vertical_bar_diameter_mm": 8.0,
+        "vertical_bar_spacing_mm": 250.0,
+        "horizontal_bar_diameter_mm": 10.0,
+        "horizontal_bar_spacing_mm": 250.0,
+        "reinforcement_basis_reference": "INDIA-2-WALL-HAND-01-REINFORCEMENT",
+    }
+    values.update(overrides)
+    return WallReinforcementInput(**values)  # type: ignore[arg-type]
+
+
+def test_frozen_benchmark_minimum_reinforcement_passes() -> None:
+    result = check_wall_minimum_reinforcement(_reinforcement())
+
+    assert result.vertical.minimum_ratio == pytest.approx(0.0012)
+    assert result.vertical.required_area_mm2_per_m == pytest.approx(180.0)
+    assert result.vertical.provided_area_mm2_per_m == pytest.approx(201.06192983)
+    assert result.horizontal.minimum_ratio == pytest.approx(0.0020)
+    assert result.horizontal.required_area_mm2_per_m == pytest.approx(300.0)
+    assert result.horizontal.provided_area_mm2_per_m == pytest.approx(314.15926536)
+    assert result.vertical.maximum_spacing_mm == pytest.approx(450.0)
+    assert result.horizontal.maximum_spacing_mm == pytest.approx(450.0)
+    assert result.vertical.status is WallAxialStatus.PASS
+    assert result.horizontal.status is WallAxialStatus.PASS
+    assert result.transverse_enclosure_required is False
+    assert result.status is WallAxialStatus.PASS
+
+
+@pytest.mark.parametrize(
+    ("kind", "vertical_ratio", "horizontal_ratio"),
+    (
+        (WallReinforcementKind.DEFORMED_415_OR_GREATER, 0.0012, 0.0020),
+        (WallReinforcementKind.WELDED_WIRE_FABRIC, 0.0012, 0.0020),
+        (WallReinforcementKind.OTHER_BARS, 0.0015, 0.0025),
+    ),
+)
+def test_material_category_selects_exact_minimum_ratios(
+    kind: WallReinforcementKind,
+    vertical_ratio: float,
+    horizontal_ratio: float,
+) -> None:
+    result = check_wall_minimum_reinforcement(_reinforcement(reinforcement_kind=kind))
+
+    assert result.vertical.minimum_ratio == pytest.approx(vertical_ratio)
+    assert result.horizontal.minimum_ratio == pytest.approx(horizontal_ratio)
+
+
+def test_maximum_spacing_uses_three_times_thickness_or_450() -> None:
+    thin = check_wall_minimum_reinforcement(
+        _reinforcement(
+            geometry=_geometry(wall_thickness_mm=100.0),
+            vertical_bar_spacing_mm=300.0,
+            horizontal_bar_spacing_mm=300.0,
+        )
+    )
+    assert thin.vertical.maximum_spacing_mm == pytest.approx(300.0)
+    assert thin.vertical.spacing_status is WallAxialStatus.PASS
+
+    thick = check_wall_minimum_reinforcement(
+        _reinforcement(
+            geometry=_geometry(wall_thickness_mm=200.0),
+            vertical_bar_spacing_mm=450.0,
+            horizontal_bar_spacing_mm=450.0,
+        )
+    )
+    assert thick.vertical.maximum_spacing_mm == pytest.approx(450.0)
+    assert thick.vertical.spacing_status is WallAxialStatus.PASS
+
+
+def test_inadequate_area_and_excess_spacing_return_fail() -> None:
+    area = check_wall_minimum_reinforcement(
+        _reinforcement(
+            vertical_bar_diameter_mm=6.0,
+            horizontal_bar_diameter_mm=6.0,
+            vertical_bar_spacing_mm=450.0,
+            horizontal_bar_spacing_mm=450.0,
+        )
+    )
+    assert area.vertical.area_status is WallAxialStatus.FAIL
+    assert area.horizontal.area_status is WallAxialStatus.FAIL
+    assert area.status is WallAxialStatus.FAIL
+
+    spacing = check_wall_minimum_reinforcement(
+        _reinforcement(
+            vertical_bar_spacing_mm=451.0,
+            horizontal_bar_spacing_mm=451.0,
+        )
+    )
+    assert spacing.vertical.spacing_status is WallAxialStatus.FAIL
+    assert spacing.horizontal.spacing_status is WallAxialStatus.FAIL
+    assert spacing.status is WallAxialStatus.FAIL
+
+
+def test_vertical_ratio_above_one_percent_requires_held_enclosure_route() -> None:
+    result = check_wall_minimum_reinforcement(
+        _reinforcement(
+            vertical_bar_diameter_mm=16.0,
+            vertical_bar_spacing_mm=100.0,
+        )
+    )
+
+    assert result.vertical.provided_ratio > 0.01
+    assert result.transverse_enclosure_required is True
+    assert result.status is WallAxialStatus.FAIL
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("vertical_bar_diameter_mm", 0.0),
+        ("vertical_bar_spacing_mm", math.inf),
+        ("horizontal_bar_diameter_mm", -1.0),
+        ("horizontal_bar_spacing_mm", 0.0),
+    ),
+)
+def test_invalid_bar_geometry_fails_closed(field: str, value: float) -> None:
+    with pytest.raises(WallContractError, match=field):
+        _reinforcement(**{field: value})
+
+
+def test_sixteen_millimetre_category_limit_is_enforced() -> None:
+    with pytest.raises(WallContractError, match="must not exceed 16 mm"):
+        _reinforcement(vertical_bar_diameter_mm=17.0)
+
+    other = _reinforcement(
+        reinforcement_kind=WallReinforcementKind.OTHER_BARS,
+        vertical_bar_diameter_mm=20.0,
+    )
+    assert other.vertical_bar_diameter_mm == pytest.approx(20.0)
+
+
+def test_wrong_type_and_blank_reference_fail_closed() -> None:
+    with pytest.raises(WallContractError, match="WallReinforcementInput"):
+        check_wall_minimum_reinforcement(object())  # type: ignore[arg-type]
+    with pytest.raises(WallContractError, match="reinforcement_basis_reference"):
+        _reinforcement(reinforcement_basis_reference=" ")
+
+
+def test_clause_and_source_provenance_is_machine_visible() -> None:
+    result = check_wall_minimum_reinforcement(_reinforcement())
+
+    assert get_clause_refs(check_wall_minimum_reinforcement) == [
+        "32.5",
+        "32.5.1",
+        "32.5.2",
+    ]
+    assert result.source_refs == (
+        "IS 456:2000 Cl. 32.5-32.5.2",
+        "IS456-2000-A6",
+        "INDIA-2-WALL-HAND-01-REINFORCEMENT",
+    )

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,69 @@
 
 ---
 
+## 2026-08-16 — Session: INDIA-2-WALL-B Reinforcement Checks
+
+**Agent:** Codex (`structural-math`, sole writer; no subagents)
+
+**Branch:** `codex/india-2-wall-b` from integrated WALL-A main at
+`7eb55746bc28c5948941261ce3450c1f6e960f74`
+
+**Focus:** Implement the Clause 32.5 minimum/provided wall reinforcement and
+spacing checks for the accepted one-grid wall.
+
+### Summary
+
+- Added typed reinforcement material, bar, spacing, and caller provenance
+  inputs to the pure wall package.
+- Implemented vertical/horizontal required and provided area, exact material
+  category ratios, `min(3t, 450 mm)` spacing, and overall dispositions.
+- Retained two-grid and transverse-enclosure design as held routes and kept the
+  wall capability unadvertised pending WALL-C-D.
+
+### Issues encountered
+
+- WALL-A's post-merge session-end check reported `HOLD_DIVERGED` and a missing
+  task-to-Git handoff receipt after PR #769 had already squash-merged.
+- The first Poppler lookup used the dependency fallback directory, but the
+  maintained `pdftotext` binary is under the native Poppler runtime.
+- Adding the Clause 32.5 decorator made the generated Indian-code manifest
+  stale.
+
+### Root causes and resolutions
+
+- Root cause: squash integration changes ancestry and the packet had no
+  versioned receipt before session end. Resolution: verify PR #769's exact
+  merged head, retain the old lane, and start WALL-B from clean integrated
+  `7eb55746`; no branch/worktree cleanup was attempted.
+- Root cause: the dependency listing did not expose the nested native Poppler
+  binary path. Resolution: locate the bundled binary read-only, then extract
+  the complete relevant Clause 32 pages from the controlled source.
+- Root cause: the manifest derives decorated references from the live source
+  tree. Resolution: regenerate it after the reinforcement function was added;
+  capability truth remains held.
+
+### Evidence
+
+- Runtime diagnosis returned `source_bound=true` in the fresh WALL-B worktree.
+- The frozen 150 mm wall benchmark returns 201.061930 mm2/m vertical steel
+  against 180 mm2/m required and 314.159265 mm2/m horizontal steel against
+  300 mm2/m required, with a 450 mm spacing limit and overall `PASS`.
+- 33 focused wall tests and 108 combined wall/clause/traceability tests passed;
+  Black, Ruff, and mypy passed.
+- Architecture validation found 0 violations across 167 files; import
+  validation found 0 broken imports across 204 files; quick gate passed 10/10.
+- The manifest registers Clause 32.5-32.5.2 without advertising wall support.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: WALL-A session end reported the already squash-merged
+  branch as diverged and missing a receipt -> verified PR #769 and started this
+  lane from clean integrated main without mutating the retained WALL-A lane.
+- ⚠️ TERMINAL ISSUE: `pdftotext` was not in the guessed dependency fallback
+  directory -> located and used the bundled native Poppler binary.
+
+---
+
 ## 2026-08-16 — Session: INDIA-2-WALL-A Geometry and Axial Kernel
 
 **Agent:** Codex (`structural-math`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-16 — INDIA-2-WALL-G0 is integrated and WALL-A is a verified local candidate; WALL-B is next after integration
+**Updated:** 2026-08-16 — INDIA-2-WALL-A is integrated and WALL-B is a verified local candidate; WALL-C is next after integration
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| INDIA-2-WALL | Implement the accepted braced empirical vertical-compression wall workflow through A-D and focused family acceptance | Main Agent + structural engineer | 🚧 ACTIVE — G0 integrated; WALL-A candidate complete; WALL-B next after integration |
+| INDIA-2-WALL | Implement the accepted braced empirical vertical-compression wall workflow through A-D and focused family acceptance | Main Agent + structural engineer | 🚧 ACTIVE — WALL-A integrated; WALL-B candidate complete; WALL-C next after integration |
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
 
 ## Up Next
@@ -158,7 +158,8 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
-| INDIA-2-WALL-A | Implemented typed bracing/geometry/action contracts, effective height, slenderness, eccentricity, empirical axial capacity, exact Clause 32 registration, and fail-closed tests | Main Agent + structural math | ✅ LOCAL CANDIDATE — 19 wall tests and 94 combined traceability tests pass; capability remains held until WALL-D |
+| INDIA-2-WALL-B | Implemented provided vertical/horizontal reinforcement area, material-ratio, spacing, and transverse-enclosure boundary checks | Main Agent + structural math | ✅ LOCAL CANDIDATE — 33 focused wall tests pass; capability remains held until WALL-D |
+| INDIA-2-WALL-A | Implemented typed bracing/geometry/action contracts, effective height, slenderness, eccentricity, empirical axial capacity, exact Clause 32 registration, and fail-closed tests | Main Agent + structural math | ✅ INTEGRATED — PR #769 merged as `7eb55746`; capability remains held until WALL-D |
 | INDIA-2-WALL-G0 | Froze one Clause 32.2 braced wall vertical-compression check with public clause provenance, pre-implementation benchmark, units, fail-closed boundaries, and focused-gate cadence | Main Agent + structural engineer | ✅ GO — owner activated WALL-A-D; applied moment, horizontal action, two-grid and alternate wall systems remain held |
 | INDIA-2-PLAN | Consolidated INDIA-2 scope, family order, packet gates, exclusions, validation cadence, and completion criteria into one execution document | Main Agent + repository owner | ✅ DONE — INDIA-2-WALL-G0 remains the next decision; no engineering implementation activated |
 | INDIA-COMPLETION-PLAN | Reconciled the canonical INDIA-0 through INDIA-4 finish waves and mapped historical staircase receipts to INDIA-2-STAIR without renaming them | Main Agent + repository owner | ✅ DONE — next discussion is INDIA-2-WALL-G0; no calculation implementation activated |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 6370,
+      "size_lines": 6443,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "7288d9cb5c11"
+      "content_hash": "8d8fb7dade72"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 700,
+      "size_lines": 701,
       "last_updated": "2026-08-16",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "8309e7b1bed3"
+      "content_hash": "aee9510b93bc"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 42,
+      "file_count": 43,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "c1f7e938bf83cbfa"
+  "content_hash": "a9fb876001c0dabc"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6370 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 700 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6443 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 701 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 42 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 43 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -66,10 +66,10 @@
     {
       "name": "india-2-remaining-is456-elements-plan.md",
       "type": "documentation",
-      "size_lines": 304,
+      "size_lines": 305,
       "last_updated": "2026-08-16",
       "description": "INDIA-2 finishes a practical, explicitly limited set of IS 456 reinforced concrete elements that are still missing from the library.",
-      "content_hash": "fde39d71e50c"
+      "content_hash": "e2c7ad3a0b59"
     },
     {
       "name": "indian-code-completion-plan.md",
@@ -127,7 +127,7 @@
       "last_updated": "2026-08-16",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-16",
-      "content_hash": "ac06941d19f2"
+      "content_hash": "70fed110cc86"
     },
     {
       "name": "pre-release-checklist.md",
@@ -165,5 +165,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "7a1345ffaf9f8dd2"
+  "content_hash": "844ae821cfe1633c"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -15,7 +15,7 @@
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
 | [etabs-killer-masterplan.md](etabs-killer-masterplan.md) | Project BHEEM: Open-Source Structural De | > **BHEEM** — **B**uilding **H**olistic **E**ngineering **E* | 2855 |
 | [gpt-5-3-codex-spark-work-program.md](gpt-5-3-codex-spark-work-program.md) |  | Use GPT-5.3-Codex-Spark as a high-throughput implementation  | 614 |
-| [india-2-remaining-is456-elements-plan.md](india-2-remaining-is456-elements-plan.md) |  | INDIA-2 finishes a practical, explicitly limited set of IS 4 | 304 |
+| [india-2-remaining-is456-elements-plan.md](india-2-remaining-is456-elements-plan.md) |  | INDIA-2 finishes a practical, explicitly limited set of IS 4 | 305 |
 | [indian-code-completion-plan.md](indian-code-completion-plan.md) |  | This is the canonical finish plan for the repository's India | 129 |
 | [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1507 |
 | [is456-solid-slabs-master-plan.md](is456-solid-slabs-master-plan.md) |  | The next element program will complete a useful, evidence-ba | 1123 |

--- a/docs/planning/india-2-remaining-is456-elements-plan.md
+++ b/docs/planning/india-2-remaining-is456-elements-plan.md
@@ -43,7 +43,7 @@ Historical staircase task IDs, PRs, and evidence remain unchanged. The former
 
 | Family | Current truth | INDIA-2 treatment |
 |---|---|---|
-| Clause 32 walls | G0 integrated; A kernel is a local candidate and capability remains held | One braced empirical vertical-compression wall check activated |
+| Clause 32 walls | G0 and A integrated; B reinforcement check is a local candidate and capability remains held | One braced empirical vertical-compression wall check activated |
 | Clause 33 stairs | One bounded longitudinal straight waist-slab flight supported | Complete; alternate stair systems remain held |
 | Clause 29 deep beams | Not implemented | Planned after the wall program |
 | Flat slabs and column punching | Not implemented | Planned after deep beams |
@@ -59,7 +59,7 @@ boundary, held with a written reason, or not implemented.
 
 | Order | Program | Why it is placed here | State |
 |---:|---|---|---|
-| 1 | `INDIA-2-WALL` | Next clause-bounded practical element; establishes the new-family workflow | G0 integrated; A candidate; B-D activated |
+| 1 | `INDIA-2-WALL` | Next clause-bounded practical element; establishes the new-family workflow | G0 and A integrated; B candidate; C-D activated |
 | — | `INDIA-2-STAIR` | Already implemented and cumulatively gated | Complete |
 | 2 | `INDIA-2-DEEP` | Extends beam capability but requires its own geometry, action, and detailing boundary | Planned |
 | 3 | `INDIA-2-FLAT` | Requires panel analysis/distribution plus column punching; broader than the existing solid-slab route | Planned |
@@ -156,9 +156,10 @@ analysis, seismic/shear-wall provisions, FEM, and IS 13920 detailing.
 Provisional packets:
 
 1. `INDIA-2-WALL-G0` — integrated GO; bounded case, sources, and benchmark.
-2. `INDIA-2-WALL-A` — candidate complete; types, geometry, effective height,
+2. `INDIA-2-WALL-A` — integrated; types, geometry, effective height,
    slenderness, eccentricity, and empirical axial-capacity contract.
-3. `INDIA-2-WALL-B` — bounded axial strength and detailing checks.
+3. `INDIA-2-WALL-B` — candidate complete; bounded minimum/provided
+   reinforcement and spacing checks.
 4. `INDIA-2-WALL-C` — typed public Python workflow and benchmark example.
 5. `INDIA-2-WALL-D` — thin API, capability truth, and evidence freeze.
 6. `INDIA-2-WALL-ACCEPTANCE` — focused family acceptance after A-D integration.
@@ -297,7 +298,7 @@ authorized programs.
 
 ## 9. Exact next action
 
-Integrate the `INDIA-2-WALL-A` candidate, then start `INDIA-2-WALL-B` from the
+Integrate the `INDIA-2-WALL-B` candidate, then start `INDIA-2-WALL-C` from the
 verified integrated head. The owner's 2026-08-16 request activates WALL-A-D and
 the later INDIA-2 families subject to each family's own G0 returning GO. No G0
 may be bypassed, and a HOLD remains a truthful non-implementation outcome.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -17,7 +17,7 @@
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; INDIA-0, INDIA-1, and the INDIA-2-STAIR family are complete |
 | **Program** | Umbrella INDIA-2 remains in progress; INDIA-3 and INDIA-4 remain planned |
-| **Next** | Integrate `INDIA-2-WALL-A`, then begin `INDIA-2-WALL-B` from the verified integrated head |
+| **Next** | Integrate `INDIA-2-WALL-B`, then begin `INDIA-2-WALL-C` from the verified integrated head |
 
 ## Required Reading
 
@@ -34,10 +34,10 @@ The historical INDIA-2A-D packets and their cumulative software gate are the
 completed `INDIA-2-STAIR` family. Do not reopen them, add another stair topology,
 add React, or begin release work without a new owner-approved scope.
 
-`INDIA-2-WALL-G0` is integrated. WALL-A now has a verified local pure-math
-candidate for the Clause 32.2 braced empirical wall geometry and axial-capacity
-kernel. The capability remains held until reinforcement, service, API, and
-evidence work completes through WALL-D.
+`INDIA-2-WALL-G0` and WALL-A are integrated. WALL-B now has a verified local
+pure-math candidate for the Clause 32.5 minimum/provided reinforcement and
+spacing checks. The capability remains held until the public workflow, API,
+and evidence work completes through WALL-D.
 
 ```bash
 ./run.sh session brief --agent orchestrator
@@ -59,13 +59,13 @@ It freezes the supported wall case, IS 456 clauses, public normalized-content
 boundary, hand benchmark and tolerance, units, fail-closed exclusions, and
 WALL-A-D packet split. No wall calculation or capability claim is part of G0.
 
-## INDIA-2-WALL-A candidate result
+## INDIA-2-WALL-B candidate result
 
-[`india-2-wall-a-axial-kernel-evidence.md`](../verification/india-2-wall-a-axial-kernel-evidence.md)
-records the exact Clause 32.2.1-32.2.5 functions, units, source IDs, frozen
-benchmark, fail-closed cases, and focused validation. After its exact reviewed
-head is integrated, WALL-B adds only the accepted minimum/provided
-reinforcement and spacing checks.
+[`india-2-wall-b-reinforcement-evidence.md`](../verification/india-2-wall-b-reinforcement-evidence.md)
+records the Clause 32.5-32.5.2 material categories, reinforcement ratios,
+provided-area calculations, spacing limits, held enclosure route, provenance,
+and focused validation. After its exact reviewed head is integrated, WALL-C
+publishes only the typed Python workflow and frozen end-to-end example.
 
 ## Review and gate boundary
 

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-16",
-  "file_count": 40,
+  "file_count": 41,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -237,6 +237,14 @@
       "content_hash": "f64b2ddf2842"
     },
     {
+      "name": "india-2-wall-b-reinforcement-evidence.md",
+      "type": "documentation",
+      "size_lines": 82,
+      "last_updated": "2026-08-16",
+      "description": "WALL-B adds one pure IS 456 provided-reinforcement check to the accepted Clause 32.2 braced-wall case. It does not select bars. The caller supplies one",
+      "content_hash": "dccc2142b26b"
+    },
+    {
       "name": "india-2-wall-g0-scope-evidence.md",
       "type": "documentation",
       "size_lines": 125,
@@ -350,7 +358,7 @@
         "capability_summary",
         "standards"
       ],
-      "content_hash": "897f658396f9"
+      "content_hash": "4c4cc51e8871"
     },
     {
       "name": "indian-code-truth-baseline.md",
@@ -439,5 +447,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "fef48e7bef42a50b"
+  "content_hash": "09011f267a04d2fa"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-16
-**Files:** 40
+**Files:** 41
 
 ## Config Files
 
@@ -40,6 +40,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [india-1d-slab-boundary-evidence.md](india-1d-slab-boundary-evidence.md) |  | INDIA-1D closes the decision boundary around already support | 71 |
 | [india-2-cumulative-gate-evidence.md](india-2-cumulative-gate-evidence.md) |  | INDIA-2A-D are integrated through exact origin/main 18da6c11 | 71 |
 | [india-2-wall-a-axial-kernel-evidence.md](india-2-wall-a-axial-kernel-evidence.md) |  | WALL-A implements the pure IS 456 layer for the accepted Cla | 83 |
+| [india-2-wall-b-reinforcement-evidence.md](india-2-wall-b-reinforcement-evidence.md) |  | WALL-B adds one pure IS 456 provided-reinforcement check to  | 82 |
 | [india-2-wall-g0-scope-evidence.md](india-2-wall-g0-scope-evidence.md) |  | activated the remaining INDIA-2 work on 2026-08-16 by asking | 125 |
 | [india-2a-staircase-scope-evidence.md](india-2a-staircase-scope-evidence.md) |  | activated INDIA-2A through INDIA-2D on 2026-08-15 by request | 111 |
 | [india-2b-staircase-actions-evidence.md](india-2b-staircase-actions-evidence.md) |  | INDIA-2B implements only the typed geometry, concrete self-w | 70 |

--- a/docs/verification/india-2-wall-b-reinforcement-evidence.md
+++ b/docs/verification/india-2-wall-b-reinforcement-evidence.md
@@ -1,0 +1,81 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-16
+doc_type: reference
+task: INDIA-2-WALL-B
+---
+
+# INDIA-2-WALL-B Reinforcement Evidence
+
+## Implemented boundary
+
+WALL-B adds one pure IS 456 provided-reinforcement check to the accepted
+Clause 32.2 braced-wall case. It does not select bars. The caller supplies one
+vertical and one horizontal bar diameter/spacing pair plus its reinforcement
+basis reference, and the result reports required area, provided area, ratio,
+spacing limit, directional dispositions, transverse-enclosure boundary, and an
+overall `PASS` or `FAIL`.
+
+The wall capability remains `HELD` and `NOT_IMPLEMENTED` until WALL-C publishes
+the typed Python workflow and WALL-D completes the FastAPI and capability-truth
+contract.
+
+## Public clause references and normalized rules
+
+`check_wall_minimum_reinforcement` is registered to IS 456:2000 Clauses 32.5,
+32.5.1, and 32.5.2. The runtime result preserves `IS456-2000-A6` and the caller's
+reinforcement-basis reference.
+
+For deformed bars of characteristic strength 415 N/mm2 or greater, and for
+welded wire fabric, both with diameter not greater than 16 mm, the minimum
+vertical and horizontal gross-area ratios are 0.0012 and 0.0020. For other bar
+types they are 0.0015 and 0.0025. Vertical and horizontal spacing are each
+limited to the smaller of three wall thicknesses and 450 mm.
+
+The accepted geometry is restricted to 100-200 mm thick one-grid walls. A wall
+thicker than 200 mm requires the separately held two-grid route. When caller-
+provided vertical reinforcement exceeds 0.01 of gross wall area, this bounded
+route returns `FAIL` because the automatic Clause 32.5.2 transverse-enclosure
+exception no longer applies.
+
+## Frozen benchmark result
+
+For the 150 mm thick `INDIA-2-WALL-HAND-01` wall:
+
+| Direction | Provided | Required | Provided result | Spacing limit | Status |
+|---|---:|---:|---:|---:|---|
+| Vertical | 8 mm at 250 mm | 180 mm2/m | 201.061930 mm2/m | 450 mm | `PASS` |
+| Horizontal | 10 mm at 250 mm | 300 mm2/m | 314.159265 mm2/m | 450 mm | `PASS` |
+
+No transverse enclosure is required by this bounded result and the overall
+reinforcement disposition is `PASS`.
+
+## Fail-closed and unsafe evidence
+
+Focused tests cover all three material categories, the 100 mm and 200 mm wall
+spacing limits, insufficient steel, excessive spacing, non-finite and
+non-positive bar inputs, the 16 mm category limit, blank provenance, wrong
+types, and the vertical-ratio-above-0.01 enclosure boundary. Valid inadequate
+detailing returns `FAIL`; malformed or unsupported input raises
+`WallContractError`.
+
+Two-grid walls, transverse-enclosure design, bar selection, lap/anchorage,
+openings, combined flexure, shear, seismic detailing, services, FastAPI, React,
+professional approval, and release remain outside WALL-B.
+
+## Verification
+
+- 33 focused wall tests passed, including the 19 integrated WALL-A tests.
+- The combined wall, clause-database, and traceability selection passed 108
+  tests.
+- Black, Ruff, and mypy passed on the wall package and focused tests.
+- Architecture validation found 0 violations across 167 files and import
+  validation found 0 broken imports across 204 files.
+- The Indian-code manifest was regenerated with Clause 32.5-32.5.2 registered
+  while the wall family remains held.
+- The packet-level quick gate passed 10/10 and all 1,151 internal links are
+  valid.
+
+These results establish bounded software behavior and public-code provenance;
+they do not constitute professional design approval or release authorization.

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -264,10 +264,10 @@
       ],
       "registration_summary": {
         "known_references": 134,
-        "registered_known_references": 67,
-        "metadata_only_references": 67,
+        "registered_known_references": 70,
+        "metadata_only_references": 64,
         "registration_only_references": 0,
-        "registration_pct": 50.0
+        "registration_pct": 52.2
       },
       "references": [
         {
@@ -803,8 +803,10 @@
           "reference_type": "clause",
           "title": "Minimum Requirements for Reinforcement in Walls",
           "category": "walls",
-          "registration_status": "METADATA_ONLY",
-          "functions": []
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.wall.reinforcement.check_wall_minimum_reinforcement"
+          ]
         },
         {
           "reference_id": "IS456:2000:32.5.1",
@@ -812,8 +814,10 @@
           "reference_type": "clause",
           "title": "Reinforcement Grids for Thick Walls",
           "category": "walls",
-          "registration_status": "METADATA_ONLY",
-          "functions": []
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.wall.reinforcement.check_wall_minimum_reinforcement"
+          ]
         },
         {
           "reference_id": "IS456:2000:32.5.2",
@@ -821,8 +825,10 @@
           "reference_type": "clause",
           "title": "Transverse Enclosure of Vertical Wall Reinforcement",
           "category": "walls",
-          "registration_status": "METADATA_ONLY",
-          "functions": []
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.wall.reinforcement.check_wall_minimum_reinforcement"
+          ]
         },
         {
           "reference_id": "IS456:2000:33.1",


### PR DESCRIPTION
## Scope
- add typed one-grid wall reinforcement input with caller provenance
- check Clause 32.5 vertical/horizontal minimum ratios and provided area
- enforce the smaller of three wall thicknesses and 450 mm spacing
- fail closed on the held two-grid and transverse-enclosure routes
- preserve wall capability as held pending WALL-C-D

## Validation
- 33 focused wall tests passed
- 108 combined wall/clause/traceability tests passed
- Black, Ruff, mypy, and Bandit passed
- architecture: 0 violations across 167 files
- imports: 0 broken across 204 files
- manifest current; 1,151 links valid; quick gate 10/10

The broad Python and 30-check gates remain reserved for whole INDIA-2 closeout.