### PR TITLE
feat(api): publish braced wall endpoint

### DIFF
--- a/Python/structural_lib/services/capabilities.py
+++ b/Python/structural_lib/services/capabilities.py
@@ -214,6 +214,23 @@ _CAPABILITIES = (
         ),
         qualified_review_required=True,
     ),
+    IS456Capability(
+        element="wall",
+        public_workflows=("design_braced_wall_is456",),
+        supported_case=(
+            "One regular 100-200 mm thick, one-grid, Clause 32.2 braced "
+            "reinforced-concrete wall under caller-supplied factored in-plane "
+            "vertical compression, with empirical axial-capacity and Clause "
+            "32.5 caller-provided minimum-reinforcement checks."
+        ),
+        held_cases=(
+            "Applied moment, horizontal action, wall shear, combined flexure, openings, and out-of-plane behavior are excluded.",
+            "Walls thicker than 200 mm, two reinforcement grids, and transverse-enclosure design are excluded.",
+            "Global analysis, load generation, load combinations, bar selection, anchorage, lap, crack width, and direct deflection are excluded.",
+            "Seismic/shear-wall provisions and IS 13920 detailing are excluded.",
+        ),
+        qualified_review_required=True,
+    ),
 )
 
 
@@ -650,6 +667,90 @@ _SEMANTIC_CONTRACT = IS456SemanticContract(
                 "Only the declared cast-in-situ longitudinal straight-flight waist-slab case is supported.",
                 "Loads, shares, and ultimate factor are caller supplied; IS 875 actions and project combinations are not generated.",
                 "Alternate stair systems, continuity, modification factors, direct deflection, crack width, landing torsion, and automatic bar selection remain held.",
+            ),
+        ),
+        IS456WorkflowContract(
+            workflow="design_braced_wall_is456",
+            element="wall",
+            fields=(
+                _field(
+                    "request",
+                    "typed braced-wall request",
+                    "BracedWallDesignInput",
+                    True,
+                    "validated explicit input contract",
+                ),
+                _field(
+                    "status",
+                    "aggregate axial and reinforcement disposition",
+                    "enumeration",
+                    True,
+                    "PASS or FAIL",
+                ),
+                _field(
+                    "wall_thickness_mm",
+                    "wall thickness",
+                    "mm",
+                    True,
+                    "finite from 100 through 200",
+                ),
+                _field(
+                    "factored_axial_load_kn",
+                    "caller-supplied factored vertical compression",
+                    "kN",
+                    True,
+                    "finite positive",
+                ),
+                _field(
+                    "supplied_eccentricity_mm",
+                    "caller-supplied transverse load eccentricity",
+                    "mm",
+                    True,
+                    "finite non-negative",
+                ),
+                _field(
+                    "axial.utilization_ratio",
+                    "empirical axial demand-to-capacity ratio",
+                    "dimensionless",
+                    True,
+                    "finite non-negative",
+                ),
+                _field(
+                    "reinforcement.status",
+                    "provided minimum-reinforcement disposition",
+                    "enumeration",
+                    True,
+                    "PASS or FAIL",
+                ),
+                _field(
+                    "qualified_review_required",
+                    "qualified review boundary",
+                    "boolean",
+                    True,
+                    "always true",
+                ),
+                _field(
+                    "complete_engineering_design_approved",
+                    "complete engineering approval",
+                    "boolean",
+                    True,
+                    "always false",
+                ),
+            ),
+            statuses=(
+                IS456StatusContract(
+                    "status",
+                    "PASS only when empirical axial capacity and both provided-reinforcement directions pass within the one-grid scope.",
+                    (
+                        "PASS is bounded software evidence, not professional design approval.",
+                        "Load generation, moments, horizontal actions, shear, openings, and seismic detailing are not represented.",
+                    ),
+                ),
+            ),
+            limitations=(
+                "Only the declared regular 100-200 mm one-grid Clause 32.2 braced wall is supported.",
+                "Factored compression, eccentricity, bracing assertions, and provenance are caller supplied.",
+                "Two-grid and transverse-enclosure design, combined flexure, shear, openings, and seismic provisions remain held.",
             ),
         ),
         IS456WorkflowContract(

--- a/Python/structural_lib/services/index.json
+++ b/Python/structural_lib/services/index.json
@@ -788,7 +788,7 @@
     {
       "name": "capabilities.py",
       "type": "python",
-      "size_lines": 1264,
+      "size_lines": 1365,
       "last_updated": "2026-08-16",
       "description": "Discoverable supported-case registry for the IS 456 public library.",
       "classes": [
@@ -847,7 +847,7 @@
         "_REPORT_IS_SAFE_ALIAS",
         "_SLAB_REVIEW_ALIAS"
       ],
-      "content_hash": "bed0fff4eda2"
+      "content_hash": "d63b9299a2e5"
     },
     {
       "name": "column_api.py",
@@ -2500,7 +2500,7 @@
     {
       "name": "wall_api.py",
       "type": "python",
-      "size_lines": 226,
+      "size_lines": 227,
       "last_updated": "2026-08-16",
       "description": "Stable orchestration for the bounded IS 456 braced-wall workflow.",
       "classes": [
@@ -2530,7 +2530,7 @@
         "_SUPPORTED_CASE",
         "_HELD_CASES"
       ],
-      "content_hash": "f1f6b9ff2210"
+      "content_hash": "15f7f316e7e9"
     },
     {
       "name": "workflow_catalog.py",
@@ -2684,5 +2684,5 @@
   ],
   "subfolders": [],
   "has_init": true,
-  "content_hash": "9299548f2ad6e891"
+  "content_hash": "40bc04cf177ddba9"
 }

--- a/Python/structural_lib/services/index.md
+++ b/Python/structural_lib/services/index.md
@@ -20,7 +20,7 @@
 | [beam_pipeline.py](beam_pipeline.py) | beam_pipeline — Unified application-layer pipeline for beam  | 10 | 3 | 636 |
 | [boq.py](boq.py) | Project Bill of Quantities (BOQ) — Aggregation Module | 4 | 1 | 209 |
 | [calculation_report.py](calculation_report.py) | Module:       calculation_report | 4 | 1 | 722 |
-| [capabilities.py](capabilities.py) | Discoverable supported-case registry for the IS 456 public l | 7 | 3 | 1264 |
+| [capabilities.py](capabilities.py) | Discoverable supported-case registry for the IS 456 public l | 7 | 3 | 1365 |
 | [column_api.py](column_api.py) | Module:       column_api | 0 | 13 | 1534 |
 | [common_api.py](common_api.py) | Module:       common_api | 0 | 5 | 721 |
 | [costing.py](costing.py) | Cost calculation utilities for structural elements. | 2 | 8 | 376 |
@@ -46,6 +46,6 @@
 | [staircase_api.py](staircase_api.py) | Stable orchestration for the bounded IS 456 straight-flight  | 3 | 1 | 209 |
 | [testing_strategies.py](testing_strategies.py) | Module:       testing_strategies | 9 | 2 | 655 |
 | [tool_manifest.py](tool_manifest.py) | Deterministic AI-tool descriptors projected from the workflo | 1 | 3 | 162 |
-| [wall_api.py](wall_api.py) | Stable orchestration for the bounded IS 456 braced-wall work | 3 | 1 | 226 |
+| [wall_api.py](wall_api.py) | Stable orchestration for the bounded IS 456 braced-wall work | 3 | 1 | 227 |
 | [workflow_catalog.py](workflow_catalog.py) | Versioned, transport-neutral catalogue for approved applicat | 6 | 6 | 377 |
 | [workflow_runner.py](workflow_runner.py) | Bounded in-memory runner for one approved beam review workfl | 5 | 3 | 486 |

--- a/Python/structural_lib/services/wall_api.py
+++ b/Python/structural_lib/services/wall_api.py
@@ -13,6 +13,7 @@ from structural_lib.codes.is456.wall import (
     BracedWallGeometry,
     WallAxialStatus,
     WallContractError,
+    WallDirectionalReinforcementResult,  # noqa: F401 - typed transport mapping
     WallReinforcementInput,
     WallReinforcementKind,
     WallReinforcementResult,

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2548,7 +2548,7 @@
     {
       "name": "test_indian_code_manifest.py",
       "type": "python",
-      "size_lines": 139,
+      "size_lines": 140,
       "last_updated": "2026-08-16",
       "description": "INDIA-0 truth-manifest and reporting contract tests.",
       "functions": [
@@ -2575,7 +2575,7 @@
         "REPO_ROOT",
         "SCRIPTS_ROOT"
       ],
-      "content_hash": "f67566619b11"
+      "content_hash": "6b69003fd020"
     },
     {
       "name": "test_inputs.py",
@@ -4727,5 +4727,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "c1462e17bae017b1"
+  "content_hash": "e01f3a932f454456"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -53,7 +53,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_git_guidance_semantics.py](test_git_guidance_semantics.py) | Semantic live-guidance discovery and coherence regressions. | 0 | 10 | 362 |
 | [test_git_handoff_receipt.py](test_git_handoff_receipt.py) | Regressions for the durable, fail-closed task-to-Git handoff | 0 | 20 | 429 |
 | [test_git_state.py](test_git_state.py) | Outcome tests for the read-only, worktree-aware Git state au | 0 | 20 | 682 |
-| [test_indian_code_manifest.py](test_indian_code_manifest.py) | INDIA-0 truth-manifest and reporting contract tests. | 0 | 6 | 139 |
+| [test_indian_code_manifest.py](test_indian_code_manifest.py) | INDIA-0 truth-manifest and reporting contract tests. | 0 | 6 | 140 |
 | [test_inputs.py](test_inputs.py) | Tests for the inputs module (TASK-276: Input Flexibility). | 7 | 0 | 464 |
 | [test_is456_common.py](test_is456_common.py) | Tests for IS 456:2000 common modules - stress_blocks, reinfo | 15 | 0 | 854 |
 | [test_is456_constants.py](test_is456_constants.py) | Tests for IS 456:2000 named design constants. | 1 | 0 | 163 |

--- a/Python/tests/integration/test_wall_publication.py
+++ b/Python/tests/integration/test_wall_publication.py
@@ -137,8 +137,16 @@ def test_invalid_public_contract_fails_closed() -> None:
         )
 
 
-def test_wall_is_not_advertised_before_wall_d_capability_packet() -> None:
-    assert all(
-        item.element != "wall"
+def test_wall_capability_names_only_the_bounded_public_workflow() -> None:
+    wall = next(
+        item
         for item in services_api.get_supported_is456_capabilities()
+        if item.element == "wall"
     )
+
+    assert wall.public_workflows == ("design_braced_wall_is456",)
+    assert "100-200 mm" in wall.supported_case
+    assert any("Applied moment" in item for item in wall.held_cases)
+    assert any("two reinforcement grids" in item for item in wall.held_cases)
+    assert any("IS 13920" in item for item in wall.held_cases)
+    assert wall.qualified_review_required

--- a/Python/tests/test_indian_code_manifest.py
+++ b/Python/tests/test_indian_code_manifest.py
@@ -87,6 +87,7 @@ def test_is456_supported_families_are_generated_from_runtime_registry() -> None:
     assert generated_supported["stair"]["workflows"] == [
         "design_straight_flight_staircase_is456"
     ]
+    assert generated_supported["wall"]["workflows"] == ["design_braced_wall_is456"]
     flat_slab = next(
         item for item in is456["capability_families"] if item["family"] == "flat_slab"
     )
@@ -126,9 +127,9 @@ def test_parity_dashboard_consumes_declared_capability_families() -> None:
     report = _run_json("parity_dashboard.py", "--section", "capabilities", "--json")
     section = report["sections"][0]
     assert section["metric_kind"] == "DECLARED_CAPABILITY_FAMILY_COVERAGE"
-    assert section["supported"] == 8
-    assert section["held"] == 13
-    assert section["pct"] == 38
+    assert section["supported"] == 9
+    assert section["held"] == 12
+    assert section["pct"] == 43
     assert section["informational"] is True
     assert report["overall_pct"] is None
     assert "capability scope" in report["overall_scope"]

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,85 @@
 
 ---
 
+## 2026-08-16 — Session: INDIA-2-WALL-D API and Capability Publication
+
+**Agent:** Codex (`api-developer`, sole writer; no subagents)
+
+**Branch:** `codex/india-2-wall-d` from integrated WALL-C main at
+`ea282b6da34c40d17a4a6090d0d284a4eb6693c7`
+
+**Focus:** Publish the thin typed wall REST route, capability/semantic truth,
+manifest promotion, and bounded evidence without adding calculation scope.
+
+### Summary
+
+- Added strict Pydantic request/response schemas and
+  `POST /api/v1/design/wall/braced-axial`, delegating all math to `wall_api`.
+- Added the sole bounded wall capability and semantic contract, removing the
+  obsolete broad IS 456 wall hold while retaining IS 13920 wall detailing.
+- Updated manifest generation, public docs, route/OpenAPI tests, unsafe-case
+  behavior, and publication evidence.
+
+### Issues encountered
+
+- WALL-C's post-merge session-end check reported `HOLD_DIVERGED` and a missing
+  task-to-Git handoff receipt after PR #771 had already squash-merged.
+- The first focused run saw the expected stale manifest plus a parity count
+  derived from that committed stale manifest.
+- The service-level 422 test changed only unsupported height; the independent
+  lateral-restraint spacing still governed effective height and kept the case
+  within the Clause 32.2 ratio limit.
+- The safe error sanitizer intentionally replaced the detailed engineering
+  message with an opaque reference.
+- Mypy rejects float values inside `Literal` even though Pydantic accepts them.
+
+### Root causes and resolutions
+
+- Root cause: squash integration changes ancestry and the packet had no
+  versioned receipt before session end. Resolution: verify PR #771's exact
+  merge, retain its lane, and start WALL-D from clean `ea282b6d`.
+- Root cause: capability promotion changes the deterministic manifest.
+  Resolution: regenerate it after adding runtime truth and rerun the manifest
+  and parity tests, which now report 9 supported and 12 held families.
+- Root cause: Clause 32.2.4 uses the lesser effective component. Resolution:
+  set both independent unsupported-height and lateral-spacing components above
+  the limit in the unsafe transport test.
+- Root cause: transport sanitization deliberately withholds detailed internal
+  error text. Resolution: assert the standard safe reference envelope while
+  core tests continue to verify the exact engineering failure.
+- Root cause: Python typing permits string/integer but not float literals.
+  Resolution: express standard concrete grades as integer literals; JSON 20.0
+  remains accepted and the service normalizes it to float.
+
+### Evidence
+
+- 20 focused publication, manifest, FastAPI, and capability tests passed.
+- The combined wall, API, manifest, clause-database, and traceability selection
+  passed 128 tests.
+- Benchmark REST output, overload `FAIL`, inadequate-reinforcement `FAIL`,
+  malformed/unsupported 422, main-app mounting, and typed OpenAPI all pass.
+- Ruff, mypy, Black, and Bandit pass on the changed paths.
+- API compatibility reports no break across 77 endpoints and 293 schemas;
+  architecture reports 0 violations across 170 files and imports report 0
+  broken across 205 files.
+- Packet quick gate passed 10/10 and all 1,153 internal links are valid.
+- The wall capability names one workflow and retains qualified review plus all
+  bounded exclusions.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: WALL-C session end reported the already squash-merged
+  branch as diverged and missing a receipt -> verified PR #771 and started this
+  lane from clean integrated main without mutating the retained WALL-C lane.
+- ⚠️ TERMINAL ISSUE: the first focused test run stopped on stale generated
+  manifest/parity evidence and a mistaken one-component slenderness fixture ->
+  regenerated truth and corrected the fixture from the confirmed governing
+  minimum-component rule.
+- ⚠️ TERMINAL ISSUE: mypy rejected Pydantic float literals -> used equivalent
+  integer grade literals and verified JSON float inputs still pass.
+
+---
+
 ## 2026-08-16 — Session: INDIA-2-WALL-C Public Python Workflow
 
 **Agent:** Codex (`backend`, sole writer; no subagents)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -36,6 +36,8 @@ manifest promotion, and bounded evidence without adding calculation scope.
 - The safe error sanitizer intentionally replaced the detailed engineering
   message with an opaque reference.
 - Mypy rejects float values inside `Literal` even though Pydantic accepts them.
+- Hosted FastAPI validation failed because the committed OpenAPI baseline still
+  described 76 endpoints and 286 schemas.
 
 ### Root causes and resolutions
 
@@ -54,6 +56,11 @@ manifest promotion, and bounded evidence without adding calculation scope.
 - Root cause: Python typing permits string/integer but not float literals.
   Resolution: express standard concrete grades as integer literals; JSON 20.0
   remains accepted and the service normalizes it to float.
+- Root cause: local compatibility validation permits additive API changes but
+  the hosted FastAPI job also requires an exact generated OpenAPI snapshot.
+  Resolution: regenerate the baseline to 77 endpoints and 293 schemas, verify
+  the semantic diff contains only the wall endpoint and seven wall schemas with
+  no removals, then rerun the exact snapshot check successfully.
 
 ### Evidence
 
@@ -81,6 +88,9 @@ manifest promotion, and bounded evidence without adding calculation scope.
   minimum-component rule.
 - ⚠️ TERMINAL ISSUE: mypy rejected Pydantic float literals -> used equivalent
   integer grade literals and verified JSON float inputs still pass.
+- ⚠️ TERMINAL ISSUE: PR #772 FastAPI validation failed on intentional OpenAPI
+  drift -> regenerated and semantically inspected the maintained snapshot;
+  local exact snapshot validation now passes with no removed paths or schemas.
 
 ---
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-16 — INDIA-2-WALL-B is integrated and WALL-C is a verified local candidate; WALL-D is next after integration
+**Updated:** 2026-08-16 — INDIA-2-WALL-C is integrated and WALL-D is a verified local publication candidate; focused wall-family acceptance is next
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| INDIA-2-WALL | Implement the accepted braced empirical vertical-compression wall workflow through A-D and focused family acceptance | Main Agent + structural engineer | 🚧 ACTIVE — WALL-A-B integrated; WALL-C candidate complete; WALL-D next after integration |
+| INDIA-2-WALL | Implement the accepted braced empirical vertical-compression wall workflow through A-D and focused family acceptance | Main Agent + structural engineer | 🚧 ACTIVE — WALL-A-C integrated; WALL-D candidate complete; focused acceptance next after integration |
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
 
 ## Up Next
@@ -158,7 +158,8 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
-| INDIA-2-WALL-C | Published one typed Python workflow composing the axial and provided-reinforcement checks with retained provenance and holds | Main Agent + backend | ✅ LOCAL CANDIDATE — 39 wall/publication tests pass; API manifest and compatibility validation pass; capability remains held until WALL-D |
+| INDIA-2-WALL-D | Added thin typed FastAPI transport, canonical wall capability/semantic truth, manifest promotion, and publication evidence | Main Agent + API developer | ✅ LOCAL CANDIDATE — 20 focused publication/manifest/API tests pass; family acceptance remains next |
+| INDIA-2-WALL-C | Published one typed Python workflow composing the axial and provided-reinforcement checks with retained provenance and holds | Main Agent + backend | ✅ INTEGRATED — PR #771 merged as `ea282b6d` |
 | INDIA-2-WALL-B | Implemented provided vertical/horizontal reinforcement area, material-ratio, spacing, and transverse-enclosure boundary checks | Main Agent + structural math | ✅ INTEGRATED — PR #770 merged as `e9e589d2`; capability remains held until WALL-D |
 | INDIA-2-WALL-A | Implemented typed bracing/geometry/action contracts, effective height, slenderness, eccentricity, empirical axial capacity, exact Clause 32 registration, and fail-closed tests | Main Agent + structural math | ✅ INTEGRATED — PR #769 merged as `7eb55746`; capability remains held until WALL-D |
 | INDIA-2-WALL-G0 | Froze one Clause 32.2 braced wall vertical-compression check with public clause provenance, pre-implementation benchmark, units, fail-closed boundaries, and focused-gate cadence | Main Agent + structural engineer | ✅ GO — owner activated WALL-A-D; applied moment, horizontal action, two-grid and alternate wall systems remain held |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 6519,
+      "size_lines": 6598,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "34f2b6c43976"
+      "content_hash": "bfc6be5607cd"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 702,
+      "size_lines": 703,
       "last_updated": "2026-08-16",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "e8d971898412"
+      "content_hash": "394cc23f4c44"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 44,
+      "file_count": 45,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "d836b4fab61907a2"
+  "content_hash": "73448127d7c2548d"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 6598,
+      "size_lines": 6608,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "bfc6be5607cd"
+      "content_hash": "add49fe91e0b"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "73448127d7c2548d"
+  "content_hash": "7317bb25e5b111a0"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6598 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6608 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 703 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6519 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 702 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6598 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 703 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 44 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 45 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -66,10 +66,10 @@
     {
       "name": "india-2-remaining-is456-elements-plan.md",
       "type": "documentation",
-      "size_lines": 306,
+      "size_lines": 308,
       "last_updated": "2026-08-16",
       "description": "INDIA-2 finishes a practical, explicitly limited set of IS 456 reinforced concrete elements that are still missing from the library.",
-      "content_hash": "62b25e37f35f"
+      "content_hash": "475e6fd8d88a"
     },
     {
       "name": "indian-code-completion-plan.md",
@@ -127,7 +127,7 @@
       "last_updated": "2026-08-16",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-16",
-      "content_hash": "38c262164de9"
+      "content_hash": "40754cfbeba0"
     },
     {
       "name": "pre-release-checklist.md",
@@ -165,5 +165,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "6b6ee019cfed1f0f"
+  "content_hash": "1eacfe39c1cb7d32"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -15,7 +15,7 @@
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
 | [etabs-killer-masterplan.md](etabs-killer-masterplan.md) | Project BHEEM: Open-Source Structural De | > **BHEEM** — **B**uilding **H**olistic **E**ngineering **E* | 2855 |
 | [gpt-5-3-codex-spark-work-program.md](gpt-5-3-codex-spark-work-program.md) |  | Use GPT-5.3-Codex-Spark as a high-throughput implementation  | 614 |
-| [india-2-remaining-is456-elements-plan.md](india-2-remaining-is456-elements-plan.md) |  | INDIA-2 finishes a practical, explicitly limited set of IS 4 | 306 |
+| [india-2-remaining-is456-elements-plan.md](india-2-remaining-is456-elements-plan.md) |  | INDIA-2 finishes a practical, explicitly limited set of IS 4 | 308 |
 | [indian-code-completion-plan.md](indian-code-completion-plan.md) |  | This is the canonical finish plan for the repository's India | 129 |
 | [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1507 |
 | [is456-solid-slabs-master-plan.md](is456-solid-slabs-master-plan.md) |  | The next element program will complete a useful, evidence-ba | 1123 |

--- a/docs/planning/india-2-remaining-is456-elements-plan.md
+++ b/docs/planning/india-2-remaining-is456-elements-plan.md
@@ -43,7 +43,7 @@ Historical staircase task IDs, PRs, and evidence remain unchanged. The former
 
 | Family | Current truth | INDIA-2 treatment |
 |---|---|---|
-| Clause 32 walls | G0 and A-B integrated; C public Python workflow is a local candidate and capability remains held | One braced empirical vertical-compression wall check activated |
+| Clause 32 walls | G0 and A-C integrated; D publication/capability promotion is a local candidate | One braced empirical vertical-compression wall check activated |
 | Clause 33 stairs | One bounded longitudinal straight waist-slab flight supported | Complete; alternate stair systems remain held |
 | Clause 29 deep beams | Not implemented | Planned after the wall program |
 | Flat slabs and column punching | Not implemented | Planned after deep beams |
@@ -59,7 +59,7 @@ boundary, held with a written reason, or not implemented.
 
 | Order | Program | Why it is placed here | State |
 |---:|---|---|---|
-| 1 | `INDIA-2-WALL` | Next clause-bounded practical element; establishes the new-family workflow | G0 and A-B integrated; C candidate; D activated |
+| 1 | `INDIA-2-WALL` | Next clause-bounded practical element; establishes the new-family workflow | G0 and A-C integrated; D candidate; acceptance next |
 | — | `INDIA-2-STAIR` | Already implemented and cumulatively gated | Complete |
 | 2 | `INDIA-2-DEEP` | Extends beam capability but requires its own geometry, action, and detailing boundary | Planned |
 | 3 | `INDIA-2-FLAT` | Requires panel analysis/distribution plus column punching; broader than the existing solid-slab route | Planned |
@@ -160,9 +160,10 @@ Provisional packets:
    slenderness, eccentricity, and empirical axial-capacity contract.
 3. `INDIA-2-WALL-B` — integrated; bounded minimum/provided
    reinforcement and spacing checks.
-4. `INDIA-2-WALL-C` — candidate complete; typed public Python workflow and
+4. `INDIA-2-WALL-C` — integrated; typed public Python workflow and
    frozen end-to-end benchmark example.
-5. `INDIA-2-WALL-D` — thin API, capability truth, and evidence freeze.
+5. `INDIA-2-WALL-D` — candidate complete; thin API, capability truth, and
+   evidence freeze.
 6. `INDIA-2-WALL-ACCEPTANCE` — focused family acceptance after A-D integration.
 
 ### 6.2 INDIA-2-STAIR — Clause 33 staircase program
@@ -299,7 +300,8 @@ authorized programs.
 
 ## 9. Exact next action
 
-Integrate the `INDIA-2-WALL-C` candidate, then start `INDIA-2-WALL-D` from the
-verified integrated head. The owner's 2026-08-16 request activates WALL-A-D and
+Integrate the `INDIA-2-WALL-D` candidate, then run focused wall-family
+acceptance from the verified integrated head. The owner's 2026-08-16 request
+activates WALL-A-D and
 the later INDIA-2 families subject to each family's own G0 returning GO. No G0
 may be bypassed, and a HOLD remains a truthful non-implementation outcome.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -17,7 +17,7 @@
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; INDIA-0, INDIA-1, and the INDIA-2-STAIR family are complete |
 | **Program** | Umbrella INDIA-2 remains in progress; INDIA-3 and INDIA-4 remain planned |
-| **Next** | Integrate `INDIA-2-WALL-C`, then begin `INDIA-2-WALL-D` from the verified integrated head |
+| **Next** | Integrate `INDIA-2-WALL-D`, then run focused wall-family acceptance from the verified integrated head |
 
 ## Required Reading
 
@@ -34,10 +34,10 @@ The historical INDIA-2A-D packets and their cumulative software gate are the
 completed `INDIA-2-STAIR` family. Do not reopen them, add another stair topology,
 add React, or begin release work without a new owner-approved scope.
 
-`INDIA-2-WALL-G0` and WALL-A-B are integrated. WALL-C now has a verified local
-typed Python workflow composing the axial and reinforcement checks with public
-clause/source provenance. The capability and FastAPI route remain held until
-WALL-D.
+`INDIA-2-WALL-G0` and WALL-A-C are integrated. WALL-D now has a verified local
+typed FastAPI route plus canonical capability/semantic truth and manifest
+promotion. After its exact head integrates, run focused family acceptance before
+starting deep-beam G0.
 
 ```bash
 ./run.sh session brief --agent orchestrator
@@ -59,13 +59,13 @@ It freezes the supported wall case, IS 456 clauses, public normalized-content
 boundary, hand benchmark and tolerance, units, fail-closed exclusions, and
 WALL-A-D packet split. No wall calculation or capability claim is part of G0.
 
-## INDIA-2-WALL-C candidate result
+## INDIA-2-WALL-D candidate result
 
-[`india-2-wall-c-public-workflow-evidence.md`](../verification/india-2-wall-c-public-workflow-evidence.md)
-records the canonical public types/function, frozen composed example, explicit
-units and provenance, held cases, API-manifest result, and focused validation.
-After its exact reviewed head is integrated, WALL-D adds only the thin FastAPI
-route, supported-capability truth, examples, and wall-family acceptance freeze.
+[`india-2-wall-d-publication-evidence.md`](../verification/india-2-wall-d-publication-evidence.md)
+records the thin REST schema/route, benchmark and unsafe-case behavior, public
+clause/source visibility, canonical capability/semantic contract, retained
+holds, manifest promotion, and focused validation. After integration, the
+acceptance packet verifies the whole wall family without new calculation scope.
 
 ## Review and gate boundary
 

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -577,8 +577,9 @@ reinforcement checks and retains explicit bracing, action, reinforcement,
 clause, source, and benchmark provenance. Moments, horizontal actions, shear,
 openings, two-grid walls, transverse-enclosure design, seismic detailing, load
 generation, automatic bar selection, qualified approval, and release remain
-outside the preview contract. The capability registry and FastAPI route remain
-held until WALL-D.
+outside the preview contract. The capability registry names only this bounded
+workflow, and the equivalent REST route is
+`POST /api/v1/design/wall/braced-axial`.
 
 Complete slab workflow results expose only reviewed span/depth serviceability
 and ordinary one-way concrete shear for beam/wall-supported UDL panels. Their

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -4147,8 +4147,9 @@ The only accepted case is one regular 100-200 mm thick one-grid braced wall
 under caller-supplied factored in-plane vertical compression. Applied moments,
 horizontal actions, shear, openings, two-grid walls, transverse-enclosure
 design, seismic detailing, load generation, bar selection, and qualified
-approval remain held. FastAPI publication and capability advertisement are
-added only by WALL-D.
+approval remain held.
+
+**FastAPI Endpoint:** `POST /api/v1/design/wall/braced-axial`
 
 ---
 

--- a/docs/reference/index.json
+++ b/docs/reference/index.json
@@ -62,18 +62,18 @@
     {
       "name": "api-stability.md",
       "type": "documentation",
-      "size_lines": 731,
+      "size_lines": 732,
       "last_updated": "2026-08-16",
       "description": "> This document defines which parts of the library are safe to depend on and which may change. This library follows Semantic Versioning:",
-      "content_hash": "b6f90c1a1546"
+      "content_hash": "ff3558cf9bbb"
     },
     {
       "name": "api.md",
       "type": "documentation",
-      "size_lines": 4237,
+      "size_lines": 4238,
       "last_updated": "2026-08-16",
       "description": "geometry, loading, reinforcement, and evidence boundaries. The primary combined beam route covers rectangular flexure and shear (plus optional serviceability),",
-      "content_hash": "2b0377525547"
+      "content_hash": "a9f902fca891"
     },
     {
       "name": "automation-catalog.md",
@@ -261,5 +261,5 @@
       "file_count": 1760
     }
   ],
-  "content_hash": "587a7b0b95affe18"
+  "content_hash": "b849abfd8b927b5f"
 }

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -19,8 +19,8 @@
 | [README.md](README.md) | Reference Documentation | Comprehensive lookup documentation for APIs, formulas, contr | 81 |
 | [agent-automation-pitfalls.md](agent-automation-pitfalls.md) |  | <!-- lint-ignore-git --> > ⚠️ **Note:** This document includ | 634 |
 | [api-levels.md](api-levels.md) |  | structural_lib exposes three API levels. Pick the one that m | 117 |
-| [api-stability.md](api-stability.md) |  | > This document defines which parts of the library are safe  | 731 |
-| [api.md](api.md) |  | geometry, loading, reinforcement, and evidence boundaries. T | 4237 |
+| [api-stability.md](api-stability.md) |  | > This document defines which parts of the library are safe  | 732 |
+| [api.md](api.md) |  | geometry, loading, reinforcement, and evidence boundaries. T | 4238 |
 | [automation-catalog.md](automation-catalog.md) |  | The exhaustive machine-generated script inventory is scripts | 61 |
 | [bbs-dxf-contract.md](bbs-dxf-contract.md) |  | This document defines the stable contracts for Bar Bending S | 116 |
 | [beam-tool-manifest.md](beam-tool-manifest.md) |  | The generated beam tool manifest describes the one approved  | 32 |

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-16",
-  "file_count": 42,
+  "file_count": 43,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -253,6 +253,14 @@
       "content_hash": "6a75d034217a"
     },
     {
+      "name": "india-2-wall-d-publication-evidence.md",
+      "type": "documentation",
+      "size_lines": 77,
+      "last_updated": "2026-08-16",
+      "description": "WALL-D publishes the integrated design_braced_wall_is456 workflow through POST /api/v1/design/wall/braced-axial and promotes exactly one bounded wall",
+      "content_hash": "0d4884916d24"
+    },
+    {
       "name": "india-2-wall-g0-scope-evidence.md",
       "type": "documentation",
       "size_lines": 125,
@@ -366,7 +374,7 @@
         "capability_summary",
         "standards"
       ],
-      "content_hash": "4c4cc51e8871"
+      "content_hash": "775f4041c294"
     },
     {
       "name": "indian-code-truth-baseline.md",
@@ -455,5 +463,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "6edaabd4f35b8455"
+  "content_hash": "07110225f9624cd3"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -255,10 +255,10 @@
     {
       "name": "india-2-wall-d-publication-evidence.md",
       "type": "documentation",
-      "size_lines": 77,
+      "size_lines": 80,
       "last_updated": "2026-08-16",
       "description": "WALL-D publishes the integrated design_braced_wall_is456 workflow through POST /api/v1/design/wall/braced-axial and promotes exactly one bounded wall",
-      "content_hash": "0d4884916d24"
+      "content_hash": "3e70433c516b"
     },
     {
       "name": "india-2-wall-g0-scope-evidence.md",
@@ -463,5 +463,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "07110225f9624cd3"
+  "content_hash": "d3f983b950a48f5e"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -42,7 +42,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [india-2-wall-a-axial-kernel-evidence.md](india-2-wall-a-axial-kernel-evidence.md) |  | WALL-A implements the pure IS 456 layer for the accepted Cla | 83 |
 | [india-2-wall-b-reinforcement-evidence.md](india-2-wall-b-reinforcement-evidence.md) |  | WALL-B adds one pure IS 456 provided-reinforcement check to  | 82 |
 | [india-2-wall-c-public-workflow-evidence.md](india-2-wall-c-public-workflow-evidence.md) |  | WALL-C publishes one canonical typed Python function, design | 80 |
-| [india-2-wall-d-publication-evidence.md](india-2-wall-d-publication-evidence.md) |  | WALL-D publishes the integrated design_braced_wall_is456 wor | 77 |
+| [india-2-wall-d-publication-evidence.md](india-2-wall-d-publication-evidence.md) |  | WALL-D publishes the integrated design_braced_wall_is456 wor | 80 |
 | [india-2-wall-g0-scope-evidence.md](india-2-wall-g0-scope-evidence.md) |  | activated the remaining INDIA-2 work on 2026-08-16 by asking | 125 |
 | [india-2a-staircase-scope-evidence.md](india-2a-staircase-scope-evidence.md) |  | activated INDIA-2A through INDIA-2D on 2026-08-15 by request | 111 |
 | [india-2b-staircase-actions-evidence.md](india-2b-staircase-actions-evidence.md) |  | INDIA-2B implements only the typed geometry, concrete self-w | 70 |

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-16
-**Files:** 42
+**Files:** 43
 
 ## Config Files
 
@@ -42,6 +42,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [india-2-wall-a-axial-kernel-evidence.md](india-2-wall-a-axial-kernel-evidence.md) |  | WALL-A implements the pure IS 456 layer for the accepted Cla | 83 |
 | [india-2-wall-b-reinforcement-evidence.md](india-2-wall-b-reinforcement-evidence.md) |  | WALL-B adds one pure IS 456 provided-reinforcement check to  | 82 |
 | [india-2-wall-c-public-workflow-evidence.md](india-2-wall-c-public-workflow-evidence.md) |  | WALL-C publishes one canonical typed Python function, design | 80 |
+| [india-2-wall-d-publication-evidence.md](india-2-wall-d-publication-evidence.md) |  | WALL-D publishes the integrated design_braced_wall_is456 wor | 77 |
 | [india-2-wall-g0-scope-evidence.md](india-2-wall-g0-scope-evidence.md) |  | activated the remaining INDIA-2 work on 2026-08-16 by asking | 125 |
 | [india-2a-staircase-scope-evidence.md](india-2a-staircase-scope-evidence.md) |  | activated INDIA-2A through INDIA-2D on 2026-08-15 by request | 111 |
 | [india-2b-staircase-actions-evidence.md](india-2b-staircase-actions-evidence.md) |  | INDIA-2B implements only the typed geometry, concrete self-w | 70 |

--- a/docs/verification/india-2-wall-d-publication-evidence.md
+++ b/docs/verification/india-2-wall-d-publication-evidence.md
@@ -65,6 +65,9 @@ and alternate wall systems remain outside the supported capability.
   passed 128 tests.
 - Black, Ruff, mypy, and Bandit passed on the changed Python/FastAPI paths.
 - API compatibility reports no break across 77 endpoints and 293 schemas.
+- The exact OpenAPI snapshot was regenerated to the same counts; semantic diff
+  inspection found only the one wall endpoint and seven wall schemas added,
+  with no path or schema removals.
 - Architecture validation found 0 violations across 170 files and structural-
   library import validation found 0 broken imports across 205 files.
 - The generated Indian-code manifest reports 9 supported and 12 held declared

--- a/docs/verification/india-2-wall-d-publication-evidence.md
+++ b/docs/verification/india-2-wall-d-publication-evidence.md
@@ -1,0 +1,76 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-16
+doc_type: reference
+task: INDIA-2-WALL-D
+---
+
+# INDIA-2-WALL-D Publication Evidence
+
+## Published boundary
+
+WALL-D publishes the integrated `design_braced_wall_is456` workflow through
+`POST /api/v1/design/wall/braced-axial` and promotes exactly one bounded `wall`
+entry in canonical capability discovery. Both surfaces delegate to the same
+typed service used by the public Python API; no engineering formula exists in
+the transport layer.
+
+The supported capability is one regular 100-200 mm thick one-grid Clause 32.2
+braced wall under caller-supplied factored in-plane vertical compression, with
+empirical axial-capacity and Clause 32.5 caller-provided minimum-reinforcement
+checks. Qualified engineering review remains mandatory.
+
+## Public clause and source visibility
+
+The typed REST result exposes Clause 32.2.1-32.2.5 and 32.5-32.5.2 identifiers,
+normalized standard/source IDs, benchmark `INDIA-2-WALL-HAND-01`, explicit
+bracing/action/reinforcement references, load-generation status, supported
+case, held cases, and approval booleans. The request and response schemas keep
+mm, kN, N/mm2, N/mm, kN/m, dimensionless ratios, and mm2/m quantities explicit.
+
+The deterministic Indian-code manifest now records `wall` as
+`SUPPORTED`/`IMPLEMENTED_BOUNDED` with the sole public workflow
+`design_braced_wall_is456`; the broad IS 13920 wall-detailing family remains
+separately `HELD`/`NOT_IMPLEMENTED`.
+
+## Transport evidence
+
+The frozen endpoint example returns:
+
+- overall and axial status `PASS`;
+- effective height 2250 mm;
+- capacity 684 N/mm, demand 500 N/mm, utilization 0.7309941520;
+- vertical provided steel 201.061930 mm2/m;
+- horizontal provided steel 314.159265 mm2/m;
+- qualified review required true and complete engineering approval false.
+
+A valid overload and valid inadequate reinforcement return HTTP 200 with a
+typed `FAIL`. Extra fields, non-finite values, unconfirmed bracing, walls above
+200 mm, and core-contract violations return HTTP 422 in the standard safe error
+envelope. OpenAPI binds the success response to `BracedWallResponse`.
+
+## Retained holds
+
+Applied moment, horizontal action, wall shear, combined flexure, openings,
+out-of-plane behavior, two-grid walls, transverse-enclosure design, global/load
+analysis, load combinations, bar selection, anchorage, lap, crack width, direct
+deflection, seismic/IS 13920 detailing, React, professional approval, release,
+and alternate wall systems remain outside the supported capability.
+
+## Focused verification
+
+- 20 focused wall publication, manifest, FastAPI, and capability tests passed.
+- The combined wall, API, manifest, clause-database, and traceability selection
+  passed 128 tests.
+- Black, Ruff, mypy, and Bandit passed on the changed Python/FastAPI paths.
+- API compatibility reports no break across 77 endpoints and 293 schemas.
+- Architecture validation found 0 violations across 170 files and structural-
+  library import validation found 0 broken imports across 205 files.
+- The generated Indian-code manifest reports 9 supported and 12 held declared
+  families, with 43 percent informational declared-capability coverage.
+- The packet quick gate passed 10/10 and all 1,153 internal links are valid.
+
+WALL-D publication does not by itself close family acceptance. The next packet
+runs the focused cumulative wall acceptance selection from integrated A-D and
+freezes its exact receipt before starting `INDIA-2-DEEP-G0`.

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -29,10 +29,10 @@
     "Python/structural_lib/codes/is13920/**/*.py"
   ],
   "capability_summary": {
-    "supported_families": 8,
-    "held_families": 13,
+    "supported_families": 9,
+    "held_families": 12,
     "total_declared_families": 21,
-    "supported_pct": 38.1
+    "supported_pct": 42.9
   },
   "standards": [
     {
@@ -43,10 +43,10 @@
       "source_root": "Python/structural_lib/codes/is456",
       "status": "SUPPORTED_SUBSET",
       "capability_summary": {
-        "supported_families": 5,
-        "held_families": 7,
+        "supported_families": 6,
+        "held_families": 6,
         "total_declared_families": 12,
-        "supported_pct": 41.7
+        "supported_pct": 50.0
       },
       "capability_families": [
         {
@@ -173,14 +173,25 @@
         {
           "capability_id": "IS456:2000:wall",
           "family": "wall",
-          "scope_status": "HELD",
-          "implementation_status": "NOT_IMPLEMENTED",
-          "claim": "IS 456 wall design is not implemented.",
-          "workflows": [],
-          "limitations": [
-            "Clause 32 requires a separately verified program."
+          "scope_status": "SUPPORTED",
+          "implementation_status": "IMPLEMENTED_BOUNDED",
+          "claim": "One regular 100-200 mm thick, one-grid, Clause 32.2 braced reinforced-concrete wall under caller-supplied factored in-plane vertical compression, with empirical axial-capacity and Clause 32.5 caller-provided minimum-reinforcement checks.",
+          "workflows": [
+            "design_braced_wall_is456"
           ],
-          "evidence": [],
+          "limitations": [
+            "Applied moment, horizontal action, wall shear, combined flexure, openings, and out-of-plane behavior are excluded.",
+            "Walls thicker than 200 mm, two reinforcement grids, and transverse-enclosure design are excluded.",
+            "Global analysis, load generation, load combinations, bar selection, anchorage, lap, crack width, and direct deflection are excluded.",
+            "Seismic/shear-wall provisions and IS 13920 detailing are excluded."
+          ],
+          "evidence": [
+            "docs/verification/india-2-wall-g0-scope-evidence.md",
+            "docs/verification/india-2-wall-a-axial-kernel-evidence.md",
+            "docs/verification/india-2-wall-b-reinforcement-evidence.md",
+            "docs/verification/india-2-wall-c-public-workflow-evidence.md",
+            "docs/verification/india-2-wall-d-publication-evidence.md"
+          ],
           "qualified_review_required": true
         },
         {

--- a/fastapi_app/index.json
+++ b/fastapi_app/index.json
@@ -2,14 +2,14 @@
   "folder": "fastapi_app",
   "type": "python-package",
   "description": "REST API + WebSocket bridge between the React frontend and the Python `structural_lib`.",
-  "last_updated": "2026-08-15",
+  "last_updated": "2026-08-16",
   "file_count": 9,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 50,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "FastAPI Backend",
       "description": "REST API + WebSocket bridge between the React frontend and the Python structural_lib. bash",
       "content_hash": "174e3838edd5"
@@ -18,7 +18,7 @@
       "name": "__init__.py",
       "type": "python",
       "size_lines": 11,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "FastAPI backend for structural_engineering_lib.",
       "content_hash": "a054fbd5a6f9"
     },
@@ -26,7 +26,7 @@
       "name": "auth.py",
       "type": "python",
       "size_lines": 378,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Authentication and Authorization Module.",
       "classes": [
         {
@@ -114,7 +114,7 @@
       "name": "config.py",
       "type": "python",
       "size_lines": 124,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Application Configuration.",
       "classes": [
         {
@@ -149,7 +149,7 @@
       "name": "error_utils.py",
       "type": "python",
       "size_lines": 74,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Error sanitization utilities for API responses.",
       "functions": [
         {
@@ -181,8 +181,8 @@
     {
       "name": "main.py",
       "type": "python",
-      "size_lines": 585,
-      "last_updated": "2026-08-15",
+      "size_lines": 595,
+      "last_updated": "2026-08-16",
       "description": "FastAPI Application Entry Point.",
       "classes": [
         {
@@ -243,12 +243,12 @@
         "API_TAGS_METADATA",
         "API_V1_PREFIX"
       ],
-      "content_hash": "aa886f99470a"
+      "content_hash": "238e1f59b057"
     },
     {
       "name": "openapi_baseline.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "components",
         "info",
@@ -261,7 +261,7 @@
     {
       "name": "ruff.toml",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": ".TOML configuration file",
       "content_hash": "a86a2bd7f0e7"
     }
@@ -275,23 +275,23 @@
     {
       "name": "models",
       "path": "models/",
-      "file_count": 19,
+      "file_count": 20,
       "is_package": true
     },
     {
       "name": "routers",
       "path": "routers/",
-      "file_count": 22,
+      "file_count": 23,
       "is_package": true
     },
     {
       "name": "tests",
       "path": "tests/",
-      "file_count": 40,
+      "file_count": 41,
       "description": "Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming.",
       "is_package": true
     }
   ],
   "has_init": true,
-  "content_hash": "c9f07cbbba6dd19b"
+  "content_hash": "a217894918003e1e"
 }

--- a/fastapi_app/index.md
+++ b/fastapi_app/index.md
@@ -3,7 +3,7 @@
 REST API + WebSocket bridge between the React frontend and the Python `structural_lib`.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-15
+**Last Updated:** 2026-08-16
 **Files:** 9
 
 ## Config Files
@@ -25,13 +25,13 @@ REST API + WebSocket bridge between the React frontend and the Python `structura
 | [auth.py](auth.py) | Authentication and Authorization Module. | 3 | 7 | 378 |
 | [config.py](config.py) | Application Configuration. | 1 | 2 | 124 |
 | [error_utils.py](error_utils.py) | Error sanitization utilities for API responses. | 0 | 3 | 74 |
-| [main.py](main.py) | FastAPI Application Entry Point. | 3 | 5 | 585 |
+| [main.py](main.py) | FastAPI Application Entry Point. | 3 | 5 | 595 |
 
 ## Subfolders
 
 | Folder | Files | Description |
 |--------|-------|-------------|
 | [examples/](examples/) | 4 |  |
-| [models/](models/) 📦 | 19 |  |
-| [routers/](routers/) 📦 | 22 |  |
-| [tests/](tests/) 📦 | 40 | Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin |
+| [models/](models/) 📦 | 20 |  |
+| [routers/](routers/) 📦 | 23 |  |
+| [tests/](tests/) 📦 | 41 | Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin |

--- a/fastapi_app/main.py
+++ b/fastapi_app/main.py
@@ -52,6 +52,7 @@ from fastapi_app.routers import (
     rebar,
     staircase,
     streaming,
+    wall,
     websocket,
     workflows,
 )
@@ -77,6 +78,7 @@ boundary and qualified engineering review.
 - **Footing Design**: Isolated-footing checks and concentric load transfer
 - **Slab Design**: Bounded simply supported one-way slab strip
 - **Staircase Design**: Bounded longitudinal straight waist-slab flight
+- **Wall Design**: Bounded Clause 32 braced-wall axial and reinforcement checks
 - **Detailing**: Reinforcement layout, spacing, and development lengths
 - **Optimization**: Cost-optimized beam cross-section selection
 - **Smart Analysis**: AI-assisted design suggestions and insights
@@ -125,6 +127,10 @@ API_TAGS_METADATA = [
     {
         "name": "staircase",
         "description": "Bounded straight-flight staircase design and maintained evidence.",
+    },
+    {
+        "name": "wall",
+        "description": "Bounded Clause 32 braced-wall checks and maintained evidence.",
     },
     {
         "name": "detailing",
@@ -511,6 +517,10 @@ app.include_router(
 )
 app.include_router(
     staircase.router,
+    prefix=API_V1_PREFIX,
+)
+app.include_router(
+    wall.router,
     prefix=API_V1_PREFIX,
 )
 app.include_router(

--- a/fastapi_app/models/index.json
+++ b/fastapi_app/models/index.json
@@ -2,14 +2,14 @@
   "folder": "fastapi_app/models",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-15",
-  "file_count": 17,
+  "last_updated": "2026-08-16",
+  "file_count": 18,
   "files": [
     {
       "name": "__init__.py",
       "type": "python",
       "size_lines": 88,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Pydantic Models Package.",
       "content_hash": "ef8eea18fcda"
     },
@@ -17,7 +17,7 @@
       "name": "analysis.py",
       "type": "python",
       "size_lines": 264,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Smart Analysis Pydantic Models.",
       "classes": [
         {
@@ -70,7 +70,7 @@
       "name": "beam.py",
       "type": "python",
       "size_lines": 797,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Beam Design and Detailing Pydantic Models.",
       "classes": [
         {
@@ -152,7 +152,7 @@
       "name": "boq.py",
       "type": "python",
       "size_lines": 107,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Pydantic models for Project BOQ endpoint.",
       "classes": [
         {
@@ -194,7 +194,7 @@
       "name": "capabilities.py",
       "type": "python",
       "size_lines": 79,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Typed transport models for canonical IS 456 capability discovery.",
       "classes": [
         {
@@ -236,7 +236,7 @@
       "name": "catalog.py",
       "type": "python",
       "size_lines": 56,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Typed transport models for the application workflow catalogue.",
       "classes": [
         {
@@ -258,7 +258,7 @@
       "name": "column.py",
       "type": "python",
       "size_lines": 1192,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Column Design Pydantic Models.",
       "classes": [
         {
@@ -340,7 +340,7 @@
       "name": "common.py",
       "type": "python",
       "size_lines": 137,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Common Pydantic Models.",
       "classes": [
         {
@@ -370,7 +370,7 @@
       "name": "compliance.py",
       "type": "python",
       "size_lines": 325,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "IS 456 Compliance Check Pydantic Models.",
       "classes": [
         {
@@ -443,7 +443,7 @@
       "name": "footing.py",
       "type": "python",
       "size_lines": 266,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Transport models for the bounded concentric isolated-footing workflow.",
       "classes": [
         {
@@ -498,7 +498,7 @@
       "name": "geometry.py",
       "type": "python",
       "size_lines": 412,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "3D Geometry Pydantic Models.",
       "classes": [
         {
@@ -574,7 +574,7 @@
       "name": "library_core.py",
       "type": "python",
       "size_lines": 367,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Requests for the bounded footing and slab public-library workflows.",
       "classes": [
         {
@@ -644,7 +644,7 @@
       "name": "metadata.py",
       "type": "python",
       "size_lines": 97,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Typed payload models for maintained static JSON metadata routes.",
       "classes": [
         {
@@ -690,7 +690,7 @@
       "name": "optimization.py",
       "type": "python",
       "size_lines": 298,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Cost Optimization Pydantic Models.",
       "classes": [
         {
@@ -736,7 +736,7 @@
       "name": "response.py",
       "type": "python",
       "size_lines": 71,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Standardized API response wrappers.",
       "classes": [
         {
@@ -778,7 +778,7 @@
       "name": "staircase.py",
       "type": "python",
       "size_lines": 139,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Transport models for the bounded straight-flight staircase workflow.",
       "classes": [
         {
@@ -811,10 +811,40 @@
       "content_hash": "e748e2b911e6"
     },
     {
+      "name": "wall.py",
+      "type": "python",
+      "size_lines": 110,
+      "last_updated": "2026-08-16",
+      "description": "Transport models for the bounded braced-wall workflow.",
+      "classes": [
+        {
+          "name": "BracedWallRequest",
+          "description": "Explicit inputs for the sole supported Clause 32 wall case."
+        },
+        {
+          "name": "BracedWallAxialResponse"
+        },
+        {
+          "name": "WallDirectionalReinforcementResponse"
+        },
+        {
+          "name": "WallReinforcementResponse"
+        },
+        {
+          "name": "BracedWallProvenanceResponse"
+        },
+        {
+          "name": "BracedWallResponse",
+          "description": "Typed transport subset of the composed wall result."
+        }
+      ],
+      "content_hash": "0c084de6d87f"
+    },
+    {
       "name": "workflows.py",
       "type": "python",
       "size_lines": 99,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Typed models for the default-disabled bounded beam workflow transport.",
       "classes": [
         {
@@ -878,5 +908,5 @@
     "DuctilityCheckRequest",
     "DuctilityCheckResponse"
   ],
-  "content_hash": "095b02f2bdcf5d08"
+  "content_hash": "84435c45ba871991"
 }

--- a/fastapi_app/models/index.md
+++ b/fastapi_app/models/index.md
@@ -1,8 +1,8 @@
 # Models
 
 **Type:** Python Package
-**Last Updated:** 2026-08-15
-**Files:** 17
+**Last Updated:** 2026-08-16
+**Files:** 18
 
 ## Public API
 
@@ -47,4 +47,5 @@
 | [optimization.py](optimization.py) | Cost Optimization Pydantic Models. | 9 | 0 | 298 |
 | [response.py](response.py) | Standardized API response wrappers. | 3 | 2 | 71 |
 | [staircase.py](staircase.py) | Transport models for the bounded straight-flight staircase w | 8 | 0 | 139 |
+| [wall.py](wall.py) | Transport models for the bounded braced-wall workflow. | 6 | 0 | 110 |
 | [workflows.py](workflows.py) | Typed models for the default-disabled bounded beam workflow  | 11 | 0 | 99 |

--- a/fastapi_app/models/wall.py
+++ b/fastapi_app/models/wall.py
@@ -1,0 +1,109 @@
+"""Transport models for the bounded braced-wall workflow."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BracedWallRequest(BaseModel):
+    """Explicit inputs for the sole supported Clause 32 wall case."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        allow_inf_nan=False,
+        str_strip_whitespace=True,
+    )
+
+    case_id: str = Field(min_length=1)
+    unsupported_height_mm: float = Field(gt=0)
+    lateral_restraint_spacing_mm: float = Field(gt=0)
+    wall_length_mm: float = Field(gt=0)
+    wall_thickness_mm: float = Field(ge=100, le=200)
+    concrete_grade_nmm2: Literal[20, 25, 30, 35, 40, 45, 50, 55, 60]
+    factored_axial_load_kn: float = Field(gt=0)
+    supplied_eccentricity_mm: float = Field(ge=0)
+    vertical_bar_diameter_mm: float = Field(gt=0)
+    vertical_bar_spacing_mm: float = Field(gt=0)
+    horizontal_bar_diameter_mm: float = Field(gt=0)
+    horizontal_bar_spacing_mm: float = Field(gt=0)
+    bracing_basis_reference: str = Field(min_length=1)
+    action_basis_reference: str = Field(min_length=1)
+    reinforcement_basis_reference: str = Field(min_length=1)
+    rotation_restraint: Literal["restrained_both_ends", "not_restrained_both_ends"] = (
+        "restrained_both_ends"
+    )
+    reinforcement_kind: Literal[
+        "deformed_415_or_greater", "other_bars", "welded_wire_fabric"
+    ] = "deformed_415_or_greater"
+    bracing_elements_in_two_directions: Literal[True] = True
+    lateral_forces_resisted_by_bracing_system: Literal[True] = True
+    diaphragm_transfer_confirmed: Literal[True] = True
+    lateral_connection_capacity_confirmed: Literal[True] = True
+
+
+class BracedWallAxialResponse(BaseModel):
+    effective_height_mm: float
+    effective_height_to_thickness_ratio: float
+    minimum_eccentricity_mm: float
+    design_eccentricity_mm: float
+    additional_eccentricity_mm: float
+    effective_compression_thickness_mm: float
+    axial_capacity_n_per_mm: float
+    axial_capacity_kn_per_m: float
+    total_axial_capacity_kn: float
+    axial_demand_n_per_mm: float
+    axial_demand_kn_per_m: float
+    utilization_ratio: float
+    status: Literal["PASS", "FAIL"]
+    source_refs: tuple[str, ...]
+    load_generation_status: str
+
+
+class WallDirectionalReinforcementResponse(BaseModel):
+    minimum_ratio: float
+    required_area_mm2_per_m: float
+    provided_area_mm2_per_m: float
+    provided_ratio: float
+    maximum_spacing_mm: float
+    provided_spacing_mm: float
+    area_status: Literal["PASS", "FAIL"]
+    spacing_status: Literal["PASS", "FAIL"]
+    status: Literal["PASS", "FAIL"]
+
+
+class WallReinforcementResponse(BaseModel):
+    vertical: WallDirectionalReinforcementResponse
+    horizontal: WallDirectionalReinforcementResponse
+    transverse_enclosure_required: bool
+    status: Literal["PASS", "FAIL"]
+    source_refs: tuple[str, ...]
+
+
+class BracedWallProvenanceResponse(BaseModel):
+    schema_version: str
+    code_edition: str
+    workflow: str
+    case_id: str
+    benchmark_id: str
+    load_generation_status: str
+    bracing_basis_reference: str
+    action_basis_reference: str
+    reinforcement_basis_reference: str
+    clause_refs: tuple[str, ...]
+    source_refs: tuple[str, ...]
+
+
+class BracedWallResponse(BaseModel):
+    """Typed transport subset of the composed wall result."""
+
+    case_id: str
+    status: Literal["PASS", "FAIL"]
+    axial: BracedWallAxialResponse
+    reinforcement: WallReinforcementResponse
+    supported_case: str
+    held_cases: tuple[str, ...]
+    provenance: BracedWallProvenanceResponse
+    qualified_review_required: Literal[True]
+    complete_engineering_design_approved: Literal[False]

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -506,6 +506,58 @@
         "title": "APIResponse[BiaxialCheckResponse]",
         "type": "object"
       },
+      "APIResponse_BracedWallResponse_": {
+        "example": {
+          "data": {
+            "Ast_mm2": 603.2
+          },
+          "success": true
+        },
+        "properties": {
+          "clause_refs": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clause Refs"
+          },
+          "data": {
+            "$ref": "#/components/schemas/BracedWallResponse"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "success": {
+            "default": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "APIResponse[BracedWallResponse]",
+        "type": "object"
+      },
       "APIResponse_BuildingGeometryResponse_": {
         "example": {
           "data": {
@@ -3266,7 +3318,7 @@
         "description": "Request for additional moment calculation per IS 456 Cl 39.7.1.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area (mm²)",
+            "description": "Total steel area (mm\u00b2)",
             "examples": [
               2400.0
             ],
@@ -3314,7 +3366,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm²)",
+            "description": "Concrete strength (N/mm\u00b2)",
             "examples": [
               25.0
             ],
@@ -3324,7 +3376,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "examples": [
               415.0
             ],
@@ -3377,22 +3429,22 @@
             "type": "number"
           },
           "Max_kNm": {
-            "description": "Additional moment about x-axis (kN·m)",
+            "description": "Additional moment about x-axis (kN\u00b7m)",
             "title": "Max Knm",
             "type": "number"
           },
           "Max_reduced_kNm": {
-            "description": "Reduced additional moment x-axis (kN·m)",
+            "description": "Reduced additional moment x-axis (kN\u00b7m)",
             "title": "Max Reduced Knm",
             "type": "number"
           },
           "May_kNm": {
-            "description": "Additional moment about y-axis (kN·m)",
+            "description": "Additional moment about y-axis (kN\u00b7m)",
             "title": "May Knm",
             "type": "number"
           },
           "May_reduced_kNm": {
-            "description": "Reduced additional moment y-axis (kN·m)",
+            "description": "Reduced additional moment y-axis (kN\u00b7m)",
             "title": "May Reduced Knm",
             "type": "number"
           },
@@ -3524,14 +3576,14 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm²)",
+            "description": "Concrete strength (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -3539,7 +3591,7 @@
           },
           "has_standard_bend": {
             "default": true,
-            "description": "True if bar has 90° bend at support",
+            "description": "True if bar has 90\u00b0 bend at support",
             "title": "Has Standard Bend",
             "type": "boolean"
           },
@@ -3748,7 +3800,7 @@
         "description": "Reinforcement bar arrangement.",
         "properties": {
           "area_provided": {
-            "description": "Total area provided (mm²)",
+            "description": "Total area provided (mm\u00b2)",
             "title": "Area Provided",
             "type": "number"
           },
@@ -3787,7 +3839,7 @@
         "description": "Information about a single standard reinforcement bar.",
         "properties": {
           "area_mm2": {
-            "description": "Cross-sectional area in mm²",
+            "description": "Cross-sectional area in mm\u00b2",
             "title": "Area Mm2",
             "type": "number"
           },
@@ -4258,13 +4310,13 @@
         "properties": {
           "asc_provided": {
             "default": 0.0,
-            "description": "Provided compression reinforcement area Asc (mm²)",
+            "description": "Provided compression reinforcement area Asc (mm\u00b2)",
             "minimum": 0.0,
             "title": "Asc Provided",
             "type": "number"
           },
           "ast_provided": {
-            "description": "Provided tension reinforcement area Ast (mm²)",
+            "description": "Provided tension reinforcement area Ast (mm\u00b2)",
             "examples": [
               615.0,
               942.0,
@@ -4304,7 +4356,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm²)",
+            "description": "fck (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -4312,14 +4364,14 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm²)",
+            "description": "fy (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
             "type": "number"
           },
           "moment": {
-            "description": "Factored design moment Mu (kN·m)",
+            "description": "Factored design moment Mu (kN\u00b7m)",
             "minimum": 0.0,
             "title": "Moment",
             "type": "number"
@@ -4333,7 +4385,7 @@
           },
           "stirrup_area": {
             "default": 0.0,
-            "description": "Two-legged stirrup area Asv (mm²)",
+            "description": "Two-legged stirrup area Asv (mm\u00b2)",
             "examples": [
               100.5,
               157.0,
@@ -4387,7 +4439,7 @@
             "type": "string"
           },
           "moment_capacity": {
-            "description": "Moment capacity Mu,cap (kN·m)",
+            "description": "Moment capacity Mu,cap (kN\u00b7m)",
             "title": "Moment Capacity",
             "type": "number"
           },
@@ -4593,7 +4645,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "Characteristic compressive strength of concrete (N/mm²)",
+            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
             "examples": [
               20.0,
               25.0,
@@ -4607,7 +4659,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "Yield strength of reinforcement steel (N/mm²)",
+            "description": "Yield strength of reinforcement steel (N/mm\u00b2)",
             "examples": [
               415.0,
               500.0,
@@ -4633,7 +4685,7 @@
             "type": "number"
           },
           "moment": {
-            "description": "Factored design moment Mu (kN·m)",
+            "description": "Factored design moment Mu (kN\u00b7m)",
             "examples": [
               100.0,
               250.0,
@@ -4680,7 +4732,7 @@
                 "type": "null"
               }
             ],
-            "description": "Beam span (mm) — required when include_serviceability=True",
+            "description": "Beam span (mm) \u2014 required when include_serviceability=True",
             "title": "Span Mm"
           },
           "stirrup_dia_mm": {
@@ -4699,7 +4751,7 @@
           },
           "torsion": {
             "default": 0.0,
-            "description": "Factored design torsional moment Tu (kN·m)",
+            "description": "Factored design torsional moment Tu (kN\u00b7m)",
             "examples": [
               0.0,
               10.0,
@@ -4735,12 +4787,12 @@
         "properties": {
           "asc_total": {
             "default": 0.0,
-            "description": "Total compression steel (mm²)",
+            "description": "Total compression steel (mm\u00b2)",
             "title": "Asc Total",
             "type": "number"
           },
           "ast_total": {
-            "description": "Total tension steel required (mm²)",
+            "description": "Total tension steel required (mm\u00b2)",
             "title": "Ast Total",
             "type": "number"
           },
@@ -4868,20 +4920,20 @@
         "properties": {
           "asc_required": {
             "default": 0.0,
-            "description": "Required compression reinforcement area Asc (mm²)",
+            "description": "Required compression reinforcement area Asc (mm\u00b2)",
             "minimum": 0.0,
             "title": "Asc Required",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required tension reinforcement area Ast (mm²)",
+            "description": "Required tension reinforcement area Ast (mm\u00b2)",
             "exclusiveMinimum": 0.0,
             "title": "Ast Required",
             "type": "number"
           },
           "asv_required": {
             "default": 0.0,
-            "description": "Required stirrup area Asv (mm²/mm)",
+            "description": "Required stirrup area Asv (mm\u00b2/mm)",
             "minimum": 0.0,
             "title": "Asv Required",
             "type": "number"
@@ -4903,7 +4955,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm²)",
+            "description": "fck (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -4911,7 +4963,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm²)",
+            "description": "fy (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -4997,12 +5049,12 @@
           },
           "asc_provided": {
             "default": 0.0,
-            "description": "Compression steel provided (mm²)",
+            "description": "Compression steel provided (mm\u00b2)",
             "title": "Asc Provided",
             "type": "number"
           },
           "ast_provided": {
-            "description": "Total tension steel provided (mm²)",
+            "description": "Total tension steel provided (mm\u00b2)",
             "title": "Ast Provided",
             "type": "number"
           },
@@ -5107,21 +5159,21 @@
         "properties": {
           "ast_end": {
             "default": 500.0,
-            "description": "Tension steel at end (mm²)",
+            "description": "Tension steel at end (mm\u00b2)",
             "minimum": 0.0,
             "title": "Ast End",
             "type": "number"
           },
           "ast_mid": {
             "default": 400.0,
-            "description": "Tension steel at mid-span (mm²)",
+            "description": "Tension steel at mid-span (mm\u00b2)",
             "minimum": 0.0,
             "title": "Ast Mid",
             "type": "number"
           },
           "ast_start": {
             "default": 500.0,
-            "description": "Tension steel at start (mm²)",
+            "description": "Tension steel at start (mm\u00b2)",
             "minimum": 0.0,
             "title": "Ast Start",
             "type": "number"
@@ -5150,7 +5202,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm²)",
+            "description": "fck (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -5158,7 +5210,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm²)",
+            "description": "fy (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -5294,7 +5346,7 @@
           },
           "fck": {
             "default": 25,
-            "description": "Concrete grade (N/mm²)",
+            "description": "Concrete grade (N/mm\u00b2)",
             "title": "Fck",
             "type": "integer"
           },
@@ -5339,7 +5391,7 @@
           },
           "ast_provided": {
             "default": 0.0,
-            "description": "Steel area provided (mm²)",
+            "description": "Steel area provided (mm\u00b2)",
             "title": "Ast Provided",
             "type": "number"
           },
@@ -5413,13 +5465,13 @@
           },
           "fck_mpa": {
             "default": 25.0,
-            "description": "Concrete strength in N/mm²",
+            "description": "Concrete strength in N/mm\u00b2",
             "title": "Fck Mpa",
             "type": "number"
           },
           "fy_mpa": {
             "default": 500.0,
-            "description": "Steel strength in N/mm²",
+            "description": "Steel strength in N/mm\u00b2",
             "title": "Fy Mpa",
             "type": "number"
           },
@@ -5431,7 +5483,7 @@
           },
           "mu_knm": {
             "default": 0.0,
-            "description": "Design moment in kN·m",
+            "description": "Design moment in kN\u00b7m",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -5503,13 +5555,13 @@
           },
           "fck_mpa": {
             "default": 25.0,
-            "description": "Concrete strength in N/mm²",
+            "description": "Concrete strength in N/mm\u00b2",
             "title": "Fck Mpa",
             "type": "number"
           },
           "fy_mpa": {
             "default": 500.0,
-            "description": "Steel strength in N/mm²",
+            "description": "Steel strength in N/mm\u00b2",
             "title": "Fy Mpa",
             "type": "number"
           },
@@ -5521,7 +5573,7 @@
           },
           "mu_knm": {
             "default": 0.0,
-            "description": "Design moment in kN·m",
+            "description": "Design moment in kN\u00b7m",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -5589,7 +5641,7 @@
         "description": "Request model for biaxial bending check per IS 456 Cl 39.6 (Bresler load contour).",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area in mm²",
+            "description": "Total steel area in mm\u00b2",
             "examples": [
               2400.0,
               3600.0,
@@ -5670,7 +5722,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete grade (N/mm²)",
+            "description": "Concrete grade (N/mm\u00b2)",
             "examples": [
               20.0,
               25.0,
@@ -5682,7 +5734,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "examples": [
               415.0,
               500.0
@@ -5901,6 +5953,379 @@
           "max_z"
         ],
         "title": "BoundingBox",
+        "type": "object"
+      },
+      "BracedWallAxialResponse": {
+        "properties": {
+          "additional_eccentricity_mm": {
+            "title": "Additional Eccentricity Mm",
+            "type": "number"
+          },
+          "axial_capacity_kn_per_m": {
+            "title": "Axial Capacity Kn Per M",
+            "type": "number"
+          },
+          "axial_capacity_n_per_mm": {
+            "title": "Axial Capacity N Per Mm",
+            "type": "number"
+          },
+          "axial_demand_kn_per_m": {
+            "title": "Axial Demand Kn Per M",
+            "type": "number"
+          },
+          "axial_demand_n_per_mm": {
+            "title": "Axial Demand N Per Mm",
+            "type": "number"
+          },
+          "design_eccentricity_mm": {
+            "title": "Design Eccentricity Mm",
+            "type": "number"
+          },
+          "effective_compression_thickness_mm": {
+            "title": "Effective Compression Thickness Mm",
+            "type": "number"
+          },
+          "effective_height_mm": {
+            "title": "Effective Height Mm",
+            "type": "number"
+          },
+          "effective_height_to_thickness_ratio": {
+            "title": "Effective Height To Thickness Ratio",
+            "type": "number"
+          },
+          "load_generation_status": {
+            "title": "Load Generation Status",
+            "type": "string"
+          },
+          "minimum_eccentricity_mm": {
+            "title": "Minimum Eccentricity Mm",
+            "type": "number"
+          },
+          "source_refs": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Source Refs",
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "PASS",
+              "FAIL"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "total_axial_capacity_kn": {
+            "title": "Total Axial Capacity Kn",
+            "type": "number"
+          },
+          "utilization_ratio": {
+            "title": "Utilization Ratio",
+            "type": "number"
+          }
+        },
+        "required": [
+          "effective_height_mm",
+          "effective_height_to_thickness_ratio",
+          "minimum_eccentricity_mm",
+          "design_eccentricity_mm",
+          "additional_eccentricity_mm",
+          "effective_compression_thickness_mm",
+          "axial_capacity_n_per_mm",
+          "axial_capacity_kn_per_m",
+          "total_axial_capacity_kn",
+          "axial_demand_n_per_mm",
+          "axial_demand_kn_per_m",
+          "utilization_ratio",
+          "status",
+          "source_refs",
+          "load_generation_status"
+        ],
+        "title": "BracedWallAxialResponse",
+        "type": "object"
+      },
+      "BracedWallProvenanceResponse": {
+        "properties": {
+          "action_basis_reference": {
+            "title": "Action Basis Reference",
+            "type": "string"
+          },
+          "benchmark_id": {
+            "title": "Benchmark Id",
+            "type": "string"
+          },
+          "bracing_basis_reference": {
+            "title": "Bracing Basis Reference",
+            "type": "string"
+          },
+          "case_id": {
+            "title": "Case Id",
+            "type": "string"
+          },
+          "clause_refs": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Clause Refs",
+            "type": "array"
+          },
+          "code_edition": {
+            "title": "Code Edition",
+            "type": "string"
+          },
+          "load_generation_status": {
+            "title": "Load Generation Status",
+            "type": "string"
+          },
+          "reinforcement_basis_reference": {
+            "title": "Reinforcement Basis Reference",
+            "type": "string"
+          },
+          "schema_version": {
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "source_refs": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Source Refs",
+            "type": "array"
+          },
+          "workflow": {
+            "title": "Workflow",
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "code_edition",
+          "workflow",
+          "case_id",
+          "benchmark_id",
+          "load_generation_status",
+          "bracing_basis_reference",
+          "action_basis_reference",
+          "reinforcement_basis_reference",
+          "clause_refs",
+          "source_refs"
+        ],
+        "title": "BracedWallProvenanceResponse",
+        "type": "object"
+      },
+      "BracedWallRequest": {
+        "additionalProperties": false,
+        "description": "Explicit inputs for the sole supported Clause 32 wall case.",
+        "properties": {
+          "action_basis_reference": {
+            "minLength": 1,
+            "title": "Action Basis Reference",
+            "type": "string"
+          },
+          "bracing_basis_reference": {
+            "minLength": 1,
+            "title": "Bracing Basis Reference",
+            "type": "string"
+          },
+          "bracing_elements_in_two_directions": {
+            "const": true,
+            "default": true,
+            "title": "Bracing Elements In Two Directions",
+            "type": "boolean"
+          },
+          "case_id": {
+            "minLength": 1,
+            "title": "Case Id",
+            "type": "string"
+          },
+          "concrete_grade_nmm2": {
+            "enum": [
+              20,
+              25,
+              30,
+              35,
+              40,
+              45,
+              50,
+              55,
+              60
+            ],
+            "title": "Concrete Grade Nmm2",
+            "type": "integer"
+          },
+          "diaphragm_transfer_confirmed": {
+            "const": true,
+            "default": true,
+            "title": "Diaphragm Transfer Confirmed",
+            "type": "boolean"
+          },
+          "factored_axial_load_kn": {
+            "exclusiveMinimum": 0.0,
+            "title": "Factored Axial Load Kn",
+            "type": "number"
+          },
+          "horizontal_bar_diameter_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Horizontal Bar Diameter Mm",
+            "type": "number"
+          },
+          "horizontal_bar_spacing_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Horizontal Bar Spacing Mm",
+            "type": "number"
+          },
+          "lateral_connection_capacity_confirmed": {
+            "const": true,
+            "default": true,
+            "title": "Lateral Connection Capacity Confirmed",
+            "type": "boolean"
+          },
+          "lateral_forces_resisted_by_bracing_system": {
+            "const": true,
+            "default": true,
+            "title": "Lateral Forces Resisted By Bracing System",
+            "type": "boolean"
+          },
+          "lateral_restraint_spacing_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Lateral Restraint Spacing Mm",
+            "type": "number"
+          },
+          "reinforcement_basis_reference": {
+            "minLength": 1,
+            "title": "Reinforcement Basis Reference",
+            "type": "string"
+          },
+          "reinforcement_kind": {
+            "default": "deformed_415_or_greater",
+            "enum": [
+              "deformed_415_or_greater",
+              "other_bars",
+              "welded_wire_fabric"
+            ],
+            "title": "Reinforcement Kind",
+            "type": "string"
+          },
+          "rotation_restraint": {
+            "default": "restrained_both_ends",
+            "enum": [
+              "restrained_both_ends",
+              "not_restrained_both_ends"
+            ],
+            "title": "Rotation Restraint",
+            "type": "string"
+          },
+          "supplied_eccentricity_mm": {
+            "minimum": 0.0,
+            "title": "Supplied Eccentricity Mm",
+            "type": "number"
+          },
+          "unsupported_height_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Unsupported Height Mm",
+            "type": "number"
+          },
+          "vertical_bar_diameter_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Vertical Bar Diameter Mm",
+            "type": "number"
+          },
+          "vertical_bar_spacing_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Vertical Bar Spacing Mm",
+            "type": "number"
+          },
+          "wall_length_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Wall Length Mm",
+            "type": "number"
+          },
+          "wall_thickness_mm": {
+            "maximum": 200.0,
+            "minimum": 100.0,
+            "title": "Wall Thickness Mm",
+            "type": "number"
+          }
+        },
+        "required": [
+          "case_id",
+          "unsupported_height_mm",
+          "lateral_restraint_spacing_mm",
+          "wall_length_mm",
+          "wall_thickness_mm",
+          "concrete_grade_nmm2",
+          "factored_axial_load_kn",
+          "supplied_eccentricity_mm",
+          "vertical_bar_diameter_mm",
+          "vertical_bar_spacing_mm",
+          "horizontal_bar_diameter_mm",
+          "horizontal_bar_spacing_mm",
+          "bracing_basis_reference",
+          "action_basis_reference",
+          "reinforcement_basis_reference"
+        ],
+        "title": "BracedWallRequest",
+        "type": "object"
+      },
+      "BracedWallResponse": {
+        "description": "Typed transport subset of the composed wall result.",
+        "properties": {
+          "axial": {
+            "$ref": "#/components/schemas/BracedWallAxialResponse"
+          },
+          "case_id": {
+            "title": "Case Id",
+            "type": "string"
+          },
+          "complete_engineering_design_approved": {
+            "const": false,
+            "title": "Complete Engineering Design Approved",
+            "type": "boolean"
+          },
+          "held_cases": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Held Cases",
+            "type": "array"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/BracedWallProvenanceResponse"
+          },
+          "qualified_review_required": {
+            "const": true,
+            "title": "Qualified Review Required",
+            "type": "boolean"
+          },
+          "reinforcement": {
+            "$ref": "#/components/schemas/WallReinforcementResponse"
+          },
+          "status": {
+            "enum": [
+              "PASS",
+              "FAIL"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "supported_case": {
+            "title": "Supported Case",
+            "type": "string"
+          }
+        },
+        "required": [
+          "case_id",
+          "status",
+          "axial",
+          "reinforcement",
+          "supported_case",
+          "held_cases",
+          "provenance",
+          "qualified_review_required",
+          "complete_engineering_design_approved"
+        ],
+        "title": "BracedWallResponse",
         "type": "object"
       },
       "BuildingBeamModel": {
@@ -6934,7 +7359,7 @@
         ],
         "properties": {
           "Ag_mm2": {
-            "description": "Gross cross-sectional area of column (mm²)",
+            "description": "Gross cross-sectional area of column (mm\u00b2)",
             "examples": [
               90000.0,
               120000.0,
@@ -6946,7 +7371,7 @@
             "type": "number"
           },
           "Asc_mm2": {
-            "description": "Area of longitudinal reinforcement (mm²)",
+            "description": "Area of longitudinal reinforcement (mm\u00b2)",
             "examples": [
               1256.64,
               1800.0,
@@ -6957,7 +7382,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic compressive strength of concrete (N/mm²)",
+            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
             "examples": [
               20.0,
               25.0,
@@ -6970,7 +7395,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Yield strength of reinforcement steel (N/mm²)",
+            "description": "Yield strength of reinforcement steel (N/mm\u00b2)",
             "examples": [
               415.0,
               500.0,
@@ -6995,17 +7420,17 @@
         "description": "Response model for short column axial capacity.",
         "properties": {
           "Ac_mm2": {
-            "description": "Net concrete area Ag - Asc (mm²)",
+            "description": "Net concrete area Ag - Asc (mm\u00b2)",
             "title": "Ac Mm2",
             "type": "number"
           },
           "Ag_mm2": {
-            "description": "Gross cross-sectional area (mm²)",
+            "description": "Gross cross-sectional area (mm\u00b2)",
             "title": "Ag Mm2",
             "type": "number"
           },
           "Asc_mm2": {
-            "description": "Area of longitudinal steel (mm²)",
+            "description": "Area of longitudinal steel (mm\u00b2)",
             "title": "Asc Mm2",
             "type": "number"
           },
@@ -7015,17 +7440,17 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength used (N/mm²)",
+            "description": "Concrete strength used (N/mm\u00b2)",
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength used (N/mm²)",
+            "description": "Steel yield strength used (N/mm\u00b2)",
             "title": "Fy",
             "type": "number"
           },
           "is_safe": {
-            "description": "Whether steel ratio is within IS 456 limits (0.8%–6%)",
+            "description": "Whether steel ratio is within IS 456 limits (0.8%\u20136%)",
             "title": "Is Safe",
             "type": "boolean"
           },
@@ -7124,7 +7549,7 @@
         "description": "Request for unified column design per IS 456.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area (mm²)",
+            "description": "Total steel area (mm\u00b2)",
             "examples": [
               2400.0
             ],
@@ -7269,7 +7694,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "Concrete strength (N/mm²)",
+            "description": "Concrete strength (N/mm\u00b2)",
             "examples": [
               25.0
             ],
@@ -7280,7 +7705,7 @@
           },
           "fy": {
             "default": 415.0,
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "examples": [
               415.0
             ],
@@ -7538,7 +7963,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "Concrete grade (N/mm²)",
+            "description": "Concrete grade (N/mm\u00b2)",
             "examples": [
               20.0,
               25.0,
@@ -7551,7 +7976,7 @@
           },
           "fy": {
             "default": 415.0,
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "examples": [
               415.0,
               500.0
@@ -7810,7 +8235,7 @@
                 "type": "null"
               }
             ],
-            "description": "Gross area of column (mm²). Defaults to b×D if omitted.",
+            "description": "Gross area of column (mm\u00b2). Defaults to b\u00d7D if omitted.",
             "examples": [
               200000.0
             ],
@@ -7826,14 +8251,14 @@
                 "type": "null"
               }
             ],
-            "description": "Confined core area to hoop centerline (mm²). Estimated if omitted.",
+            "description": "Confined core area to hoop centerline (mm\u00b2). Estimated if omitted.",
             "examples": [
               102400.0
             ],
             "title": "Ak Mm2"
           },
           "D_mm": {
-            "description": "Column depth — longer dimension (mm)",
+            "description": "Column depth \u2014 longer dimension (mm)",
             "examples": [
               400.0,
               500.0,
@@ -7845,7 +8270,7 @@
             "type": "number"
           },
           "b_mm": {
-            "description": "Column width — shorter dimension (mm)",
+            "description": "Column width \u2014 shorter dimension (mm)",
             "examples": [
               300.0,
               400.0,
@@ -7880,7 +8305,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic concrete strength (N/mm²)",
+            "description": "Characteristic concrete strength (N/mm\u00b2)",
             "examples": [
               20.0,
               25.0,
@@ -7892,7 +8317,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Yield strength of steel (N/mm²)",
+            "description": "Yield strength of steel (N/mm\u00b2)",
             "examples": [
               415.0,
               500.0
@@ -8024,7 +8449,7 @@
         "description": "Request model for short column uniaxial bending design per IS 456 Cl 39.5.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total longitudinal reinforcement area, symmetrically placed (mm²)",
+            "description": "Total longitudinal reinforcement area, symmetrically placed (mm\u00b2)",
             "examples": [
               2700.0,
               1800.0,
@@ -8093,7 +8518,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic concrete strength (N/mm²)",
+            "description": "Characteristic concrete strength (N/mm\u00b2)",
             "examples": [
               20.0,
               25.0,
@@ -8105,7 +8530,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "examples": [
               415.0,
               500.0
@@ -8435,7 +8860,7 @@
             "type": "string"
           },
           "mu_knm": {
-            "description": "Factored moment (kN·m)",
+            "description": "Factored moment (kN\u00b7m)",
             "minimum": 0.0,
             "title": "Mu Knm",
             "type": "number"
@@ -8482,7 +8907,7 @@
             "type": "boolean"
           },
           "mu_knm": {
-            "description": "Applied moment (kN·m)",
+            "description": "Applied moment (kN\u00b7m)",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -8528,7 +8953,7 @@
           },
           "asv_mm2": {
             "default": 100.0,
-            "description": "Area of stirrup legs (mm²)",
+            "description": "Area of stirrup legs (mm\u00b2)",
             "minimum": 0.0,
             "title": "Asv Mm2",
             "type": "number"
@@ -8586,14 +9011,14 @@
             "description": "Default deflection parameters"
           },
           "fck_nmm2": {
-            "description": "Concrete strength (N/mm²)",
+            "description": "Concrete strength (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck Nmm2",
             "type": "number"
           },
           "fy_nmm2": {
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy Nmm2",
@@ -9195,7 +9620,7 @@
         "description": "Concrete quantities for one grade.",
         "properties": {
           "cost_inr": {
-            "description": "Cost in ₹",
+            "description": "Cost in \u20b9",
             "title": "Cost Inr",
             "type": "number"
           },
@@ -9205,7 +9630,7 @@
             "type": "string"
           },
           "total_volume_m3": {
-            "description": "Total volume in m³",
+            "description": "Total volume in m\u00b3",
             "title": "Total Volume M3",
             "type": "number"
           }
@@ -9486,27 +9911,27 @@
         "description": "Detailed cost breakdown.",
         "properties": {
           "concrete_cost": {
-            "description": "Cost of concrete (₹)",
+            "description": "Cost of concrete (\u20b9)",
             "title": "Concrete Cost",
             "type": "number"
           },
           "cost_per_meter": {
-            "description": "Cost per meter length (₹/m)",
+            "description": "Cost per meter length (\u20b9/m)",
             "title": "Cost Per Meter",
             "type": "number"
           },
           "formwork_cost": {
-            "description": "Cost of formwork (₹)",
+            "description": "Cost of formwork (\u20b9)",
             "title": "Formwork Cost",
             "type": "number"
           },
           "steel_cost": {
-            "description": "Cost of reinforcement (₹)",
+            "description": "Cost of reinforcement (\u20b9)",
             "title": "Steel Cost",
             "type": "number"
           },
           "total_cost": {
-            "description": "Total cost (₹)",
+            "description": "Total cost (\u20b9)",
             "title": "Total Cost",
             "type": "number"
           }
@@ -9535,7 +9960,7 @@
             "type": "string"
           },
           "estimated_concrete": {
-            "description": "Estimated concrete (m³/m)",
+            "description": "Estimated concrete (m\u00b3/m)",
             "title": "Estimated Concrete",
             "type": "number"
           },
@@ -9572,7 +9997,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm²)",
+            "description": "fck (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -9580,7 +10005,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm²)",
+            "description": "fy (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -9601,7 +10026,7 @@
             "type": "integer"
           },
           "moment": {
-            "description": "Factored design moment Mu (kN·m)",
+            "description": "Factored design moment Mu (kN\u00b7m)",
             "minimum": 0.0,
             "title": "Moment",
             "type": "number"
@@ -9699,7 +10124,7 @@
         "properties": {
           "concrete_cost": {
             "default": 6000.0,
-            "description": "Cost of concrete per m³ (₹/m³)",
+            "description": "Cost of concrete per m\u00b3 (\u20b9/m\u00b3)",
             "examples": [
               5000.0,
               6000.0,
@@ -9711,7 +10136,7 @@
           },
           "formwork_cost": {
             "default": 400.0,
-            "description": "Cost of formwork per m² (₹/m²)",
+            "description": "Cost of formwork per m\u00b2 (\u20b9/m\u00b2)",
             "examples": [
               350.0,
               400.0,
@@ -9723,7 +10148,7 @@
           },
           "steel_cost": {
             "default": 60.0,
-            "description": "Cost of reinforcement steel per kg (₹/kg)",
+            "description": "Cost of reinforcement steel per kg (\u20b9/kg)",
             "examples": [
               55.0,
               60.0,
@@ -9819,7 +10244,7 @@
           },
           "es_nmm2": {
             "default": 200000.0,
-            "description": "Modulus of elasticity of steel (N/mm²)",
+            "description": "Modulus of elasticity of steel (N/mm\u00b2)",
             "exclusiveMinimum": 0.0,
             "title": "Es Nmm2",
             "type": "number"
@@ -9840,7 +10265,7 @@
                 "type": "null"
               }
             ],
-            "description": "Steel stress at service (N/mm²)",
+            "description": "Steel stress at service (N/mm\u00b2)",
             "title": "Fs Service Nmm2"
           },
           "h_mm": {
@@ -10258,7 +10683,7 @@
             "type": "integer"
           },
           "total_concrete_m3": {
-            "description": "Total concrete volume (m³)",
+            "description": "Total concrete volume (m\u00b3)",
             "title": "Total Concrete M3",
             "type": "number"
           },
@@ -10765,14 +11190,14 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm²)",
+            "description": "Concrete strength (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -11026,7 +11451,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic compressive strength of concrete (N/mm²)",
+            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
             "examples": [
               20.0,
               25.0,
@@ -11075,22 +11500,22 @@
             "type": "number"
           },
           "is_capped": {
-            "description": "Whether τc' was capped at τc,max",
+            "description": "Whether \u03c4c' was capped at \u03c4c,max",
             "title": "Is Capped",
             "type": "boolean"
           },
           "tau_c_base": {
-            "description": "Base shear strength τc (N/mm²)",
+            "description": "Base shear strength \u03c4c (N/mm\u00b2)",
             "title": "Tau C Base",
             "type": "number"
           },
           "tau_c_enhanced": {
-            "description": "Enhanced shear strength τc' (N/mm²)",
+            "description": "Enhanced shear strength \u03c4c' (N/mm\u00b2)",
             "title": "Tau C Enhanced",
             "type": "number"
           },
           "tau_c_max": {
-            "description": "Maximum shear stress τc,max (N/mm²)",
+            "description": "Maximum shear stress \u03c4c,max (N/mm\u00b2)",
             "title": "Tau C Max",
             "type": "number"
           }
@@ -11235,13 +11660,13 @@
         "properties": {
           "asc_required": {
             "default": 0,
-            "description": "Required compression steel mm²",
+            "description": "Required compression steel mm\u00b2",
             "minimum": 0.0,
             "title": "Asc Required",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required tension steel mm²",
+            "description": "Required tension steel mm\u00b2",
             "minimum": 0.0,
             "title": "Ast Required",
             "type": "number"
@@ -11268,13 +11693,13 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete grade N/mm²",
+            "description": "Concrete grade N/mm\u00b2",
             "exclusiveMinimum": 0.0,
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel grade N/mm²",
+            "description": "Steel grade N/mm\u00b2",
             "exclusiveMinimum": 0.0,
             "title": "Fy",
             "type": "number"
@@ -11286,7 +11711,7 @@
           },
           "moment": {
             "default": 0,
-            "description": "Design moment kN·m",
+            "description": "Design moment kN\u00b7m",
             "minimum": 0.0,
             "title": "Moment",
             "type": "number"
@@ -11520,22 +11945,22 @@
         "properties": {
           "asc_required": {
             "default": 0.0,
-            "description": "Compression steel if needed (mm²)",
+            "description": "Compression steel if needed (mm\u00b2)",
             "title": "Asc Required",
             "type": "number"
           },
           "ast_max": {
-            "description": "Maximum allowed steel area (mm²)",
+            "description": "Maximum allowed steel area (mm\u00b2)",
             "title": "Ast Max",
             "type": "number"
           },
           "ast_min": {
-            "description": "Minimum required steel area (mm²)",
+            "description": "Minimum required steel area (mm\u00b2)",
             "title": "Ast Min",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required tension steel area (mm²)",
+            "description": "Required tension steel area (mm\u00b2)",
             "title": "Ast Required",
             "type": "number"
           },
@@ -11545,7 +11970,7 @@
             "type": "boolean"
           },
           "moment_capacity": {
-            "description": "Singly reinforced limiting moment Mu,lim (kN·m)",
+            "description": "Singly reinforced limiting moment Mu,lim (kN\u00b7m)",
             "title": "Moment Capacity",
             "type": "number"
           },
@@ -13215,7 +13640,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm²)",
+            "description": "Concrete strength (N/mm\u00b2)",
             "examples": [
               25.0
             ],
@@ -13225,7 +13650,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "examples": [
               415.0
             ],
@@ -13696,22 +14121,22 @@
         "description": "Torsion calculation details embedded in the primary beam result.",
         "properties": {
           "al_torsion": {
-            "description": "Longitudinal torsion steel (mm²)",
+            "description": "Longitudinal torsion steel (mm\u00b2)",
             "title": "Al Torsion",
             "type": "number"
           },
           "asv_shear": {
-            "description": "Shear stirrup demand (mm²/mm)",
+            "description": "Shear stirrup demand (mm\u00b2/mm)",
             "title": "Asv Shear",
             "type": "number"
           },
           "asv_torsion": {
-            "description": "Torsion stirrup demand (mm²/mm)",
+            "description": "Torsion stirrup demand (mm\u00b2/mm)",
             "title": "Asv Torsion",
             "type": "number"
           },
           "asv_total": {
-            "description": "Combined stirrup demand (mm²/mm)",
+            "description": "Combined stirrup demand (mm\u00b2/mm)",
             "title": "Asv Total",
             "type": "number"
           },
@@ -13750,17 +14175,17 @@
             "type": "number"
           },
           "tau_c": {
-            "description": "Concrete shear strength (N/mm²)",
+            "description": "Concrete shear strength (N/mm\u00b2)",
             "title": "Tau C",
             "type": "number"
           },
           "tau_c_max": {
-            "description": "Maximum shear stress (N/mm²)",
+            "description": "Maximum shear stress (N/mm\u00b2)",
             "title": "Tau C Max",
             "type": "number"
           },
           "tau_ve": {
-            "description": "Equivalent shear stress (N/mm²)",
+            "description": "Equivalent shear stress (N/mm\u00b2)",
             "title": "Tau Ve",
             "type": "number"
           }
@@ -13947,7 +14372,7 @@
         "description": "Request for long (slender) column design per IS 456 Cl 39.7.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area (mm²)",
+            "description": "Total steel area (mm\u00b2)",
             "examples": [
               2400.0
             ],
@@ -14036,7 +14461,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm²)",
+            "description": "Concrete strength (N/mm\u00b2)",
             "examples": [
               25.0
             ],
@@ -14046,7 +14471,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm²)",
+            "description": "Steel yield strength (N/mm\u00b2)",
             "examples": [
               415.0
             ],
@@ -14709,17 +15134,17 @@
         "properties": {
           "asc_required": {
             "default": 0.0,
-            "description": "Compression steel (mm²)",
+            "description": "Compression steel (mm\u00b2)",
             "title": "Asc Required",
             "type": "number"
           },
           "ast_required": {
-            "description": "Tension steel required (mm²)",
+            "description": "Tension steel required (mm\u00b2)",
             "title": "Ast Required",
             "type": "number"
           },
           "concrete_volume": {
-            "description": "Concrete volume (m³/m)",
+            "description": "Concrete volume (m\u00b3/m)",
             "title": "Concrete Volume",
             "type": "number"
           },
@@ -14732,7 +15157,7 @@
             "type": "number"
           },
           "formwork_area": {
-            "description": "Formwork area (m²/m)",
+            "description": "Formwork area (m\u00b2/m)",
             "title": "Formwork Area",
             "type": "number"
           },
@@ -14787,7 +15212,7 @@
         "description": "Request model for P-M interaction curve generation.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total area of longitudinal reinforcement (mm²)",
+            "description": "Total area of longitudinal reinforcement (mm\u00b2)",
             "examples": [
               2400.0,
               3000.0,
@@ -14834,7 +15259,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic compressive strength of concrete (N/mm²)",
+            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
             "examples": [
               25.0,
               30.0,
@@ -14846,7 +15271,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Characteristic yield strength of steel (N/mm²)",
+            "description": "Characteristic yield strength of steel (N/mm\u00b2)",
             "examples": [
               415.0,
               500.0
@@ -14884,7 +15309,7 @@
         "description": "Response model for P-M interaction curve.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area (mm²)",
+            "description": "Total steel area (mm\u00b2)",
             "title": "Asc Mm2",
             "type": "number"
           },
@@ -14894,12 +15319,12 @@
             "type": "number"
           },
           "Mu_0_kNm": {
-            "description": "Pure bending capacity (kN·m)",
+            "description": "Pure bending capacity (kN\u00b7m)",
             "title": "Mu 0 Knm",
             "type": "number"
           },
           "Mu_bal_kNm": {
-            "description": "Balanced point moment capacity (kN·m)",
+            "description": "Balanced point moment capacity (kN\u00b7m)",
             "title": "Mu Bal Knm",
             "type": "number"
           },
@@ -14930,12 +15355,12 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength used (N/mm²)",
+            "description": "Concrete strength used (N/mm\u00b2)",
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength used (N/mm²)",
+            "description": "Steel yield strength used (N/mm\u00b2)",
             "title": "Fy",
             "type": "number"
           },
@@ -14976,7 +15401,7 @@
         "description": "A single point on the P-M interaction curve.",
         "properties": {
           "Mu_kNm": {
-            "description": "Moment (kN·m)",
+            "description": "Moment (kN\u00b7m)",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -15002,12 +15427,12 @@
             "type": "integer"
           },
           "ast_provided": {
-            "description": "Provided steel area (mm²)",
+            "description": "Provided steel area (mm\u00b2)",
             "title": "Ast Provided",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required steel area (mm²)",
+            "description": "Required steel area (mm\u00b2)",
             "title": "Ast Required",
             "type": "number"
           },
@@ -15037,12 +15462,12 @@
             "type": "integer"
           },
           "fck_nmm2": {
-            "description": "Concrete grade (N/mm²)",
+            "description": "Concrete grade (N/mm\u00b2)",
             "title": "Fck Nmm2",
             "type": "integer"
           },
           "fy_nmm2": {
-            "description": "Steel grade (N/mm²)",
+            "description": "Steel grade (N/mm\u00b2)",
             "title": "Fy Nmm2",
             "type": "integer"
           },
@@ -15114,7 +15539,7 @@
             "type": "integer"
           },
           "mu_knm": {
-            "description": "Factored bending moment (kN·m)",
+            "description": "Factored bending moment (kN\u00b7m)",
             "examples": [
               120.0,
               200.0
@@ -15325,7 +15750,7 @@
                 "type": "null"
               }
             ],
-            "description": "Concrete costs by grade {fck: ₹/m³}. Defaults: {25: 6000, 30: 7000, 35: 8000, 40: 9500}",
+            "description": "Concrete costs by grade {fck: \u20b9/m\u00b3}. Defaults: {25: 6000, 30: 7000, 35: 8000, 40: 9500}",
             "title": "Concrete Costs"
           },
           "dataset": {
@@ -15348,7 +15773,7 @@
           },
           "steel_cost_per_kg": {
             "default": 60.0,
-            "description": "Steel rate ₹/kg",
+            "description": "Steel rate \u20b9/kg",
             "exclusiveMinimum": 0.0,
             "title": "Steel Cost Per Kg",
             "type": "number"
@@ -15383,12 +15808,12 @@
             "$ref": "#/components/schemas/BOQEvidenceResponse"
           },
           "grand_total_concrete_m3": {
-            "description": "Total concrete volume in m³",
+            "description": "Total concrete volume in m\u00b3",
             "title": "Grand Total Concrete M3",
             "type": "number"
           },
           "grand_total_cost_inr": {
-            "description": "Grand total cost in ₹",
+            "description": "Grand total cost in \u20b9",
             "title": "Grand Total Cost Inr",
             "type": "number"
           },
@@ -15491,7 +15916,7 @@
                 "type": "null"
               }
             ],
-            "description": "Steel area provided (mm²)",
+            "description": "Steel area provided (mm\u00b2)",
             "title": "Ast Provided Mm2"
           },
           "geometry": {
@@ -15647,7 +16072,7 @@
         "properties": {
           "ast_mm2": {
             "default": 0.0,
-            "description": "Steel area (mm²)",
+            "description": "Steel area (mm\u00b2)",
             "title": "Ast Mm2",
             "type": "number"
           },
@@ -15757,12 +16182,12 @@
         "properties": {
           "ast_provided": {
             "default": 0.0,
-            "description": "Current steel area (mm²)",
+            "description": "Current steel area (mm\u00b2)",
             "title": "Ast Provided",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required steel area (mm²)",
+            "description": "Required steel area (mm\u00b2)",
             "minimum": 0.0,
             "title": "Ast Required",
             "type": "number"
@@ -15814,7 +16239,7 @@
             "type": "string"
           },
           "current_ast_mm2": {
-            "description": "Current steel area (mm²)",
+            "description": "Current steel area (mm\u00b2)",
             "title": "Current Ast Mm2",
             "type": "number"
           },
@@ -15829,7 +16254,7 @@
             "type": "string"
           },
           "min_ast_mm2": {
-            "description": "Minimum required steel area (mm²)",
+            "description": "Minimum required steel area (mm\u00b2)",
             "title": "Min Ast Mm2",
             "type": "number"
           },
@@ -16056,13 +16481,13 @@
         "description": "Shear design result.",
         "properties": {
           "asv_required": {
-            "description": "Required stirrup area (mm²/mm)",
+            "description": "Required stirrup area (mm\u00b2/mm)",
             "title": "Asv Required",
             "type": "number"
           },
           "asv_required_unit": {
-            "const": "mm²/mm",
-            "default": "mm²/mm",
+            "const": "mm\u00b2/mm",
+            "default": "mm\u00b2/mm",
             "description": "Unit of asv_required (stirrup area per unit spacing)",
             "title": "Asv Required Unit",
             "type": "string"
@@ -16083,17 +16508,17 @@
             "type": "number"
           },
           "tau_c": {
-            "description": "Concrete shear strength (N/mm²)",
+            "description": "Concrete shear strength (N/mm\u00b2)",
             "title": "Tau C",
             "type": "number"
           },
           "tau_c_max": {
-            "description": "Maximum shear stress limit (N/mm²)",
+            "description": "Maximum shear stress limit (N/mm\u00b2)",
             "title": "Tau C Max",
             "type": "number"
           },
           "tau_v": {
-            "description": "Nominal shear stress (N/mm²)",
+            "description": "Nominal shear stress (N/mm\u00b2)",
             "title": "Tau V",
             "type": "number"
           }
@@ -16327,7 +16752,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm²)",
+            "description": "fck (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -16335,7 +16760,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm²)",
+            "description": "fy (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -16354,7 +16779,7 @@
             "type": "boolean"
           },
           "moment": {
-            "description": "Factored moment Mu (kN·m)",
+            "description": "Factored moment Mu (kN\u00b7m)",
             "minimum": 0.0,
             "title": "Moment",
             "type": "number"
@@ -16565,7 +16990,7 @@
         "description": "Steel quantities for one grade.",
         "properties": {
           "cost_inr": {
-            "description": "Cost in ₹",
+            "description": "Cost in \u20b9",
             "title": "Cost Inr",
             "type": "number"
           },
@@ -16592,7 +17017,7 @@
         "description": "Stirrup arrangement.",
         "properties": {
           "area_per_meter": {
-            "description": "Asv/sv provided (mm²/mm)",
+            "description": "Asv/sv provided (mm\u00b2/mm)",
             "title": "Area Per Meter",
             "type": "number"
           },
@@ -16703,12 +17128,12 @@
             "type": "integer"
           },
           "concrete_m3": {
-            "description": "Total concrete in m³",
+            "description": "Total concrete in m\u00b3",
             "title": "Concrete M3",
             "type": "number"
           },
           "cost_inr": {
-            "description": "Total cost in ₹",
+            "description": "Total cost in \u20b9",
             "title": "Cost Inr",
             "type": "number"
           },
@@ -17403,7 +17828,7 @@
             "type": "object"
           },
           "title": {
-            "description": "Short title (e.g., '4Ø16mm')",
+            "description": "Short title (e.g., '4\u00d816mm')",
             "title": "Title",
             "type": "string"
           }
@@ -17491,7 +17916,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "Characteristic compressive strength of concrete (N/mm²)",
+            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -17499,14 +17924,14 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "Yield strength of reinforcement steel (N/mm²)",
+            "description": "Yield strength of reinforcement steel (N/mm\u00b2)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
             "type": "number"
           },
           "moment": {
-            "description": "Factored bending moment Mu (kN·m)",
+            "description": "Factored bending moment Mu (kN\u00b7m)",
             "examples": [
               100.0,
               250.0
@@ -17543,7 +17968,7 @@
             "type": "number"
           },
           "torsion": {
-            "description": "Factored torsional moment Tu (kN·m)",
+            "description": "Factored torsional moment Tu (kN\u00b7m)",
             "examples": [
               5.0,
               15.0,
@@ -17579,22 +18004,22 @@
         "description": "Response model for torsion design.",
         "properties": {
           "al_torsion": {
-            "description": "Longitudinal steel for torsion (mm²)",
+            "description": "Longitudinal steel for torsion (mm\u00b2)",
             "title": "Al Torsion",
             "type": "number"
           },
           "asv_shear": {
-            "description": "Stirrup area for shear (mm²/mm)",
+            "description": "Stirrup area for shear (mm\u00b2/mm)",
             "title": "Asv Shear",
             "type": "number"
           },
           "asv_torsion": {
-            "description": "Stirrup area for torsion (mm²/mm)",
+            "description": "Stirrup area for torsion (mm\u00b2/mm)",
             "title": "Asv Torsion",
             "type": "number"
           },
           "asv_total": {
-            "description": "Total stirrup area (mm²/mm)",
+            "description": "Total stirrup area (mm\u00b2/mm)",
             "title": "Asv Total",
             "type": "number"
           },
@@ -17604,7 +18029,7 @@
             "type": "boolean"
           },
           "me_knm": {
-            "description": "Equivalent moment Me (kN·m)",
+            "description": "Equivalent moment Me (kN\u00b7m)",
             "title": "Me Knm",
             "type": "number"
           },
@@ -17614,7 +18039,7 @@
             "type": "string"
           },
           "mu_knm": {
-            "description": "Applied bending moment (kN·m)",
+            "description": "Applied bending moment (kN\u00b7m)",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -17635,22 +18060,22 @@
             "type": "boolean"
           },
           "tc": {
-            "description": "Concrete shear strength τc (N/mm²)",
+            "description": "Concrete shear strength \u03c4c (N/mm\u00b2)",
             "title": "Tc",
             "type": "number"
           },
           "tc_max": {
-            "description": "Maximum shear stress limit τc,max (N/mm²)",
+            "description": "Maximum shear stress limit \u03c4c,max (N/mm\u00b2)",
             "title": "Tc Max",
             "type": "number"
           },
           "tu_knm": {
-            "description": "Applied torsional moment (kN·m)",
+            "description": "Applied torsional moment (kN\u00b7m)",
             "title": "Tu Knm",
             "type": "number"
           },
           "tv_equiv": {
-            "description": "Equivalent shear stress τve (N/mm²)",
+            "description": "Equivalent shear stress \u03c4ve (N/mm\u00b2)",
             "title": "Tv Equiv",
             "type": "number"
           },
@@ -18035,6 +18460,109 @@
           "ok"
         ],
         "title": "ValidationResult",
+        "type": "object"
+      },
+      "WallDirectionalReinforcementResponse": {
+        "properties": {
+          "area_status": {
+            "enum": [
+              "PASS",
+              "FAIL"
+            ],
+            "title": "Area Status",
+            "type": "string"
+          },
+          "maximum_spacing_mm": {
+            "title": "Maximum Spacing Mm",
+            "type": "number"
+          },
+          "minimum_ratio": {
+            "title": "Minimum Ratio",
+            "type": "number"
+          },
+          "provided_area_mm2_per_m": {
+            "title": "Provided Area Mm2 Per M",
+            "type": "number"
+          },
+          "provided_ratio": {
+            "title": "Provided Ratio",
+            "type": "number"
+          },
+          "provided_spacing_mm": {
+            "title": "Provided Spacing Mm",
+            "type": "number"
+          },
+          "required_area_mm2_per_m": {
+            "title": "Required Area Mm2 Per M",
+            "type": "number"
+          },
+          "spacing_status": {
+            "enum": [
+              "PASS",
+              "FAIL"
+            ],
+            "title": "Spacing Status",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "PASS",
+              "FAIL"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "minimum_ratio",
+          "required_area_mm2_per_m",
+          "provided_area_mm2_per_m",
+          "provided_ratio",
+          "maximum_spacing_mm",
+          "provided_spacing_mm",
+          "area_status",
+          "spacing_status",
+          "status"
+        ],
+        "title": "WallDirectionalReinforcementResponse",
+        "type": "object"
+      },
+      "WallReinforcementResponse": {
+        "properties": {
+          "horizontal": {
+            "$ref": "#/components/schemas/WallDirectionalReinforcementResponse"
+          },
+          "source_refs": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Source Refs",
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "PASS",
+              "FAIL"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "transverse_enclosure_required": {
+            "title": "Transverse Enclosure Required",
+            "type": "boolean"
+          },
+          "vertical": {
+            "$ref": "#/components/schemas/WallDirectionalReinforcementResponse"
+          }
+        },
+        "required": [
+          "vertical",
+          "horizontal",
+          "transverse_enclosure_required",
+          "status",
+          "source_refs"
+        ],
+        "title": "WallReinforcementResponse",
         "type": "object"
       },
       "WorkflowAuditModel": {
@@ -18652,7 +19180,7 @@
           },
           "mu_knm": {
             "default": 100.0,
-            "description": "Design moment (kN·m)",
+            "description": "Design moment (kN\u00b7m)",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -18719,7 +19247,7 @@
       "name": "Structural Engineering Library",
       "url": "https://github.com/yourusername/structural_engineering_lib"
     },
-    "description": "\n## IS 456:2000 Compliant Structural Engineering Library\n\nThis API exposes the library's route-specific supported IS 456:2000 reinforced\nconcrete calculations. Each result remains subject to the documented case\nboundary and qualified engineering review.\n\n### Features\n\n- **Beam Design**: Flexure, shear, and combined design calculations\n- **Column Design**: Bounded rectangular short/long-column workflows\n- **Footing Design**: Isolated-footing checks and concentric load transfer\n- **Slab Design**: Bounded simply supported one-way slab strip\n- **Staircase Design**: Bounded longitudinal straight waist-slab flight\n- **Detailing**: Reinforcement layout, spacing, and development lengths\n- **Optimization**: Cost-optimized beam cross-section selection\n- **Smart Analysis**: AI-assisted design suggestions and insights\n- **3D Geometry**: Visualization-ready mesh generation\n\n### Design Codes\n\n- IS 456:2000 - Plain and Reinforced Concrete\n- IS 13920 - Ductile Detailing for Seismic Resistance\n\n### Units\n\nAll inputs and outputs use consistent units:\n- **Length**: millimeters (mm)\n- **Force**: kilonewtons (kN)\n- **Moment**: kilonewton-meters (kN·m)\n- **Stress**: N/mm² (MPa)\n- **Area**: mm²\n",
+    "description": "\n## IS 456:2000 Compliant Structural Engineering Library\n\nThis API exposes the library's route-specific supported IS 456:2000 reinforced\nconcrete calculations. Each result remains subject to the documented case\nboundary and qualified engineering review.\n\n### Features\n\n- **Beam Design**: Flexure, shear, and combined design calculations\n- **Column Design**: Bounded rectangular short/long-column workflows\n- **Footing Design**: Isolated-footing checks and concentric load transfer\n- **Slab Design**: Bounded simply supported one-way slab strip\n- **Staircase Design**: Bounded longitudinal straight waist-slab flight\n- **Wall Design**: Bounded Clause 32 braced-wall axial and reinforcement checks\n- **Detailing**: Reinforcement layout, spacing, and development lengths\n- **Optimization**: Cost-optimized beam cross-section selection\n- **Smart Analysis**: AI-assisted design suggestions and insights\n- **3D Geometry**: Visualization-ready mesh generation\n\n### Design Codes\n\n- IS 456:2000 - Plain and Reinforced Concrete\n- IS 13920 - Ductile Detailing for Seismic Resistance\n\n### Units\n\nAll inputs and outputs use consistent units:\n- **Length**: millimeters (mm)\n- **Force**: kilonewtons (kN)\n- **Moment**: kilonewton-meters (kN\u00b7m)\n- **Stress**: N/mm\u00b2 (MPa)\n- **Area**: mm\u00b2\n",
     "license": {
       "name": "MIT License",
       "url": "https://opensource.org/licenses/MIT"
@@ -19181,7 +19709,7 @@
     },
     "/api/v1/design/beam/enhanced-shear": {
       "post": {
-        "description": "Calculate enhanced design shear strength τc' for sections close to supports per IS 456:2000 Cl 40.3. Applies when a concentrated load acts within 2d of the face of support.",
+        "description": "Calculate enhanced design shear strength \u03c4c' for sections close to supports per IS 456:2000 Cl 40.3. Applies when a concentrated load acts within 2d of the face of support.",
         "operationId": "enhanced_shear_api_v1_design_beam_enhanced_shear_post",
         "requestBody": {
           "content": {
@@ -19307,7 +19835,7 @@
     },
     "/api/v1/design/column": {
       "post": {
-        "description": "Complete column design check — classifies the column, computes effective length, applies minimum eccentricity, checks axial and bending capacity per the appropriate IS 456 clause.",
+        "description": "Complete column design check \u2014 classifies the column, computes effective length, applies minimum eccentricity, checks axial and bending capacity per the appropriate IS 456 clause.",
         "operationId": "design_column_api_v1_design_column_post",
         "requestBody": {
           "content": {
@@ -19349,7 +19877,7 @@
     },
     "/api/v1/design/column/additional-moment": {
       "post": {
-        "description": "Calculate additional moment Ma = Pu × eadd for slender columns, where eadd = D × (le/D)² / 2000. Includes k-factor reduction per Cl 39.7.1.1.",
+        "description": "Calculate additional moment Ma = Pu \u00d7 eadd for slender columns, where eadd = D \u00d7 (le/D)\u00b2 / 2000. Includes k-factor reduction per Cl 39.7.1.1.",
         "operationId": "additional_moment_api_v1_design_column_additional_moment_post",
         "requestBody": {
           "content": {
@@ -19391,7 +19919,7 @@
     },
     "/api/v1/design/column/axial": {
       "post": {
-        "description": "Calculate the axial load capacity of a short column under pure axial load (or minimum eccentricity) per IS 456:2000 Cl. 39.3: Pu = 0.4·fck·Ac + 0.67·fy·Asc.",
+        "description": "Calculate the axial load capacity of a short column under pure axial load (or minimum eccentricity) per IS 456:2000 Cl. 39.3: Pu = 0.4\u00b7fck\u00b7Ac + 0.67\u00b7fy\u00b7Asc.",
         "operationId": "column_axial_capacity_api_v1_design_column_axial_post",
         "requestBody": {
           "content": {
@@ -19433,7 +19961,7 @@
     },
     "/api/v1/design/column/biaxial-check": {
       "post": {
-        "description": "Check a column section under biaxial bending using the Bresler load contour method per IS 456:2000 Cl. 39.6. Returns the interaction ratio (Mux/Mux1)^αn + (Muy/Muy1)^αn and safety status.",
+        "description": "Check a column section under biaxial bending using the Bresler load contour method per IS 456:2000 Cl. 39.6. Returns the interaction ratio (Mux/Mux1)^\u03b1n + (Muy/Muy1)^\u03b1n and safety status.",
         "operationId": "biaxial_check_api_v1_design_column_biaxial_check_post",
         "requestBody": {
           "content": {
@@ -19643,7 +20171,7 @@
     },
     "/api/v1/design/column/effective-length": {
       "post": {
-        "description": "Calculate the effective length of a column based on end restraint conditions per IS 456:2000 Cl. 25.2, Table 28. Returns le = ratio × l for seven standard end-condition cases.",
+        "description": "Calculate the effective length of a column based on end restraint conditions per IS 456:2000 Cl. 25.2, Table 28. Returns le = ratio \u00d7 l for seven standard end-condition cases.",
         "operationId": "calculate_effective_length_api_v1_design_column_effective_length_post",
         "requestBody": {
           "content": {
@@ -20265,6 +20793,48 @@
         "summary": "Design a bounded straight-flight waist-slab staircase",
         "tags": [
           "staircase"
+        ]
+      }
+    },
+    "/api/v1/design/wall/braced-axial": {
+      "post": {
+        "description": "Validate transport inputs and delegate all calculation to the service.",
+        "operationId": "design_braced_wall_api_v1_design_wall_braced_axial_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BracedWallRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse_BracedWallResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed"
+          }
+        },
+        "summary": "Check a bounded Clause 32 braced wall",
+        "tags": [
+          "wall"
         ]
       }
     },
@@ -21897,6 +22467,10 @@
     {
       "description": "Bounded straight-flight staircase design and maintained evidence.",
       "name": "staircase"
+    },
+    {
+      "description": "Bounded Clause 32 braced-wall checks and maintained evidence.",
+      "name": "wall"
     },
     {
       "description": "Reinforcement detailing including bar layout, spacing, and anchorage.",

--- a/fastapi_app/routers/__init__.py
+++ b/fastapi_app/routers/__init__.py
@@ -21,6 +21,7 @@ from fastapi_app.routers import (
     rebar,
     staircase,
     streaming,
+    wall,
     websocket,
     workflows,
 )
@@ -42,6 +43,7 @@ __all__ = [
     "rebar",
     "staircase",
     "streaming",
+    "wall",
     "websocket",
     "workflows",
 ]

--- a/fastapi_app/routers/index.json
+++ b/fastapi_app/routers/index.json
@@ -2,22 +2,22 @@
   "folder": "fastapi_app/routers",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-15",
-  "file_count": 20,
+  "last_updated": "2026-08-16",
+  "file_count": 21,
   "files": [
     {
       "name": "__init__.py",
       "type": "python",
-      "size_lines": 48,
-      "last_updated": "2026-08-15",
+      "size_lines": 50,
+      "last_updated": "2026-08-16",
       "description": "FastAPI Routers Package.",
-      "content_hash": "4b42c977ea21"
+      "content_hash": "b3d691cb13cb"
     },
     {
       "name": "analysis.py",
       "type": "python",
       "size_lines": 338,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Smart Analysis Router.",
       "functions": [
         {
@@ -45,7 +45,7 @@
       "name": "capabilities.py",
       "type": "python",
       "size_lines": 23,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Public discovery route for the canonical supported IS 456 contract.",
       "functions": [
         {
@@ -59,7 +59,7 @@
       "name": "catalog.py",
       "type": "python",
       "size_lines": 51,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Thin read-only transport for the canonical application workflow catalogue.",
       "functions": [
         {
@@ -77,7 +77,7 @@
       "name": "column.py",
       "type": "python",
       "size_lines": 764,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Column Design Router.",
       "functions": [
         {
@@ -178,7 +178,7 @@
       "name": "design.py",
       "type": "python",
       "size_lines": 1027,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Beam Design Router.",
       "functions": [
         {
@@ -255,7 +255,7 @@
       "name": "detailing.py",
       "type": "python",
       "size_lines": 412,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Beam Detailing Router.",
       "functions": [
         {
@@ -293,7 +293,7 @@
       "name": "export.py",
       "type": "python",
       "size_lines": 805,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Export Router — BBS, DXF, and Report exports.",
       "classes": [
         {
@@ -362,7 +362,7 @@
       "name": "footing.py",
       "type": "python",
       "size_lines": 69,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "FastAPI transport for the bounded concentric isolated-footing service.",
       "functions": [
         {
@@ -379,7 +379,7 @@
       "name": "geometry.py",
       "type": "python",
       "size_lines": 653,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "3D Geometry Router.",
       "functions": [
         {
@@ -421,7 +421,7 @@
       "name": "health.py",
       "type": "python",
       "size_lines": 208,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Health Check Router.",
       "classes": [
         {
@@ -460,7 +460,7 @@
       "name": "imports.py",
       "type": "python",
       "size_lines": 992,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "CSV Import Router.",
       "classes": [
         {
@@ -548,7 +548,7 @@
       "name": "insights.py",
       "type": "python",
       "size_lines": 579,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Insights Router.",
       "classes": [
         {
@@ -636,7 +636,7 @@
       "name": "library_core.py",
       "type": "python",
       "size_lines": 229,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Thin FastAPI consumers for the supported footing and slab library routes.",
       "functions": [
         {
@@ -695,7 +695,7 @@
       "name": "optimization.py",
       "type": "python",
       "size_lines": 331,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Cost Optimization Router.",
       "functions": [
         {
@@ -723,7 +723,7 @@
       "name": "rebar.py",
       "type": "python",
       "size_lines": 269,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Rebar Validation and Application Router.",
       "classes": [
         {
@@ -777,7 +777,7 @@
       "name": "staircase.py",
       "type": "python",
       "size_lines": 66,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "FastAPI transport for the bounded straight-flight staircase service.",
       "functions": [
         {
@@ -794,7 +794,7 @@
       "name": "streaming.py",
       "type": "python",
       "size_lines": 351,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Server-Sent Events (SSE) Router for Batch Processing.",
       "classes": [
         {
@@ -847,10 +847,27 @@
       "content_hash": "43cf71831126"
     },
     {
+      "name": "wall.py",
+      "type": "python",
+      "size_lines": 117,
+      "last_updated": "2026-08-16",
+      "description": "FastAPI transport for the bounded braced-wall service.",
+      "functions": [
+        {
+          "name": "design_braced_wall",
+          "description": "Validate transport inputs and delegate all calculation to the service.",
+          "params": [
+            "request"
+          ]
+        }
+      ],
+      "content_hash": "86ff00d4e37c"
+    },
+    {
       "name": "websocket.py",
       "type": "python",
       "size_lines": 428,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "WebSocket Router for Live Design Updates.",
       "classes": [
         {
@@ -905,7 +922,7 @@
       "name": "workflows.py",
       "type": "python",
       "size_lines": 172,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Default-disabled transport for the one allowlisted beam workflow.",
       "functions": [
         {
@@ -955,8 +972,9 @@
     "rebar",
     "staircase",
     "streaming",
+    "wall",
     "websocket",
     "workflows"
   ],
-  "content_hash": "5e178a70e312bf6c"
+  "content_hash": "2d77a2c89490743a"
 }

--- a/fastapi_app/routers/index.md
+++ b/fastapi_app/routers/index.md
@@ -1,8 +1,8 @@
 # Routers
 
 **Type:** Python Package
-**Last Updated:** 2026-08-15
-**Files:** 20
+**Last Updated:** 2026-08-16
+**Files:** 21
 
 ## Public API
 
@@ -22,6 +22,7 @@
 - `rebar`
 - `staircase`
 - `streaming`
+- `wall`
 - `websocket`
 - `workflows`
 
@@ -29,7 +30,7 @@
 
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
-| [__init__.py](__init__.py) | FastAPI Routers Package. | 0 | 0 | 48 |
+| [__init__.py](__init__.py) | FastAPI Routers Package. | 0 | 0 | 50 |
 | [analysis.py](analysis.py) | Smart Analysis Router. | 0 | 3 | 338 |
 | [capabilities.py](capabilities.py) | Public discovery route for the canonical supported IS 456 co | 0 | 1 | 23 |
 | [catalog.py](catalog.py) | Thin read-only transport for the canonical application workf | 0 | 1 | 51 |
@@ -47,5 +48,6 @@
 | [rebar.py](rebar.py) | Rebar Validation and Application Router. | 7 | 2 | 269 |
 | [staircase.py](staircase.py) | FastAPI transport for the bounded straight-flight staircase  | 0 | 1 | 66 |
 | [streaming.py](streaming.py) | Server-Sent Events (SSE) Router for Batch Processing. | 3 | 3 | 351 |
+| [wall.py](wall.py) | FastAPI transport for the bounded braced-wall service. | 0 | 1 | 117 |
 | [websocket.py](websocket.py) | WebSocket Router for Live Design Updates. | 3 | 3 | 428 |
 | [workflows.py](workflows.py) | Default-disabled transport for the one allowlisted beam work | 0 | 4 | 172 |

--- a/fastapi_app/routers/wall.py
+++ b/fastapi_app/routers/wall.py
@@ -1,0 +1,116 @@
+"""FastAPI transport for the bounded braced-wall service."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+
+import structural_lib.services.wall_api as wall_api
+from fastapi_app.error_utils import sanitize_error, sanitize_error_string
+from fastapi_app.models.response import APIResponse, error_response, success_response
+from fastapi_app.models.wall import BracedWallRequest, BracedWallResponse
+
+router = APIRouter(prefix="/design/wall", tags=["wall"])
+
+
+def _direction_payload(
+    result: wall_api.WallDirectionalReinforcementResult,
+) -> dict[str, object]:
+    return {
+        "minimum_ratio": result.minimum_ratio,
+        "required_area_mm2_per_m": result.required_area_mm2_per_m,
+        "provided_area_mm2_per_m": result.provided_area_mm2_per_m,
+        "provided_ratio": result.provided_ratio,
+        "maximum_spacing_mm": result.maximum_spacing_mm,
+        "provided_spacing_mm": result.provided_spacing_mm,
+        "area_status": result.area_status,
+        "spacing_status": result.spacing_status,
+        "status": result.status,
+    }
+
+
+def _result_payload(result: wall_api.BracedWallDesignResult) -> dict[str, object]:
+    return {
+        "case_id": result.case_id,
+        "status": result.status,
+        "axial": {
+            "effective_height_mm": result.axial.geometry.effective_height_mm,
+            "effective_height_to_thickness_ratio": (
+                result.axial.geometry.effective_height_to_thickness_ratio
+            ),
+            "minimum_eccentricity_mm": result.axial.minimum_eccentricity_mm,
+            "design_eccentricity_mm": result.axial.design_eccentricity_mm,
+            "additional_eccentricity_mm": result.axial.additional_eccentricity_mm,
+            "effective_compression_thickness_mm": (
+                result.axial.effective_compression_thickness_mm
+            ),
+            "axial_capacity_n_per_mm": result.axial.axial_capacity_n_per_mm,
+            "axial_capacity_kn_per_m": result.axial.axial_capacity_kn_per_m,
+            "total_axial_capacity_kn": result.axial.total_axial_capacity_kn,
+            "axial_demand_n_per_mm": result.axial.axial_demand_n_per_mm,
+            "axial_demand_kn_per_m": result.axial.axial_demand_kn_per_m,
+            "utilization_ratio": result.axial.utilization_ratio,
+            "status": result.axial.status,
+            "source_refs": result.axial.source_refs,
+            "load_generation_status": result.axial.load_generation_status,
+        },
+        "reinforcement": {
+            "vertical": _direction_payload(result.reinforcement.vertical),
+            "horizontal": _direction_payload(result.reinforcement.horizontal),
+            "transverse_enclosure_required": (
+                result.reinforcement.transverse_enclosure_required
+            ),
+            "status": result.reinforcement.status,
+            "source_refs": result.reinforcement.source_refs,
+        },
+        "supported_case": result.supported_case,
+        "held_cases": result.held_cases,
+        "provenance": result.provenance,
+        "qualified_review_required": result.qualified_review_required,
+        "complete_engineering_design_approved": (
+            result.complete_engineering_design_approved
+        ),
+    }
+
+
+@router.post(
+    "/braced-axial",
+    response_model=APIResponse[BracedWallResponse],
+    summary="Check a bounded Clause 32 braced wall",
+)
+async def design_braced_wall(request: BracedWallRequest):
+    """Validate transport inputs and delegate all calculation to the service."""
+    try:
+        result = wall_api.design_braced_wall_is456(
+            wall_api.BracedWallDesignInput(**request.model_dump())
+        )
+        return success_response(jsonable_encoder(_result_payload(result)))
+    except wall_api.WallContractError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            content=error_response(
+                {
+                    "code": "REQUEST_VALIDATION_ERROR",
+                    "message": "Request validation failed",
+                    "details": [
+                        {
+                            "type": "value_error",
+                            "loc": ["body"],
+                            "msg": sanitize_error_string(str(exc), "braced wall"),
+                        }
+                    ],
+                }
+            ),
+        )
+    except Exception as exc:  # pragma: no cover - defensive transport boundary
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content=error_response(
+                {
+                    "code": "INTERNAL_ERROR",
+                    "message": sanitize_error(exc, "braced wall"),
+                    "details": [],
+                }
+            ),
+        )

--- a/fastapi_app/tests/index.json
+++ b/fastapi_app/tests/index.json
@@ -2,14 +2,14 @@
   "folder": "fastapi_app/tests",
   "type": "python-package",
   "description": "Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming.",
-  "last_updated": "2026-08-15",
-  "file_count": 38,
+  "last_updated": "2026-08-16",
+  "file_count": 39,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 33,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "title": "FastAPI Tests",
       "description": "Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming. | File | Scope |",
       "content_hash": "1df0bb09bec8"
@@ -18,7 +18,7 @@
       "name": "__init__.py",
       "type": "python",
       "size_lines": 6,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "FastAPI Tests Package.",
       "content_hash": "419d87c58f98"
     },
@@ -26,7 +26,7 @@
       "name": "conftest.py",
       "type": "python",
       "size_lines": 159,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Test Fixtures for FastAPI Tests.",
       "functions": [
         {
@@ -71,7 +71,7 @@
       "name": "test_auth.py",
       "type": "python",
       "size_lines": 243,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for Authentication and Rate Limiting.",
       "classes": [
         {
@@ -121,7 +121,7 @@
       "name": "test_beam_primary_route.py",
       "type": "python",
       "size_lines": 311,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Focused FastAPI contract tests for the primary IS 456 beam route.",
       "functions": [
         {
@@ -210,7 +210,7 @@
       "name": "test_bundled_sample_evidence.py",
       "type": "python",
       "size_lines": 84,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Reproducible software evidence for the bundled 153-beam acceptance sample.",
       "functions": [
         {
@@ -225,8 +225,8 @@
     {
       "name": "test_capabilities.py",
       "type": "python",
-      "size_lines": 32,
-      "last_updated": "2026-08-15",
+      "size_lines": 37,
+      "last_updated": "2026-08-16",
       "description": "Cross-surface tests for canonical capability discovery.",
       "functions": [
         {
@@ -242,13 +242,13 @@
           ]
         }
       ],
-      "content_hash": "bf3205115765"
+      "content_hash": "e293b5c9b919"
     },
     {
       "name": "test_catalog.py",
       "type": "python",
       "size_lines": 41,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Cross-layer tests for the thin workflow catalogue transport.",
       "functions": [
         {
@@ -276,7 +276,7 @@
       "name": "test_column_additional_moment.py",
       "type": "python",
       "size_lines": 203,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for POST /api/v1/design/column/additional-moment endpoint.",
       "classes": [
         {
@@ -303,7 +303,7 @@
       "name": "test_column_biaxial.py",
       "type": "python",
       "size_lines": 179,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for POST /api/v1/design/column/biaxial-check endpoint.",
       "classes": [
         {
@@ -360,7 +360,7 @@
       "name": "test_column_detailing.py",
       "type": "python",
       "size_lines": 150,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for POST /api/v1/design/column/detailing endpoint.",
       "classes": [
         {
@@ -410,7 +410,7 @@
       "name": "test_column_effective_length.py",
       "type": "python",
       "size_lines": 169,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for POST /api/v1/design/column/effective-length endpoint.",
       "classes": [
         {
@@ -447,7 +447,7 @@
       "name": "test_column_pm_interaction.py",
       "type": "python",
       "size_lines": 106,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for POST /api/v1/design/column/interaction-curve endpoint.",
       "classes": [
         {
@@ -480,7 +480,7 @@
       "name": "test_column_review_response.py",
       "type": "python",
       "size_lines": 140,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Focused contracts for the rectangular-column check-and-review slice.",
       "functions": [
         {
@@ -509,7 +509,7 @@
       "name": "test_column_uniaxial.py",
       "type": "python",
       "size_lines": 142,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for POST /api/v1/design/column/uniaxial endpoint.",
       "classes": [
         {
@@ -553,7 +553,7 @@
       "name": "test_config.py",
       "type": "python",
       "size_lines": 126,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for safe, environment-configurable FastAPI settings.",
       "functions": [
         {
@@ -616,7 +616,7 @@
       "name": "test_design_compliance.py",
       "type": "python",
       "size_lines": 381,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for design router compliance endpoints.",
       "classes": [
         {
@@ -682,7 +682,7 @@
       "name": "test_detailing_anchorage.py",
       "type": "python",
       "size_lines": 98,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for detailing router anchorage endpoint.",
       "classes": [
         {
@@ -708,7 +708,7 @@
       "name": "test_endpoints.py",
       "type": "python",
       "size_lines": 1057,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Integration Tests for FastAPI Endpoints.",
       "classes": [
         {
@@ -836,7 +836,7 @@
       "name": "test_error_sanitization.py",
       "type": "python",
       "size_lines": 118,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for error sanitization utilities (TASK-796).",
       "classes": [
         {
@@ -873,7 +873,7 @@
       "name": "test_export_bbs_dxf.py",
       "type": "python",
       "size_lines": 202,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for export router endpoints.",
       "classes": [
         {
@@ -918,7 +918,7 @@
       "name": "test_footing.py",
       "type": "python",
       "size_lines": 236,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Contract tests for the isolated concentric-footing FastAPI slice.",
       "functions": [
         {
@@ -952,7 +952,7 @@
       "name": "test_geometry_full.py",
       "type": "python",
       "size_lines": 244,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for geometry router advanced endpoints.",
       "classes": [
         {
@@ -996,7 +996,7 @@
       "name": "test_imports_formats.py",
       "type": "python",
       "size_lines": 82,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for import router extended endpoints.",
       "classes": [
         {
@@ -1027,7 +1027,7 @@
       "name": "test_insights_dashboard.py",
       "type": "python",
       "size_lines": 388,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for insights router endpoints.",
       "classes": [
         {
@@ -1080,7 +1080,7 @@
       "name": "test_integration.py",
       "type": "python",
       "size_lines": 390,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Integration tests for FastAPI structural design endpoints.",
       "classes": [
         {
@@ -1155,7 +1155,7 @@
       "name": "test_library_core.py",
       "type": "python",
       "size_lines": 397,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Request-to-public-library evidence for the new footing and slab consumers.",
       "functions": [
         {
@@ -1256,7 +1256,7 @@
       "name": "test_load.py",
       "type": "python",
       "size_lines": 278,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Load Tests for FastAPI Application.",
       "classes": [
         {
@@ -1327,7 +1327,7 @@
       "name": "test_maintenance_route_coverage.py",
       "type": "python",
       "size_lines": 150,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Direct contract coverage for routes identified by the MAINT-004 parity audit.",
       "functions": [
         {
@@ -1385,7 +1385,7 @@
       "name": "test_optimization_pareto.py",
       "type": "python",
       "size_lines": 158,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for Pareto multi-objective beam optimization endpoint.",
       "classes": [
         {
@@ -1409,7 +1409,7 @@
       "name": "test_plausibility_validators.py",
       "type": "python",
       "size_lines": 761,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for cross-field plausibility validators (TASK-729).",
       "classes": [
         {
@@ -1552,7 +1552,7 @@
       "name": "test_public_documentation_contract.py",
       "type": "python",
       "size_lines": 70,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Executable contracts for the public REST documentation.",
       "functions": [
         {
@@ -1583,7 +1583,7 @@
       "name": "test_security.py",
       "type": "python",
       "size_lines": 407,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Security Tests for FastAPI Application.",
       "classes": [
         {
@@ -1671,7 +1671,7 @@
       "name": "test_staircase.py",
       "type": "python",
       "size_lines": 146,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Contract tests for the straight-flight staircase FastAPI slice.",
       "functions": [
         {
@@ -1702,7 +1702,7 @@
       "name": "test_streaming.py",
       "type": "python",
       "size_lines": 276,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for SSE Streaming Endpoint.",
       "classes": [
         {
@@ -1734,7 +1734,7 @@
       "name": "test_typed_response_contracts.py",
       "type": "python",
       "size_lines": 72,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "OpenAPI and envelope contracts for the typed column and library-core routes.",
       "functions": [
         {
@@ -1765,10 +1765,41 @@
       "content_hash": "5d973d54a33b"
     },
     {
+      "name": "test_wall.py",
+      "type": "python",
+      "size_lines": 163,
+      "last_updated": "2026-08-16",
+      "description": "Contract tests for the bounded braced-wall FastAPI slice.",
+      "functions": [
+        {
+          "name": "test_wall_benchmark_returns_typed_pass_with_provenance"
+        },
+        {
+          "name": "test_wall_rejects_unknown_nonfinite_and_unsupported_scope"
+        },
+        {
+          "name": "test_wall_service_validation_uses_safe_error_envelope"
+        },
+        {
+          "name": "test_wall_valid_overload_and_inadequate_steel_remain_json_safe_fail"
+        },
+        {
+          "name": "test_wall_openapi_exposes_typed_success_schema"
+        },
+        {
+          "name": "test_wall_is_mounted_in_main_app",
+          "params": [
+            "client"
+          ]
+        }
+      ],
+      "content_hash": "a09b6566972d"
+    },
+    {
       "name": "test_websocket.py",
       "type": "python",
       "size_lines": 211,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Tests for WebSocket Live Design Endpoint.",
       "classes": [
         {
@@ -1792,7 +1823,7 @@
       "name": "test_workflows.py",
       "type": "python",
       "size_lines": 176,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Transport gates for the explicitly activated bounded workflow runner.",
       "functions": [
         {
@@ -1835,5 +1866,5 @@
   ],
   "subfolders": [],
   "has_init": true,
-  "content_hash": "4480d732a2d30812"
+  "content_hash": "7054af87a2c24957"
 }

--- a/fastapi_app/tests/index.md
+++ b/fastapi_app/tests/index.md
@@ -3,8 +3,8 @@
 Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-15
-**Files:** 38
+**Last Updated:** 2026-08-16
+**Files:** 39
 
 ## Documentation Files
 
@@ -21,7 +21,7 @@ Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin
 | [test_auth.py](test_auth.py) | Tests for Authentication and Rate Limiting. | 3 | 2 | 243 |
 | [test_beam_primary_route.py](test_beam_primary_route.py) | Focused FastAPI contract tests for the primary IS 456 beam r | 0 | 12 | 311 |
 | [test_bundled_sample_evidence.py](test_bundled_sample_evidence.py) | Reproducible software evidence for the bundled 153-beam acce | 0 | 1 | 84 |
-| [test_capabilities.py](test_capabilities.py) | Cross-surface tests for canonical capability discovery. | 0 | 2 | 32 |
+| [test_capabilities.py](test_capabilities.py) | Cross-surface tests for canonical capability discovery. | 0 | 2 | 37 |
 | [test_catalog.py](test_catalog.py) | Cross-layer tests for the thin workflow catalogue transport. | 0 | 3 | 41 |
 | [test_column_additional_moment.py](test_column_additional_moment.py) | Tests for POST /api/v1/design/column/additional-moment endpo | 1 | 0 | 203 |
 | [test_column_biaxial.py](test_column_biaxial.py) | Tests for POST /api/v1/design/column/biaxial-check endpoint. | 4 | 0 | 179 |
@@ -51,5 +51,6 @@ Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin
 | [test_staircase.py](test_staircase.py) | Contract tests for the straight-flight staircase FastAPI sli | 0 | 6 | 146 |
 | [test_streaming.py](test_streaming.py) | Tests for SSE Streaming Endpoint. | 2 | 0 | 276 |
 | [test_typed_response_contracts.py](test_typed_response_contracts.py) | OpenAPI and envelope contracts for the typed column and libr | 0 | 3 | 72 |
+| [test_wall.py](test_wall.py) | Contract tests for the bounded braced-wall FastAPI slice. | 0 | 6 | 163 |
 | [test_websocket.py](test_websocket.py) | Tests for WebSocket Live Design Endpoint. | 1 | 0 | 211 |
 | [test_workflows.py](test_workflows.py) | Transport gates for the explicitly activated bounded workflo | 0 | 5 | 176 |

--- a/fastapi_app/tests/test_capabilities.py
+++ b/fastapi_app/tests/test_capabilities.py
@@ -18,6 +18,11 @@ def test_capability_route_matches_python_contract(client: TestClient):
     assert all(
         item["qualified_review_required"] for item in body["data"]["capabilities"]
     )
+    wall = next(
+        item for item in body["data"]["capabilities"] if item["element"] == "wall"
+    )
+    assert wall["public_workflows"] == ["design_braced_wall_is456"]
+    assert "100-200 mm" in wall["supported_case"]
 
 
 def test_capability_route_has_a_typed_openapi_success_schema(client: TestClient):

--- a/fastapi_app/tests/test_wall.py
+++ b/fastapi_app/tests/test_wall.py
@@ -1,0 +1,162 @@
+"""Contract tests for the bounded braced-wall FastAPI slice."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fastapi_app.routers.wall import router
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    return app
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "case_id": "INDIA-2-WALL-HAND-01",
+        "unsupported_height_mm": 3000.0,
+        "lateral_restraint_spacing_mm": 4000.0,
+        "wall_length_mm": 4000.0,
+        "wall_thickness_mm": 150.0,
+        "concrete_grade_nmm2": 20.0,
+        "factored_axial_load_kn": 2000.0,
+        "supplied_eccentricity_mm": 0.0,
+        "vertical_bar_diameter_mm": 8.0,
+        "vertical_bar_spacing_mm": 250.0,
+        "horizontal_bar_diameter_mm": 10.0,
+        "horizontal_bar_spacing_mm": 250.0,
+        "bracing_basis_reference": "INDIA-2-WALL-HAND-01-BRACING",
+        "action_basis_reference": "INDIA-2-WALL-HAND-01-ACTIONS",
+        "reinforcement_basis_reference": ("INDIA-2-WALL-HAND-01-REINFORCEMENT"),
+    }
+
+
+def test_wall_benchmark_returns_typed_pass_with_provenance() -> None:
+    response = TestClient(_app()).post(
+        "/api/v1/design/wall/braced-axial",
+        json=_payload(),
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["status"] == "PASS"
+    assert data["axial"]["effective_height_mm"] == pytest.approx(2250.0)
+    assert data["axial"]["axial_capacity_n_per_mm"] == pytest.approx(684.0)
+    assert data["axial"]["utilization_ratio"] == pytest.approx(0.7309941520)
+    assert data["reinforcement"]["vertical"][
+        "provided_area_mm2_per_m"
+    ] == pytest.approx(201.06192983)
+    assert data["reinforcement"]["horizontal"][
+        "provided_area_mm2_per_m"
+    ] == pytest.approx(314.15926536)
+    assert data["provenance"]["workflow"] == "design_braced_wall_is456"
+    assert data["provenance"]["clause_refs"] == [
+        "32.2.1",
+        "32.2.2",
+        "32.2.3",
+        "32.2.4",
+        "32.2.5",
+        "32.5",
+        "32.5.1",
+        "32.5.2",
+    ]
+    assert data["held_cases"] and data["qualified_review_required"] is True
+    assert data["complete_engineering_design_approved"] is False
+
+
+def test_wall_rejects_unknown_nonfinite_and_unsupported_scope() -> None:
+    client = TestClient(_app())
+    invalid_requests: list[dict[str, object]] = []
+
+    extra = deepcopy(_payload())
+    extra["not_a_contract_field"] = True
+    invalid_requests.append(extra)
+    nonfinite = deepcopy(_payload())
+    nonfinite["wall_length_mm"] = "NaN"
+    invalid_requests.append(nonfinite)
+    alternate = deepcopy(_payload())
+    alternate["bracing_elements_in_two_directions"] = False
+    invalid_requests.append(alternate)
+    two_grid = deepcopy(_payload())
+    two_grid["wall_thickness_mm"] = 201.0
+    invalid_requests.append(two_grid)
+
+    for invalid in invalid_requests:
+        response = client.post("/api/v1/design/wall/braced-axial", json=invalid)
+        assert response.status_code == 422
+
+
+def test_wall_service_validation_uses_safe_error_envelope() -> None:
+    invalid = deepcopy(_payload())
+    invalid["unsupported_height_mm"] = 6100.0
+    invalid["lateral_restraint_spacing_mm"] = 6100.0
+    invalid["wall_thickness_mm"] = 150.0
+
+    response = TestClient(_app()).post(
+        "/api/v1/design/wall/braced-axial",
+        json=invalid,
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert set(body) == {"success", "data", "error"}
+    assert body["success"] is False and body["data"] is None
+    assert body["error"]["code"] == "REQUEST_VALIDATION_ERROR"
+    assert body["error"]["message"] == "Request validation failed"
+    assert body["error"]["details"][0]["msg"].startswith(
+        "Error during braced wall. Reference:"
+    )
+
+
+def test_wall_valid_overload_and_inadequate_steel_remain_json_safe_fail() -> None:
+    overloaded = deepcopy(_payload())
+    overloaded["factored_axial_load_kn"] = 3000.0
+    overload_response = TestClient(_app()).post(
+        "/api/v1/design/wall/braced-axial",
+        json=overloaded,
+    )
+    assert overload_response.status_code == 200
+    assert overload_response.json()["data"]["axial"]["status"] == "FAIL"
+    assert overload_response.json()["data"]["status"] == "FAIL"
+
+    inadequate = deepcopy(_payload())
+    inadequate.update(
+        {
+            "vertical_bar_diameter_mm": 6.0,
+            "vertical_bar_spacing_mm": 450.0,
+            "horizontal_bar_diameter_mm": 6.0,
+            "horizontal_bar_spacing_mm": 450.0,
+        }
+    )
+    inadequate_response = TestClient(_app()).post(
+        "/api/v1/design/wall/braced-axial",
+        json=inadequate,
+    )
+    assert inadequate_response.status_code == 200
+    assert inadequate_response.json()["data"]["reinforcement"]["status"] == "FAIL"
+    assert inadequate_response.json()["data"]["status"] == "FAIL"
+
+
+def test_wall_openapi_exposes_typed_success_schema() -> None:
+    schema = _app().openapi()
+    operation = schema["paths"]["/api/v1/design/wall/braced-axial"]["post"]
+
+    assert operation["responses"]["200"]["content"]["application/json"]["schema"][
+        "$ref"
+    ].endswith("APIResponse_BracedWallResponse_")
+    response_schema = schema["components"]["schemas"]["BracedWallResponse"]
+    assert response_schema["properties"]["axial"]
+    assert response_schema["properties"]["reinforcement"]
+
+
+def test_wall_is_mounted_in_main_app(client: TestClient) -> None:
+    response = client.post("/api/v1/design/wall/braced-axial", json=_payload())
+
+    assert response.status_code == 200
+    assert response.json()["data"]["status"] == "PASS"

--- a/scripts/_lib/indian_code_manifest.py
+++ b/scripts/_lib/indian_code_manifest.py
@@ -71,15 +71,17 @@ _IS456_EVIDENCE = {
         "docs/verification/india-2c-staircase-design-evidence.md",
         "docs/verification/india-2d-staircase-publication-evidence.md",
     ),
+    "wall": (
+        "docs/verification/india-2-wall-g0-scope-evidence.md",
+        "docs/verification/india-2-wall-a-axial-kernel-evidence.md",
+        "docs/verification/india-2-wall-b-reinforcement-evidence.md",
+        "docs/verification/india-2-wall-c-public-workflow-evidence.md",
+        "docs/verification/india-2-wall-d-publication-evidence.md",
+    ),
 }
 
 _HELD_FAMILIES: dict[str, tuple[dict[str, Any], ...]] = {
     "IS456:2000": (
-        {
-            "family": "wall",
-            "claim": "IS 456 wall design is not implemented.",
-            "limitations": ["Clause 32 requires a separately verified program."],
-        },
         {
             "family": "deep_beam",
             "claim": "IS 456 deep-beam design is not implemented.",


### PR DESCRIPTION
## Scope
- publish strict request/response schemas and POST /api/v1/design/wall/braced-axial
- delegate all engineering calculation to the integrated wall service
- promote exactly one bounded wall capability and semantic contract
- update deterministic Indian-code truth from broad wall hold to bounded support
- retain IS 13920 wall detailing and all alternate wall cases as held

## Validation
- 20 focused publication/manifest/FastAPI/capability tests and 128 combined focused tests passed
- valid overload and inadequate reinforcement remain typed FAIL; unsupported inputs return safe 422
- API compatibility: no break across 77 endpoints and 293 schemas
- Black, Ruff, mypy, and Bandit passed
- architecture: 0 violations across 170 files
- imports: 0 broken across 205 files
- manifest/parity: 9 supported, 12 held; 43% informational scope
- 1,153 links valid; quick gate 10/10

Focused wall-family acceptance follows after this exact packet integrates. Broad Python and 30-check gates remain reserved for whole INDIA-2 closeout.