### PR TITLE
feat(footing): add bounded strap analysis

### DIFF
--- a/Python/structural_lib/codes/is456/clauses.json
+++ b/Python/structural_lib/codes/is456/clauses.json
@@ -1074,6 +1074,17 @@
         "minimum thickness"
       ]
     },
+    "34.1.2": {
+      "title": "Minimum Edge Thickness for Footings",
+      "section": "34 - Footings",
+      "category": "footings",
+      "keywords": [
+        "footing",
+        "edge thickness",
+        "soil foundation",
+        "minimum depth"
+      ]
+    },
     "34.2": {
       "title": "Moments and Forces",
       "section": "34 - Footings",

--- a/Python/structural_lib/codes/is456/strap_footing/__init__.py
+++ b/Python/structural_lib/codes/is456/strap_footing/__init__.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Bounded property-line strap-footing analysis for INDIA-2."""
+
+from structural_lib.codes.is456.strap_footing.analysis import (
+    StrapFootingAnalysisResult,
+    StrapFootingClearSpanActionResult,
+    StrapFootingGeometryResult,
+    StrapFootingLoadCase,
+    StrapFootingLoadCaseResult,
+    StrapFootingTensionFace,
+    analyze_property_line_strap_footing,
+    resolve_property_line_strap_geometry,
+)
+from structural_lib.codes.is456.strap_footing.models import (
+    StrapFootingActionInput,
+    StrapFootingAnalysisInput,
+    StrapFootingAnalysisMethod,
+    StrapFootingApprovalInput,
+    StrapFootingContractError,
+    StrapFootingGeometryInput,
+    StrapFootingPressureModel,
+)
+
+__all__ = [
+    "StrapFootingActionInput",
+    "StrapFootingAnalysisInput",
+    "StrapFootingAnalysisMethod",
+    "StrapFootingAnalysisResult",
+    "StrapFootingApprovalInput",
+    "StrapFootingClearSpanActionResult",
+    "StrapFootingContractError",
+    "StrapFootingGeometryInput",
+    "StrapFootingGeometryResult",
+    "StrapFootingLoadCase",
+    "StrapFootingLoadCaseResult",
+    "StrapFootingPressureModel",
+    "StrapFootingTensionFace",
+    "analyze_property_line_strap_footing",
+    "resolve_property_line_strap_geometry",
+]

--- a/Python/structural_lib/codes/is456/strap_footing/analysis.py
+++ b/Python/structural_lib/codes/is456/strap_footing/analysis.py
@@ -1,0 +1,463 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Rigid equal-pressure statics for the bounded property-line strap footing."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+
+from structural_lib.codes.is456.strap_footing.models import (
+    StrapFootingAnalysisInput,
+    StrapFootingContractError,
+    StrapFootingGeometryInput,
+)
+from structural_lib.codes.is456.traceability import clause
+
+__all__ = [
+    "StrapFootingAnalysisResult",
+    "StrapFootingClearSpanActionResult",
+    "StrapFootingGeometryResult",
+    "StrapFootingLoadCase",
+    "StrapFootingLoadCaseResult",
+    "StrapFootingTensionFace",
+    "analyze_property_line_strap_footing",
+    "resolve_property_line_strap_geometry",
+]
+
+
+_SOURCE_REFS = (
+    "IS 456:2000 Cl. 34.1, 34.1.2, 34.2.3.1",
+    "IS456-2000-A5",
+    "IS456-AMD6-2024",
+    "NPTEL-AFE-C3-STRAP Section 3.6.1 and Fig. 3.2",
+    "INDIA-2-STRAP-HAND-01",
+)
+_PRESSURE_RELATIVE_TOLERANCE = 1e-6
+_ZERO_ABSOLUTE_TOLERANCE = 1e-9
+
+
+class StrapFootingLoadCase(StrEnum):
+    """Action levels represented by the frozen model."""
+
+    SERVICE = "service"
+    FACTORED = "factored"
+
+
+class StrapFootingTensionFace(StrEnum):
+    """Tension face implied by the clear-strap moment sign convention."""
+
+    BOTTOM = "bottom"
+    TOP = "top"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class StrapFootingGeometryResult:
+    """Resolved coordinates and dimensions for the G0-frozen topology."""
+
+    input: StrapFootingGeometryInput
+    exterior_footing_area_m2: float
+    interior_footing_area_m2: float
+    exterior_footing_centroid_x_mm: float
+    interior_footing_centroid_x_mm: float
+    exterior_column_eccentricity_mm: float
+    reaction_spacing_mm: float
+    exterior_footing_inner_edge_x_mm: float
+    interior_footing_outer_edge_x_mm: float
+    interior_footing_inner_edge_x_mm: float
+    clear_strap_start_x_mm: float
+    clear_strap_end_x_mm: float
+    clear_strap_length_mm: float
+    clear_strap_centroid_x_mm: float
+    clear_span_to_overall_depth_ratio: float
+    rigid_equal_pressure_eligible: bool
+    source_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StrapFootingLoadCaseResult:
+    """Reactions, pressure, bearing and equilibrium for one action level."""
+
+    load_case: StrapFootingLoadCase
+    exterior_column_load_kn: float
+    interior_column_load_kn: float
+    clear_strap_line_load_kn_per_m: float
+    clear_strap_total_load_kn: float
+    total_downward_load_kn: float
+    exterior_reaction_kn: float
+    interior_reaction_kn: float
+    exterior_net_pressure_kn_per_m2: float
+    interior_net_pressure_kn_per_m2: float
+    pressure_relative_mismatch: float
+    equal_uniform_net_pressure: bool
+    exterior_footing_carrier_kn_per_m2: float
+    interior_footing_carrier_kn_per_m2: float
+    exterior_gross_pressure_kn_per_m2: float
+    interior_gross_pressure_kn_per_m2: float
+    vertical_equilibrium_residual_kn: float
+    moment_equilibrium_residual_kn_m: float
+
+
+@dataclass(frozen=True)
+class StrapFootingClearSpanActionResult:
+    """Signed shear and moment envelope across the clear strap.
+
+    Upward shear is positive. Positive moment denotes bottom tension and
+    negative moment denotes top tension.
+    """
+
+    load_case: StrapFootingLoadCase
+    exterior_face_x_mm: float
+    exterior_face_shear_kn: float
+    exterior_face_moment_kn_m: float
+    interior_face_x_mm: float
+    interior_face_shear_kn: float
+    interior_face_moment_kn_m: float
+    governing_shear_demand_kn: float
+    governing_shear_x_mm: float
+    governing_moment_demand_kn_m: float
+    governing_moment_signed_kn_m: float
+    governing_moment_x_mm: float
+    governing_tension_face: StrapFootingTensionFace
+
+
+@dataclass(frozen=True)
+class StrapFootingAnalysisResult:
+    """Complete action result for the bounded property-line strap system."""
+
+    input: StrapFootingAnalysisInput
+    geometry: StrapFootingGeometryResult
+    service: StrapFootingLoadCaseResult
+    factored: StrapFootingLoadCaseResult
+    service_clear_strap: StrapFootingClearSpanActionResult
+    factored_clear_strap: StrapFootingClearSpanActionResult
+    common_factored_multiplier: float
+    allowable_gross_bearing_pressure_kn_per_m2: float
+    exterior_service_bearing_utilization: float
+    interior_service_bearing_utilization: float
+    exterior_service_bearing_within_allowable: bool
+    interior_service_bearing_within_allowable: bool
+    gross_service_bearing_within_allowable: bool
+    source_refs: tuple[str, ...]
+
+
+def _zero_small(value: float) -> float:
+    if math.isclose(value, 0.0, rel_tol=0.0, abs_tol=_ZERO_ABSOLUTE_TOLERANCE):
+        return 0.0
+    return value
+
+
+def _tension_face(moment_kn_m: float) -> StrapFootingTensionFace:
+    if math.isclose(
+        moment_kn_m,
+        0.0,
+        rel_tol=0.0,
+        abs_tol=_ZERO_ABSOLUTE_TOLERANCE,
+    ):
+        return StrapFootingTensionFace.NONE
+    if moment_kn_m > 0.0:
+        return StrapFootingTensionFace.BOTTOM
+    return StrapFootingTensionFace.TOP
+
+
+@clause("34.1", "34.1.2")
+def resolve_property_line_strap_geometry(
+    geometry: StrapFootingGeometryInput,
+) -> StrapFootingGeometryResult:
+    """Resolve coordinates only for the G0-approved property-line topology."""
+
+    if not isinstance(geometry, StrapFootingGeometryInput):
+        raise StrapFootingContractError("geometry must be a StrapFootingGeometryInput")
+    exterior_centroid = geometry.exterior_footing_length_mm / 2.0
+    interior_centroid = geometry.interior_column_center_x_mm
+    interior_outer_edge = interior_centroid - geometry.interior_footing_length_mm / 2.0
+    interior_inner_edge = interior_centroid + geometry.interior_footing_length_mm / 2.0
+    clear_start = geometry.exterior_footing_length_mm
+    clear_end = interior_outer_edge
+    clear_length = clear_end - clear_start
+    return StrapFootingGeometryResult(
+        input=geometry,
+        exterior_footing_area_m2=(
+            geometry.exterior_footing_length_mm
+            * geometry.exterior_footing_width_mm
+            / 1_000_000.0
+        ),
+        interior_footing_area_m2=(
+            geometry.interior_footing_length_mm
+            * geometry.interior_footing_width_mm
+            / 1_000_000.0
+        ),
+        exterior_footing_centroid_x_mm=exterior_centroid,
+        interior_footing_centroid_x_mm=interior_centroid,
+        exterior_column_eccentricity_mm=(
+            exterior_centroid - geometry.exterior_column_center_x_mm
+        ),
+        reaction_spacing_mm=interior_centroid - exterior_centroid,
+        exterior_footing_inner_edge_x_mm=clear_start,
+        interior_footing_outer_edge_x_mm=interior_outer_edge,
+        interior_footing_inner_edge_x_mm=interior_inner_edge,
+        clear_strap_start_x_mm=clear_start,
+        clear_strap_end_x_mm=clear_end,
+        clear_strap_length_mm=clear_length,
+        clear_strap_centroid_x_mm=(clear_start + clear_end) / 2.0,
+        clear_span_to_overall_depth_ratio=(
+            clear_length / geometry.strap_overall_depth_mm
+        ),
+        rigid_equal_pressure_eligible=True,
+        source_refs=_SOURCE_REFS
+        + (
+            geometry.geometry_basis_reference,
+            geometry.rigidity_basis_reference,
+            geometry.strap_isolation_basis_reference,
+        ),
+    )
+
+
+def _load_case_result(
+    *,
+    load_case: StrapFootingLoadCase,
+    geometry: StrapFootingGeometryResult,
+    exterior_column_load_kn: float,
+    interior_column_load_kn: float,
+    clear_strap_line_load_kn_per_m: float,
+    exterior_footing_carrier_kn_per_m2: float,
+    interior_footing_carrier_kn_per_m2: float,
+) -> StrapFootingLoadCaseResult:
+    x_q1_m = geometry.input.exterior_column_center_x_mm / 1000.0
+    x_q2_m = geometry.input.interior_column_center_x_mm / 1000.0
+    x_r1_m = geometry.exterior_footing_centroid_x_mm / 1000.0
+    x_r2_m = geometry.interior_footing_centroid_x_mm / 1000.0
+    x_w_m = geometry.clear_strap_centroid_x_mm / 1000.0
+    clear_length_m = geometry.clear_strap_length_mm / 1000.0
+    strap_total_load = clear_strap_line_load_kn_per_m * clear_length_m
+    total_downward = (
+        exterior_column_load_kn + interior_column_load_kn + strap_total_load
+    )
+
+    reaction_spacing_m = x_r2_m - x_r1_m
+    exterior_reaction = (
+        exterior_column_load_kn * (x_r2_m - x_q1_m)
+        + strap_total_load * (x_r2_m - x_w_m)
+    ) / reaction_spacing_m
+    interior_reaction = total_downward - exterior_reaction
+    if exterior_reaction <= 0.0 or interior_reaction <= 0.0:
+        raise StrapFootingContractError(
+            f"{load_case.value} actions produce a non-positive footing reaction"
+        )
+
+    exterior_pressure = exterior_reaction / geometry.exterior_footing_area_m2
+    interior_pressure = interior_reaction / geometry.interior_footing_area_m2
+    pressure_relative_mismatch = abs(exterior_pressure - interior_pressure) / max(
+        exterior_pressure,
+        interior_pressure,
+    )
+    equal_pressure = pressure_relative_mismatch <= _PRESSURE_RELATIVE_TOLERANCE
+    if not equal_pressure:
+        raise StrapFootingContractError(
+            f"{load_case.value} net footing pressures must be equal within "
+            f"relative tolerance {_PRESSURE_RELATIVE_TOLERANCE:g}; "
+            f"observed mismatch {pressure_relative_mismatch:.12g}"
+        )
+
+    vertical_residual = exterior_reaction + interior_reaction - total_downward
+    moment_residual = (
+        exterior_reaction * x_r1_m
+        + interior_reaction * x_r2_m
+        - exterior_column_load_kn * x_q1_m
+        - interior_column_load_kn * x_q2_m
+        - strap_total_load * x_w_m
+    )
+    return StrapFootingLoadCaseResult(
+        load_case=load_case,
+        exterior_column_load_kn=exterior_column_load_kn,
+        interior_column_load_kn=interior_column_load_kn,
+        clear_strap_line_load_kn_per_m=clear_strap_line_load_kn_per_m,
+        clear_strap_total_load_kn=strap_total_load,
+        total_downward_load_kn=total_downward,
+        exterior_reaction_kn=exterior_reaction,
+        interior_reaction_kn=interior_reaction,
+        exterior_net_pressure_kn_per_m2=exterior_pressure,
+        interior_net_pressure_kn_per_m2=interior_pressure,
+        pressure_relative_mismatch=pressure_relative_mismatch,
+        equal_uniform_net_pressure=True,
+        exterior_footing_carrier_kn_per_m2=exterior_footing_carrier_kn_per_m2,
+        interior_footing_carrier_kn_per_m2=interior_footing_carrier_kn_per_m2,
+        exterior_gross_pressure_kn_per_m2=(
+            exterior_pressure + exterior_footing_carrier_kn_per_m2
+        ),
+        interior_gross_pressure_kn_per_m2=(
+            interior_pressure + interior_footing_carrier_kn_per_m2
+        ),
+        vertical_equilibrium_residual_kn=_zero_small(vertical_residual),
+        moment_equilibrium_residual_kn_m=_zero_small(moment_residual),
+    )
+
+
+def _clear_span_actions(
+    *,
+    load_case: StrapFootingLoadCase,
+    geometry: StrapFootingGeometryResult,
+    load_result: StrapFootingLoadCaseResult,
+) -> StrapFootingClearSpanActionResult:
+    exterior_face_x_m = geometry.clear_strap_start_x_mm / 1000.0
+    exterior_column_x_m = geometry.input.exterior_column_center_x_mm / 1000.0
+    exterior_reaction_x_m = geometry.exterior_footing_centroid_x_mm / 1000.0
+    clear_length_m = geometry.clear_strap_length_mm / 1000.0
+    line_load = load_result.clear_strap_line_load_kn_per_m
+
+    exterior_shear = (
+        load_result.exterior_reaction_kn - load_result.exterior_column_load_kn
+    )
+    exterior_moment = load_result.exterior_reaction_kn * (
+        exterior_face_x_m - exterior_reaction_x_m
+    ) - load_result.exterior_column_load_kn * (exterior_face_x_m - exterior_column_x_m)
+    interior_shear = exterior_shear - line_load * clear_length_m
+    interior_moment = (
+        exterior_moment
+        + exterior_shear * clear_length_m
+        - line_load * clear_length_m**2 / 2.0
+    )
+
+    shear_candidates = (
+        (abs(exterior_shear), geometry.clear_strap_start_x_mm),
+        (abs(interior_shear), geometry.clear_strap_end_x_mm),
+    )
+    governing_shear, governing_shear_x = max(shear_candidates, key=lambda item: item[0])
+
+    moment_candidates = [
+        (
+            abs(exterior_moment),
+            exterior_moment,
+            geometry.clear_strap_start_x_mm,
+        ),
+        (
+            abs(interior_moment),
+            interior_moment,
+            geometry.clear_strap_end_x_mm,
+        ),
+    ]
+    if line_load > 0.0:
+        critical_local_x_m = exterior_shear / line_load
+        if 0.0 < critical_local_x_m < clear_length_m:
+            critical_moment = (
+                exterior_moment
+                + exterior_shear * critical_local_x_m
+                - line_load * critical_local_x_m**2 / 2.0
+            )
+            moment_candidates.append(
+                (
+                    abs(critical_moment),
+                    critical_moment,
+                    geometry.clear_strap_start_x_mm + critical_local_x_m * 1000.0,
+                )
+            )
+    governing_moment, governing_signed_moment, governing_moment_x = max(
+        moment_candidates,
+        key=lambda item: item[0],
+    )
+
+    return StrapFootingClearSpanActionResult(
+        load_case=load_case,
+        exterior_face_x_mm=geometry.clear_strap_start_x_mm,
+        exterior_face_shear_kn=_zero_small(exterior_shear),
+        exterior_face_moment_kn_m=_zero_small(exterior_moment),
+        interior_face_x_mm=geometry.clear_strap_end_x_mm,
+        interior_face_shear_kn=_zero_small(interior_shear),
+        interior_face_moment_kn_m=_zero_small(interior_moment),
+        governing_shear_demand_kn=governing_shear,
+        governing_shear_x_mm=governing_shear_x,
+        governing_moment_demand_kn_m=governing_moment,
+        governing_moment_signed_kn_m=_zero_small(governing_signed_moment),
+        governing_moment_x_mm=governing_moment_x,
+        governing_tension_face=_tension_face(governing_signed_moment),
+    )
+
+
+@clause("34.1", "34.2.3.1")
+def analyze_property_line_strap_footing(
+    footing_input: StrapFootingAnalysisInput,
+) -> StrapFootingAnalysisResult:
+    """Calculate reactions, bearing and clear-strap actions for the frozen case."""
+
+    if not isinstance(footing_input, StrapFootingAnalysisInput):
+        raise StrapFootingContractError(
+            "footing_input must be a StrapFootingAnalysisInput"
+        )
+    geometry = resolve_property_line_strap_geometry(footing_input.geometry)
+    actions = footing_input.actions
+
+    service = _load_case_result(
+        load_case=StrapFootingLoadCase.SERVICE,
+        geometry=geometry,
+        exterior_column_load_kn=actions.service_exterior_column_load_kn,
+        interior_column_load_kn=actions.service_interior_column_load_kn,
+        clear_strap_line_load_kn_per_m=(actions.service_clear_strap_line_load_kn_per_m),
+        exterior_footing_carrier_kn_per_m2=(
+            actions.service_exterior_footing_carrier_kn_per_m2
+        ),
+        interior_footing_carrier_kn_per_m2=(
+            actions.service_interior_footing_carrier_kn_per_m2
+        ),
+    )
+    factored = _load_case_result(
+        load_case=StrapFootingLoadCase.FACTORED,
+        geometry=geometry,
+        exterior_column_load_kn=actions.factored_exterior_column_load_kn,
+        interior_column_load_kn=actions.factored_interior_column_load_kn,
+        clear_strap_line_load_kn_per_m=(
+            actions.factored_clear_strap_line_load_kn_per_m
+        ),
+        exterior_footing_carrier_kn_per_m2=(
+            actions.factored_exterior_footing_carrier_kn_per_m2
+        ),
+        interior_footing_carrier_kn_per_m2=(
+            actions.factored_interior_footing_carrier_kn_per_m2
+        ),
+    )
+    service_clear_strap = _clear_span_actions(
+        load_case=StrapFootingLoadCase.SERVICE,
+        geometry=geometry,
+        load_result=service,
+    )
+    factored_clear_strap = _clear_span_actions(
+        load_case=StrapFootingLoadCase.FACTORED,
+        geometry=geometry,
+        load_result=factored,
+    )
+    allowable = actions.allowable_gross_bearing_pressure_kn_per_m2
+    exterior_bearing_utilization = service.exterior_gross_pressure_kn_per_m2 / allowable
+    interior_bearing_utilization = service.interior_gross_pressure_kn_per_m2 / allowable
+    exterior_bearing_safe = service.exterior_gross_pressure_kn_per_m2 <= allowable
+    interior_bearing_safe = service.interior_gross_pressure_kn_per_m2 <= allowable
+
+    return StrapFootingAnalysisResult(
+        input=footing_input,
+        geometry=geometry,
+        service=service,
+        factored=factored,
+        service_clear_strap=service_clear_strap,
+        factored_clear_strap=factored_clear_strap,
+        common_factored_multiplier=actions.common_factored_multiplier,
+        allowable_gross_bearing_pressure_kn_per_m2=allowable,
+        exterior_service_bearing_utilization=exterior_bearing_utilization,
+        interior_service_bearing_utilization=interior_bearing_utilization,
+        exterior_service_bearing_within_allowable=exterior_bearing_safe,
+        interior_service_bearing_within_allowable=interior_bearing_safe,
+        gross_service_bearing_within_allowable=(
+            exterior_bearing_safe and interior_bearing_safe
+        ),
+        source_refs=_SOURCE_REFS
+        + (
+            actions.load_basis_reference,
+            actions.bearing_settlement_basis_reference,
+            actions.footing_carrier_basis_reference,
+            actions.strap_line_load_basis_reference,
+            actions.load_pattern_basis_reference,
+            footing_input.approvals.exterior_footing_verification_reference,
+            footing_input.approvals.interior_footing_verification_reference,
+            footing_input.approvals.transfer_verification_reference,
+            footing_input.approvals.construction_verification_reference,
+        ),
+    )

--- a/Python/structural_lib/codes/is456/strap_footing/index.json
+++ b/Python/structural_lib/codes/is456/strap_footing/index.json
@@ -1,0 +1,133 @@
+{
+  "folder": "Python/structural_lib/codes/is456/strap_footing",
+  "type": "python-package",
+  "description": "",
+  "last_updated": "2026-08-16",
+  "file_count": 3,
+  "files": [
+    {
+      "name": "__init__.py",
+      "type": "python",
+      "size_lines": 42,
+      "last_updated": "2026-08-16",
+      "description": "Bounded property-line strap-footing analysis for INDIA-2.",
+      "content_hash": "d8a17edab325"
+    },
+    {
+      "name": "analysis.py",
+      "type": "python",
+      "size_lines": 464,
+      "last_updated": "2026-08-16",
+      "description": "Rigid equal-pressure statics for the bounded property-line strap footing.",
+      "classes": [
+        {
+          "name": "StrapFootingLoadCase",
+          "description": "Action levels represented by the frozen model."
+        },
+        {
+          "name": "StrapFootingTensionFace",
+          "description": "Tension face implied by the clear-strap moment sign convention."
+        },
+        {
+          "name": "StrapFootingGeometryResult",
+          "description": "Resolved coordinates and dimensions for the G0-frozen topology."
+        },
+        {
+          "name": "StrapFootingLoadCaseResult",
+          "description": "Reactions, pressure, bearing and equilibrium for one action level."
+        },
+        {
+          "name": "StrapFootingClearSpanActionResult",
+          "description": "Signed shear and moment envelope across the clear strap."
+        },
+        {
+          "name": "StrapFootingAnalysisResult",
+          "description": "Complete action result for the bounded property-line strap system."
+        }
+      ],
+      "functions": [
+        {
+          "name": "resolve_property_line_strap_geometry",
+          "description": "Resolve coordinates only for the G0-approved property-line topology.",
+          "params": [
+            "geometry"
+          ]
+        },
+        {
+          "name": "analyze_property_line_strap_footing",
+          "description": "Calculate reactions, bearing and clear-strap actions for the frozen case.",
+          "params": [
+            "footing_input"
+          ]
+        }
+      ],
+      "constants": [
+        "_SOURCE_REFS",
+        "_PRESSURE_RELATIVE_TOLERANCE",
+        "_ZERO_ABSOLUTE_TOLERANCE"
+      ],
+      "content_hash": "777f8b2634a7"
+    },
+    {
+      "name": "models.py",
+      "type": "python",
+      "size_lines": 450,
+      "last_updated": "2026-08-16",
+      "description": "Typed contracts for the bounded INDIA-2 property-line strap footing.",
+      "classes": [
+        {
+          "name": "StrapFootingContractError",
+          "description": "Raised when input is outside the G0-frozen strap-footing scope."
+        },
+        {
+          "name": "StrapFootingAnalysisMethod",
+          "description": "Analysis method admitted by the first strap-footing workflow."
+        },
+        {
+          "name": "StrapFootingPressureModel",
+          "description": "Soil-pressure model admitted by the first strap-footing workflow."
+        },
+        {
+          "name": "StrapFootingGeometryInput",
+          "description": "Caller-confirmed geometry for the G0-frozen property-line system."
+        },
+        {
+          "name": "StrapFootingActionInput",
+          "description": "Caller-approved service and factored actions for the frozen system.",
+          "public_methods": [
+            "common_factored_multiplier"
+          ]
+        },
+        {
+          "name": "StrapFootingApprovalInput",
+          "description": "External footing, transfer, and construction prerequisites."
+        },
+        {
+          "name": "StrapFootingAnalysisInput",
+          "description": "Complete input to the bounded property-line strap action kernel."
+        }
+      ],
+      "content_hash": "18d80933a286"
+    }
+  ],
+  "subfolders": [],
+  "has_init": true,
+  "public_api": [
+    "StrapFootingActionInput",
+    "StrapFootingAnalysisInput",
+    "StrapFootingAnalysisMethod",
+    "StrapFootingAnalysisResult",
+    "StrapFootingApprovalInput",
+    "StrapFootingClearSpanActionResult",
+    "StrapFootingContractError",
+    "StrapFootingGeometryInput",
+    "StrapFootingGeometryResult",
+    "StrapFootingLoadCase",
+    "StrapFootingLoadCaseResult",
+    "StrapFootingPressureModel",
+    "StrapFootingTensionFace",
+    "analyze_property_line_strap_footing",
+    "resolve_property_line_strap_geometry"
+  ],
+  "content_hash": "719ff497d8fd5b7a"
+}

--- a/Python/structural_lib/codes/is456/strap_footing/index.md
+++ b/Python/structural_lib/codes/is456/strap_footing/index.md
@@ -1,0 +1,31 @@
+# Strap Footing
+
+**Type:** Python Package
+**Last Updated:** 2026-08-16
+**Files:** 3
+
+## Public API
+
+- `StrapFootingActionInput`
+- `StrapFootingAnalysisInput`
+- `StrapFootingAnalysisMethod`
+- `StrapFootingAnalysisResult`
+- `StrapFootingApprovalInput`
+- `StrapFootingClearSpanActionResult`
+- `StrapFootingContractError`
+- `StrapFootingGeometryInput`
+- `StrapFootingGeometryResult`
+- `StrapFootingLoadCase`
+- `StrapFootingLoadCaseResult`
+- `StrapFootingPressureModel`
+- `StrapFootingTensionFace`
+- `analyze_property_line_strap_footing`
+- `resolve_property_line_strap_geometry`
+
+## Python Files
+
+| File | Description | Classes | Functions | Lines |
+|------|-------------|---------|-----------|-------|
+| [__init__.py](__init__.py) | Bounded property-line strap-footing analysis for INDIA-2. | 0 | 0 | 42 |
+| [analysis.py](analysis.py) | Rigid equal-pressure statics for the bounded property-line s | 6 | 2 | 464 |
+| [models.py](models.py) | Typed contracts for the bounded INDIA-2 property-line strap  | 7 | 0 | 450 |

--- a/Python/structural_lib/codes/is456/strap_footing/models.py
+++ b/Python/structural_lib/codes/is456/strap_footing/models.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Typed contracts for the bounded INDIA-2 property-line strap footing."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from numbers import Real
+
+__all__ = [
+    "StrapFootingActionInput",
+    "StrapFootingAnalysisInput",
+    "StrapFootingAnalysisMethod",
+    "StrapFootingApprovalInput",
+    "StrapFootingContractError",
+    "StrapFootingGeometryInput",
+    "StrapFootingPressureModel",
+]
+
+
+class StrapFootingContractError(ValueError):
+    """Raised when input is outside the G0-frozen strap-footing scope."""
+
+
+class StrapFootingAnalysisMethod(StrEnum):
+    """Analysis method admitted by the first strap-footing workflow."""
+
+    RIGID_EQUAL_PRESSURE = "rigid_equal_pressure"
+
+
+class StrapFootingPressureModel(StrEnum):
+    """Soil-pressure model admitted by the first strap-footing workflow."""
+
+    EQUAL_UNIFORM_NET = "equal_uniform_net"
+
+
+def _finite_real(value: object, field_name: str, unit: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise StrapFootingContractError(f"{field_name} must be a real value in {unit}")
+    normalized = float(value)
+    if not math.isfinite(normalized):
+        raise StrapFootingContractError(f"{field_name} must be finite in {unit}")
+    return normalized
+
+
+def _positive_finite(value: object, field_name: str, unit: str) -> float:
+    normalized = _finite_real(value, field_name, unit)
+    if normalized <= 0.0:
+        raise StrapFootingContractError(f"{field_name} must be positive in {unit}")
+    return normalized
+
+
+def _nonnegative_finite(value: object, field_name: str, unit: str) -> float:
+    normalized = _finite_real(value, field_name, unit)
+    if normalized < 0.0:
+        raise StrapFootingContractError(f"{field_name} must be non-negative in {unit}")
+    return normalized
+
+
+def _non_blank(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise StrapFootingContractError(f"{field_name} must be non-blank")
+    return value.strip()
+
+
+def _require_bool(value: object, field_name: str, expected: bool) -> None:
+    if value is not expected:
+        raise StrapFootingContractError(f"{field_name} must be explicitly {expected}")
+
+
+@dataclass(frozen=True)
+class StrapFootingGeometryInput:
+    """Caller-confirmed geometry for the G0-frozen property-line system.
+
+    All dimensions and global longitudinal coordinates are in mm. ``x = 0``
+    is the property-line edge of the exterior footing. The interior footing is
+    centred on the interior column. The clear strap extends from the exterior
+    footing inner edge to the interior footing outer edge.
+    """
+
+    exterior_footing_length_mm: float
+    exterior_footing_width_mm: float
+    exterior_footing_depth_mm: float
+    interior_footing_length_mm: float
+    interior_footing_width_mm: float
+    interior_footing_depth_mm: float
+    exterior_column_side_mm: float
+    interior_column_side_mm: float
+    exterior_column_center_x_mm: float
+    interior_column_center_x_mm: float
+    strap_width_mm: float
+    strap_overall_depth_mm: float
+    strap_effective_depth_mm: float
+    footing_count: int
+    column_count: int
+    footings_rectangular: bool
+    footings_parallel: bool
+    footings_constant_depth: bool
+    columns_square: bool
+    columns_and_strap_share_centerline: bool
+    interior_column_centered_on_footing: bool
+    strap_straight_and_prismatic: bool
+    strap_centered_across_footings: bool
+    foundation_on_soil: bool
+    strap_soil_contact: bool
+    openings_present: bool
+    pedestals_present: bool
+    analysis_method: StrapFootingAnalysisMethod
+    pressure_model: StrapFootingPressureModel
+    geometry_basis_reference: str
+    rigidity_basis_reference: str
+    strap_isolation_basis_reference: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "exterior_footing_length_mm",
+            "exterior_footing_width_mm",
+            "exterior_footing_depth_mm",
+            "interior_footing_length_mm",
+            "interior_footing_width_mm",
+            "interior_footing_depth_mm",
+            "exterior_column_side_mm",
+            "interior_column_side_mm",
+            "exterior_column_center_x_mm",
+            "interior_column_center_x_mm",
+            "strap_width_mm",
+            "strap_overall_depth_mm",
+            "strap_effective_depth_mm",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _positive_finite(getattr(self, name), name, "mm"),
+            )
+
+        for name, value, expected in (
+            ("footing_count", self.footing_count, 2),
+            ("column_count", self.column_count, 2),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise StrapFootingContractError(f"{name} must be an integer")
+            if value != expected:
+                raise StrapFootingContractError(
+                    f"{name} must equal {expected} for the frozen strap-footing case"
+                )
+
+        for name in (
+            "footings_rectangular",
+            "footings_parallel",
+            "footings_constant_depth",
+            "columns_square",
+            "columns_and_strap_share_centerline",
+            "interior_column_centered_on_footing",
+            "strap_straight_and_prismatic",
+            "strap_centered_across_footings",
+            "foundation_on_soil",
+        ):
+            _require_bool(getattr(self, name), name, True)
+        for name in (
+            "strap_soil_contact",
+            "openings_present",
+            "pedestals_present",
+        ):
+            _require_bool(getattr(self, name), name, False)
+
+        if self.analysis_method is not StrapFootingAnalysisMethod.RIGID_EQUAL_PRESSURE:
+            raise StrapFootingContractError(
+                "analysis_method must be StrapFootingAnalysisMethod.RIGID_EQUAL_PRESSURE"
+            )
+        if self.pressure_model is not StrapFootingPressureModel.EQUAL_UNIFORM_NET:
+            raise StrapFootingContractError(
+                "pressure_model must be StrapFootingPressureModel.EQUAL_UNIFORM_NET"
+            )
+
+        for name in (
+            "exterior_footing_depth_mm",
+            "interior_footing_depth_mm",
+        ):
+            if getattr(self, name) < 150.0:
+                raise StrapFootingContractError(
+                    f"{name} must be at least 150 mm for a footing on soil"
+                )
+        if self.strap_effective_depth_mm >= self.strap_overall_depth_mm:
+            raise StrapFootingContractError(
+                "strap_effective_depth_mm must be less than strap_overall_depth_mm"
+            )
+        if self.strap_width_mm > min(
+            self.exterior_footing_width_mm,
+            self.interior_footing_width_mm,
+        ):
+            raise StrapFootingContractError(
+                "strap_width_mm must not exceed either footing width"
+            )
+
+        for prefix in ("exterior", "interior"):
+            column_side = getattr(self, f"{prefix}_column_side_mm")
+            footing_length = getattr(self, f"{prefix}_footing_length_mm")
+            footing_width = getattr(self, f"{prefix}_footing_width_mm")
+            if column_side >= min(footing_length, footing_width):
+                raise StrapFootingContractError(
+                    f"{prefix}_column_side_mm must be less than both footing dimensions"
+                )
+
+        exterior_left_face = (
+            self.exterior_column_center_x_mm - self.exterior_column_side_mm / 2.0
+        )
+        exterior_right_face = (
+            self.exterior_column_center_x_mm + self.exterior_column_side_mm / 2.0
+        )
+        if (
+            exterior_left_face <= 0.0
+            or exterior_right_face >= self.exterior_footing_length_mm
+        ):
+            raise StrapFootingContractError(
+                "the complete exterior column plan must lie inside the exterior footing"
+            )
+        exterior_centroid = self.exterior_footing_length_mm / 2.0
+        if self.exterior_column_center_x_mm >= exterior_centroid:
+            raise StrapFootingContractError(
+                "exterior column must be eccentric toward the property-line edge"
+            )
+
+        interior_left_edge = (
+            self.interior_column_center_x_mm - self.interior_footing_length_mm / 2.0
+        )
+        if interior_left_edge <= self.exterior_footing_length_mm:
+            raise StrapFootingContractError(
+                "footings must have positive clear separation along the strap"
+            )
+        clear_span = interior_left_edge - self.exterior_footing_length_mm
+        if clear_span / self.strap_overall_depth_mm <= 2.5:
+            raise StrapFootingContractError(
+                "clear strap span-to-overall-depth ratio must exceed 2.5"
+            )
+
+        for name in (
+            "geometry_basis_reference",
+            "rigidity_basis_reference",
+            "strap_isolation_basis_reference",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _non_blank(getattr(self, name), name),
+            )
+
+
+@dataclass(frozen=True)
+class StrapFootingActionInput:
+    """Caller-approved service and factored actions for the frozen system."""
+
+    service_exterior_column_load_kn: float
+    service_interior_column_load_kn: float
+    factored_exterior_column_load_kn: float
+    factored_interior_column_load_kn: float
+    service_clear_strap_line_load_kn_per_m: float
+    factored_clear_strap_line_load_kn_per_m: float
+    service_exterior_footing_carrier_kn_per_m2: float
+    service_interior_footing_carrier_kn_per_m2: float
+    factored_exterior_footing_carrier_kn_per_m2: float
+    factored_interior_footing_carrier_kn_per_m2: float
+    allowable_gross_bearing_pressure_kn_per_m2: float
+    load_combination_approved: bool
+    bearing_and_settlement_approved: bool
+    equal_uniform_pressure_approved: bool
+    footing_carrier_basis_approved: bool
+    strap_line_load_basis_approved: bool
+    load_pattern_compatible: bool
+    column_moments_present: bool
+    horizontal_actions_present: bool
+    uplift_or_load_reversal_present: bool
+    independently_factored_or_patterned_actions_present: bool
+    load_basis_reference: str
+    bearing_settlement_basis_reference: str
+    footing_carrier_basis_reference: str
+    strap_line_load_basis_reference: str
+    load_pattern_basis_reference: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "service_exterior_column_load_kn",
+            "service_interior_column_load_kn",
+            "factored_exterior_column_load_kn",
+            "factored_interior_column_load_kn",
+            "allowable_gross_bearing_pressure_kn_per_m2",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _positive_finite(getattr(self, name), name, "kN or kN/m2"),
+            )
+        for name in (
+            "service_clear_strap_line_load_kn_per_m",
+            "factored_clear_strap_line_load_kn_per_m",
+            "service_exterior_footing_carrier_kn_per_m2",
+            "service_interior_footing_carrier_kn_per_m2",
+            "factored_exterior_footing_carrier_kn_per_m2",
+            "factored_interior_footing_carrier_kn_per_m2",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _nonnegative_finite(getattr(self, name), name, "kN/m or kN/m2"),
+            )
+
+        factor = (
+            self.factored_exterior_column_load_kn / self.service_exterior_column_load_kn
+        )
+        if factor < 1.0:
+            raise StrapFootingContractError(
+                "factored actions must not be less than their service actions"
+            )
+        pairs = (
+            (
+                "interior column",
+                self.service_interior_column_load_kn,
+                self.factored_interior_column_load_kn,
+            ),
+            (
+                "clear strap line load",
+                self.service_clear_strap_line_load_kn_per_m,
+                self.factored_clear_strap_line_load_kn_per_m,
+            ),
+            (
+                "exterior footing carrier",
+                self.service_exterior_footing_carrier_kn_per_m2,
+                self.factored_exterior_footing_carrier_kn_per_m2,
+            ),
+            (
+                "interior footing carrier",
+                self.service_interior_footing_carrier_kn_per_m2,
+                self.factored_interior_footing_carrier_kn_per_m2,
+            ),
+        )
+        for label, service, factored in pairs:
+            if service == 0.0:
+                if factored != 0.0:
+                    raise StrapFootingContractError(
+                        f"zero service {label} requires zero factored {label}"
+                    )
+                continue
+            if not math.isclose(
+                factored / service,
+                factor,
+                rel_tol=1e-9,
+                abs_tol=1e-9,
+            ):
+                raise StrapFootingContractError(
+                    "all factored/service action ratios must share one common multiplier"
+                )
+
+        for name in (
+            "load_combination_approved",
+            "bearing_and_settlement_approved",
+            "equal_uniform_pressure_approved",
+            "footing_carrier_basis_approved",
+            "strap_line_load_basis_approved",
+            "load_pattern_compatible",
+        ):
+            _require_bool(getattr(self, name), name, True)
+        for name in (
+            "column_moments_present",
+            "horizontal_actions_present",
+            "uplift_or_load_reversal_present",
+            "independently_factored_or_patterned_actions_present",
+        ):
+            _require_bool(getattr(self, name), name, False)
+
+        for name in (
+            "load_basis_reference",
+            "bearing_settlement_basis_reference",
+            "footing_carrier_basis_reference",
+            "strap_line_load_basis_reference",
+            "load_pattern_basis_reference",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _non_blank(getattr(self, name), name),
+            )
+
+    @property
+    def common_factored_multiplier(self) -> float:
+        """Return the enforced factored-to-service action multiplier."""
+
+        return (
+            self.factored_exterior_column_load_kn / self.service_exterior_column_load_kn
+        )
+
+
+@dataclass(frozen=True)
+class StrapFootingApprovalInput:
+    """External footing, transfer, and construction prerequisites."""
+
+    exterior_footing_design_verified: bool
+    interior_footing_design_verified: bool
+    column_and_strap_transfer_verified: bool
+    footing_reinforcement_and_anchorage_verified: bool
+    supporting_areas_verified: bool
+    construction_clearances_verified: bool
+    exterior_footing_verification_reference: str
+    interior_footing_verification_reference: str
+    transfer_verification_reference: str
+    construction_verification_reference: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "exterior_footing_design_verified",
+            "interior_footing_design_verified",
+            "column_and_strap_transfer_verified",
+            "footing_reinforcement_and_anchorage_verified",
+            "supporting_areas_verified",
+            "construction_clearances_verified",
+        ):
+            _require_bool(getattr(self, name), name, True)
+        for name in (
+            "exterior_footing_verification_reference",
+            "interior_footing_verification_reference",
+            "transfer_verification_reference",
+            "construction_verification_reference",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _non_blank(getattr(self, name), name),
+            )
+
+
+@dataclass(frozen=True)
+class StrapFootingAnalysisInput:
+    """Complete input to the bounded property-line strap action kernel."""
+
+    geometry: StrapFootingGeometryInput
+    actions: StrapFootingActionInput
+    approvals: StrapFootingApprovalInput
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.geometry, StrapFootingGeometryInput):
+            raise StrapFootingContractError(
+                "geometry must be a StrapFootingGeometryInput"
+            )
+        if not isinstance(self.actions, StrapFootingActionInput):
+            raise StrapFootingContractError("actions must be a StrapFootingActionInput")
+        if not isinstance(self.approvals, StrapFootingApprovalInput):
+            raise StrapFootingContractError(
+                "approvals must be a StrapFootingApprovalInput"
+            )

--- a/Python/tests/codes/is456/strap_footing/__init__.py
+++ b/Python/tests/codes/is456/strap_footing/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the bounded INDIA-2 strap-footing workflow."""

--- a/Python/tests/codes/is456/strap_footing/index.json
+++ b/Python/tests/codes/is456/strap_footing/index.json
@@ -1,0 +1,94 @@
+{
+  "folder": "Python/tests/codes/is456/strap_footing",
+  "type": "python-package",
+  "description": "",
+  "last_updated": "2026-08-16",
+  "file_count": 2,
+  "files": [
+    {
+      "name": "__init__.py",
+      "type": "python",
+      "size_lines": 2,
+      "last_updated": "2026-08-16",
+      "description": "Tests for the bounded INDIA-2 strap-footing workflow.",
+      "content_hash": "905acba6a654"
+    },
+    {
+      "name": "test_analysis.py",
+      "type": "python",
+      "size_lines": 364,
+      "last_updated": "2026-08-16",
+      "description": "INDIA-2-FOUNDATION-STRAP-A benchmark and boundary tests.",
+      "functions": [
+        {
+          "name": "test_frozen_geometry_is_resolved_exactly"
+        },
+        {
+          "name": "test_frozen_reactions_bearing_and_equilibrium_are_exact"
+        },
+        {
+          "name": "test_frozen_clear_strap_actions_are_exact"
+        },
+        {
+          "name": "test_zero_strap_load_reduces_to_source_reaction_equations"
+        },
+        {
+          "name": "test_valid_bearing_failure_is_reported"
+        },
+        {
+          "name": "test_pressure_mismatch_fails_closed"
+        },
+        {
+          "name": "test_invalid_geometry_scalars_fail_closed",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_each_geometry_scope_carrier_fails_closed",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_geometry_boundaries_fail_closed"
+        },
+        {
+          "name": "test_invalid_action_scalars_fail_closed",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_action_factor_boundaries_fail_closed"
+        },
+        {
+          "name": "test_each_action_scope_carrier_fails_closed",
+          "params": [
+            "field",
+            "value"
+          ]
+        },
+        {
+          "name": "test_external_approvals_and_references_are_required"
+        },
+        {
+          "name": "test_wrong_typed_inputs_fail_closed"
+        },
+        {
+          "name": "test_results_are_frozen_deterministic_and_source_bound"
+        },
+        {
+          "name": "test_clause_registration_is_exact"
+        }
+      ],
+      "content_hash": "20a93ab4eb7a"
+    }
+  ],
+  "subfolders": [],
+  "has_init": true,
+  "content_hash": "4ead26f666195df4"
+}

--- a/Python/tests/codes/is456/strap_footing/index.md
+++ b/Python/tests/codes/is456/strap_footing/index.md
@@ -1,0 +1,12 @@
+# Strap Footing
+
+**Type:** Python Package
+**Last Updated:** 2026-08-16
+**Files:** 2
+
+## Python Files
+
+| File | Description | Classes | Functions | Lines |
+|------|-------------|---------|-----------|-------|
+| [__init__.py](__init__.py) | Tests for the bounded INDIA-2 strap-footing workflow. | 0 | 0 | 2 |
+| [test_analysis.py](test_analysis.py) | INDIA-2-FOUNDATION-STRAP-A benchmark and boundary tests. | 0 | 16 | 364 |

--- a/Python/tests/codes/is456/strap_footing/test_analysis.py
+++ b/Python/tests/codes/is456/strap_footing/test_analysis.py
@@ -1,0 +1,363 @@
+"""INDIA-2-FOUNDATION-STRAP-A benchmark and boundary tests."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from structural_lib.codes.is456.strap_footing import (
+    StrapFootingActionInput,
+    StrapFootingAnalysisInput,
+    StrapFootingAnalysisMethod,
+    StrapFootingApprovalInput,
+    StrapFootingContractError,
+    StrapFootingGeometryInput,
+    StrapFootingPressureModel,
+    StrapFootingTensionFace,
+    analyze_property_line_strap_footing,
+    resolve_property_line_strap_geometry,
+)
+from structural_lib.codes.is456.traceability import get_clause_refs
+
+
+def _geometry(**overrides: object) -> StrapFootingGeometryInput:
+    values: dict[str, object] = {
+        "exterior_footing_length_mm": 2400.0,
+        "exterior_footing_width_mm": 2500.0,
+        "exterior_footing_depth_mm": 700.0,
+        "interior_footing_length_mm": 2500.0,
+        "interior_footing_width_mm": 3200.0,
+        "interior_footing_depth_mm": 700.0,
+        "exterior_column_side_mm": 500.0,
+        "interior_column_side_mm": 500.0,
+        "exterior_column_center_x_mm": 400.0,
+        "interior_column_center_x_mm": 6400.0,
+        "strap_width_mm": 500.0,
+        "strap_overall_depth_mm": 950.0,
+        "strap_effective_depth_mm": 850.0,
+        "footing_count": 2,
+        "column_count": 2,
+        "footings_rectangular": True,
+        "footings_parallel": True,
+        "footings_constant_depth": True,
+        "columns_square": True,
+        "columns_and_strap_share_centerline": True,
+        "interior_column_centered_on_footing": True,
+        "strap_straight_and_prismatic": True,
+        "strap_centered_across_footings": True,
+        "foundation_on_soil": True,
+        "strap_soil_contact": False,
+        "openings_present": False,
+        "pedestals_present": False,
+        "analysis_method": StrapFootingAnalysisMethod.RIGID_EQUAL_PRESSURE,
+        "pressure_model": StrapFootingPressureModel.EQUAL_UNIFORM_NET,
+        "geometry_basis_reference": "INDIA-2-STRAP-HAND-01-GEOMETRY",
+        "rigidity_basis_reference": "INDIA-2-STRAP-HAND-01-RIGIDITY",
+        "strap_isolation_basis_reference": "INDIA-2-STRAP-HAND-01-ISOLATION",
+    }
+    values.update(overrides)
+    return StrapFootingGeometryInput(**values)  # type: ignore[arg-type]
+
+
+def _actions(**overrides: object) -> StrapFootingActionInput:
+    values: dict[str, object] = {
+        "service_exterior_column_load_kn": 1025.5625,
+        "service_interior_column_load_kn": 1741.4375,
+        "factored_exterior_column_load_kn": 1538.34375,
+        "factored_interior_column_load_kn": 2612.15625,
+        "service_clear_strap_line_load_kn_per_m": 12.0,
+        "factored_clear_strap_line_load_kn_per_m": 18.0,
+        "service_exterior_footing_carrier_kn_per_m2": 20.0,
+        "service_interior_footing_carrier_kn_per_m2": 20.0,
+        "factored_exterior_footing_carrier_kn_per_m2": 30.0,
+        "factored_interior_footing_carrier_kn_per_m2": 30.0,
+        "allowable_gross_bearing_pressure_kn_per_m2": 250.0,
+        "load_combination_approved": True,
+        "bearing_and_settlement_approved": True,
+        "equal_uniform_pressure_approved": True,
+        "footing_carrier_basis_approved": True,
+        "strap_line_load_basis_approved": True,
+        "load_pattern_compatible": True,
+        "column_moments_present": False,
+        "horizontal_actions_present": False,
+        "uplift_or_load_reversal_present": False,
+        "independently_factored_or_patterned_actions_present": False,
+        "load_basis_reference": "INDIA-2-STRAP-HAND-01-LOAD",
+        "bearing_settlement_basis_reference": "INDIA-2-STRAP-HAND-01-GEOTECH",
+        "footing_carrier_basis_reference": "INDIA-2-STRAP-HAND-01-CARRIER",
+        "strap_line_load_basis_reference": "INDIA-2-STRAP-HAND-01-LINE-LOAD",
+        "load_pattern_basis_reference": "INDIA-2-STRAP-HAND-01-PATTERN",
+    }
+    values.update(overrides)
+    return StrapFootingActionInput(**values)  # type: ignore[arg-type]
+
+
+def _approvals(**overrides: object) -> StrapFootingApprovalInput:
+    values: dict[str, object] = {
+        "exterior_footing_design_verified": True,
+        "interior_footing_design_verified": True,
+        "column_and_strap_transfer_verified": True,
+        "footing_reinforcement_and_anchorage_verified": True,
+        "supporting_areas_verified": True,
+        "construction_clearances_verified": True,
+        "exterior_footing_verification_reference": "EXT-FOOTING-01",
+        "interior_footing_verification_reference": "INT-FOOTING-01",
+        "transfer_verification_reference": "TRANSFER-01",
+        "construction_verification_reference": "CONSTRUCTION-01",
+    }
+    values.update(overrides)
+    return StrapFootingApprovalInput(**values)  # type: ignore[arg-type]
+
+
+def _input(**overrides: object) -> StrapFootingAnalysisInput:
+    values: dict[str, object] = {
+        "geometry": _geometry(),
+        "actions": _actions(),
+        "approvals": _approvals(),
+    }
+    values.update(overrides)
+    return StrapFootingAnalysisInput(**values)  # type: ignore[arg-type]
+
+
+def test_frozen_geometry_is_resolved_exactly() -> None:
+    result = resolve_property_line_strap_geometry(_geometry())
+
+    assert result.exterior_footing_area_m2 == pytest.approx(6.0)
+    assert result.interior_footing_area_m2 == pytest.approx(8.0)
+    assert result.exterior_footing_centroid_x_mm == pytest.approx(1200.0)
+    assert result.interior_footing_centroid_x_mm == pytest.approx(6400.0)
+    assert result.exterior_column_eccentricity_mm == pytest.approx(800.0)
+    assert result.reaction_spacing_mm == pytest.approx(5200.0)
+    assert result.clear_strap_start_x_mm == pytest.approx(2400.0)
+    assert result.clear_strap_end_x_mm == pytest.approx(5150.0)
+    assert result.clear_strap_length_mm == pytest.approx(2750.0)
+    assert result.clear_strap_centroid_x_mm == pytest.approx(3775.0)
+    assert result.clear_span_to_overall_depth_ratio == pytest.approx(2750.0 / 950.0)
+    assert result.rigid_equal_pressure_eligible is True
+
+
+def test_frozen_reactions_bearing_and_equilibrium_are_exact() -> None:
+    result = analyze_property_line_strap_footing(_input())
+
+    assert result.service.exterior_reaction_kn == pytest.approx(1200.0)
+    assert result.service.interior_reaction_kn == pytest.approx(1600.0)
+    assert result.service.exterior_net_pressure_kn_per_m2 == pytest.approx(200.0)
+    assert result.service.interior_net_pressure_kn_per_m2 == pytest.approx(200.0)
+    assert result.service.exterior_gross_pressure_kn_per_m2 == pytest.approx(220.0)
+    assert result.service.interior_gross_pressure_kn_per_m2 == pytest.approx(220.0)
+    assert result.exterior_service_bearing_utilization == pytest.approx(0.88)
+    assert result.interior_service_bearing_utilization == pytest.approx(0.88)
+    assert result.gross_service_bearing_within_allowable is True
+    assert result.factored.exterior_reaction_kn == pytest.approx(1800.0)
+    assert result.factored.interior_reaction_kn == pytest.approx(2400.0)
+    assert result.factored.exterior_net_pressure_kn_per_m2 == pytest.approx(300.0)
+    assert result.factored.interior_net_pressure_kn_per_m2 == pytest.approx(300.0)
+    assert result.common_factored_multiplier == pytest.approx(1.5)
+    assert result.service.vertical_equilibrium_residual_kn == pytest.approx(0.0)
+    assert result.service.moment_equilibrium_residual_kn_m == pytest.approx(0.0)
+    assert result.factored.vertical_equilibrium_residual_kn == pytest.approx(0.0)
+    assert result.factored.moment_equilibrium_residual_kn_m == pytest.approx(0.0)
+
+
+def test_frozen_clear_strap_actions_are_exact() -> None:
+    result = analyze_property_line_strap_footing(_input())
+
+    assert result.service_clear_strap.exterior_face_shear_kn == pytest.approx(174.4375)
+    assert result.service_clear_strap.exterior_face_moment_kn_m == pytest.approx(
+        -611.125
+    )
+    assert result.service_clear_strap.interior_face_shear_kn == pytest.approx(141.4375)
+    assert result.service_clear_strap.interior_face_moment_kn_m == pytest.approx(
+        -176.796875
+    )
+    assert result.factored_clear_strap.governing_shear_demand_kn == pytest.approx(
+        261.65625
+    )
+    assert result.factored_clear_strap.governing_moment_demand_kn_m == pytest.approx(
+        916.6875
+    )
+    assert result.factored_clear_strap.governing_moment_x_mm == pytest.approx(2400.0)
+    assert (
+        result.factored_clear_strap.governing_tension_face
+        is StrapFootingTensionFace.TOP
+    )
+
+
+def test_zero_strap_load_reduces_to_source_reaction_equations() -> None:
+    q1 = 1200.0 / (1.0 + 0.8 / 5.2)
+    q2 = 2800.0 - q1
+    actions = _actions(
+        service_exterior_column_load_kn=q1,
+        service_interior_column_load_kn=q2,
+        factored_exterior_column_load_kn=1.5 * q1,
+        factored_interior_column_load_kn=1.5 * q2,
+        service_clear_strap_line_load_kn_per_m=0.0,
+        factored_clear_strap_line_load_kn_per_m=0.0,
+    )
+    result = analyze_property_line_strap_footing(_input(actions=actions))
+
+    expected_r1 = q1 * (1.0 + 0.8 / 5.2)
+    expected_r2 = q2 - q1 * 0.8 / 5.2
+    assert result.service.exterior_reaction_kn == pytest.approx(expected_r1)
+    assert result.service.interior_reaction_kn == pytest.approx(expected_r2)
+
+
+def test_valid_bearing_failure_is_reported() -> None:
+    result = analyze_property_line_strap_footing(
+        _input(actions=_actions(allowable_gross_bearing_pressure_kn_per_m2=210.0))
+    )
+    assert result.gross_service_bearing_within_allowable is False
+
+
+def test_pressure_mismatch_fails_closed() -> None:
+    with pytest.raises(StrapFootingContractError, match="net footing pressures"):
+        analyze_property_line_strap_footing(
+            _input(geometry=_geometry(exterior_footing_width_mm=2400.0))
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("exterior_footing_length_mm", 0.0),
+        ("interior_footing_width_mm", math.inf),
+        ("strap_overall_depth_mm", math.nan),
+        ("strap_effective_depth_mm", -1.0),
+        ("exterior_column_side_mm", True),
+        ("interior_column_center_x_mm", "6400"),
+    ),
+)
+def test_invalid_geometry_scalars_fail_closed(field: str, value: object) -> None:
+    with pytest.raises(StrapFootingContractError, match=field):
+        _geometry(**{field: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("footing_count", 3),
+        ("column_count", 3),
+        ("footings_rectangular", False),
+        ("columns_square", False),
+        ("interior_column_centered_on_footing", False),
+        ("strap_straight_and_prismatic", False),
+        ("foundation_on_soil", False),
+        ("strap_soil_contact", True),
+        ("openings_present", True),
+        ("pedestals_present", True),
+        ("analysis_method", "elastic"),
+        ("pressure_model", "linear"),
+    ),
+)
+def test_each_geometry_scope_carrier_fails_closed(field: str, value: object) -> None:
+    with pytest.raises(StrapFootingContractError, match=field):
+        _geometry(**{field: value})
+
+
+def test_geometry_boundaries_fail_closed() -> None:
+    with pytest.raises(StrapFootingContractError, match="at least 150"):
+        _geometry(exterior_footing_depth_mm=149.0)
+    with pytest.raises(StrapFootingContractError, match="less than strap_overall"):
+        _geometry(strap_effective_depth_mm=950.0)
+    with pytest.raises(StrapFootingContractError, match="complete exterior column"):
+        _geometry(exterior_column_center_x_mm=200.0)
+    with pytest.raises(StrapFootingContractError, match="property-line edge"):
+        _geometry(exterior_column_center_x_mm=1300.0)
+    with pytest.raises(StrapFootingContractError, match="positive clear separation"):
+        _geometry(interior_column_center_x_mm=3600.0)
+    with pytest.raises(StrapFootingContractError, match="span-to-overall-depth"):
+        _geometry(strap_overall_depth_mm=1100.0)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("service_exterior_column_load_kn", 0.0),
+        ("factored_interior_column_load_kn", math.inf),
+        ("service_clear_strap_line_load_kn_per_m", math.nan),
+        ("factored_exterior_footing_carrier_kn_per_m2", -1.0),
+        ("allowable_gross_bearing_pressure_kn_per_m2", True),
+    ),
+)
+def test_invalid_action_scalars_fail_closed(field: str, value: object) -> None:
+    with pytest.raises(StrapFootingContractError, match=field):
+        _actions(**{field: value})
+
+
+def test_action_factor_boundaries_fail_closed() -> None:
+    with pytest.raises(StrapFootingContractError, match="must not be less"):
+        _actions(factored_exterior_column_load_kn=1000.0)
+    with pytest.raises(StrapFootingContractError, match="common multiplier"):
+        _actions(factored_interior_column_load_kn=2600.0)
+    with pytest.raises(StrapFootingContractError, match="zero service"):
+        _actions(
+            service_clear_strap_line_load_kn_per_m=0.0,
+            factored_clear_strap_line_load_kn_per_m=1.0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("load_combination_approved", False),
+        ("bearing_and_settlement_approved", False),
+        ("equal_uniform_pressure_approved", False),
+        ("load_pattern_compatible", False),
+        ("column_moments_present", True),
+        ("horizontal_actions_present", True),
+        ("uplift_or_load_reversal_present", True),
+        ("independently_factored_or_patterned_actions_present", True),
+    ),
+)
+def test_each_action_scope_carrier_fails_closed(field: str, value: object) -> None:
+    with pytest.raises(StrapFootingContractError, match=field):
+        _actions(**{field: value})
+
+
+def test_external_approvals_and_references_are_required() -> None:
+    with pytest.raises(StrapFootingContractError, match="supporting_areas_verified"):
+        _approvals(supporting_areas_verified=False)
+    with pytest.raises(
+        StrapFootingContractError, match="transfer_verification_reference"
+    ):
+        _approvals(transfer_verification_reference=" ")
+    with pytest.raises(StrapFootingContractError, match="geometry_basis_reference"):
+        _geometry(geometry_basis_reference=" ")
+    with pytest.raises(StrapFootingContractError, match="load_basis_reference"):
+        _actions(load_basis_reference=" ")
+
+
+def test_wrong_typed_inputs_fail_closed() -> None:
+    with pytest.raises(StrapFootingContractError, match="geometry"):
+        StrapFootingAnalysisInput(  # type: ignore[arg-type]
+            geometry=object(), actions=_actions(), approvals=_approvals()
+        )
+    with pytest.raises(StrapFootingContractError, match="geometry"):
+        resolve_property_line_strap_geometry(object())  # type: ignore[arg-type]
+    with pytest.raises(StrapFootingContractError, match="footing_input"):
+        analyze_property_line_strap_footing(object())  # type: ignore[arg-type]
+
+
+def test_results_are_frozen_deterministic_and_source_bound() -> None:
+    first = analyze_property_line_strap_footing(_input())
+    second = analyze_property_line_strap_footing(_input())
+    assert first == second
+    assert first.source_refs[:5] == (
+        "IS 456:2000 Cl. 34.1, 34.1.2, 34.2.3.1",
+        "IS456-2000-A5",
+        "IS456-AMD6-2024",
+        "NPTEL-AFE-C3-STRAP Section 3.6.1 and Fig. 3.2",
+        "INDIA-2-STRAP-HAND-01",
+    )
+    with pytest.raises(FrozenInstanceError):
+        first.common_factored_multiplier = 1.0  # type: ignore[misc]
+
+
+def test_clause_registration_is_exact() -> None:
+    assert get_clause_refs(resolve_property_line_strap_geometry) == ["34.1", "34.1.2"]
+    assert get_clause_refs(analyze_property_line_strap_footing) == [
+        "34.1",
+        "34.2.3.1",
+    ]

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,65 @@
 
 ---
 
+## 2026-08-16 — Session: INDIA-2-FOUNDATION-STRAP-A
+
+**Agent:** Codex (`structural-math`, sole writer; one bounded independent
+exact-head audit after the candidate is committed)
+
+**Branch:** `codex/india-2-foundation-strap-a` from merged STRAP-G0
+`70cd2894485d88b72d22544ee18533733789d0f1`
+
+**Git handoff receipt:** `docs/verification/india-2-foundation-strap-a-git-handoff-receipt.json`
+
+**Focus:** Implement only the frozen property-line strap statics, equal-pressure
+eligibility, bearing, clear-span actions, and equilibrium. Strength,
+publication, React, broad Python, and the full 30-check gate remain outside A.
+
+### Summary
+
+- Added immutable, finite, unit-explicit geometry/action/approval contracts
+  with strict topology, common-factor, no-soil-contact, and external-verification
+  boundaries.
+- Added reaction, equal-pressure, gross-bearing, clear-strap action, and exact
+  equilibrium results, including the zero-line-load source reduction.
+- Kept strap capability held at 12 supported / 9 held until B-D and focused
+  family acceptance finish.
+
+### Issues encountered
+
+- The first manifest help command guessed `scripts/indian_code_manifest.py`,
+  but the maintained executable is `scripts/generate_indian_code_manifest.py`.
+- The first focused manifest test reported one IS 456 registration-only
+  reference after STRAP-A registered Clause `34.1.2`.
+- The first architecture/import command guessed `check_architecture.py` and
+  `check_imports.py`; the maintained executables have different names.
+
+### Root causes and resolutions
+
+- Root cause: the executable path was inferred from the helper module name
+  instead of discovered with `rg --files`. Resolution: locate and use the
+  maintained generator entry point. Evidence: explicit `--write`/`--check`,
+  manifest tests, semantic truth checks, and the focused quick gate pass.
+  ⚠️ TERMINAL ISSUE: guessed manifest script path did not exist -> discovered
+  and used `scripts/generate_indian_code_manifest.py`.
+- Confirmed root cause: Clause `34.1.2` was absent from the normalized clause
+  metadata even though G0/A use it and the new resolver registered it. The
+  registration scanner therefore truthfully classified the reference as
+  registration-only. Resolution: add the bounded Clause `34.1.2` metadata
+  identity and regenerate the manifest without changing capability status.
+  Evidence: the cross-standard registration invariant, all manifest tests,
+  deterministic generation, and the focused gate pass with zero IS 456
+  registration-only references.
+- Root cause: validation filenames were inferred from check labels instead of
+  discovered through the maintained automation registry. Resolution: run
+  `./run.sh find` and use `check_architecture_boundaries.py` plus
+  `validate_imports.py`. Evidence: both maintained checks and the quick gate
+  pass.
+  ⚠️ TERMINAL ISSUE: guessed validation script names did not exist ->
+  repository automation discovery identified the maintained commands.
+
+---
+
 ## 2026-08-16 — Session: INDIA-2-FOUNDATION-STRAP-G0
 
 **Agent:** Codex (`structural-engineer`, sole writer; one bounded independent

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-16 — STRAP-G0 returned GO; STRAP-A is next
+**Updated:** 2026-08-16 — STRAP-A analysis complete; STRAP-B is next after merge
 
 ---
 
@@ -133,7 +133,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-2-FOUNDATION-STRAP-A | Implement typed strap geometry/action/approval contracts, equal-pressure/common-factor eligibility, reactions, bearing, clear-strap actions, and equilibrium | Main Agent + structural math | focused analysis packet | P0 | 🚧 NEXT after STRAP-G0 merges unchanged; strength/publication remain held |
+| INDIA-2-FOUNDATION-STRAP-B | Implement exact strap flexure, shear, detailing, anchorage, and composed disposition | Main Agent + structural math | focused strength packet | P0 | 🚧 NEXT after STRAP-A merges unchanged; publication remains held |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 
 ## Backlog
@@ -159,6 +159,7 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-2-FOUNDATION-STRAP-A | Implemented typed strap geometry/action/approval contracts, equal-pressure/common-factor eligibility, reactions, bearing, clear-strap actions, and equilibrium | Main Agent + structural math | ✅ COMPLETE — frozen benchmark, source-equation reduction, valid bearing failure, and fail-closed boundaries pass; strength/publication remain held |
 | INDIA-2-FOUNDATION-STRAP-G0 | Froze one property-line two-footing system with equal uniform pressure, an explicit no-soil-contact strap model, independent benchmark, and externally verified footing-slab prerequisites | Main Agent + structural engineer | ✅ GO — STRAP-A-D and focused acceptance activated; public capability remains held |
 | INDIA-2-FOUNDATION-COMBINED | Implemented, published, and focused-accepted one bounded symmetric equal-load two-column rigid rectangular combined-footing workflow | Main Agent + structural engineer | ✅ DONE — G0/A-D integrated; 84 family tests, 339 focused public-contract tests, frozen and non-frozen benchmarks, exact-head audit, and hosted checks pass; qualified review and excluded systems remain held |
 | INDIA-2-FOUNDATION-COMBINED-D | Published strict nested FastAPI transport, exact OpenAPI drift, capability/semantic truth, and deterministic manifest promotion | Main Agent + API developer | ✅ COMPLETE — one bounded workflow is supported at 12/21 truth and all 80 routes have direct tests; integration receipt remains live-closeout evidence |

--- a/docs/planning/india-2-next-session-publication-and-closeout-plan.md
+++ b/docs/planning/india-2-next-session-publication-and-closeout-plan.md
@@ -15,8 +15,9 @@ doc_type: spec
 COMBINED-C/D and focused family acceptance are integrated. STRAP-G0 returned
 GO for one source-bound property-line two-footing model with equal uniform net
 pressure, a straight no-soil-contact strap, explicit service/factored actions,
-and externally verified footing slabs. The next packet is
-`INDIA-2-FOUNDATION-STRAP-A` after G0 merges unchanged with required checks
+and externally verified footing slabs. STRAP-A implements its bounded statics,
+bearing, clear-strap actions, and exact equilibrium. The next packet is
+`INDIA-2-FOUNDATION-STRAP-B` after A merges unchanged with required checks
 green.
 
 Finish the bounded strap sequence A -> B -> C -> D -> focused acceptance, one

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,11 +4,11 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-16
-- Focus: Merge STRAP-G0 unchanged, then begin only STRAP-A analysis
+- Focus: Merge STRAP-A unchanged, then begin only STRAP-B strength
 - Combined acceptance: PR #792 squash-merged as 8e039b112e38436fcae36326b46afa9c436fb970; tree=873aea4cdca8aa9633b30a7c9b74138e5a73a6ce
-- STRAP-G0: GO for one property-line two-footing/equal-pressure/no-soil-contact strap model; footing slabs and transfer remain external prerequisites
-- G0 candidate identity: VERIFY_EXACT_HEAD_TREE_PR_AND_HOSTED_CHECKS_AT_CLOSEOUT
-- Next action: START_STRAP_A_ONLY_AFTER_G0_MERGE
+- STRAP-G0: PR #793 squash-merged as 70cd2894485d88b72d22544ee18533733789d0f1; audited tree=60d5636265e157e723236909b1de7f582791b297
+- STRAP-A: bounded statics, bearing, actions, and equilibrium implemented; strength/publication remain held
+- Next action: START_STRAP_B_ONLY_AFTER_A_MERGE
 <!-- HANDOFF:END -->
 
 **Date:** 2026-08-16
@@ -17,7 +17,7 @@
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; INDIA-0, INDIA-1, and the INDIA-2-STAIR family are complete |
 | **Program** | Umbrella INDIA-2 remains in progress; INDIA-3 and INDIA-4 remain planned |
-| **Next** | Begin `INDIA-2-FOUNDATION-STRAP-A` only after STRAP-G0 merges unchanged |
+| **Next** | Begin `INDIA-2-FOUNDATION-STRAP-B` only after STRAP-A merges unchanged |
 
 ## Required Reading
 
@@ -120,9 +120,8 @@ authorization, or cleanup authority.
 
 ## Exact next action
 
-After verifying STRAP-G0 merged unchanged into current `origin/main`, create a
-fresh STRAP-A lane. Implement only typed geometry/action/approval contracts,
-common-factor and equal-pressure eligibility, reactions, gross service bearing,
-clear-strap shear/moment actions, source identities, and exact vertical/moment
-closure. Strength, public Python, FastAPI, capability promotion, React, broad
-Python, and the 30-check gate remain outside STRAP-A.
+After verifying STRAP-A merged unchanged into current `origin/main`, create a
+fresh STRAP-B lane. Implement only exact strap flexure, minimum/provided and
+side-face steel, shear/stirrups, cover/spacing, anchorage, and the composed
+strength disposition. Public Python, FastAPI, capability promotion, React,
+broad Python, and the 30-check gate remain outside STRAP-B.

--- a/docs/verification/india-2-foundation-strap-a-analysis-evidence.md
+++ b/docs/verification/india-2-foundation-strap-a-analysis-evidence.md
@@ -1,0 +1,55 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-16
+doc_type: verification
+task: INDIA-2-FOUNDATION-STRAP-A
+---
+
+# INDIA-2 Foundation Strap A Analysis Evidence
+
+## Scope and retained boundary
+
+This packet implements only the G0-frozen two-footing property-line analysis:
+strict typed topology/action/approval inputs, reaction statics, equal uniform
+net-pressure eligibility, gross service bearing, clear-strap shear and moment,
+and vertical/moment equilibrium. Strap strength, the public composition,
+FastAPI transport, capability promotion, React, release, broad Python, and the
+full 30-check gate remain outside this packet.
+
+The contract requires separate caller-qualified references for both footing
+slabs, transfer regions, reinforcement/anchorage, supporting areas, settlement,
+and construction clearances. It fails closed for strap soil contact, unequal
+pressure, independently factored actions, unsupported topology/actions, missing
+approvals, non-finite values, or absent provenance.
+
+## Frozen and independent evidence
+
+`INDIA-2-STRAP-HAND-01` reproduces `1200/1600 kN` service reactions,
+`200 kN/m2` equal net pressure, `220 kN/m2` gross service pressure, `0.88`
+bearing utilization, and exact service/factored vertical and moment closure.
+The clear-strap faces reproduce service `V = 174.4375/141.4375 kN` and
+`M = -611.125/-176.796875 kN m`; the factored envelope is `261.65625 kN`
+shear and `916.6875 kN m` top-tension moment. Setting the strap line load to
+zero independently reproduces the source reaction equations. A valid bearing
+failure returns `False`; inputs outside the frozen domain raise the typed
+contract error without a design result.
+
+## Provenance and cadence
+
+The implementation carries normalized Clause 34 identities, the controlled
+base/amendment source IDs, the IISc/NPTEL strap-model identity, the frozen hand
+benchmark ID, and caller references. No source scan, protected prose, or table
+image is committed. Focused gates run for A; broad Python and the 30-check gate
+remain deferred to the final INDIA-2 boundary unless a confirmed repository-
+wide failure forces either earlier.
+
+## Verification
+
+- Direct STRAP-A benchmark/boundary tests pass.
+- Formatting, lint, typing, architecture, imports, deterministic manifest,
+  maintained indexes/links, source binding, and the quick gate pass.
+- Capability remains held at `12 supported / 9 held`; its limitation now says
+  G0 and A exist while strength/publication remain pending.
+- Exact candidate commit/tree, independent audit, hosted checks, and merge
+  identity are bound by the packet Git handoff receipt.

--- a/docs/verification/india-2-foundation-strap-a-git-handoff-receipt.json
+++ b/docs/verification/india-2-foundation-strap-a-git-handoff-receipt.json
@@ -1,0 +1,155 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-16T10:43:12Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2:user-request-finish-strap-footing",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-16T10:43:12Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-foundation-strap-a",
+      "head_sha": "13dd95bce9dd77da8dec5e126afa21a38f3f4139",
+      "task_id": "INDIA-2-FOUNDATION-STRAP-A"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "0f5f8d8edd15482d3c36b0d1bd7c4a288ca14825f8568d5a57432799e9a66c6f",
+    "state": {
+      "branch": "codex/india-2-foundation-strap-a",
+      "default_base": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "70cd2894485d88b72d22544ee18533733789d0f1",
+        "status": "ahead"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 74.685,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-india-2-foundation-strap-a",
+      "head_sha": "13dd95bce9dd77da8dec5e126afa21a38f3f4139",
+      "hold_reasons": [
+        "changed paths: 1"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-16T10:43:37.959624+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-foundation-strap-a",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 1,
+        "modified_paths": [],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/india-2-foundation-strap-a-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-foundation-strap-a"
+    }
+  },
+  "local_state_receipt_hash": "sha256:0f5f8d8edd15482d3c36b0d1bd7c4a288ca14825f8568d5a57432799e9a66c6f",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-16T10:43:37.959764+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-16T10:43:12Z",
+    "owner": "Main Agent under user instruction to preserve Git state",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "fastapi_app",
+      "react_app",
+      "private_sources",
+      "pyproject.toml",
+      "CHANGELOG.md"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "Python/structural_lib/codes/is456/strap_footing",
+      "Python/tests/codes/is456/strap_footing",
+      "docs/verification/india-2-foundation-strap-a-analysis-evidence.md",
+      "docs/verification/india-2-foundation-strap-a-git-handoff-source-evidence.json"
+    ],
+    "shared_paths": [
+      "Python/structural_lib/codes/is456/clauses.json",
+      "scripts/_lib/indian_code_manifest.py",
+      "docs/verification/indian-code-capability-coverage.json",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "INDIA-2-FOUNDATION-STRAP-A"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-2-foundation-strap-a-git-handoff-source-evidence.json
+++ b/docs/verification/india-2-foundation-strap-a-git-handoff-source-evidence.json
@@ -1,0 +1,53 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-16T10:43:12Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2:user-request-finish-strap-footing",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-16T10:43:12Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-foundation-strap-a",
+      "head_sha": "13dd95bce9dd77da8dec5e126afa21a38f3f4139",
+      "task_id": "INDIA-2-FOUNDATION-STRAP-A"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-16T10:43:12Z",
+    "owner": "Main Agent under user instruction to preserve Git state",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -279,7 +279,7 @@
           "claim": "Strap-footing design is not implemented.",
           "workflows": [],
           "limitations": [
-            "G0 accepted one bounded property-line strap model; implementation and publication remain pending."
+            "G0 and the bounded analysis kernel are implemented; strap strength and publication remain pending."
           ],
           "evidence": [],
           "qualified_review_required": true
@@ -312,11 +312,11 @@
         }
       ],
       "registration_summary": {
-        "known_references": 173,
-        "registered_known_references": 95,
+        "known_references": 174,
+        "registered_known_references": 96,
         "metadata_only_references": 78,
         "registration_only_references": 0,
-        "registration_pct": 54.9
+        "registration_pct": 55.2
       },
       "references": [
         {
@@ -1314,7 +1314,20 @@
             "structural_lib.codes.is456.combined_footing.analysis.analyze_symmetric_combined_footing",
             "structural_lib.codes.is456.combined_footing.analysis.resolve_symmetric_combined_footing_geometry",
             "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength",
-            "structural_lib.codes.is456.footing.bearing.size_footing"
+            "structural_lib.codes.is456.footing.bearing.size_footing",
+            "structural_lib.codes.is456.strap_footing.analysis.analyze_property_line_strap_footing",
+            "structural_lib.codes.is456.strap_footing.analysis.resolve_property_line_strap_geometry"
+          ]
+        },
+        {
+          "reference_id": "IS456:2000:34.1.2",
+          "reference": "34.1.2",
+          "reference_type": "clause",
+          "title": "Minimum Edge Thickness for Footings",
+          "category": "footings",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.strap_footing.analysis.resolve_property_line_strap_geometry"
           ]
         },
         {
@@ -1365,7 +1378,8 @@
             "structural_lib.codes.is456.combined_footing.analysis.resolve_symmetric_combined_footing_geometry",
             "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength",
             "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
-            "structural_lib.codes.is456.footing.flexure.footing_flexure"
+            "structural_lib.codes.is456.footing.flexure.footing_flexure",
+            "structural_lib.codes.is456.strap_footing.analysis.analyze_property_line_strap_footing"
           ]
         },
         {

--- a/scripts/_lib/indian_code_manifest.py
+++ b/scripts/_lib/indian_code_manifest.py
@@ -110,7 +110,7 @@ _HELD_FAMILIES: dict[str, tuple[dict[str, Any], ...]] = {
             "family": "strap_footing",
             "claim": "Strap-footing design is not implemented.",
             "limitations": [
-                "G0 accepted one bounded property-line strap model; implementation and publication remain pending."
+                "G0 and the bounded analysis kernel are implemented; strap strength and publication remain pending."
             ],
         },
         {


### PR DESCRIPTION
## Scope\n- add strict property-line strap-footing geometry/action/approval contracts\n- calculate equal-pressure reactions, bearing, clear-span actions, and equilibrium\n- bind Clause 34.1.2 metadata and retain strap capability as held\n\n## Validation\n- 43 direct STRAP-A tests\n- 121 focused strap/combined/manifest tests\n- Ruff, Black, mypy\n- architecture 0/196; imports 0/640; links 1,258\n- manifest deterministic at 12 supported / 9 held\n- quick gate 10/10\n\nBroad Python and the 30-check gate remain deferred to final INDIA-2 closeout per the accepted cadence.