### PR TITLE
feat(is456): add flat slab geometry kernel

### DIFF
--- a/Python/structural_lib/codes/is456/clauses.json
+++ b/Python/structural_lib/codes/is456/clauses.json
@@ -6,7 +6,7 @@
     "version": "2000 (Reaffirmed 2021)",
     "source": "Bureau of Indian Standards",
     "last_updated": "2026-08-16",
-    "total_clauses": 143,
+    "total_clauses": 152,
     "includes_references": [
       "IS 13920:2016"
     ],
@@ -579,6 +579,97 @@
         "side face",
         "wall minimum reinforcement",
         "Amendment 3"
+      ]
+    },
+    "31": {
+      "title": "Flat Slabs",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "flat slab",
+        "column supported slab",
+        "direct design"
+      ]
+    },
+    "31.1": {
+      "title": "Flat Slabs - General",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "flat slab",
+        "drop",
+        "column head"
+      ]
+    },
+    "31.1.1": {
+      "title": "Column Strip, Middle Strip and Panel Definitions",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "column strip",
+        "middle strip",
+        "panel"
+      ]
+    },
+    "31.2": {
+      "title": "Flat Slab Proportioning",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "proportioning",
+        "thickness",
+        "drop"
+      ]
+    },
+    "31.2.1": {
+      "title": "Thickness of Flat Slab",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "thickness",
+        "span depth",
+        "minimum thickness"
+      ]
+    },
+    "31.3": {
+      "title": "Determination of Flat Slab Bending Moment",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "bending moment",
+        "analysis method",
+        "panel"
+      ]
+    },
+    "31.3.1": {
+      "title": "Methods of Flat Slab Analysis and Design",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "direct design",
+        "equivalent frame",
+        "analysis"
+      ]
+    },
+    "31.4": {
+      "title": "Direct Design Method",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "direct design",
+        "gravity load",
+        "moment distribution"
+      ]
+    },
+    "31.4.1": {
+      "title": "Direct Design Method Limitations",
+      "section": "31 - Flat Slabs",
+      "category": "slabs",
+      "keywords": [
+        "three spans",
+        "panel regularity",
+        "column offset",
+        "live dead ratio"
       ]
     },
     "31.6": {

--- a/Python/structural_lib/codes/is456/flat_slab/__init__.py
+++ b/Python/structural_lib/codes/is456/flat_slab/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Bounded IS 456 Clause 31 interior flat-slab contracts."""
+
+from structural_lib.codes.is456.flat_slab.geometry import (
+    FlatSlabDirection,
+    FlatSlabDirectionGeometry,
+    FlatSlabGeometryResult,
+    resolve_regular_interior_flat_slab_geometry,
+)
+from structural_lib.codes.is456.flat_slab.models import (
+    FlatSlabAnalysisMethod,
+    FlatSlabContractError,
+    FlatSlabGravityLoad,
+    FlatSlabGridGeometry,
+    FlatSlabMaterial,
+    FlatSlabPanelInput,
+    FlatSlabPanelLocation,
+)
+
+__all__ = [
+    "FlatSlabAnalysisMethod",
+    "FlatSlabContractError",
+    "FlatSlabDirection",
+    "FlatSlabDirectionGeometry",
+    "FlatSlabGeometryResult",
+    "FlatSlabGravityLoad",
+    "FlatSlabGridGeometry",
+    "FlatSlabMaterial",
+    "FlatSlabPanelInput",
+    "FlatSlabPanelLocation",
+    "resolve_regular_interior_flat_slab_geometry",
+]

--- a/Python/structural_lib/codes/is456/flat_slab/geometry.py
+++ b/Python/structural_lib/codes/is456/flat_slab/geometry.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Clause 31 geometry, eligibility, and strip widths for the bounded panel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from structural_lib.codes.is456.flat_slab.models import (
+    FlatSlabContractError,
+    FlatSlabPanelInput,
+)
+from structural_lib.codes.is456.traceability import clause
+
+__all__ = [
+    "FlatSlabDirection",
+    "FlatSlabDirectionGeometry",
+    "FlatSlabGeometryResult",
+    "resolve_regular_interior_flat_slab_geometry",
+]
+
+
+_SOURCE_REFS = (
+    "IS 456:2000 Cl. 31.1.1, 31.2.1, 31.3.1, 31.4.1",
+    "IS456-2000-A6",
+)
+
+
+class FlatSlabDirection(StrEnum):
+    """Orthogonal panel directions."""
+
+    X = "x"
+    Y = "y"
+
+
+@dataclass(frozen=True)
+class FlatSlabDirectionGeometry:
+    """Clear-span and design-strip geometry in one direction, all in mm."""
+
+    direction: FlatSlabDirection
+    centre_to_centre_span_mm: float
+    transverse_span_mm: float
+    support_width_mm: float
+    face_to_face_clear_span_mm: float
+    minimum_clear_span_component_mm: float
+    governing_clear_span_mm: float
+    column_strip_half_width_mm: float
+    column_strip_total_width_mm: float
+    middle_strip_width_mm: float
+
+
+@dataclass(frozen=True)
+class FlatSlabGeometryResult:
+    """Resolved G0 topology and exact Clause 31 applicability carriers."""
+
+    input: FlatSlabPanelInput
+    x: FlatSlabDirectionGeometry
+    y: FlatSlabDirectionGeometry
+    minimum_slab_thickness_mm: float
+    service_live_dead_ratio: float
+    expected_factored_uniform_load_kn_per_m2: float
+    direct_design_eligible: bool
+    source_refs: tuple[str, ...]
+
+
+def _resolve_direction(
+    *,
+    direction: FlatSlabDirection,
+    centre_span_mm: float,
+    transverse_span_mm: float,
+    support_width_mm: float,
+) -> FlatSlabDirectionGeometry:
+    face_to_face = centre_span_mm - support_width_mm
+    minimum_component = 0.65 * centre_span_mm
+    governing_clear_span = max(face_to_face, minimum_component)
+    half_column_strip = min(0.25 * transverse_span_mm, 0.25 * centre_span_mm)
+    total_column_strip = 2.0 * half_column_strip
+    middle_strip = transverse_span_mm - total_column_strip
+    return FlatSlabDirectionGeometry(
+        direction=direction,
+        centre_to_centre_span_mm=centre_span_mm,
+        transverse_span_mm=transverse_span_mm,
+        support_width_mm=support_width_mm,
+        face_to_face_clear_span_mm=face_to_face,
+        minimum_clear_span_component_mm=minimum_component,
+        governing_clear_span_mm=governing_clear_span,
+        column_strip_half_width_mm=half_column_strip,
+        column_strip_total_width_mm=total_column_strip,
+        middle_strip_width_mm=middle_strip,
+    )
+
+
+@clause("31.1.1", "31.2.1", "31.3.1", "31.4.1")
+def resolve_regular_interior_flat_slab_geometry(
+    panel: FlatSlabPanelInput,
+) -> FlatSlabGeometryResult:
+    """Resolve geometry only for the G0-approved square interior panel."""
+    if not isinstance(panel, FlatSlabPanelInput):
+        raise FlatSlabContractError("panel must be a FlatSlabPanelInput")
+
+    geometry = panel.geometry
+    x = _resolve_direction(
+        direction=FlatSlabDirection.X,
+        centre_span_mm=geometry.centre_to_centre_span_x_mm,
+        transverse_span_mm=geometry.centre_to_centre_span_y_mm,
+        support_width_mm=geometry.column_width_x_mm,
+    )
+    y = _resolve_direction(
+        direction=FlatSlabDirection.Y,
+        centre_span_mm=geometry.centre_to_centre_span_y_mm,
+        transverse_span_mm=geometry.centre_to_centre_span_x_mm,
+        support_width_mm=geometry.column_width_y_mm,
+    )
+    gravity_load = panel.gravity_load
+    return FlatSlabGeometryResult(
+        input=panel,
+        x=x,
+        y=y,
+        minimum_slab_thickness_mm=125.0,
+        service_live_dead_ratio=(
+            gravity_load.service_live_load_kn_per_m2
+            / gravity_load.service_dead_load_kn_per_m2
+        ),
+        expected_factored_uniform_load_kn_per_m2=1.5
+        * (
+            gravity_load.service_dead_load_kn_per_m2
+            + gravity_load.service_live_load_kn_per_m2
+        ),
+        direct_design_eligible=True,
+        source_refs=_SOURCE_REFS
+        + (
+            geometry.geometry_basis_reference,
+            panel.material.material_basis_reference,
+            gravity_load.load_basis_reference,
+        ),
+    )

--- a/Python/structural_lib/codes/is456/flat_slab/index.json
+++ b/Python/structural_lib/codes/is456/flat_slab/index.json
@@ -1,0 +1,105 @@
+{
+  "folder": "Python/structural_lib/codes/is456/flat_slab",
+  "type": "python-package",
+  "description": "",
+  "last_updated": "2026-08-16",
+  "file_count": 3,
+  "files": [
+    {
+      "name": "__init__.py",
+      "type": "python",
+      "size_lines": 34,
+      "last_updated": "2026-08-16",
+      "description": "Bounded IS 456 Clause 31 interior flat-slab contracts.",
+      "content_hash": "26aa401c7cf9"
+    },
+    {
+      "name": "geometry.py",
+      "type": "python",
+      "size_lines": 138,
+      "last_updated": "2026-08-16",
+      "description": "Clause 31 geometry, eligibility, and strip widths for the bounded panel.",
+      "classes": [
+        {
+          "name": "FlatSlabDirection",
+          "description": "Orthogonal panel directions."
+        },
+        {
+          "name": "FlatSlabDirectionGeometry",
+          "description": "Clear-span and design-strip geometry in one direction, all in mm."
+        },
+        {
+          "name": "FlatSlabGeometryResult",
+          "description": "Resolved G0 topology and exact Clause 31 applicability carriers."
+        }
+      ],
+      "functions": [
+        {
+          "name": "resolve_regular_interior_flat_slab_geometry",
+          "description": "Resolve geometry only for the G0-approved square interior panel.",
+          "params": [
+            "panel"
+          ]
+        }
+      ],
+      "constants": [
+        "_SOURCE_REFS"
+      ],
+      "content_hash": "f91614a8096e"
+    },
+    {
+      "name": "models.py",
+      "type": "python",
+      "size_lines": 317,
+      "last_updated": "2026-08-16",
+      "description": "Typed contracts for the bounded INDIA-2 Clause 31 flat-slab case.",
+      "classes": [
+        {
+          "name": "FlatSlabContractError",
+          "description": "Raised when an input is outside the frozen INDIA-2 flat-slab scope."
+        },
+        {
+          "name": "FlatSlabAnalysisMethod",
+          "description": "Analysis methods admitted by the first flat-slab workflow."
+        },
+        {
+          "name": "FlatSlabPanelLocation",
+          "description": "Panel locations admitted by the first flat-slab workflow."
+        },
+        {
+          "name": "FlatSlabGridGeometry",
+          "description": "Caller-confirmed geometry for the first equal-span square panel."
+        },
+        {
+          "name": "FlatSlabMaterial",
+          "description": "Concrete and reinforcement grades for the G0-frozen case."
+        },
+        {
+          "name": "FlatSlabGravityLoad",
+          "description": "Approved-basis uniform gravity actions; the library generates no load."
+        },
+        {
+          "name": "FlatSlabPanelInput",
+          "description": "Complete typed input foundation for later FLAT-B-D calculations."
+        }
+      ],
+      "content_hash": "3979b274be71"
+    }
+  ],
+  "subfolders": [],
+  "has_init": true,
+  "public_api": [
+    "FlatSlabAnalysisMethod",
+    "FlatSlabContractError",
+    "FlatSlabDirection",
+    "FlatSlabDirectionGeometry",
+    "FlatSlabGeometryResult",
+    "FlatSlabGravityLoad",
+    "FlatSlabGridGeometry",
+    "FlatSlabMaterial",
+    "FlatSlabPanelInput",
+    "FlatSlabPanelLocation",
+    "resolve_regular_interior_flat_slab_geometry"
+  ],
+  "content_hash": "203a77af7f7bbc6f"
+}

--- a/Python/structural_lib/codes/is456/flat_slab/index.md
+++ b/Python/structural_lib/codes/is456/flat_slab/index.md
@@ -1,0 +1,27 @@
+# Flat Slab
+
+**Type:** Python Package
+**Last Updated:** 2026-08-16
+**Files:** 3
+
+## Public API
+
+- `FlatSlabAnalysisMethod`
+- `FlatSlabContractError`
+- `FlatSlabDirection`
+- `FlatSlabDirectionGeometry`
+- `FlatSlabGeometryResult`
+- `FlatSlabGravityLoad`
+- `FlatSlabGridGeometry`
+- `FlatSlabMaterial`
+- `FlatSlabPanelInput`
+- `FlatSlabPanelLocation`
+- `resolve_regular_interior_flat_slab_geometry`
+
+## Python Files
+
+| File | Description | Classes | Functions | Lines |
+|------|-------------|---------|-----------|-------|
+| [__init__.py](__init__.py) | Bounded IS 456 Clause 31 interior flat-slab contracts. | 0 | 0 | 34 |
+| [geometry.py](geometry.py) | Clause 31 geometry, eligibility, and strip widths for the bo | 3 | 1 | 138 |
+| [models.py](models.py) | Typed contracts for the bounded INDIA-2 Clause 31 flat-slab  | 7 | 0 | 317 |

--- a/Python/structural_lib/codes/is456/flat_slab/models.py
+++ b/Python/structural_lib/codes/is456/flat_slab/models.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Typed contracts for the bounded INDIA-2 Clause 31 flat-slab case."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from numbers import Real
+
+__all__ = [
+    "FlatSlabAnalysisMethod",
+    "FlatSlabContractError",
+    "FlatSlabGravityLoad",
+    "FlatSlabGridGeometry",
+    "FlatSlabMaterial",
+    "FlatSlabPanelInput",
+    "FlatSlabPanelLocation",
+]
+
+
+class FlatSlabContractError(ValueError):
+    """Raised when an input is outside the frozen INDIA-2 flat-slab scope."""
+
+
+class FlatSlabAnalysisMethod(StrEnum):
+    """Analysis methods admitted by the first flat-slab workflow."""
+
+    DIRECT_DESIGN = "direct_design"
+
+
+class FlatSlabPanelLocation(StrEnum):
+    """Panel locations admitted by the first flat-slab workflow."""
+
+    INTERIOR = "interior"
+
+
+def _positive_finite(value: float, field_name: str, unit: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise FlatSlabContractError(f"{field_name} must be a real value in {unit}")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0.0:
+        raise FlatSlabContractError(
+            f"{field_name} must be finite and positive in {unit}"
+        )
+    return normalized
+
+
+def _positive_integer(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise FlatSlabContractError(f"{field_name} must be a positive integer")
+    return value
+
+
+def _non_blank(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise FlatSlabContractError(f"{field_name} must be a non-blank string")
+    return value.strip()
+
+
+@dataclass(frozen=True)
+class FlatSlabGridGeometry:
+    """Caller-confirmed geometry for the first equal-span square panel.
+
+    All dimensions are in mm. The contract deliberately rejects every
+    topology that would require exterior-panel, drop/head, opening, offset,
+    unequal-span, equivalent-frame, or FEM treatment.
+    """
+
+    centre_to_centre_span_x_mm: float
+    centre_to_centre_span_y_mm: float
+    continuous_span_count_x: int
+    continuous_span_count_y: int
+    column_width_x_mm: float
+    column_width_y_mm: float
+    overall_depth_mm: float
+    conservative_effective_depth_mm: float
+    analysis_method: FlatSlabAnalysisMethod
+    panel_location: FlatSlabPanelLocation
+    all_spans_equal_x: bool
+    all_spans_equal_y: bool
+    columns_offset_from_grid: bool
+    solid_slab: bool
+    drop_present: bool
+    column_head_present: bool
+    marginal_beam_or_wall_present: bool
+    openings_present: bool
+    geometry_basis_reference: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "centre_to_centre_span_x_mm",
+            "centre_to_centre_span_y_mm",
+            "column_width_x_mm",
+            "column_width_y_mm",
+            "overall_depth_mm",
+            "conservative_effective_depth_mm",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _positive_finite(getattr(self, name), name, "mm"),
+            )
+        for name in ("continuous_span_count_x", "continuous_span_count_y"):
+            object.__setattr__(
+                self,
+                name,
+                _positive_integer(getattr(self, name), name),
+            )
+            if getattr(self, name) < 3:
+                raise FlatSlabContractError(
+                    f"{name} must be at least 3 for the direct design route"
+                )
+
+        if not math.isclose(
+            self.centre_to_centre_span_x_mm,
+            self.centre_to_centre_span_y_mm,
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise FlatSlabContractError(
+                "centre_to_centre spans must be equal for the square-panel route"
+            )
+        if not math.isclose(
+            self.column_width_x_mm,
+            self.column_width_y_mm,
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise FlatSlabContractError(
+                "column widths must be equal for the square-column route"
+            )
+        if self.column_width_x_mm >= self.centre_to_centre_span_x_mm:
+            raise FlatSlabContractError(
+                "column_width_x_mm must be less than the panel span"
+            )
+        if self.column_width_y_mm >= self.centre_to_centre_span_y_mm:
+            raise FlatSlabContractError(
+                "column_width_y_mm must be less than the panel span"
+            )
+        if self.overall_depth_mm < 125.0:
+            raise FlatSlabContractError(
+                "overall_depth_mm must be at least 125 mm for a flat slab"
+            )
+        if self.conservative_effective_depth_mm >= self.overall_depth_mm:
+            raise FlatSlabContractError(
+                "conservative_effective_depth_mm must be less than overall_depth_mm"
+            )
+        if self.analysis_method is not FlatSlabAnalysisMethod.DIRECT_DESIGN:
+            raise FlatSlabContractError(
+                "analysis_method must be FlatSlabAnalysisMethod.DIRECT_DESIGN"
+            )
+        if self.panel_location is not FlatSlabPanelLocation.INTERIOR:
+            raise FlatSlabContractError(
+                "panel_location must be FlatSlabPanelLocation.INTERIOR"
+            )
+
+        required_true = (
+            "all_spans_equal_x",
+            "all_spans_equal_y",
+            "solid_slab",
+        )
+        for name in required_true:
+            if getattr(self, name) is not True:
+                raise FlatSlabContractError(f"{name} must be explicitly True")
+        required_false = (
+            "columns_offset_from_grid",
+            "drop_present",
+            "column_head_present",
+            "marginal_beam_or_wall_present",
+            "openings_present",
+        )
+        for name in required_false:
+            if getattr(self, name) is not False:
+                raise FlatSlabContractError(f"{name} must be explicitly False")
+        object.__setattr__(
+            self,
+            "geometry_basis_reference",
+            _non_blank(self.geometry_basis_reference, "geometry_basis_reference"),
+        )
+
+
+@dataclass(frozen=True)
+class FlatSlabMaterial:
+    """Concrete and reinforcement grades for the G0-frozen case."""
+
+    concrete_grade_nmm2: float
+    steel_grade_nmm2: float
+    uncoated_deformed_bars: bool
+    material_basis_reference: str
+
+    def __post_init__(self) -> None:
+        concrete_grade = _positive_finite(
+            self.concrete_grade_nmm2,
+            "concrete_grade_nmm2",
+            "N/mm2",
+        )
+        if concrete_grade not in {
+            20.0,
+            25.0,
+            30.0,
+            35.0,
+            40.0,
+            45.0,
+            50.0,
+            55.0,
+            60.0,
+        }:
+            raise FlatSlabContractError(
+                "concrete_grade_nmm2 must be a standard M20-M60 grade"
+            )
+        steel_grade = _positive_finite(
+            self.steel_grade_nmm2,
+            "steel_grade_nmm2",
+            "N/mm2",
+        )
+        if steel_grade not in {415.0, 500.0}:
+            raise FlatSlabContractError(
+                "steel_grade_nmm2 must be Fe415 or Fe500 for this route"
+            )
+        if self.uncoated_deformed_bars is not True:
+            raise FlatSlabContractError(
+                "uncoated_deformed_bars must be explicitly True"
+            )
+        object.__setattr__(self, "concrete_grade_nmm2", concrete_grade)
+        object.__setattr__(self, "steel_grade_nmm2", steel_grade)
+        object.__setattr__(
+            self,
+            "material_basis_reference",
+            _non_blank(self.material_basis_reference, "material_basis_reference"),
+        )
+
+
+@dataclass(frozen=True)
+class FlatSlabGravityLoad:
+    """Approved-basis uniform gravity actions; the library generates no load."""
+
+    service_dead_load_kn_per_m2: float
+    service_live_load_kn_per_m2: float
+    factored_uniform_load_kn_per_m2: float
+    self_weight_included: bool
+    identical_full_loading_on_represented_panels: bool
+    patterned_loading_required: bool
+    unbalanced_or_lateral_moment_transfer_present: bool
+    load_combination_approved: bool
+    load_basis_reference: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "service_dead_load_kn_per_m2",
+            "service_live_load_kn_per_m2",
+            "factored_uniform_load_kn_per_m2",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _positive_finite(getattr(self, name), name, "kN/m2"),
+            )
+        live_dead_ratio = (
+            self.service_live_load_kn_per_m2 / self.service_dead_load_kn_per_m2
+        )
+        if live_dead_ratio > 0.5 + 1e-12:
+            raise FlatSlabContractError(
+                "service live/dead load ratio must not exceed 0.5 for this route"
+            )
+        expected_factored_load = 1.5 * (
+            self.service_dead_load_kn_per_m2 + self.service_live_load_kn_per_m2
+        )
+        if not math.isclose(
+            self.factored_uniform_load_kn_per_m2,
+            expected_factored_load,
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise FlatSlabContractError(
+                "factored_uniform_load_kn_per_m2 must equal 1.5 times the "
+                "service dead-plus-live load for this route"
+            )
+        required_true = (
+            "self_weight_included",
+            "identical_full_loading_on_represented_panels",
+            "load_combination_approved",
+        )
+        for name in required_true:
+            if getattr(self, name) is not True:
+                raise FlatSlabContractError(f"{name} must be explicitly True")
+        required_false = (
+            "patterned_loading_required",
+            "unbalanced_or_lateral_moment_transfer_present",
+        )
+        for name in required_false:
+            if getattr(self, name) is not False:
+                raise FlatSlabContractError(f"{name} must be explicitly False")
+        object.__setattr__(
+            self,
+            "load_basis_reference",
+            _non_blank(self.load_basis_reference, "load_basis_reference"),
+        )
+
+
+@dataclass(frozen=True)
+class FlatSlabPanelInput:
+    """Complete typed input foundation for later FLAT-B-D calculations."""
+
+    geometry: FlatSlabGridGeometry
+    material: FlatSlabMaterial
+    gravity_load: FlatSlabGravityLoad
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.geometry, FlatSlabGridGeometry):
+            raise FlatSlabContractError("geometry must be a FlatSlabGridGeometry")
+        if not isinstance(self.material, FlatSlabMaterial):
+            raise FlatSlabContractError("material must be a FlatSlabMaterial")
+        if not isinstance(self.gravity_load, FlatSlabGravityLoad):
+            raise FlatSlabContractError("gravity_load must be a FlatSlabGravityLoad")

--- a/Python/structural_lib/codes/is456/index.json
+++ b/Python/structural_lib/codes/is456/index.json
@@ -40,7 +40,7 @@
         "figures",
         "annexures"
       ],
-      "content_hash": "8d7652e119eb"
+      "content_hash": "e5d1c291ae0f"
     },
     {
       "name": "compliance.py",
@@ -404,6 +404,12 @@
       "is_package": true
     },
     {
+      "name": "flat_slab",
+      "path": "flat_slab/",
+      "file_count": 5,
+      "is_package": true
+    },
+    {
       "name": "footing",
       "path": "footing/",
       "file_count": 10,
@@ -450,5 +456,5 @@
     "list_clauses_by_category",
     "search_clauses"
   ],
-  "content_hash": "7d14f40d242c0722"
+  "content_hash": "ddede2f7c301a74f"
 }

--- a/Python/structural_lib/codes/is456/index.md
+++ b/Python/structural_lib/codes/is456/index.md
@@ -56,6 +56,7 @@
 | [column/](column/) 📦 | 12 |  |
 | [common/](common/) 📦 | 5 |  |
 | [deep_beam/](deep_beam/) 📦 | 6 |  |
+| [flat_slab/](flat_slab/) 📦 | 5 |  |
 | [footing/](footing/) 📦 | 10 |  |
 | [slab/](slab/) 📦 | 16 |  |
 | [staircase/](staircase/) 📦 | 7 |  |

--- a/Python/tests/codes/is456/flat_slab/__init__.py
+++ b/Python/tests/codes/is456/flat_slab/__init__.py
@@ -1,0 +1,1 @@
+"""Focused tests for the bounded IS 456 flat-slab package."""

--- a/Python/tests/codes/is456/flat_slab/index.json
+++ b/Python/tests/codes/is456/flat_slab/index.json
@@ -1,0 +1,92 @@
+{
+  "folder": "Python/tests/codes/is456/flat_slab",
+  "type": "python-package",
+  "description": "",
+  "last_updated": "2026-08-16",
+  "file_count": 2,
+  "files": [
+    {
+      "name": "__init__.py",
+      "type": "python",
+      "size_lines": 2,
+      "last_updated": "2026-08-16",
+      "description": "Focused tests for the bounded IS 456 flat-slab package.",
+      "content_hash": "9dd87ba2e4c2"
+    },
+    {
+      "name": "test_geometry.py",
+      "type": "python",
+      "size_lines": 290,
+      "last_updated": "2026-08-16",
+      "description": "INDIA-2-FLAT-A benchmark and fail-closed geometry tests.",
+      "functions": [
+        {
+          "name": "test_hand_benchmark_geometry_and_strip_widths_in_both_directions"
+        },
+        {
+          "name": "test_minimum_clear_span_component_can_govern"
+        },
+        {
+          "name": "test_invalid_geometry_dimensions_fail_closed",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_direct_design_requires_at_least_three_spans",
+          "params": [
+            "field"
+          ]
+        },
+        {
+          "name": "test_square_panel_and_square_column_boundaries_fail_closed"
+        },
+        {
+          "name": "test_depth_and_method_boundaries_fail_closed"
+        },
+        {
+          "name": "test_each_topology_boundary_is_explicit",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_geometry_reference_is_required"
+        },
+        {
+          "name": "test_material_contract_accepts_only_frozen_grades_and_bar_type"
+        },
+        {
+          "name": "test_gravity_load_contract_matches_benchmark_and_half_ratio_boundary"
+        },
+        {
+          "name": "test_each_load_boundary_is_explicit",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_load_dimensions_and_reference_fail_closed"
+        },
+        {
+          "name": "test_composed_input_types_fail_closed",
+          "params": [
+            "field",
+            "value",
+            "message"
+          ]
+        },
+        {
+          "name": "test_resolver_type_clause_and_source_provenance"
+        }
+      ],
+      "content_hash": "5d229ea12de2"
+    }
+  ],
+  "subfolders": [],
+  "has_init": true,
+  "content_hash": "8c8c1e965bf6d643"
+}

--- a/Python/tests/codes/is456/flat_slab/index.md
+++ b/Python/tests/codes/is456/flat_slab/index.md
@@ -1,0 +1,12 @@
+# Flat Slab
+
+**Type:** Python Package
+**Last Updated:** 2026-08-16
+**Files:** 2
+
+## Python Files
+
+| File | Description | Classes | Functions | Lines |
+|------|-------------|---------|-----------|-------|
+| [__init__.py](__init__.py) | Focused tests for the bounded IS 456 flat-slab package. | 0 | 0 | 2 |
+| [test_geometry.py](test_geometry.py) | INDIA-2-FLAT-A benchmark and fail-closed geometry tests. | 0 | 14 | 290 |

--- a/Python/tests/codes/is456/flat_slab/test_geometry.py
+++ b/Python/tests/codes/is456/flat_slab/test_geometry.py
@@ -1,0 +1,289 @@
+"""INDIA-2-FLAT-A benchmark and fail-closed geometry tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from structural_lib.codes.is456.flat_slab import (
+    FlatSlabAnalysisMethod,
+    FlatSlabContractError,
+    FlatSlabDirection,
+    FlatSlabGravityLoad,
+    FlatSlabGridGeometry,
+    FlatSlabMaterial,
+    FlatSlabPanelInput,
+    FlatSlabPanelLocation,
+    resolve_regular_interior_flat_slab_geometry,
+)
+from structural_lib.codes.is456.traceability import get_clause_refs
+
+
+def _benchmark_geometry(**overrides: object) -> FlatSlabGridGeometry:
+    values: dict[str, object] = {
+        "centre_to_centre_span_x_mm": 6000.0,
+        "centre_to_centre_span_y_mm": 6000.0,
+        "continuous_span_count_x": 3,
+        "continuous_span_count_y": 3,
+        "column_width_x_mm": 500.0,
+        "column_width_y_mm": 500.0,
+        "overall_depth_mm": 300.0,
+        "conservative_effective_depth_mm": 260.0,
+        "analysis_method": FlatSlabAnalysisMethod.DIRECT_DESIGN,
+        "panel_location": FlatSlabPanelLocation.INTERIOR,
+        "all_spans_equal_x": True,
+        "all_spans_equal_y": True,
+        "columns_offset_from_grid": False,
+        "solid_slab": True,
+        "drop_present": False,
+        "column_head_present": False,
+        "marginal_beam_or_wall_present": False,
+        "openings_present": False,
+        "geometry_basis_reference": "INDIA-2-FLAT-HAND-01-GEOMETRY",
+    }
+    values.update(overrides)
+    return FlatSlabGridGeometry(**values)  # type: ignore[arg-type]
+
+
+def _benchmark_material(**overrides: object) -> FlatSlabMaterial:
+    values: dict[str, object] = {
+        "concrete_grade_nmm2": 30.0,
+        "steel_grade_nmm2": 500.0,
+        "uncoated_deformed_bars": True,
+        "material_basis_reference": "INDIA-2-FLAT-HAND-01-MATERIAL",
+    }
+    values.update(overrides)
+    return FlatSlabMaterial(**values)  # type: ignore[arg-type]
+
+
+def _benchmark_load(**overrides: object) -> FlatSlabGravityLoad:
+    values: dict[str, object] = {
+        "service_dead_load_kn_per_m2": 9.0,
+        "service_live_load_kn_per_m2": 4.0,
+        "factored_uniform_load_kn_per_m2": 19.5,
+        "self_weight_included": True,
+        "identical_full_loading_on_represented_panels": True,
+        "patterned_loading_required": False,
+        "unbalanced_or_lateral_moment_transfer_present": False,
+        "load_combination_approved": True,
+        "load_basis_reference": "INDIA-2-FLAT-HAND-01-LOAD",
+    }
+    values.update(overrides)
+    return FlatSlabGravityLoad(**values)  # type: ignore[arg-type]
+
+
+def _benchmark_panel(**overrides: object) -> FlatSlabPanelInput:
+    values: dict[str, object] = {
+        "geometry": _benchmark_geometry(),
+        "material": _benchmark_material(),
+        "gravity_load": _benchmark_load(),
+    }
+    values.update(overrides)
+    return FlatSlabPanelInput(**values)  # type: ignore[arg-type]
+
+
+def test_hand_benchmark_geometry_and_strip_widths_in_both_directions() -> None:
+    result = resolve_regular_interior_flat_slab_geometry(_benchmark_panel())
+
+    assert result.direct_design_eligible is True
+    assert result.minimum_slab_thickness_mm == pytest.approx(125.0)
+    assert result.service_live_dead_ratio == pytest.approx(4.0 / 9.0)
+    assert result.expected_factored_uniform_load_kn_per_m2 == pytest.approx(19.5)
+    for direction_result, direction in (
+        (result.x, FlatSlabDirection.X),
+        (result.y, FlatSlabDirection.Y),
+    ):
+        assert direction_result.direction is direction
+        assert direction_result.centre_to_centre_span_mm == pytest.approx(6000.0)
+        assert direction_result.transverse_span_mm == pytest.approx(6000.0)
+        assert direction_result.support_width_mm == pytest.approx(500.0)
+        assert direction_result.face_to_face_clear_span_mm == pytest.approx(5500.0)
+        assert direction_result.minimum_clear_span_component_mm == pytest.approx(3900.0)
+        assert direction_result.governing_clear_span_mm == pytest.approx(5500.0)
+        assert direction_result.column_strip_half_width_mm == pytest.approx(1500.0)
+        assert direction_result.column_strip_total_width_mm == pytest.approx(3000.0)
+        assert direction_result.middle_strip_width_mm == pytest.approx(3000.0)
+        assert (
+            direction_result.column_strip_total_width_mm
+            + direction_result.middle_strip_width_mm
+            == pytest.approx(direction_result.transverse_span_mm)
+        )
+
+
+def test_minimum_clear_span_component_can_govern() -> None:
+    panel = _benchmark_panel(
+        geometry=_benchmark_geometry(
+            column_width_x_mm=2500.0,
+            column_width_y_mm=2500.0,
+        )
+    )
+    result = resolve_regular_interior_flat_slab_geometry(panel)
+
+    assert result.x.face_to_face_clear_span_mm == pytest.approx(3500.0)
+    assert result.x.minimum_clear_span_component_mm == pytest.approx(3900.0)
+    assert result.x.governing_clear_span_mm == pytest.approx(3900.0)
+    assert result.y.governing_clear_span_mm == pytest.approx(3900.0)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("centre_to_centre_span_x_mm", 0.0),
+        ("centre_to_centre_span_y_mm", math.inf),
+        ("column_width_x_mm", math.nan),
+        ("column_width_y_mm", -1.0),
+        ("overall_depth_mm", 0.0),
+        ("conservative_effective_depth_mm", math.inf),
+    ),
+)
+def test_invalid_geometry_dimensions_fail_closed(field: str, value: float) -> None:
+    with pytest.raises(FlatSlabContractError, match=field):
+        _benchmark_geometry(**{field: value})
+
+
+@pytest.mark.parametrize(
+    "field", ("continuous_span_count_x", "continuous_span_count_y")
+)
+def test_direct_design_requires_at_least_three_spans(field: str) -> None:
+    with pytest.raises(FlatSlabContractError, match="at least 3"):
+        _benchmark_geometry(**{field: 2})
+    with pytest.raises(FlatSlabContractError, match="positive integer"):
+        _benchmark_geometry(**{field: True})
+
+
+def test_square_panel_and_square_column_boundaries_fail_closed() -> None:
+    with pytest.raises(FlatSlabContractError, match="spans must be equal"):
+        _benchmark_geometry(centre_to_centre_span_y_mm=5000.0)
+    with pytest.raises(FlatSlabContractError, match="column widths must be equal"):
+        _benchmark_geometry(column_width_y_mm=600.0)
+    with pytest.raises(FlatSlabContractError, match="column_width_x_mm"):
+        _benchmark_geometry(column_width_x_mm=6000.0, column_width_y_mm=6000.0)
+
+
+def test_depth_and_method_boundaries_fail_closed() -> None:
+    with pytest.raises(FlatSlabContractError, match="at least 125"):
+        _benchmark_geometry(overall_depth_mm=124.999)
+    with pytest.raises(FlatSlabContractError, match="effective_depth_mm"):
+        _benchmark_geometry(conservative_effective_depth_mm=300.0)
+    with pytest.raises(FlatSlabContractError, match="analysis_method"):
+        _benchmark_geometry(analysis_method="equivalent_frame")
+    with pytest.raises(FlatSlabContractError, match="panel_location"):
+        _benchmark_geometry(panel_location="exterior")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("all_spans_equal_x", False),
+        ("all_spans_equal_y", False),
+        ("solid_slab", False),
+        ("columns_offset_from_grid", True),
+        ("drop_present", True),
+        ("column_head_present", True),
+        ("marginal_beam_or_wall_present", True),
+        ("openings_present", True),
+    ),
+)
+def test_each_topology_boundary_is_explicit(field: str, value: bool) -> None:
+    with pytest.raises(FlatSlabContractError, match=field):
+        _benchmark_geometry(**{field: value})
+
+
+def test_geometry_reference_is_required() -> None:
+    with pytest.raises(FlatSlabContractError, match="geometry_basis_reference"):
+        _benchmark_geometry(geometry_basis_reference=" ")
+
+
+def test_material_contract_accepts_only_frozen_grades_and_bar_type() -> None:
+    accepted = _benchmark_material()
+    assert accepted.concrete_grade_nmm2 == pytest.approx(30.0)
+    assert accepted.steel_grade_nmm2 == pytest.approx(500.0)
+
+    with pytest.raises(FlatSlabContractError, match="standard M20-M60"):
+        _benchmark_material(concrete_grade_nmm2=27.0)
+    with pytest.raises(FlatSlabContractError, match="Fe415 or Fe500"):
+        _benchmark_material(steel_grade_nmm2=550.0)
+    with pytest.raises(FlatSlabContractError, match="uncoated_deformed_bars"):
+        _benchmark_material(uncoated_deformed_bars=False)
+    with pytest.raises(FlatSlabContractError, match="material_basis_reference"):
+        _benchmark_material(material_basis_reference=" ")
+
+
+def test_gravity_load_contract_matches_benchmark_and_half_ratio_boundary() -> None:
+    accepted = _benchmark_load()
+    assert accepted.factored_uniform_load_kn_per_m2 == pytest.approx(19.5)
+
+    boundary = _benchmark_load(
+        service_dead_load_kn_per_m2=8.0,
+        service_live_load_kn_per_m2=4.0,
+        factored_uniform_load_kn_per_m2=18.0,
+    )
+    assert (
+        boundary.service_live_load_kn_per_m2 / boundary.service_dead_load_kn_per_m2
+        == pytest.approx(0.5)
+    )
+
+    with pytest.raises(FlatSlabContractError, match="must not exceed 0.5"):
+        _benchmark_load(service_live_load_kn_per_m2=5.0)
+    with pytest.raises(FlatSlabContractError, match="must equal 1.5"):
+        _benchmark_load(factored_uniform_load_kn_per_m2=19.0)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("self_weight_included", False),
+        ("identical_full_loading_on_represented_panels", False),
+        ("patterned_loading_required", True),
+        ("unbalanced_or_lateral_moment_transfer_present", True),
+        ("load_combination_approved", False),
+    ),
+)
+def test_each_load_boundary_is_explicit(field: str, value: bool) -> None:
+    with pytest.raises(FlatSlabContractError, match=field):
+        _benchmark_load(**{field: value})
+
+
+def test_load_dimensions_and_reference_fail_closed() -> None:
+    with pytest.raises(FlatSlabContractError, match="service_dead_load_kn_per_m2"):
+        _benchmark_load(service_dead_load_kn_per_m2=math.nan)
+    with pytest.raises(FlatSlabContractError, match="service_live_load_kn_per_m2"):
+        _benchmark_load(service_live_load_kn_per_m2=0.0)
+    with pytest.raises(FlatSlabContractError, match="load_basis_reference"):
+        _benchmark_load(load_basis_reference=" ")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("geometry", object(), "FlatSlabGridGeometry"),
+        ("material", object(), "FlatSlabMaterial"),
+        ("gravity_load", object(), "FlatSlabGravityLoad"),
+    ),
+)
+def test_composed_input_types_fail_closed(
+    field: str, value: object, message: str
+) -> None:
+    with pytest.raises(FlatSlabContractError, match=message):
+        _benchmark_panel(**{field: value})
+
+
+def test_resolver_type_clause_and_source_provenance() -> None:
+    with pytest.raises(FlatSlabContractError, match="FlatSlabPanelInput"):
+        resolve_regular_interior_flat_slab_geometry(object())  # type: ignore[arg-type]
+
+    result = resolve_regular_interior_flat_slab_geometry(_benchmark_panel())
+    assert get_clause_refs(resolve_regular_interior_flat_slab_geometry) == [
+        "31.1.1",
+        "31.2.1",
+        "31.3.1",
+        "31.4.1",
+    ]
+    assert result.source_refs == (
+        "IS 456:2000 Cl. 31.1.1, 31.2.1, 31.3.1, 31.4.1",
+        "IS456-2000-A6",
+        "INDIA-2-FLAT-HAND-01-GEOMETRY",
+        "INDIA-2-FLAT-HAND-01-MATERIAL",
+        "INDIA-2-FLAT-HAND-01-LOAD",
+    )

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -4676,7 +4676,7 @@
     {
       "name": "codes",
       "path": "codes/",
-      "file_count": 36,
+      "file_count": 40,
       "is_package": true
     },
     {
@@ -4727,5 +4727,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "2f41cd3f968a0532"
+  "content_hash": "4cd576c83f72f352"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -88,7 +88,7 @@ This document describes the test taxonomy and structure for the structural_engin
 
 | Folder | Files | Description |
 |--------|-------|-------------|
-| [codes/](codes/) 📦 | 36 |  |
+| [codes/](codes/) 📦 | 40 |  |
 | [data/](data/) | 5 |  |
 | [fixtures/](fixtures/) | 11 |  |
 | [helpers/](helpers/) 📦 | 2 |  |

--- a/Python/tests/unit/test_clauses_json.py
+++ b/Python/tests/unit/test_clauses_json.py
@@ -217,3 +217,25 @@ DEEP_BEAM_CLAUSES = [
 def test_clauses_deep_beam_section(clauses, clause_id):
     """Deep-beam clause identity exists in clauses.json."""
     assert clause_id in clauses, f"Missing deep-beam clause: {clause_id}"
+
+
+# --- Coverage tests: flat slabs ---
+
+
+FLAT_SLAB_CLAUSES = [
+    "31",
+    "31.1",
+    "31.1.1",
+    "31.2",
+    "31.2.1",
+    "31.3",
+    "31.3.1",
+    "31.4",
+    "31.4.1",
+]
+
+
+@pytest.mark.parametrize("clause_id", FLAT_SLAB_CLAUSES)
+def test_clauses_flat_slab_section(clauses, clause_id):
+    """Flat-slab clause identity exists in clauses.json."""
+    assert clause_id in clauses, f"Missing flat-slab clause: {clause_id}"

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -36,6 +36,9 @@ direct-design eligibility, clear-span, and strip-definition foundation.
   vocabulary, and the committed generated manifest was stale.
 - The first closeout command chain stopped after `session end` reported the
   expected task-owned uncommitted packet and three index-bearing folders.
+- The first connected-GitHub PR creation call was rejected before mutation
+  because it supplied separate owner/repository fields instead of the
+  connector's required `repository_full_name` field.
 
 ### Root causes and resolutions
 
@@ -54,6 +57,10 @@ direct-design eligibility, clear-span, and strip-definition foundation.
   treat its successful handoff, session-log, receipt, link, and governance
   checks as the closeout result; regenerate the handoff-mutated indexes and run
   the remaining final checks separately before commit.
+- Root cause: the connector schema was inferred from an older call shape.
+  Resolution: inspect the live callable metadata in `ALL_TOOLS`, bind the
+  repository as `Pravin-surawase/structural_engineering_lib`, and retry without
+  changing the already-pushed source commit.
 
 ### Evidence
 
@@ -85,6 +92,9 @@ direct-design eligibility, clear-span, and strip-definition foundation.
   dirty task packet and stopped the chained final checks → retained its passing
   handoff/governance result and ran the remaining index, link, quick, and diff
   checks separately.
+- ⚠️ TERMINAL ISSUE: the first connected PR-creation call failed schema
+  validation for missing `repository_full_name` → inspected the live tool
+  declaration and retried with the required full repository identity.
 
 ---
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,89 @@
 
 ---
 
+## 2026-08-16 — Session: INDIA-2-FLAT-A Geometry and Eligibility
+
+**Agent:** Codex (`structural-math`, sole writer; no subagents)
+
+**Branch:** `codex/india-2-flat-a` from integrated FLAT-G0 main at
+`d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6`
+
+**Git handoff receipt:** `docs/verification/india-2-flat-a-git-handoff-receipt.json`
+
+**Focus:** Implement only the G0-frozen typed grid/panel/material/load,
+direct-design eligibility, clear-span, and strip-definition foundation.
+
+### Summary
+
+- Added a separate pure `flat_slab` package so the new column-supported panel
+  case cannot reuse or inflate the existing beam/wall-supported slab claim.
+- Added fail-closed geometry, material, and approved-basis gravity-load
+  contracts plus both directional clear-span and column/middle-strip results.
+- Registered only the required Clause 31 identifiers and kept flat slab
+  `HELD`/`NOT_IMPLEMENTED` until the later publication packet.
+
+### Issues encountered
+
+- The first combined test command guessed a nonexistent
+  `Python/tests/test_traceability.py` path and stopped before collection.
+- After correcting the test path, the first combined run reported three
+  deterministic-contract failures: the clause count remained 143 after nine
+  new identifiers, the new records used a category outside the closed registry
+  vocabulary, and the committed generated manifest was stale.
+- The first closeout command chain stopped after `session end` reported the
+  expected task-owned uncommitted packet and three index-bearing folders.
+
+### Root causes and resolutions
+
+- Root cause: the traceability test filename was inferred instead of
+  discovered. Resolution: use `rg --files Python/tests` to select the
+  maintained `Python/tests/test_clause_traceability.py`; the corrected focused
+  selection runs normally.
+- Root cause: `clauses.json` deliberately binds identifier count and categories
+  as explicit metadata, and manifest registration totals are generated from
+  that exact registry. Resolution: update the count from 143 to 152, use the
+  existing `slabs` category, add direct flat-slab coverage assertions, and
+  regenerate the deterministic manifest. Evidence: all 131 combined geometry,
+  clause, traceability, and manifest tests pass.
+- Root cause: `session end` is intentionally non-zero while a pre-commit packet
+  remains dirty, so later commands joined with `&&` did not run. Resolution:
+  treat its successful handoff, session-log, receipt, link, and governance
+  checks as the closeout result; regenerate the handoff-mutated indexes and run
+  the remaining final checks separately before commit.
+
+### Evidence
+
+- The direct 33-test package reproduces 5500 mm governing clear span and
+  3000/3000 mm column/middle strips in both directions for the frozen benchmark.
+- Large-column, exact three-span, exact live/dead `0.5`, every topology/load
+  flag, nested type, non-finite input, and provenance boundaries are directly
+  tested.
+- The combined 131-test selection passes with 152 identifier-only clause
+  records and current 10-supported/11-held manifest truth.
+- Black, Ruff, mypy, and Bandit pass on the changed executable paths.
+- Architecture validation reports zero violations across 180 files; import
+  validation reports zero broken imports across 612 Python files.
+- All 1,196 internal links are valid, all seven touched folder indexes are
+  current, token efficiency passes, and the quick repository gate passes 10/10.
+- Broad Python and 30-check gates remain deferred to whole-INDIA-2 closeout;
+  no public workflow, professional approval, release, or cleanup is included.
+
+### Terminal issues
+
+- ⚠️ TERMINAL ISSUE: the first combined pytest command named nonexistent
+  `Python/tests/test_traceability.py` → `rg --files` identified the maintained
+  `Python/tests/test_clause_traceability.py`, and the corrected selection ran.
+- ⚠️ TERMINAL ISSUE: the corrected first combined test run failed the clause
+  count, category vocabulary, and generated-manifest contracts → updated the
+  exact registry metadata, used category `slabs`, regenerated the manifest,
+  and passed all 131 tests.
+- ⚠️ TERMINAL ISSUE: pre-commit `session end` returned non-zero for the expected
+  dirty task packet and stopped the chained final checks → retained its passing
+  handoff/governance result and ran the remaining index, link, quick, and diff
+  checks separately.
+
+---
+
 ## 2026-08-16 — Session: INDIA-2-FLAT-G0 Scope and Benchmark Decision
 
 **Agent:** Codex (`structural-engineer`, sole writer; one bounded read-only

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -127,7 +127,7 @@
 
 | ID | Task | Owner | Status |
 |----|------|-------|--------|
-| INDIA-2-FLAT | Implement the G0-frozen equal-span square interior flat-slab and centred-column punching workflow through focused family acceptance | Main Agent + structural engineer | 🚧 ACTIVE — G0 returned GO; FLAT-A geometry, eligibility, clear-span, and strip contracts are next; unequal/exterior/drop/opening/moment-transfer cases remain held |
+| INDIA-2-FLAT | Implement the G0-frozen equal-span square interior flat-slab and centred-column punching workflow through focused family acceptance | Main Agent + structural engineer | 🚧 ACTIVE — G0 and FLAT-A geometry/eligibility are complete; FLAT-B bounded gravity moment distribution is next; unequal/exterior/drop/opening/moment-transfer cases remain held |
 | GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 GIT-7E ACTIVE — fresh lane from verified `origin/main` `b91838f`; semantic live-guidance control and durable task-to-Git receipt in progress; all retirement targets remain held and no deletion is authorized |
 
 ## Up Next
@@ -159,6 +159,7 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-2-FLAT-A | Added typed grid/panel/material/load contracts, direct-design eligibility, both clear-span directions, strip definitions, exact Clause 31 registration, and fail-closed tests | Main Agent + structural math | ✅ COMPLETE — 131 focused geometry/clause/traceability/manifest tests pass; capability remains held until FLAT-E |
 | INDIA-2-FLAT-G0 | Froze one equal-span square interior flat-slab direct-design and centred square-column punching case with a pre-implementation hand benchmark | Main Agent + structural engineer | ✅ GO — FLAT-A-E owner-activated; unequal/exterior/drop/head/opening/patterned-load/moment-transfer and punching-reinforcement cases remain held |
 | INDIA-2-DEEP | Implemented and accepted one bounded simply supported Clause 29 positive-reinforcement workflow with public provenance | Main Agent + structural engineer | ✅ DONE — G0 and A-D integrated; 157-test focused family selection and independent hand benchmark pass; qualified review and excluded deep-beam systems remain held |
 | INDIA-2-DEEP-D | Added thin typed FastAPI transport, canonical deep-beam capability/semantic truth, deterministic manifest promotion, and publication evidence | Main Agent + API developer | ✅ COMPLETE — public bounded workflow is supported; React, release, and all held systems remain excluded |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 7341,
+      "size_lines": 7351,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "50323fc00a77"
+      "content_hash": "89770c7ccf7e"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "67053c325d5bf005"
+  "content_hash": "73aaafb53de0c763"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 7258,
+      "size_lines": 7341,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "7755c3003d70"
+      "content_hash": "50323fc00a77"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 712,
+      "size_lines": 713,
       "last_updated": "2026-08-16",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "296e8a7ff0b3"
+      "content_hash": "c51f5652c569"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 69,
+      "file_count": 72,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "045b3b83d3426661"
+  "content_hash": "67053c325d5bf005"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 7258 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 712 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 7341 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 713 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 33 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 69 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 72 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 7341 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 7351 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 713 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -69,7 +69,7 @@
       "size_lines": 326,
       "last_updated": "2026-08-16",
       "description": "INDIA-2 finishes a practical, explicitly limited set of IS 456 reinforced concrete elements that are still missing from the library.",
-      "content_hash": "4628c786a35b"
+      "content_hash": "22da3a746fcf"
     },
     {
       "name": "indian-code-completion-plan.md",
@@ -123,11 +123,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 116,
+      "size_lines": 124,
       "last_updated": "2026-08-16",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-16",
-      "content_hash": "6aab49846b47"
+      "content_hash": "323dc26029b2"
     },
     {
       "name": "pre-release-checklist.md",
@@ -165,5 +165,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "64aec0037173256b"
+  "content_hash": "6b574caaba60d11a"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -22,7 +22,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 116 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 124 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/india-2-remaining-is456-elements-plan.md
+++ b/docs/planning/india-2-remaining-is456-elements-plan.md
@@ -243,7 +243,7 @@ collapse, seismic diaphragm design, and cases outside the selected topology.
 Activated packets:
 
 1. G0 scope/source/benchmark decision — complete GO.
-2. A panel geometry, eligibility, and strip definitions.
+2. A panel geometry, eligibility, and strip definitions — implemented.
 3. B bounded gravity analysis and moment distribution.
 4. C flexure, serviceability, and detailing checks.
 5. D column-punching checks and fail-closed boundaries.
@@ -317,9 +317,9 @@ authorized programs.
 
 ## 9. Exact next action
 
-Implement `INDIA-2-FLAT-A` next from the G0-frozen equal-span square interior
-case. Do not expand the topology while adding typed grid/panel/material/load,
-direct-design eligibility, clear-span, and strip contracts. The owner's
+Implement `INDIA-2-FLAT-B` next from the integrated FLAT-A contracts. Do not
+expand the topology while adding the total static moment and bounded interior
+negative/positive and column/middle-strip distribution in both directions. The owner's
 2026-08-16 request activates the remaining INDIA-2 families subject to each
 family's own G0 returning GO. No G0 may be bypassed, and a HOLD remains a
 truthful non-implementation outcome.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,9 +4,9 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-16
-- Focus: Decide one source-bound flat-slab/direct-design and column-punching
-- Git receipt: docs/verification/india-2-flat-g0-git-handoff-receipt.json | sha256:a450bf672bada20ce299f55963831ca94bc1a9952d29eecb6f0b7ccf7658bef7 | HOLD
-- Git identity: codex/india-2-flat-g0@f7eb91c3f2719dd04e5739e67572e9530b60ad3e | upstream=origin/main@f7eb91c3f2719dd04e5739e67572e9530b60ad3e | base=origin/main@f7eb91c3f2719dd04e5739e67572e9530b60ad3e | tree=dirty | operation=none
+- Focus: Implement only the G0-frozen typed grid/panel/material/load,
+- Git receipt: docs/verification/india-2-flat-a-git-handoff-receipt.json | sha256:057607da422b50e5248a035856ffef71a72a166bd0d6b6057856a8417bdba2e0 | HOLD
+- Git identity: codex/india-2-flat-a@d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6 | upstream=origin/main@d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6 | base=origin/main@d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: WAIT_FOR_EXACT_HEAD_AUDIT
 <!-- HANDOFF:END -->
@@ -17,7 +17,7 @@
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; INDIA-0, INDIA-1, and the INDIA-2-STAIR family are complete |
 | **Program** | Umbrella INDIA-2 remains in progress; INDIA-3 and INDIA-4 remain planned |
-| **Next** | Implement `INDIA-2-FLAT-A` from the frozen G0 topology without expanding scope |
+| **Next** | Implement `INDIA-2-FLAT-B` moment distribution from the FLAT-A contracts without expanding scope |
 
 ## Required Reading
 
@@ -96,6 +96,14 @@ span/depth, and no-reinforcement punching. Unequal/exterior/drop/head/opening,
 patterned-load, moment-transfer, punching-reinforcement, equivalent-frame, and
 FEM cases remain held.
 
+## INDIA-2-FLAT-A implementation result
+
+[`india-2-flat-a-geometry-evidence.md`](../verification/india-2-flat-a-geometry-evidence.md)
+records typed grid/panel/material/load contracts, both clear-span and strip
+directions, direct-design eligibility, exact Clause 31 identifier registration,
+and fail-closed behavior for every topology outside G0. Flat slab remains held
+until FLAT-E publication.
+
 ## Review and gate boundary
 
 Each calculation packet requires focused tests, benchmarks, architecture and PR
@@ -103,10 +111,10 @@ checks, plus the quick gate. The expensive full Python and 30-check gate runs
 once after the whole accepted INDIA-2 wave is integrated unless an
 outcome-changing repository-wide issue appears earlier.
 
-Deep-beam acceptance and flat-slab G0 are complete. Begin `INDIA-2-FLAT-A`
-with only typed geometry, direct-design eligibility, clear-span, and strip
-contracts for the frozen case. Foundation programs remain later, separate G0
-decisions.
+Deep-beam acceptance, flat-slab G0, and FLAT-A are complete. Begin
+`INDIA-2-FLAT-B` with only total static moment and bounded interior/strip
+distribution in both directions. Foundation programs remain later, separate
+G0 decisions.
 
 Cumulative qualified structural-engineering review belongs to INDIA-4 after the
 accepted INDIA-2 and INDIA-3 scope is frozen. Packet-level source and engineering

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-16",
-  "file_count": 67,
+  "file_count": 70,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -427,6 +427,44 @@
       "content_hash": "300737e95db2"
     },
     {
+      "name": "india-2-flat-a-geometry-evidence.md",
+      "type": "documentation",
+      "size_lines": 92,
+      "last_updated": "2026-08-16",
+      "description": "FLAT-A implements the typed pure-math foundation for the G0-approved case: one solid square interior panel in an equal-span orthogonal column grid, using the",
+      "content_hash": "900cb6f84a05"
+    },
+    {
+      "name": "india-2-flat-a-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "cc730ae93c28"
+    },
+    {
+      "name": "india-2-flat-a-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "2bea10221b15"
+    },
+    {
       "name": "india-2-flat-g0-git-handoff-receipt.json",
       "type": "config",
       "last_updated": "2026-08-16",
@@ -678,7 +716,7 @@
         "capability_summary",
         "standards"
       ],
-      "content_hash": "a293d786c69f"
+      "content_hash": "6a6e2a314b1f"
     },
     {
       "name": "indian-code-truth-baseline.md",
@@ -767,5 +805,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "c9ccca646b16fde1"
+  "content_hash": "68035ac4fceacce2"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-16
-**Files:** 67
+**Files:** 70
 
 ## Config Files
 
@@ -26,6 +26,8 @@ Benchmark examples and verification packs for validating library calculations ag
 - [india-2-deep-d-git-handoff-source-evidence.json](india-2-deep-d-git-handoff-source-evidence.json)
 - [india-2-deep-g0-git-handoff-receipt.json](india-2-deep-g0-git-handoff-receipt.json)
 - [india-2-deep-g0-git-handoff-source-evidence.json](india-2-deep-g0-git-handoff-source-evidence.json)
+- [india-2-flat-a-git-handoff-receipt.json](india-2-flat-a-git-handoff-receipt.json)
+- [india-2-flat-a-git-handoff-source-evidence.json](india-2-flat-a-git-handoff-source-evidence.json)
 - [india-2-flat-g0-git-handoff-receipt.json](india-2-flat-g0-git-handoff-receipt.json)
 - [india-2-flat-g0-git-handoff-source-evidence.json](india-2-flat-g0-git-handoff-source-evidence.json)
 - [india-2-plan-git-handoff-receipt.json](india-2-plan-git-handoff-receipt.json)
@@ -61,6 +63,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [india-2-deep-d-publication-evidence.md](india-2-deep-d-publication-evidence.md) |  | POST /api/v1/design/deep-beam/simply-supported is a thin typ | 73 |
 | [india-2-deep-family-acceptance-evidence.md](india-2-deep-family-acceptance-evidence.md) |  | exact integrated G0/A-D starting head was ce45e22032ea234f58 | 93 |
 | [india-2-deep-g0-scope-evidence.md](india-2-deep-g0-scope-evidence.md) |  | supported, solid rectangular, top-loaded deep beam without o | 166 |
+| [india-2-flat-a-geometry-evidence.md](india-2-flat-a-geometry-evidence.md) |  | FLAT-A implements the typed pure-math foundation for the G0- | 92 |
 | [india-2-flat-g0-scope-evidence.md](india-2-flat-g0-scope-evidence.md) |  | interior panel in an equal-span orthogonal grid, designed by | 215 |
 | [india-2-wall-a-axial-kernel-evidence.md](india-2-wall-a-axial-kernel-evidence.md) |  | WALL-A implements the pure IS 456 layer for the accepted Cla | 83 |
 | [india-2-wall-b-reinforcement-evidence.md](india-2-wall-b-reinforcement-evidence.md) |  | WALL-B adds one pure IS 456 provided-reinforcement check to  | 82 |

--- a/docs/verification/india-2-flat-a-geometry-evidence.md
+++ b/docs/verification/india-2-flat-a-geometry-evidence.md
@@ -1,0 +1,91 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-16
+doc_type: reference
+task: INDIA-2-FLAT-A
+---
+
+# INDIA-2-FLAT-A Geometry and Eligibility Evidence
+
+## Implemented boundary
+
+FLAT-A implements the typed pure-math foundation for the G0-approved case: one
+solid square interior panel in an equal-span orthogonal column grid, using the
+direct design method under identical uniform gravity loading. It adds no panel
+moment, reinforcement, serviceability disposition, punching calculation, or
+public capability claim; those belong to FLAT-B-E.
+
+`FlatSlabGridGeometry` requires explicit mm dimensions, at least three
+continuous equal spans in each direction, a square panel and square column,
+the 125 mm minimum overall depth, a smaller caller-confirmed conservative
+effective depth, the direct design method, the interior-panel location, every
+supported topology assertion, and a non-blank geometry reference.
+
+`FlatSlabMaterial` admits standard M20-M60 concrete, Fe415 or Fe500 uncoated
+deformed bars, and explicit provenance. `FlatSlabGravityLoad` accepts service
+dead/live and factored uniform loads in kN/m2 only when self-weight and an
+approved `1.5(D + L)` combination are already included, live/dead is at most
+`0.5`, all represented panels carry identical full gravity loading, and neither
+patterned loading nor moment transfer is required.
+
+## Normalized Clause 31 behavior
+
+`resolve_regular_interior_flat_slab_geometry` exposes, in each orthogonal
+direction:
+
+- centre-to-centre and transverse spans;
+- support width and face-to-face clear span;
+- the `0.65` centre-span lower component and governing clear span;
+- column-strip width on each side of the support centreline, total column-strip
+  width, and remaining middle-strip width; and
+- exact direction, units, source identities, and caller evidence.
+
+The result also retains the 125 mm minimum thickness, service live/dead ratio,
+expected factored uniform load, and affirmative direct-design eligibility. The
+strip widths partition the full transverse span exactly.
+
+Unsupported unequal or rectangular panels, fewer than three spans, unequal
+spans, offset columns, non-solid slabs, drops, column heads, marginal beams or
+walls, openings, exterior panels, equivalent-frame analysis, coated bars,
+unsupported grades, incomplete load basis, patterned loading, moment transfer,
+and non-finite values raise `FlatSlabContractError`; no partial geometry result
+is produced.
+
+## Public clause registration
+
+The identifier-only traceability database registers Clause 31, 31.1, 31.1.1,
+31.2, 31.2.1, 31.3, 31.3.1, 31.4, and 31.4.1 with titles, sections, the existing
+`slabs` category, and search keywords. No clause prose, figure, or table value
+is stored. The resolver is decorated with Clauses 31.1.1, 31.2.1, 31.3.1, and
+31.4.1 and retains `IS456-2000-A6` plus the three caller evidence references.
+
+## Benchmark and unsafe evidence
+
+The frozen `INDIA-2-FLAT-HAND-01` inputs resolve identically in both
+directions: centre span 6000 mm, face-to-face clear span 5500 mm, lower clear-
+span component 3900 mm, governing clear span 5500 mm, 1500 mm half-column
+strip, 3000 mm total column strip, and 3000 mm middle strip. Service live/dead
+is `4/9`, the expected factored load is 19.5 kN/m2, and the geometry is direct-
+design eligible.
+
+A large-column case proves the `0.65` span component can govern. Tests also
+cover the exact three-span and live/dead `0.5` boundaries, every frozen
+topology/load assertion, material/action mismatch, clause/source provenance,
+nested type contracts, non-finite values, and all out-of-domain cases listed
+above.
+
+The direct flat-slab geometry package passes 33 tests; the combined geometry,
+clause-database, traceability, and deterministic-manifest selection passes 131
+tests. The clause database contains 152 identifier-only records. Black, Ruff,
+mypy, and Bandit pass on the changed executable paths. Architecture validation
+reports zero violations across 180 files, and import validation reports zero
+broken imports across 612 Python files. All 1,196 internal links are valid, all
+seven touched folder indexes are current, the token-efficiency control passes,
+and the quick repository gate passes 10/10.
+
+The generated manifest remains current at 10 supported and 11 held families;
+flat slab remains `HELD`/`NOT_IMPLEMENTED` until FLAT-E publication. The broad
+Python suite and 30-check repository gate remain deferred to whole-INDIA-2
+closeout unless an outcome-changing repository-wide issue appears earlier.
+The next packet is `INDIA-2-FLAT-B`.

--- a/docs/verification/india-2-flat-a-git-handoff-receipt.json
+++ b/docs/verification/india-2-flat-a-git-handoff-receipt.json
@@ -1,0 +1,205 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-16T04:43:25Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2:user-request-continue-and-complete",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-16T04:43:25Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-flat-a",
+      "head_sha": "d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6",
+      "task_id": "INDIA-2-FLAT-A"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "057607da422b50e5248a035856ffef71a72a166bd0d6b6057856a8417bdba2e0",
+    "state": {
+      "branch": "codex/india-2-flat-a",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 90.336,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-india-2-flat-a",
+      "head_sha": "d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6",
+      "hold_reasons": [
+        "changed paths: 30"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-16T04:47:23.162441+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-flat-a",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 30,
+        "modified_paths": [
+          "Python/structural_lib/codes/is456/clauses.json",
+          "Python/structural_lib/codes/is456/index.json",
+          "Python/structural_lib/codes/is456/index.md",
+          "Python/tests/index.json",
+          "Python/tests/index.md",
+          "Python/tests/unit/test_clauses_json.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/index.json",
+          "docs/planning/index.md",
+          "docs/planning/india-2-remaining-is456-elements-plan.md",
+          "docs/planning/next-session-brief.md",
+          "docs/verification/index.json",
+          "docs/verification/index.md",
+          "docs/verification/indian-code-capability-coverage.json",
+          "scripts/_lib/indian_code_manifest.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "Python/structural_lib/codes/is456/flat_slab/__init__.py",
+          "Python/structural_lib/codes/is456/flat_slab/geometry.py",
+          "Python/structural_lib/codes/is456/flat_slab/index.json",
+          "Python/structural_lib/codes/is456/flat_slab/index.md",
+          "Python/structural_lib/codes/is456/flat_slab/models.py",
+          "Python/tests/codes/is456/flat_slab/__init__.py",
+          "Python/tests/codes/is456/flat_slab/index.json",
+          "Python/tests/codes/is456/flat_slab/index.md",
+          "Python/tests/codes/is456/flat_slab/test_geometry.py",
+          "docs/verification/india-2-flat-a-geometry-evidence.md",
+          "docs/verification/india-2-flat-a-git-handoff-receipt.json",
+          "docs/verification/india-2-flat-a-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-flat-a"
+    }
+  },
+  "local_state_receipt_hash": "sha256:057607da422b50e5248a035856ffef71a72a166bd0d6b6057856a8417bdba2e0",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-16T04:47:23.162596+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-16T04:43:25Z",
+    "owner": "Main Agent under user instruction to preserve Git state",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/codes/is456/flat_slab/moments.py",
+      "Python/structural_lib/codes/is456/flat_slab/reinforcement.py",
+      "Python/structural_lib/codes/is456/flat_slab/punching.py",
+      "Python/structural_lib/services/**",
+      "fastapi_app/**",
+      "react_app/**",
+      "refs/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "Python/structural_lib/codes/is456/flat_slab/__init__.py",
+      "Python/structural_lib/codes/is456/flat_slab/models.py",
+      "Python/structural_lib/codes/is456/flat_slab/geometry.py",
+      "Python/structural_lib/codes/is456/flat_slab/index.json",
+      "Python/structural_lib/codes/is456/flat_slab/index.md",
+      "Python/tests/codes/is456/flat_slab/__init__.py",
+      "Python/tests/codes/is456/flat_slab/test_geometry.py",
+      "Python/tests/codes/is456/flat_slab/index.json",
+      "Python/tests/codes/is456/flat_slab/index.md",
+      "docs/verification/india-2-flat-a-geometry-evidence.md",
+      "docs/verification/india-2-flat-a-git-handoff-source-evidence.json"
+    ],
+    "shared_paths": [
+      "Python/structural_lib/codes/is456/clauses.json",
+      "Python/structural_lib/codes/is456/index.json",
+      "Python/structural_lib/codes/is456/index.md",
+      "Python/tests/index.json",
+      "Python/tests/index.md",
+      "Python/tests/unit/test_clauses_json.py",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/index.json",
+      "docs/index.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/planning/india-2-remaining-is456-elements-plan.md",
+      "docs/planning/next-session-brief.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md",
+      "docs/verification/indian-code-capability-coverage.json",
+      "scripts/_lib/indian_code_manifest.py"
+    ],
+    "task_id": "INDIA-2-FLAT-A"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-2-flat-a-git-handoff-source-evidence.json
+++ b/docs/verification/india-2-flat-a-git-handoff-source-evidence.json
@@ -1,0 +1,53 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-16T04:43:25Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2:user-request-continue-and-complete",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-16T04:43:25Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-flat-a",
+      "head_sha": "d5cad72a1a4ce36c44520a0e9f5dd6a151b93eb6",
+      "task_id": "INDIA-2-FLAT-A"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-16T04:43:25Z",
+    "owner": "Main Agent under user instruction to preserve Git state",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -288,11 +288,11 @@
         }
       ],
       "registration_summary": {
-        "known_references": 142,
-        "registered_known_references": 74,
-        "metadata_only_references": 68,
+        "known_references": 151,
+        "registered_known_references": 78,
+        "metadata_only_references": 73,
         "registration_only_references": 0,
-        "registration_pct": 52.1
+        "registration_pct": 51.7
       },
       "references": [
         {
@@ -776,6 +776,95 @@
           "registration_status": "REGISTERED",
           "functions": [
             "structural_lib.codes.is456.deep_beam.reinforcement.check_simply_supported_deep_beam_reinforcement"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:31",
+          "reference": "31",
+          "reference_type": "clause",
+          "title": "Flat Slabs",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:31.1",
+          "reference": "31.1",
+          "reference_type": "clause",
+          "title": "Flat Slabs - General",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:31.1.1",
+          "reference": "31.1.1",
+          "reference_type": "clause",
+          "title": "Column Strip, Middle Strip and Panel Definitions",
+          "category": "slabs",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.flat_slab.geometry.resolve_regular_interior_flat_slab_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:31.2",
+          "reference": "31.2",
+          "reference_type": "clause",
+          "title": "Flat Slab Proportioning",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:31.2.1",
+          "reference": "31.2.1",
+          "reference_type": "clause",
+          "title": "Thickness of Flat Slab",
+          "category": "slabs",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.flat_slab.geometry.resolve_regular_interior_flat_slab_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:31.3",
+          "reference": "31.3",
+          "reference_type": "clause",
+          "title": "Determination of Flat Slab Bending Moment",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:31.3.1",
+          "reference": "31.3.1",
+          "reference_type": "clause",
+          "title": "Methods of Flat Slab Analysis and Design",
+          "category": "slabs",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.flat_slab.geometry.resolve_regular_interior_flat_slab_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:31.4",
+          "reference": "31.4",
+          "reference_type": "clause",
+          "title": "Direct Design Method",
+          "category": "slabs",
+          "registration_status": "METADATA_ONLY",
+          "functions": []
+        },
+        {
+          "reference_id": "IS456:2000:31.4.1",
+          "reference": "31.4.1",
+          "reference_type": "clause",
+          "title": "Direct Design Method Limitations",
+          "category": "slabs",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.flat_slab.geometry.resolve_regular_interior_flat_slab_geometry"
           ]
         },
         {

--- a/scripts/_lib/indian_code_manifest.py
+++ b/scripts/_lib/indian_code_manifest.py
@@ -85,7 +85,10 @@ _IS456_EVIDENCE = {
         "docs/verification/india-2-deep-d-publication-evidence.md",
         "docs/verification/india-2-deep-family-acceptance-evidence.md",
     ),
-    "flat_slab": ("docs/verification/india-2-flat-g0-scope-evidence.md",),
+    "flat_slab": (
+        "docs/verification/india-2-flat-g0-scope-evidence.md",
+        "docs/verification/india-2-flat-a-geometry-evidence.md",
+    ),
 }
 
 _HELD_FAMILIES: dict[str, tuple[dict[str, Any], ...]] = {


### PR DESCRIPTION
## Summary
- add fail-closed typed geometry, material, and gravity-load contracts for the G0-approved square interior flat-slab case
- resolve Clause 31 clear spans and column/middle strip widths in both directions with explicit units and provenance
- register identifier-only Clause 31 traceability while keeping flat slab HELD until FLAT-E

## Verification
- 33 direct geometry tests; 131 combined geometry/clauses/traceability/manifest tests
- Black, Ruff, mypy, Bandit
- architecture 0/180; imports 0/612
- 1,196 links; touched indexes current; token efficiency PASS; quick gate 10/10
- immutable independent audit PASS at `f84d319140c0b60e9de66e1437abf4277d129212`, tree `e3821ef47385f60d63c8ae371a7a8cdbb5b314ce`

## Boundaries
No moment distribution, reinforcement, serviceability, punching, API/UI, professional approval, release, or cleanup. Broad Python and 30-check gates remain deferred to the final INDIA-2 integration boundary.