### PR TITLE
feat(is456): add deep beam geometry kernel

### DIFF
--- a/Python/structural_lib/codes/is456/clauses.json
+++ b/Python/structural_lib/codes/is456/clauses.json
@@ -6,7 +6,7 @@
     "version": "2000 (Reaffirmed 2021)",
     "source": "Bureau of Indian Standards",
     "last_updated": "2026-08-16",
-    "total_clauses": 135,
+    "total_clauses": 143,
     "includes_references": [
       "IS 13920:2016"
     ],
@@ -499,6 +499,86 @@
         "transverse reinforcement",
         "pitch",
         "lateral ties"
+      ]
+    },
+    "29": {
+      "title": "Deep Beams",
+      "section": "29 - Deep Beams",
+      "category": "flexure",
+      "keywords": [
+        "deep beam",
+        "lever arm",
+        "reinforcement"
+      ]
+    },
+    "29.1": {
+      "title": "Deep-Beam Classification and General Requirements",
+      "section": "29 - Deep Beams",
+      "category": "flexure",
+      "keywords": [
+        "effective span",
+        "overall depth",
+        "shear"
+      ]
+    },
+    "29.2": {
+      "title": "Deep-Beam Lever Arm",
+      "section": "29 - Deep Beams",
+      "category": "flexure",
+      "keywords": [
+        "lever arm",
+        "simply supported",
+        "continuous"
+      ]
+    },
+    "29.3": {
+      "title": "Deep-Beam Reinforcement",
+      "section": "29 - Deep Beams",
+      "category": "detailing",
+      "keywords": [
+        "reinforcement",
+        "anchorage",
+        "distribution"
+      ]
+    },
+    "29.3.1": {
+      "title": "Positive Reinforcement in Deep Beams",
+      "section": "29 - Deep Beams",
+      "category": "detailing",
+      "keywords": [
+        "positive reinforcement",
+        "development length",
+        "tension zone"
+      ]
+    },
+    "29.3.2": {
+      "title": "Negative Reinforcement in Deep Beams",
+      "section": "29 - Deep Beams",
+      "category": "detailing",
+      "keywords": [
+        "negative reinforcement",
+        "continuous beam",
+        "distribution"
+      ]
+    },
+    "29.3.3": {
+      "title": "Vertical Reinforcement for Hanging Action",
+      "section": "29 - Deep Beams",
+      "category": "detailing",
+      "keywords": [
+        "hanging action",
+        "suspension stirrups",
+        "vertical reinforcement"
+      ]
+    },
+    "29.3.4": {
+      "title": "Side-Face Reinforcement in Deep Beams",
+      "section": "29 - Deep Beams",
+      "category": "detailing",
+      "keywords": [
+        "side face",
+        "wall minimum reinforcement",
+        "Amendment 3"
       ]
     },
     "31.6": {

--- a/Python/structural_lib/codes/is456/deep_beam/__init__.py
+++ b/Python/structural_lib/codes/is456/deep_beam/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Bounded IS 456 Clause 29 simply supported deep-beam contracts."""
+
+from structural_lib.codes.is456.deep_beam.geometry import (
+    DeepBeamGeometryResult,
+    resolve_simply_supported_deep_beam_geometry,
+)
+from structural_lib.codes.is456.deep_beam.models import (
+    DeepBeamActionInput,
+    DeepBeamContractError,
+    DeepBeamGeometry,
+    DeepBeamLeverArmCase,
+    DeepBeamSupportType,
+)
+
+__all__ = [
+    "DeepBeamActionInput",
+    "DeepBeamContractError",
+    "DeepBeamGeometry",
+    "DeepBeamGeometryResult",
+    "DeepBeamLeverArmCase",
+    "DeepBeamSupportType",
+    "resolve_simply_supported_deep_beam_geometry",
+]

--- a/Python/structural_lib/codes/is456/deep_beam/geometry.py
+++ b/Python/structural_lib/codes/is456/deep_beam/geometry.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Clause 29.1-29.3.1 geometry for simply supported deep beams."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from structural_lib.codes.is456.deep_beam.models import (
+    DeepBeamContractError,
+    DeepBeamGeometry,
+    DeepBeamLeverArmCase,
+)
+from structural_lib.codes.is456.traceability import clause
+
+__all__ = [
+    "DeepBeamGeometryResult",
+    "resolve_simply_supported_deep_beam_geometry",
+]
+
+
+_SOURCE_REFS = (
+    "IS 456:2000 Cl. 29.1-29.3.1",
+    "IS456-2000-A6",
+)
+
+
+@dataclass(frozen=True)
+class DeepBeamGeometryResult:
+    """Resolved effective span, classification, lever arm, and tie zone."""
+
+    input: DeepBeamGeometry
+    centre_to_centre_span_component_mm: float
+    clear_span_component_mm: float
+    effective_span_mm: float
+    effective_span_to_depth_ratio: float
+    lever_arm_case: DeepBeamLeverArmCase
+    lever_arm_mm: float
+    positive_reinforcement_zone_depth_mm: float
+    source_refs: tuple[str, ...]
+
+
+@clause("29.1", "29.2", "29.3.1")
+def resolve_simply_supported_deep_beam_geometry(
+    geometry: DeepBeamGeometry,
+) -> DeepBeamGeometryResult:
+    """Resolve the sole supported Clause 29 simply supported geometry."""
+    if not isinstance(geometry, DeepBeamGeometry):
+        raise DeepBeamContractError("geometry must be a DeepBeamGeometry")
+
+    centre_component = geometry.centre_to_centre_span_mm
+    clear_component = 1.15 * geometry.clear_span_mm
+    effective_span = min(centre_component, clear_component)
+    ratio = effective_span / geometry.overall_depth_mm
+    if ratio >= 2.0:
+        raise DeepBeamContractError(
+            "effective_span_mm / overall_depth_mm must be less than 2.0 "
+            "for the simply supported Clause 29 route"
+        )
+
+    if ratio < 1.0:
+        lever_arm_case = DeepBeamLeverArmCase.RATIO_BELOW_ONE
+        lever_arm_mm = 0.6 * effective_span
+    else:
+        lever_arm_case = DeepBeamLeverArmCase.RATIO_ONE_TO_TWO
+        lever_arm_mm = 0.2 * (effective_span + 2.0 * geometry.overall_depth_mm)
+
+    reinforcement_zone_depth = 0.25 * geometry.overall_depth_mm - 0.05 * effective_span
+    return DeepBeamGeometryResult(
+        input=geometry,
+        centre_to_centre_span_component_mm=centre_component,
+        clear_span_component_mm=clear_component,
+        effective_span_mm=effective_span,
+        effective_span_to_depth_ratio=ratio,
+        lever_arm_case=lever_arm_case,
+        lever_arm_mm=lever_arm_mm,
+        positive_reinforcement_zone_depth_mm=reinforcement_zone_depth,
+        source_refs=_SOURCE_REFS
+        + (
+            geometry.geometry_basis_reference,
+            geometry.bearing_nodal_zone_reference,
+        ),
+    )

--- a/Python/structural_lib/codes/is456/deep_beam/index.json
+++ b/Python/structural_lib/codes/is456/deep_beam/index.json
@@ -1,0 +1,85 @@
+{
+  "folder": "Python/structural_lib/codes/is456/deep_beam",
+  "type": "python-package",
+  "description": "",
+  "last_updated": "2026-08-16",
+  "file_count": 3,
+  "files": [
+    {
+      "name": "__init__.py",
+      "type": "python",
+      "size_lines": 26,
+      "last_updated": "2026-08-16",
+      "description": "Bounded IS 456 Clause 29 simply supported deep-beam contracts.",
+      "content_hash": "879b3a47ed25"
+    },
+    {
+      "name": "geometry.py",
+      "type": "python",
+      "size_lines": 84,
+      "last_updated": "2026-08-16",
+      "description": "Clause 29.1-29.3.1 geometry for simply supported deep beams.",
+      "classes": [
+        {
+          "name": "DeepBeamGeometryResult",
+          "description": "Resolved effective span, classification, lever arm, and tie zone."
+        }
+      ],
+      "functions": [
+        {
+          "name": "resolve_simply_supported_deep_beam_geometry",
+          "description": "Resolve the sole supported Clause 29 simply supported geometry.",
+          "params": [
+            "geometry"
+          ]
+        }
+      ],
+      "constants": [
+        "_SOURCE_REFS"
+      ],
+      "content_hash": "8f0bc42061c3"
+    },
+    {
+      "name": "models.py",
+      "type": "python",
+      "size_lines": 188,
+      "last_updated": "2026-08-16",
+      "description": "Typed contracts for the bounded INDIA-2 Clause 29 deep-beam case.",
+      "classes": [
+        {
+          "name": "DeepBeamContractError",
+          "description": "Raised when an input is outside the frozen INDIA-2 deep-beam scope."
+        },
+        {
+          "name": "DeepBeamSupportType",
+          "description": "Support systems admitted by the first Clause 29 workflow."
+        },
+        {
+          "name": "DeepBeamLeverArmCase",
+          "description": "Normalized Clause 29.2 simply supported lever-arm branches."
+        },
+        {
+          "name": "DeepBeamGeometry",
+          "description": "Caller-confirmed geometry and external bearing/nodal prerequisite."
+        },
+        {
+          "name": "DeepBeamActionInput",
+          "description": "Geometry, material grades, and caller-supplied positive design moment."
+        }
+      ],
+      "content_hash": "fa064b8ad53e"
+    }
+  ],
+  "subfolders": [],
+  "has_init": true,
+  "public_api": [
+    "DeepBeamActionInput",
+    "DeepBeamContractError",
+    "DeepBeamGeometry",
+    "DeepBeamGeometryResult",
+    "DeepBeamLeverArmCase",
+    "DeepBeamSupportType",
+    "resolve_simply_supported_deep_beam_geometry"
+  ],
+  "content_hash": "dc58edd70174b232"
+}

--- a/Python/structural_lib/codes/is456/deep_beam/index.md
+++ b/Python/structural_lib/codes/is456/deep_beam/index.md
@@ -1,0 +1,23 @@
+# Deep Beam
+
+**Type:** Python Package
+**Last Updated:** 2026-08-16
+**Files:** 3
+
+## Public API
+
+- `DeepBeamActionInput`
+- `DeepBeamContractError`
+- `DeepBeamGeometry`
+- `DeepBeamGeometryResult`
+- `DeepBeamLeverArmCase`
+- `DeepBeamSupportType`
+- `resolve_simply_supported_deep_beam_geometry`
+
+## Python Files
+
+| File | Description | Classes | Functions | Lines |
+|------|-------------|---------|-----------|-------|
+| [__init__.py](__init__.py) | Bounded IS 456 Clause 29 simply supported deep-beam contract | 0 | 0 | 26 |
+| [geometry.py](geometry.py) | Clause 29.1-29.3.1 geometry for simply supported deep beams. | 1 | 1 | 84 |
+| [models.py](models.py) | Typed contracts for the bounded INDIA-2 Clause 29 deep-beam  | 5 | 0 | 188 |

--- a/Python/structural_lib/codes/is456/deep_beam/models.py
+++ b/Python/structural_lib/codes/is456/deep_beam/models.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Typed contracts for the bounded INDIA-2 Clause 29 deep-beam case."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from numbers import Real
+
+__all__ = [
+    "DeepBeamActionInput",
+    "DeepBeamContractError",
+    "DeepBeamGeometry",
+    "DeepBeamLeverArmCase",
+    "DeepBeamSupportType",
+]
+
+
+class DeepBeamContractError(ValueError):
+    """Raised when an input is outside the frozen INDIA-2 deep-beam scope."""
+
+
+class DeepBeamSupportType(StrEnum):
+    """Support systems admitted by the first Clause 29 workflow."""
+
+    SIMPLY_SUPPORTED = "simply_supported"
+
+
+class DeepBeamLeverArmCase(StrEnum):
+    """Normalized Clause 29.2 simply supported lever-arm branches."""
+
+    RATIO_BELOW_ONE = "effective_span_to_depth_below_one"
+    RATIO_ONE_TO_TWO = "effective_span_to_depth_from_one_to_below_two"
+
+
+def _positive_finite(value: float, field_name: str, unit: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise DeepBeamContractError(f"{field_name} must be a real value in {unit}")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0.0:
+        raise DeepBeamContractError(
+            f"{field_name} must be finite and positive in {unit}"
+        )
+    return normalized
+
+
+def _non_blank(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise DeepBeamContractError(f"{field_name} must be a non-blank string")
+    return value.strip()
+
+
+@dataclass(frozen=True)
+class DeepBeamGeometry:
+    """Caller-confirmed geometry and external bearing/nodal prerequisite.
+
+    All dimensions are in mm. Only a simply supported, top-loaded, solid
+    rectangular member without openings, dapped ends, or hanging action is
+    admitted by the first INDIA-2 deep-beam workflow.
+    """
+
+    centre_to_centre_span_mm: float
+    clear_span_mm: float
+    overall_depth_mm: float
+    beam_width_mm: float
+    support_type: DeepBeamSupportType
+    solid_rectangular_section: bool
+    openings_present: bool
+    dapped_ends_present: bool
+    top_loaded: bool
+    hanging_action_required: bool
+    bearing_nodal_zone_verified: bool
+    geometry_basis_reference: str
+    bearing_nodal_zone_reference: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "centre_to_centre_span_mm",
+            "clear_span_mm",
+            "overall_depth_mm",
+            "beam_width_mm",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _positive_finite(getattr(self, name), name, "mm"),
+            )
+        if self.clear_span_mm >= self.centre_to_centre_span_mm:
+            raise DeepBeamContractError(
+                "clear_span_mm must be less than centre_to_centre_span_mm"
+            )
+        if self.support_type is not DeepBeamSupportType.SIMPLY_SUPPORTED:
+            raise DeepBeamContractError(
+                "support_type must be DeepBeamSupportType.SIMPLY_SUPPORTED"
+            )
+        if self.solid_rectangular_section is not True:
+            raise DeepBeamContractError(
+                "solid_rectangular_section must be explicitly True"
+            )
+        if self.openings_present is not False:
+            raise DeepBeamContractError("openings_present must be explicitly False")
+        if self.dapped_ends_present is not False:
+            raise DeepBeamContractError("dapped_ends_present must be explicitly False")
+        if self.top_loaded is not True:
+            raise DeepBeamContractError("top_loaded must be explicitly True")
+        if self.hanging_action_required is not False:
+            raise DeepBeamContractError(
+                "hanging_action_required must be explicitly False"
+            )
+        if self.bearing_nodal_zone_verified is not True:
+            raise DeepBeamContractError(
+                "bearing_nodal_zone_verified must be explicitly True"
+            )
+        object.__setattr__(
+            self,
+            "geometry_basis_reference",
+            _non_blank(self.geometry_basis_reference, "geometry_basis_reference"),
+        )
+        object.__setattr__(
+            self,
+            "bearing_nodal_zone_reference",
+            _non_blank(
+                self.bearing_nodal_zone_reference,
+                "bearing_nodal_zone_reference",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class DeepBeamActionInput:
+    """Geometry, material grades, and caller-supplied positive design moment."""
+
+    geometry: DeepBeamGeometry
+    concrete_grade_nmm2: float
+    steel_grade_nmm2: float
+    factored_positive_moment_knm: float
+    action_basis_reference: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.geometry, DeepBeamGeometry):
+            raise DeepBeamContractError("geometry must be a DeepBeamGeometry")
+        concrete_grade = _positive_finite(
+            self.concrete_grade_nmm2,
+            "concrete_grade_nmm2",
+            "N/mm2",
+        )
+        if concrete_grade not in {
+            20.0,
+            25.0,
+            30.0,
+            35.0,
+            40.0,
+            45.0,
+            50.0,
+            55.0,
+            60.0,
+        }:
+            raise DeepBeamContractError(
+                "concrete_grade_nmm2 must be a standard M20-M60 grade"
+            )
+        steel_grade = _positive_finite(
+            self.steel_grade_nmm2,
+            "steel_grade_nmm2",
+            "N/mm2",
+        )
+        if steel_grade not in {415.0, 500.0}:
+            raise DeepBeamContractError(
+                "steel_grade_nmm2 must be Fe415 or Fe500 for this route"
+            )
+        object.__setattr__(self, "concrete_grade_nmm2", concrete_grade)
+        object.__setattr__(self, "steel_grade_nmm2", steel_grade)
+        object.__setattr__(
+            self,
+            "factored_positive_moment_knm",
+            _positive_finite(
+                self.factored_positive_moment_knm,
+                "factored_positive_moment_knm",
+                "kN m",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "action_basis_reference",
+            _non_blank(self.action_basis_reference, "action_basis_reference"),
+        )

--- a/Python/structural_lib/codes/is456/index.json
+++ b/Python/structural_lib/codes/is456/index.json
@@ -40,7 +40,7 @@
         "figures",
         "annexures"
       ],
-      "content_hash": "56afab4418e5"
+      "content_hash": "8d7652e119eb"
     },
     {
       "name": "compliance.py",
@@ -398,6 +398,12 @@
       "is_package": true
     },
     {
+      "name": "deep_beam",
+      "path": "deep_beam/",
+      "file_count": 5,
+      "is_package": true
+    },
+    {
       "name": "footing",
       "path": "footing/",
       "file_count": 10,
@@ -444,5 +450,5 @@
     "list_clauses_by_category",
     "search_clauses"
   ],
-  "content_hash": "cde6adc5424a1a92"
+  "content_hash": "568f71f875819e66"
 }

--- a/Python/structural_lib/codes/is456/index.md
+++ b/Python/structural_lib/codes/is456/index.md
@@ -55,6 +55,7 @@
 | [beam/](beam/) 📦 | 6 |  |
 | [column/](column/) 📦 | 12 |  |
 | [common/](common/) 📦 | 5 |  |
+| [deep_beam/](deep_beam/) 📦 | 5 |  |
 | [footing/](footing/) 📦 | 10 |  |
 | [slab/](slab/) 📦 | 16 |  |
 | [staircase/](staircase/) 📦 | 7 |  |

--- a/Python/tests/codes/is456/deep_beam/__init__.py
+++ b/Python/tests/codes/is456/deep_beam/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the bounded IS 456 deep-beam package."""

--- a/Python/tests/codes/is456/deep_beam/index.json
+++ b/Python/tests/codes/is456/deep_beam/index.json
@@ -1,0 +1,74 @@
+{
+  "folder": "Python/tests/codes/is456/deep_beam",
+  "type": "python-package",
+  "description": "",
+  "last_updated": "2026-08-16",
+  "file_count": 2,
+  "files": [
+    {
+      "name": "__init__.py",
+      "type": "python",
+      "size_lines": 2,
+      "last_updated": "2026-08-16",
+      "description": "Tests for the bounded IS 456 deep-beam package.",
+      "content_hash": "fee493bfa478"
+    },
+    {
+      "name": "test_geometry.py",
+      "type": "python",
+      "size_lines": 194,
+      "last_updated": "2026-08-16",
+      "description": "INDIA-2-DEEP-A benchmark and fail-closed geometry tests.",
+      "functions": [
+        {
+          "name": "test_hand_benchmark_effective_span_classification_and_lever_arm"
+        },
+        {
+          "name": "test_clear_span_component_can_govern_effective_span"
+        },
+        {
+          "name": "test_ratio_below_one_uses_point_six_span_lever_arm"
+        },
+        {
+          "name": "test_ratio_one_is_continuous_between_lever_arm_branches"
+        },
+        {
+          "name": "test_ratio_just_below_two_is_accepted_and_two_fails_closed"
+        },
+        {
+          "name": "test_invalid_dimensions_fail_closed",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_clear_span_must_be_less_than_support_centre_span"
+        },
+        {
+          "name": "test_each_topology_and_external_confirmation_is_required",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_support_type_and_references_fail_closed"
+        },
+        {
+          "name": "test_action_material_and_reference_contracts"
+        },
+        {
+          "name": "test_wrong_types_fail_closed"
+        },
+        {
+          "name": "test_clause_and_source_provenance_is_machine_visible"
+        }
+      ],
+      "content_hash": "c52a6789bf22"
+    }
+  ],
+  "subfolders": [],
+  "has_init": true,
+  "content_hash": "c1e1a1b2a5a1a474"
+}

--- a/Python/tests/codes/is456/deep_beam/index.md
+++ b/Python/tests/codes/is456/deep_beam/index.md
@@ -1,0 +1,12 @@
+# Deep Beam
+
+**Type:** Python Package
+**Last Updated:** 2026-08-16
+**Files:** 2
+
+## Python Files
+
+| File | Description | Classes | Functions | Lines |
+|------|-------------|---------|-----------|-------|
+| [__init__.py](__init__.py) | Tests for the bounded IS 456 deep-beam package. | 0 | 0 | 2 |
+| [test_geometry.py](test_geometry.py) | INDIA-2-DEEP-A benchmark and fail-closed geometry tests. | 0 | 12 | 194 |

--- a/Python/tests/codes/is456/deep_beam/test_geometry.py
+++ b/Python/tests/codes/is456/deep_beam/test_geometry.py
@@ -1,0 +1,193 @@
+"""INDIA-2-DEEP-A benchmark and fail-closed geometry tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from structural_lib.codes.is456.deep_beam import (
+    DeepBeamActionInput,
+    DeepBeamContractError,
+    DeepBeamGeometry,
+    DeepBeamLeverArmCase,
+    DeepBeamSupportType,
+    resolve_simply_supported_deep_beam_geometry,
+)
+from structural_lib.codes.is456.traceability import get_clause_refs
+
+
+def _benchmark_geometry(**overrides: object) -> DeepBeamGeometry:
+    values: dict[str, object] = {
+        "centre_to_centre_span_mm": 3000.0,
+        "clear_span_mm": 2800.0,
+        "overall_depth_mm": 2000.0,
+        "beam_width_mm": 300.0,
+        "support_type": DeepBeamSupportType.SIMPLY_SUPPORTED,
+        "solid_rectangular_section": True,
+        "openings_present": False,
+        "dapped_ends_present": False,
+        "top_loaded": True,
+        "hanging_action_required": False,
+        "bearing_nodal_zone_verified": True,
+        "geometry_basis_reference": "INDIA-2-DEEP-HAND-01-GEOMETRY",
+        "bearing_nodal_zone_reference": "INDIA-2-DEEP-HAND-01-BEARING",
+    }
+    values.update(overrides)
+    return DeepBeamGeometry(**values)  # type: ignore[arg-type]
+
+
+def _benchmark_action(**overrides: object) -> DeepBeamActionInput:
+    values: dict[str, object] = {
+        "geometry": _benchmark_geometry(),
+        "concrete_grade_nmm2": 30.0,
+        "steel_grade_nmm2": 500.0,
+        "factored_positive_moment_knm": 900.0,
+        "action_basis_reference": "INDIA-2-DEEP-HAND-01-ACTIONS",
+    }
+    values.update(overrides)
+    return DeepBeamActionInput(**values)  # type: ignore[arg-type]
+
+
+def test_hand_benchmark_effective_span_classification_and_lever_arm() -> None:
+    result = resolve_simply_supported_deep_beam_geometry(_benchmark_geometry())
+
+    assert result.centre_to_centre_span_component_mm == pytest.approx(3000.0)
+    assert result.clear_span_component_mm == pytest.approx(3220.0)
+    assert result.effective_span_mm == pytest.approx(3000.0)
+    assert result.effective_span_to_depth_ratio == pytest.approx(1.5)
+    assert result.lever_arm_case is DeepBeamLeverArmCase.RATIO_ONE_TO_TWO
+    assert result.lever_arm_mm == pytest.approx(1400.0)
+    assert result.positive_reinforcement_zone_depth_mm == pytest.approx(350.0)
+
+
+def test_clear_span_component_can_govern_effective_span() -> None:
+    result = resolve_simply_supported_deep_beam_geometry(
+        _benchmark_geometry(centre_to_centre_span_mm=4000.0)
+    )
+
+    assert result.clear_span_component_mm == pytest.approx(3220.0)
+    assert result.effective_span_mm == pytest.approx(3220.0)
+
+
+def test_ratio_below_one_uses_point_six_span_lever_arm() -> None:
+    result = resolve_simply_supported_deep_beam_geometry(
+        _benchmark_geometry(overall_depth_mm=4000.0)
+    )
+
+    assert result.effective_span_to_depth_ratio == pytest.approx(0.75)
+    assert result.lever_arm_case is DeepBeamLeverArmCase.RATIO_BELOW_ONE
+    assert result.lever_arm_mm == pytest.approx(1800.0)
+
+
+def test_ratio_one_is_continuous_between_lever_arm_branches() -> None:
+    result = resolve_simply_supported_deep_beam_geometry(
+        _benchmark_geometry(overall_depth_mm=3000.0)
+    )
+
+    assert result.effective_span_to_depth_ratio == pytest.approx(1.0)
+    assert result.lever_arm_case is DeepBeamLeverArmCase.RATIO_ONE_TO_TWO
+    assert result.lever_arm_mm == pytest.approx(1800.0)
+
+
+def test_ratio_just_below_two_is_accepted_and_two_fails_closed() -> None:
+    accepted = resolve_simply_supported_deep_beam_geometry(
+        _benchmark_geometry(overall_depth_mm=1500.1)
+    )
+    assert accepted.effective_span_to_depth_ratio < 2.0
+
+    with pytest.raises(DeepBeamContractError, match="must be less than 2.0"):
+        resolve_simply_supported_deep_beam_geometry(
+            _benchmark_geometry(overall_depth_mm=1500.0)
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("centre_to_centre_span_mm", 0.0),
+        ("clear_span_mm", math.inf),
+        ("overall_depth_mm", -1.0),
+        ("beam_width_mm", math.nan),
+    ),
+)
+def test_invalid_dimensions_fail_closed(field: str, value: float) -> None:
+    with pytest.raises(DeepBeamContractError, match=field):
+        _benchmark_geometry(**{field: value})
+
+
+def test_clear_span_must_be_less_than_support_centre_span() -> None:
+    with pytest.raises(DeepBeamContractError, match="clear_span_mm"):
+        _benchmark_geometry(clear_span_mm=3000.0)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("solid_rectangular_section", False),
+        ("openings_present", True),
+        ("dapped_ends_present", True),
+        ("top_loaded", False),
+        ("hanging_action_required", True),
+        ("bearing_nodal_zone_verified", False),
+    ),
+)
+def test_each_topology_and_external_confirmation_is_required(
+    field: str, value: bool
+) -> None:
+    with pytest.raises(DeepBeamContractError, match=field):
+        _benchmark_geometry(**{field: value})
+
+
+def test_support_type_and_references_fail_closed() -> None:
+    with pytest.raises(DeepBeamContractError, match="support_type"):
+        _benchmark_geometry(support_type="continuous")
+    with pytest.raises(DeepBeamContractError, match="geometry_basis_reference"):
+        _benchmark_geometry(geometry_basis_reference=" ")
+    with pytest.raises(DeepBeamContractError, match="bearing_nodal_zone_reference"):
+        _benchmark_geometry(bearing_nodal_zone_reference=" ")
+
+
+def test_action_material_and_reference_contracts() -> None:
+    accepted = _benchmark_action()
+    assert accepted.concrete_grade_nmm2 == pytest.approx(30.0)
+    assert accepted.steel_grade_nmm2 == pytest.approx(500.0)
+    assert accepted.factored_positive_moment_knm == pytest.approx(900.0)
+
+    with pytest.raises(DeepBeamContractError, match="standard M20-M60"):
+        _benchmark_action(concrete_grade_nmm2=27.0)
+    with pytest.raises(DeepBeamContractError, match="Fe415 or Fe500"):
+        _benchmark_action(steel_grade_nmm2=550.0)
+    with pytest.raises(DeepBeamContractError, match="factored_positive_moment_knm"):
+        _benchmark_action(factored_positive_moment_knm=0.0)
+    with pytest.raises(DeepBeamContractError, match="action_basis_reference"):
+        _benchmark_action(action_basis_reference=" ")
+
+
+def test_wrong_types_fail_closed() -> None:
+    with pytest.raises(DeepBeamContractError, match="DeepBeamGeometry"):
+        DeepBeamActionInput(
+            geometry=object(),  # type: ignore[arg-type]
+            concrete_grade_nmm2=30.0,
+            steel_grade_nmm2=500.0,
+            factored_positive_moment_knm=900.0,
+            action_basis_reference="benchmark",
+        )
+    with pytest.raises(DeepBeamContractError, match="DeepBeamGeometry"):
+        resolve_simply_supported_deep_beam_geometry(object())  # type: ignore[arg-type]
+
+
+def test_clause_and_source_provenance_is_machine_visible() -> None:
+    result = resolve_simply_supported_deep_beam_geometry(_benchmark_geometry())
+
+    assert get_clause_refs(resolve_simply_supported_deep_beam_geometry) == [
+        "29.1",
+        "29.2",
+        "29.3.1",
+    ]
+    assert result.source_refs == (
+        "IS 456:2000 Cl. 29.1-29.3.1",
+        "IS456-2000-A6",
+        "INDIA-2-DEEP-HAND-01-GEOMETRY",
+        "INDIA-2-DEEP-HAND-01-BEARING",
+    )

--- a/Python/tests/codes/is456/index.json
+++ b/Python/tests/codes/is456/index.json
@@ -21,6 +21,12 @@
       "is_package": true
     },
     {
+      "name": "deep_beam",
+      "path": "deep_beam/",
+      "file_count": 4,
+      "is_package": true
+    },
+    {
       "name": "slab",
       "path": "slab/",
       "file_count": 7
@@ -39,5 +45,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "c48fab64113dbe81"
+  "content_hash": "9469e7850a641cee"
 }

--- a/Python/tests/codes/is456/index.md
+++ b/Python/tests/codes/is456/index.md
@@ -15,6 +15,7 @@
 | Folder | Files | Description |
 |--------|-------|-------------|
 | [column/](column/) 📦 | 7 |  |
+| [deep_beam/](deep_beam/) 📦 | 4 |  |
 | [slab/](slab/) | 7 |  |
 | [staircase/](staircase/) 📦 | 5 |  |
 | [wall/](wall/) 📦 | 5 |  |

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -4676,7 +4676,7 @@
     {
       "name": "codes",
       "path": "codes/",
-      "file_count": 31,
+      "file_count": 35,
       "is_package": true
     },
     {
@@ -4727,5 +4727,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "e01f3a932f454456"
+  "content_hash": "c3484ec152ece8c7"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -88,7 +88,7 @@ This document describes the test taxonomy and structure for the structural_engin
 
 | Folder | Files | Description |
 |--------|-------|-------------|
-| [codes/](codes/) 📦 | 31 |  |
+| [codes/](codes/) 📦 | 35 |  |
 | [data/](data/) | 5 |  |
 | [fixtures/](fixtures/) | 11 |  |
 | [helpers/](helpers/) 📦 | 2 |  |

--- a/Python/tests/unit/test_clauses_json.py
+++ b/Python/tests/unit/test_clauses_json.py
@@ -196,3 +196,24 @@ WALL_CLAUSES = ["32.1", "32.2", "32.3", "32.4", "32.5"]
 def test_clauses_walls_section(clauses, clause_id):
     """Wall clause exists in clauses.json."""
     assert clause_id in clauses, f"Missing wall clause: {clause_id}"
+
+
+# --- Coverage tests: deep beams ---
+
+
+DEEP_BEAM_CLAUSES = [
+    "29",
+    "29.1",
+    "29.2",
+    "29.3",
+    "29.3.1",
+    "29.3.2",
+    "29.3.3",
+    "29.3.4",
+]
+
+
+@pytest.mark.parametrize("clause_id", DEEP_BEAM_CLAUSES)
+def test_clauses_deep_beam_section(clauses, clause_id):
+    """Deep-beam clause identity exists in clauses.json."""
+    assert clause_id in clauses, f"Missing deep-beam clause: {clause_id}"

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,73 @@
 
 ---
 
+## 2026-08-16 — Session: INDIA-2-DEEP-A Geometry and Lever Arm
+
+**Agent:** Codex (`structural-math`, sole writer; no subagents)
+
+**Branch:** `codex/india-2-deep-a` from integrated DEEP-G0 main at
+`d3b9928f4e15573f10feb41de3d8981ed8ca14d6`
+
+**Git handoff receipt:** `docs/verification/india-2-deep-a-git-handoff-receipt.json`
+
+**Focus:** Implement the frozen Clause 29 geometry, action, classification, lever-arm, provenance, and fail-closed contracts only.
+
+### Summary
+
+- Added an internal `codes/is456/deep_beam` package with typed geometry,
+  material/action, support, and lever-arm branch contracts.
+- Implemented effective-span resolution, the simply supported `l/D < 2`
+  boundary, both Clause 29.2 lever-arm branches, and the Clause 29.3.1 positive-
+  reinforcement zone depth.
+- Added exact Clause 29 identities to the public identifier-only traceability
+  database and focused benchmark/boundary tests without publishing capability.
+
+### Issues encountered
+
+- The traceability database had no Clause 29 identifiers, so decorating the new
+  resolver would warn and public clause lookup could not resolve the source.
+- Initial source provenance included the frozen geometry benchmark ID both as a
+  static resolver source and as the caller's geometry-basis reference.
+
+### Root causes and resolutions
+
+- Root cause: prior supported families had never required Clause 29 records.
+  Resolution: add identifier-only records for Clause 29, 29.1, 29.2, 29.3, and
+  29.3.1-29.3.4; update the database count and coverage test.
+- Root cause: the static source tuple and caller evidence used the same
+  benchmark identity. Resolution: keep only the standard identities static and
+  append the caller geometry and bearing/nodal references once.
+
+### Evidence
+
+- The direct deep-beam package passes 20 tests; the combined geometry, clause-
+  database, traceability, and manifest selection passes 109 tests.
+- Benchmark outputs are effective span 3000 mm, `l/D = 1.5`, lever arm 1400
+  mm, and positive-reinforcement zone depth 350 mm.
+- Below-one, exactly-one, just-below-two, and exact-two ratio boundaries pass or
+  fail closed as specified; every topology and external-verification assertion
+  is directly exercised.
+- Black, Ruff, mypy, and Bandit pass; architecture reports 0 violations across
+  173 files and imports report 0 broken across 208 files.
+- Manifest/parity truth remains 9 supported and 12 held families with 100%
+  actionable parity and all 77 endpoints directly tested; touched indexes and
+  quick gate 10/10 pass.
+- Link and hosted evidence is recorded in `india-2-deep-a-geometry-evidence.md`
+  and the exact PR checks.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: three initially inferred validation paths did not exist
+  (`scripts/indian_code_manifest.py`,
+  `Python/tests/unit/test_clause_traceability.py`, and
+  `scripts/check_architecture.py`/`scripts/check_imports.py`) → discovered the
+  maintained entrypoints with `rg --files` and `./run.sh find`, then passed
+  `scripts/generate_indian_code_manifest.py --check`,
+  `Python/tests/test_clause_traceability.py`,
+  `scripts/check_architecture_boundaries.py`, and `scripts/validate_imports.py`.
+
+---
+
 ## 2026-08-16 — Session: INDIA-2-DEEP-G0 Scope and Evidence Decision
 
 **Agent:** Codex (`structural-engineer`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-16 — INDIA-2-DEEP-G0 is GO for one bounded simply supported Clause 29 positive-reinforcement check; DEEP-A is next
+**Updated:** 2026-08-16 — INDIA-2-DEEP-A implements the bounded geometry/classification/lever-arm foundation; DEEP-B is next
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| INDIA-2-DEEP | Implement one bounded simply supported Clause 29 positive-reinforcement check through A-D and focused family acceptance | Main Agent + structural engineer | 🚧 ACTIVE — G0 is GO; DEEP-A geometry, classification, lever-arm, action, and typed fail-closed contracts are next |
+| INDIA-2-DEEP | Implement one bounded simply supported Clause 29 positive-reinforcement check through A-D and focused family acceptance | Main Agent + structural engineer | 🚧 ACTIVE — G0 is GO and DEEP-A is complete; DEEP-B positive tie, placement, anchorage, side-face, and composed dispositions are next |
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
 
 ## Up Next
@@ -158,6 +158,7 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-2-DEEP-A | Added typed geometry/material/action contracts, effective-span classification, both Clause 29.2 lever-arm branches, tension-zone depth, exact clause registration, and fail-closed tests | Main Agent + structural math | ✅ COMPLETE — 65 focused geometry/clause-database tests pass; no reinforcement or capability claim before DEEP-B-D |
 | INDIA-2-DEEP-G0 | Froze one simply supported solid rectangular deep-beam positive-reinforcement check with public clause provenance and a pre-implementation hand benchmark | Main Agent + structural engineer | ✅ GO — caller-supplied positive factored moment; bearing/nodal verification is an external prerequisite; openings, hanging action, continuous beams, generalized strut-and-tie, and alternate systems remain held |
 | INDIA-2-WALL | Implemented and accepted one bounded braced empirical vertical-compression wall workflow with public Clause 32 provenance | Main Agent + structural engineer | ✅ DONE — A-D integrated; 135-test focused family selection and independent hand benchmark pass; qualified review and excluded wall systems remain held |
 | INDIA-2-WALL-D | Added thin typed FastAPI transport, canonical wall capability/semantic truth, manifest promotion, and publication evidence | Main Agent + API developer | ✅ INTEGRATED — PR #772 merged as `46094a8c`; family acceptance passed from that exact integrated head |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 6757,
+      "size_lines": 6824,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "5658b69eed85"
+      "content_hash": "fbb38076549a"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 705,
+      "size_lines": 706,
       "last_updated": "2026-08-16",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "2ddcff36465e"
+      "content_hash": "b748443a0420"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 51,
+      "file_count": 54,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "a7073957f1d84951"
+  "content_hash": "d594ef24e541d765"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6757 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 705 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 6824 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 706 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 51 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 54 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -69,7 +69,7 @@
       "size_lines": 315,
       "last_updated": "2026-08-16",
       "description": "INDIA-2 finishes a practical, explicitly limited set of IS 456 reinforced concrete elements that are still missing from the library.",
-      "content_hash": "2f0e7bcb6d46"
+      "content_hash": "50973cb2d3e5"
     },
     {
       "name": "indian-code-completion-plan.md",
@@ -123,11 +123,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 92,
+      "size_lines": 94,
       "last_updated": "2026-08-16",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-16",
-      "content_hash": "4c87e6f56ca9"
+      "content_hash": "04963c5382ee"
     },
     {
       "name": "pre-release-checklist.md",
@@ -165,5 +165,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "8daa5ef644798a95"
+  "content_hash": "4fb8db2988477cb7"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -22,7 +22,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 92 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 94 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/india-2-remaining-is456-elements-plan.md
+++ b/docs/planning/india-2-remaining-is456-elements-plan.md
@@ -45,7 +45,7 @@ Historical staircase task IDs, PRs, and evidence remain unchanged. The former
 |---|---|---|
 | Clause 32 walls | Focused family acceptance complete after A-D integration | One braced empirical vertical-compression wall check supported; alternate wall systems held |
 | Clause 33 stairs | One bounded longitudinal straight waist-slab flight supported | Complete; alternate stair systems remain held |
-| Clause 29 deep beams | G0 is GO; calculation code remains unimplemented | One simply supported positive-moment reinforcement check activated |
+| Clause 29 deep beams | G0 GO; A geometry/classification/lever-arm kernel complete | One simply supported positive-moment reinforcement check active; B-D pending |
 | Flat slabs and column punching | Not implemented | Planned after deep beams |
 | Combined footing | Not implemented | Separate foundation program |
 | Strap footing | Not implemented | Separate foundation program |
@@ -61,7 +61,7 @@ boundary, held with a written reason, or not implemented.
 |---:|---|---|---|
 | 1 | `INDIA-2-WALL` | First clause-bounded remaining element; established the new-family workflow | Complete within the written bounded case |
 | — | `INDIA-2-STAIR` | Already implemented and cumulatively gated | Complete |
-| 2 | `INDIA-2-DEEP` | Extends beam capability under its own geometry, action, and detailing boundary | G0 GO; A-D and acceptance pending |
+| 2 | `INDIA-2-DEEP` | Extends beam capability under its own geometry, action, and detailing boundary | G0 and A complete; B-D and acceptance pending |
 | 3 | `INDIA-2-FLAT` | Requires panel analysis/distribution plus column punching; broader than the existing solid-slab route | Planned |
 | 4 | Foundation extensions | Each uses a different analysis model and must be activated separately | Planned, order provisional |
 | 5 | `INDIA-2-CLOSEOUT` | Reconcile truth, run final cumulative gates, and freeze the INDIA-2 evidence set | Pending |
@@ -203,7 +203,7 @@ sections, prestressing, cyclic/seismic design, generalized strut-and-tie
 modelling, nonlinear analysis, and FEM.
 
 Packets are G0 decision (GO); A typed geometry/classification, effective-span,
-lever-arm, action, and fail-closed contract; B positive tie, placement,
+lever-arm, action, and fail-closed contract (complete); B positive tie, placement,
 anchorage, side-face, and composed dispositions; C public Python workflow; D
 thin API/capability/evidence; then one focused family acceptance bundle.
 
@@ -306,7 +306,7 @@ authorized programs.
 
 ## 9. Exact next action
 
-Implement `INDIA-2-DEEP-A` from the verified integrated G0 head without adding
+Implement `INDIA-2-DEEP-B` from the verified integrated A head without adding
 continuous beams, openings, hanging action, load analysis, bearing/nodal-zone
 design, or generalized strut-and-tie scope. The owner's 2026-08-16 request
 activates the remaining INDIA-2 families subject to each family's own G0

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,9 +4,9 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-16
-- Focus: Decide one public-source, benchmarked Clause 29 deep-beam boundary before calculation implementation.
-- Git receipt: docs/verification/india-2-deep-g0-git-handoff-receipt.json | sha256:cc7f9a80b62148dd4ba68c392f981ef1cea91945fa3e149eec4ee94ad0e3fba9 | HOLD
-- Git identity: codex/india-2-deep-g0@90ea7c1e4adf05c04e986dc3657e0403d598930d | upstream=NONE@UNKNOWN | base=origin/main@90ea7c1e4adf05c04e986dc3657e0403d598930d | tree=dirty | operation=none
+- Focus: Implement the frozen Clause 29 geometry, action, classification, lever-arm, provenance, and fail-closed contracts only.
+- Git receipt: docs/verification/india-2-deep-a-git-handoff-receipt.json | sha256:c677fdd8a70d80a958c72bbc071719ce13b3a04b65396e7ba27802ccda8c8ee8 | HOLD
+- Git identity: codex/india-2-deep-a@d3b9928f4e15573f10feb41de3d8981ed8ca14d6 | upstream=NONE@UNKNOWN | base=origin/main@d3b9928f4e15573f10feb41de3d8981ed8ca14d6 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: WAIT_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->
@@ -17,7 +17,7 @@
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; INDIA-0, INDIA-1, and the INDIA-2-STAIR family are complete |
 | **Program** | Umbrella INDIA-2 remains in progress; INDIA-3 and INDIA-4 remain planned |
-| **Next** | Implement `INDIA-2-DEEP-A` from the integrated G0 head within the frozen simply supported positive-moment boundary |
+| **Next** | Implement `INDIA-2-DEEP-B` from integrated A: positive tie, placement, anchorage, side-face, and composed pure-math dispositions |
 
 ## Required Reading
 
@@ -71,8 +71,10 @@ focused validation, retained holds, and deferred broad-gate boundary.
 
 [`india-2-deep-g0-scope-evidence.md`](../verification/india-2-deep-g0-scope-evidence.md)
 records GO for one simply supported solid rectangular deep-beam positive-
-reinforcement check. DEEP-A may implement only the typed effective-span,
-classification, lever-arm, caller-action, and fail-closed contracts. Bearing
+reinforcement check. [`india-2-deep-a-geometry-evidence.md`](../verification/india-2-deep-a-geometry-evidence.md)
+records the implemented typed effective-span, classification, lever-arm,
+caller-action, and fail-closed contracts. DEEP-B may add only the frozen
+positive tie, placement, continuity, anchorage, side-face, and composed checks. Bearing
 and compression-nodal regions require a caller-supplied external verification;
 continuous beams, openings, hanging action, negative moment, load generation,
 generalized strut-and-tie, nonlinear analysis, and FEM remain held.

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-16",
-  "file_count": 49,
+  "file_count": 52,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -197,6 +197,44 @@
         "task_archive"
       ],
       "content_hash": "aab91df123a3"
+    },
+    {
+      "name": "india-2-deep-a-geometry-evidence.md",
+      "type": "documentation",
+      "size_lines": 73,
+      "last_updated": "2026-08-16",
+      "description": "DEEP-A implements the typed pure-math foundation for the G0-approved case: one simply supported, top-loaded, solid rectangular deep beam without openings,",
+      "content_hash": "6e1bf2ca5125"
+    },
+    {
+      "name": "india-2-deep-a-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "68f24505a82b"
+    },
+    {
+      "name": "india-2-deep-a-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "8639954ae9ee"
     },
     {
       "name": "india-2-deep-g0-git-handoff-receipt.json",
@@ -450,7 +488,7 @@
         "capability_summary",
         "standards"
       ],
-      "content_hash": "438a4cff928c"
+      "content_hash": "34c3062e24dc"
     },
     {
       "name": "indian-code-truth-baseline.md",
@@ -539,5 +577,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "bb6968753013eb9c"
+  "content_hash": "e0ba5c90d73989c3"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-16
-**Files:** 49
+**Files:** 52
 
 ## Config Files
 
@@ -14,6 +14,8 @@ Benchmark examples and verification packs for validating library calculations ag
 - [git-primary-session-log-reconcile-handoff-source-evidence.json](git-primary-session-log-reconcile-handoff-source-evidence.json)
 - [india-2-cumulative-git-handoff-receipt.json](india-2-cumulative-git-handoff-receipt.json)
 - [india-2-cumulative-git-handoff-source-evidence.json](india-2-cumulative-git-handoff-source-evidence.json)
+- [india-2-deep-a-git-handoff-receipt.json](india-2-deep-a-git-handoff-receipt.json)
+- [india-2-deep-a-git-handoff-source-evidence.json](india-2-deep-a-git-handoff-source-evidence.json)
 - [india-2-deep-g0-git-handoff-receipt.json](india-2-deep-g0-git-handoff-receipt.json)
 - [india-2-deep-g0-git-handoff-source-evidence.json](india-2-deep-g0-git-handoff-source-evidence.json)
 - [india-2-plan-git-handoff-receipt.json](india-2-plan-git-handoff-receipt.json)
@@ -43,6 +45,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [india-1c-isolated-footing-workflow-evidence.md](india-1c-isolated-footing-workflow-evidence.md) |  | INDIA-1C publishes the existing bounded concentric isolated- | 53 |
 | [india-1d-slab-boundary-evidence.md](india-1d-slab-boundary-evidence.md) |  | INDIA-1D closes the decision boundary around already support | 71 |
 | [india-2-cumulative-gate-evidence.md](india-2-cumulative-gate-evidence.md) |  | INDIA-2A-D are integrated through exact origin/main 18da6c11 | 71 |
+| [india-2-deep-a-geometry-evidence.md](india-2-deep-a-geometry-evidence.md) |  | DEEP-A implements the typed pure-math foundation for the G0- | 73 |
 | [india-2-deep-g0-scope-evidence.md](india-2-deep-g0-scope-evidence.md) |  | supported, solid rectangular, top-loaded deep beam without o | 166 |
 | [india-2-wall-a-axial-kernel-evidence.md](india-2-wall-a-axial-kernel-evidence.md) |  | WALL-A implements the pure IS 456 layer for the accepted Cla | 83 |
 | [india-2-wall-b-reinforcement-evidence.md](india-2-wall-b-reinforcement-evidence.md) |  | WALL-B adds one pure IS 456 provided-reinforcement check to  | 82 |

--- a/docs/verification/india-2-deep-a-geometry-evidence.md
+++ b/docs/verification/india-2-deep-a-geometry-evidence.md
@@ -1,0 +1,72 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-16
+doc_type: reference
+task: INDIA-2-DEEP-A
+---
+
+# INDIA-2-DEEP-A Geometry and Lever-Arm Evidence
+
+## Implemented boundary
+
+DEEP-A implements the typed pure-math foundation for the G0-approved case: one
+simply supported, top-loaded, solid rectangular deep beam without openings,
+dapped ends, or hanging action. It adds no reinforcement-area or final design
+disposition; those belong to DEEP-B.
+
+`DeepBeamGeometry` requires explicit mm geometry, the supported support type,
+all topology assertions, geometry provenance, and affirmative external
+bearing/compression-nodal verification with a non-blank reference.
+`DeepBeamActionInput` accepts standard M20-M60 concrete, Fe415 or Fe500 steel,
+one caller-supplied positive factored moment in kN m, and its action reference.
+
+## Normalized Clause 29 behavior
+
+`resolve_simply_supported_deep_beam_geometry` exposes:
+
+- both effective-span components and their governing minimum;
+- effective-span/overall-depth ratio, failing closed at or above `2.0`;
+- the visually verified `0.6l` lever arm below ratio one;
+- the `0.2(l + 2D)` lever arm from ratio one to below two;
+- the Clause 29.3.1 positive-reinforcement zone depth; and
+- exact clause, standard, geometry-basis, and external bearing/nodal references.
+
+The two lever-arm branches produce the same value at ratio one. Unsupported
+continuous support, openings, non-solid sections, dapped ends, non-top loading,
+hanging action, missing bearing/nodal confirmation, invalid material/action,
+and non-finite values raise `DeepBeamContractError`; they do not produce a
+partial geometry result.
+
+## Public clause registration
+
+The identifier-only traceability database now registers Clause 29, 29.1, 29.2,
+29.3, and 29.3.1-29.3.4 with titles, sections, categories, and search keywords.
+No clause prose or table content is stored. The resolver is decorated with
+Clauses 29.1, 29.2, and 29.3.1, and its runtime result retains
+`IS456-2000-A6` plus caller evidence.
+
+## Benchmark and unsafe evidence
+
+The frozen `INDIA-2-DEEP-HAND-01` geometry resolves exactly to effective span
+3000 mm, ratio 1.5, lever arm 1400 mm, and positive-reinforcement zone depth
+350 mm. A clear-span-controlled case, the below-one branch, the ratio-one
+continuity point, the just-below-two boundary, and exact ratio-two rejection are
+all directly tested.
+
+The direct deep-beam package passes 20 tests; the combined geometry,
+clause-database, traceability, and deterministic-manifest selection passes 109
+tests. The clause database now contains 143 identifier-only records. Black,
+Ruff, mypy, and Bandit pass on the changed executable paths. Architecture
+validation reports 0 violations across 173 files and import validation reports
+0 broken imports across 208 files.
+
+The generated manifest remains current at 9 supported and 12 held families;
+deep beam remains `HELD`/`NOT_IMPLEMENTED` until the later publication packet.
+Actionable parity remains 100%, all 77 endpoints retain direct tests, touched
+folder indexes are current, and quick gate passes 10/10. Required hosted checks
+must pass on the unchanged reviewed head before integration.
+
+The broad Python suite and 30-check repository gate remain deferred to the one
+whole-INDIA-2 closeout, unless an outcome-changing repository-wide issue
+appears earlier. The next packet is `INDIA-2-DEEP-B`.

--- a/docs/verification/india-2-deep-a-git-handoff-receipt.json
+++ b/docs/verification/india-2-deep-a-git-handoff-receipt.json
@@ -1,0 +1,183 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-15T20:49:09Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2:user-request-start-and-finish",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-15T20:49:09Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-deep-a",
+      "head_sha": "d3b9928f4e15573f10feb41de3d8981ed8ca14d6",
+      "task_id": "INDIA-2-DEEP-A"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "c677fdd8a70d80a958c72bbc071719ce13b3a04b65396e7ba27802ccda8c8ee8",
+    "state": {
+      "branch": "codex/india-2-deep-a",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "d3b9928f4e15573f10feb41de3d8981ed8ca14d6",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 85.669,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-india-2-deep-a",
+      "head_sha": "d3b9928f4e15573f10feb41de3d8981ed8ca14d6",
+      "hold_reasons": [
+        "changed paths: 30"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-15T20:49:34.171885+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-deep-a",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 30,
+        "modified_paths": [
+          "Python/structural_lib/codes/is456/clauses.json",
+          "Python/structural_lib/codes/is456/index.json",
+          "Python/structural_lib/codes/is456/index.md",
+          "Python/tests/codes/is456/index.json",
+          "Python/tests/codes/is456/index.md",
+          "Python/tests/index.json",
+          "Python/tests/index.md",
+          "Python/tests/unit/test_clauses_json.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/index.json",
+          "docs/planning/index.md",
+          "docs/planning/india-2-remaining-is456-elements-plan.md",
+          "docs/planning/next-session-brief.md",
+          "docs/verification/index.json",
+          "docs/verification/index.md",
+          "docs/verification/indian-code-capability-coverage.json"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "Python/structural_lib/codes/is456/deep_beam/__init__.py",
+          "Python/structural_lib/codes/is456/deep_beam/geometry.py",
+          "Python/structural_lib/codes/is456/deep_beam/index.json",
+          "Python/structural_lib/codes/is456/deep_beam/index.md",
+          "Python/structural_lib/codes/is456/deep_beam/models.py",
+          "Python/tests/codes/is456/deep_beam/__init__.py",
+          "Python/tests/codes/is456/deep_beam/index.json",
+          "Python/tests/codes/is456/deep_beam/index.md",
+          "Python/tests/codes/is456/deep_beam/test_geometry.py",
+          "docs/verification/india-2-deep-a-geometry-evidence.md",
+          "docs/verification/india-2-deep-a-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-deep-a"
+    }
+  },
+  "local_state_receipt_hash": "sha256:c677fdd8a70d80a958c72bbc071719ce13b3a04b65396e7ba27802ccda8c8ee8",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-15T20:49:34.172056+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-15T20:49:09Z",
+    "owner": "Main Agent under user instruction to preserve Git state",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/services/**",
+      "fastapi_app/**",
+      "react_app/**",
+      "refs/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "Python/structural_lib/codes/is456/deep_beam",
+      "Python/tests/codes/is456/deep_beam",
+      "Python/structural_lib/codes/is456/clauses.json",
+      "Python/tests/unit/test_clauses_json.py",
+      "docs/verification/india-2-deep-a-geometry-evidence.md",
+      "docs/verification/india-2-deep-a-git-handoff-source-evidence.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/india-2-remaining-is456-elements-plan.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "INDIA-2-DEEP-A"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-2-deep-a-git-handoff-source-evidence.json
+++ b/docs/verification/india-2-deep-a-git-handoff-source-evidence.json
@@ -1,0 +1,53 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-15T20:49:09Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2:user-request-start-and-finish",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-15T20:49:09Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-deep-a",
+      "head_sha": "d3b9928f4e15573f10feb41de3d8981ed8ca14d6",
+      "task_id": "INDIA-2-DEEP-A"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-15T20:49:09Z",
+    "owner": "Main Agent under user instruction to preserve Git state",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -275,11 +275,11 @@
         }
       ],
       "registration_summary": {
-        "known_references": 134,
-        "registered_known_references": 70,
-        "metadata_only_references": 64,
+        "known_references": 142,
+        "registered_known_references": 73,
+        "metadata_only_references": 69,
         "registration_only_references": 0,
-        "registration_pct": 52.2
+        "registration_pct": 51.4
       },
       "references": [
         {
@@ -677,6 +677,84 @@
           "reference_type": "clause",
           "title": "Transverse Reinforcement in Columns",
           "category": "columns",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:29",
+          "reference": "29",
+          "reference_type": "clause",
+          "title": "Deep Beams",
+          "category": "flexure",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:29.1",
+          "reference": "29.1",
+          "reference_type": "clause",
+          "title": "Deep-Beam Classification and General Requirements",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.deep_beam.geometry.resolve_simply_supported_deep_beam_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:29.2",
+          "reference": "29.2",
+          "reference_type": "clause",
+          "title": "Deep-Beam Lever Arm",
+          "category": "flexure",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.deep_beam.geometry.resolve_simply_supported_deep_beam_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:29.3",
+          "reference": "29.3",
+          "reference_type": "clause",
+          "title": "Deep-Beam Reinforcement",
+          "category": "detailing",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:29.3.1",
+          "reference": "29.3.1",
+          "reference_type": "clause",
+          "title": "Positive Reinforcement in Deep Beams",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.deep_beam.geometry.resolve_simply_supported_deep_beam_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:29.3.2",
+          "reference": "29.3.2",
+          "reference_type": "clause",
+          "title": "Negative Reinforcement in Deep Beams",
+          "category": "detailing",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:29.3.3",
+          "reference": "29.3.3",
+          "reference_type": "clause",
+          "title": "Vertical Reinforcement for Hanging Action",
+          "category": "detailing",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:29.3.4",
+          "reference": "29.3.4",
+          "reference_type": "clause",
+          "title": "Side-Face Reinforcement in Deep Beams",
+          "category": "detailing",
           "registration_status": "METADATA_ONLY",
           "functions": []
         },


### PR DESCRIPTION
## Scope
- add typed fail-closed contracts for the approved simply supported solid rectangular deep-beam case
- implement IS 456 Clause 29 effective span, classification, lever-arm branches, and positive-reinforcement zone geometry
- register public Clause 29 identifiers and retain exact runtime source/caller provenance
- keep deep-beam capability held until the reinforcement and publication packets

## Validation
- 20 direct deep-beam tests; 109 focused deep-beam, clause, traceability, and manifest tests
- Black, Ruff, mypy, Bandit, architecture 0 violations, imports 0 broken
- manifest current; 1,168 links valid; quick gate 10/10
- broad Python and full 30-check gates intentionally deferred to whole-INDIA-2 integration

## Boundaries
- no continuous beams, openings, dapped ends, hanging action, bearing/nodal calculation, load generation, auto-sizing, seismic, FEM, or release action
- external bearing/compression-nodal verification remains an explicit prerequisite

Task: INDIA-2-DEEP-A