### PR TITLE
feat(footing): add strap strength checks

### DIFF
--- a/Python/structural_lib/codes/is456/clauses.json
+++ b/Python/structural_lib/codes/is456/clauses.json
@@ -6,7 +6,7 @@
     "version": "2000 (Reaffirmed 2021)",
     "source": "Bureau of Indian Standards",
     "last_updated": "2026-08-16",
-    "total_clauses": 173,
+    "total_clauses": 175,
     "includes_references": [
       "IS 13920:2016"
     ],
@@ -408,6 +408,17 @@
         "bars"
       ]
     },
+    "26.4": {
+      "title": "Nominal Cover to Reinforcement",
+      "section": "26 - Detailing",
+      "category": "detailing",
+      "keywords": [
+        "nominal cover",
+        "durability",
+        "reinforcement cover",
+        "fire resistance"
+      ]
+    },
     "26.4.2.2": {
       "title": "Minimum Nominal Cover for Footings",
       "section": "26 - Detailing",
@@ -419,13 +430,14 @@
       ]
     },
     "26.5.1.1": {
-      "title": "Minimum Shear Reinforcement",
+      "title": "Minimum Tension Reinforcement in Beams",
       "section": "26 - Detailing",
-      "category": "shear",
+      "category": "detailing",
       "keywords": [
-        "minimum stirrups",
-        "shear reinforcement",
-        "Asv"
+        "beam",
+        "minimum tension reinforcement",
+        "longitudinal steel",
+        "Ast"
       ]
     },
     "26.5.1.2": {

--- a/Python/structural_lib/codes/is456/strap_footing/__init__.py
+++ b/Python/structural_lib/codes/is456/strap_footing/__init__.py
@@ -18,8 +18,19 @@ from structural_lib.codes.is456.strap_footing.models import (
     StrapFootingAnalysisMethod,
     StrapFootingApprovalInput,
     StrapFootingContractError,
+    StrapFootingDesignInput,
     StrapFootingGeometryInput,
+    StrapFootingMaterialInput,
     StrapFootingPressureModel,
+    StrapFootingReinforcementInput,
+)
+from structural_lib.codes.is456.strap_footing.strength import (
+    StrapFootingDesignDisposition,
+    StrapFootingFlexureResult,
+    StrapFootingShearResult,
+    StrapFootingSideFaceResult,
+    StrapFootingStrengthResult,
+    check_property_line_strap_footing_strength,
 )
 
 __all__ = [
@@ -30,12 +41,21 @@ __all__ = [
     "StrapFootingApprovalInput",
     "StrapFootingClearSpanActionResult",
     "StrapFootingContractError",
+    "StrapFootingDesignDisposition",
+    "StrapFootingDesignInput",
+    "StrapFootingFlexureResult",
     "StrapFootingGeometryInput",
     "StrapFootingGeometryResult",
     "StrapFootingLoadCase",
     "StrapFootingLoadCaseResult",
+    "StrapFootingMaterialInput",
     "StrapFootingPressureModel",
+    "StrapFootingReinforcementInput",
+    "StrapFootingShearResult",
+    "StrapFootingSideFaceResult",
+    "StrapFootingStrengthResult",
     "StrapFootingTensionFace",
     "analyze_property_line_strap_footing",
+    "check_property_line_strap_footing_strength",
     "resolve_property_line_strap_geometry",
 ]

--- a/Python/structural_lib/codes/is456/strap_footing/index.json
+++ b/Python/structural_lib/codes/is456/strap_footing/index.json
@@ -3,15 +3,15 @@
   "type": "python-package",
   "description": "",
   "last_updated": "2026-08-16",
-  "file_count": 3,
+  "file_count": 4,
   "files": [
     {
       "name": "__init__.py",
       "type": "python",
-      "size_lines": 42,
+      "size_lines": 62,
       "last_updated": "2026-08-16",
       "description": "Bounded property-line strap-footing analysis for INDIA-2.",
-      "content_hash": "d8a17edab325"
+      "content_hash": "f2bf6a09e753"
     },
     {
       "name": "analysis.py",
@@ -71,7 +71,7 @@
     {
       "name": "models.py",
       "type": "python",
-      "size_lines": 450,
+      "size_lines": 633,
       "last_updated": "2026-08-16",
       "description": "Typed contracts for the bounded INDIA-2 property-line strap footing.",
       "classes": [
@@ -105,9 +105,76 @@
         {
           "name": "StrapFootingAnalysisInput",
           "description": "Complete input to the bounded property-line strap action kernel."
+        },
+        {
+          "name": "StrapFootingMaterialInput",
+          "description": "Material grades admitted by the bounded strap strength check."
+        },
+        {
+          "name": "StrapFootingReinforcementInput",
+          "description": "Caller-supplied strap bars and approved detailing carriers."
+        },
+        {
+          "name": "StrapFootingDesignInput",
+          "description": "Complete input to the bounded strap strength composition."
         }
       ],
-      "content_hash": "18d80933a286"
+      "constants": [
+        "_SUPPORTED_CONCRETE_GRADES_NMM2",
+        "_SUPPORTED_STEEL_GRADES_NMM2",
+        "_SUPPORTED_BAR_DIAMETERS_MM"
+      ],
+      "content_hash": "2e2284c07a98"
+    },
+    {
+      "name": "strength.py",
+      "type": "python",
+      "size_lines": 575,
+      "last_updated": "2026-08-16",
+      "description": "Strength and detailing checks for the bounded property-line strap.",
+      "classes": [
+        {
+          "name": "StrapFootingDesignDisposition",
+          "description": "Aggregate outcomes admitted by the bounded strength workflow."
+        },
+        {
+          "name": "StrapFootingFlexureResult",
+          "description": "Exact stress-block, minimum steel, spacing, cover and anchorage checks."
+        },
+        {
+          "name": "StrapFootingSideFaceResult",
+          "description": "Side-face steel and vertical spacing check for the deep strap web."
+        },
+        {
+          "name": "StrapFootingShearResult",
+          "description": "Table 19/20 shear and supplied vertical-stirrup check."
+        },
+        {
+          "name": "StrapFootingStrengthResult",
+          "description": "Composed service, strength and detailing disposition.",
+          "public_methods": [
+            "is_safe_within_supported_scope"
+          ]
+        }
+      ],
+      "functions": [
+        {
+          "name": "check_property_line_strap_footing_strength",
+          "description": "Check the G0-frozen strap reinforcement and detailing schedule.",
+          "params": [
+            "footing_input"
+          ]
+        }
+      ],
+      "constants": [
+        "_SOURCE_REFS",
+        "_CLAUSE_REFS",
+        "_LIMITATIONS",
+        "_SIDE_FACE_RATIO_TOTAL",
+        "_SIDE_FACE_DEPTH_THRESHOLD_MM",
+        "_MAX_SIDE_FACE_SPACING_MM"
+      ],
+      "content_hash": "78076bc84746"
     }
   ],
   "subfolders": [],
@@ -120,14 +187,19 @@
     "StrapFootingApprovalInput",
     "StrapFootingClearSpanActionResult",
     "StrapFootingContractError",
+    "StrapFootingDesignDisposition",
+    "StrapFootingDesignInput",
+    "StrapFootingFlexureResult",
     "StrapFootingGeometryInput",
     "StrapFootingGeometryResult",
     "StrapFootingLoadCase",
     "StrapFootingLoadCaseResult",
+    "StrapFootingMaterialInput",
     "StrapFootingPressureModel",
-    "StrapFootingTensionFace",
-    "analyze_property_line_strap_footing",
-    "resolve_property_line_strap_geometry"
+    "StrapFootingReinforcementInput",
+    "StrapFootingShearResult",
+    "StrapFootingSideFaceResult",
+    "StrapFootingStrengthResult"
   ],
-  "content_hash": "719ff497d8fd5b7a"
+  "content_hash": "bc24fbba69050743"
 }

--- a/Python/structural_lib/codes/is456/strap_footing/index.md
+++ b/Python/structural_lib/codes/is456/strap_footing/index.md
@@ -2,7 +2,7 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-16
-**Files:** 3
+**Files:** 4
 
 ## Public API
 
@@ -13,19 +13,25 @@
 - `StrapFootingApprovalInput`
 - `StrapFootingClearSpanActionResult`
 - `StrapFootingContractError`
+- `StrapFootingDesignDisposition`
+- `StrapFootingDesignInput`
+- `StrapFootingFlexureResult`
 - `StrapFootingGeometryInput`
 - `StrapFootingGeometryResult`
 - `StrapFootingLoadCase`
 - `StrapFootingLoadCaseResult`
+- `StrapFootingMaterialInput`
 - `StrapFootingPressureModel`
-- `StrapFootingTensionFace`
-- `analyze_property_line_strap_footing`
-- `resolve_property_line_strap_geometry`
+- `StrapFootingReinforcementInput`
+- `StrapFootingShearResult`
+- `StrapFootingSideFaceResult`
+- `StrapFootingStrengthResult`
 
 ## Python Files
 
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
-| [__init__.py](__init__.py) | Bounded property-line strap-footing analysis for INDIA-2. | 0 | 0 | 42 |
+| [__init__.py](__init__.py) | Bounded property-line strap-footing analysis for INDIA-2. | 0 | 0 | 62 |
 | [analysis.py](analysis.py) | Rigid equal-pressure statics for the bounded property-line s | 6 | 2 | 464 |
-| [models.py](models.py) | Typed contracts for the bounded INDIA-2 property-line strap  | 7 | 0 | 450 |
+| [models.py](models.py) | Typed contracts for the bounded INDIA-2 property-line strap  | 10 | 0 | 633 |
+| [strength.py](strength.py) | Strength and detailing checks for the bounded property-line  | 5 | 1 | 575 |

--- a/Python/structural_lib/codes/is456/strap_footing/models.py
+++ b/Python/structural_lib/codes/is456/strap_footing/models.py
@@ -16,8 +16,16 @@ __all__ = [
     "StrapFootingApprovalInput",
     "StrapFootingContractError",
     "StrapFootingGeometryInput",
+    "StrapFootingDesignInput",
+    "StrapFootingMaterialInput",
     "StrapFootingPressureModel",
+    "StrapFootingReinforcementInput",
 ]
+
+
+_SUPPORTED_CONCRETE_GRADES_NMM2 = (20.0, 25.0, 30.0, 35.0, 40.0)
+_SUPPORTED_STEEL_GRADES_NMM2 = (415.0, 500.0)
+_SUPPORTED_BAR_DIAMETERS_MM = (8.0, 10.0, 12.0, 16.0, 20.0, 25.0, 32.0, 36.0)
 
 
 class StrapFootingContractError(ValueError):
@@ -68,6 +76,19 @@ def _non_blank(value: object, field_name: str) -> str:
 def _require_bool(value: object, field_name: str, expected: bool) -> None:
     if value is not expected:
         raise StrapFootingContractError(f"{field_name} must be explicitly {expected}")
+
+
+def _supported_discrete_value(
+    value: object,
+    field_name: str,
+    unit: str,
+    supported: tuple[float, ...],
+) -> float:
+    normalized = _positive_finite(value, field_name, unit)
+    if normalized not in supported:
+        choices = ", ".join(f"{candidate:g}" for candidate in supported)
+        raise StrapFootingContractError(f"{field_name} must be one of {choices} {unit}")
+    return normalized
 
 
 @dataclass(frozen=True)
@@ -447,3 +468,165 @@ class StrapFootingAnalysisInput:
             raise StrapFootingContractError(
                 "approvals must be a StrapFootingApprovalInput"
             )
+
+
+@dataclass(frozen=True)
+class StrapFootingMaterialInput:
+    """Material grades admitted by the bounded strap strength check."""
+
+    strap_concrete_grade_nmm2: float
+    steel_grade_nmm2: float
+    uncoated_deformed_bars: bool
+    material_basis_reference: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "strap_concrete_grade_nmm2",
+            _supported_discrete_value(
+                self.strap_concrete_grade_nmm2,
+                "strap_concrete_grade_nmm2",
+                "N/mm2",
+                _SUPPORTED_CONCRETE_GRADES_NMM2,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "steel_grade_nmm2",
+            _supported_discrete_value(
+                self.steel_grade_nmm2,
+                "steel_grade_nmm2",
+                "N/mm2",
+                _SUPPORTED_STEEL_GRADES_NMM2,
+            ),
+        )
+        _require_bool(
+            self.uncoated_deformed_bars,
+            "uncoated_deformed_bars",
+            True,
+        )
+        object.__setattr__(
+            self,
+            "material_basis_reference",
+            _non_blank(self.material_basis_reference, "material_basis_reference"),
+        )
+
+
+@dataclass(frozen=True)
+class StrapFootingReinforcementInput:
+    """Caller-supplied strap bars and approved detailing carriers.
+
+    Valid but inadequate provision produces ``FAIL``. Unsupported layouts,
+    material forms, or missing approvals fail closed before calculation.
+    """
+
+    top_bar_count: int
+    top_bar_diameter_mm: float
+    bottom_bar_count: int
+    bottom_bar_diameter_mm: float
+    side_face_bar_count_each_face: int
+    side_face_bar_diameter_mm: float
+    side_face_vertical_spacing_mm: float
+    stirrup_leg_count: int
+    stirrup_diameter_mm: float
+    stirrup_spacing_mm: float
+    nominal_cover_mm: float
+    required_nominal_cover_mm: float
+    maximum_aggregate_size_mm: float
+    available_top_anchorage_exterior_mm: float
+    available_top_anchorage_interior_mm: float
+    available_bottom_anchorage_exterior_mm: float
+    available_bottom_anchorage_interior_mm: float
+    vertical_closed_stirrups: bool
+    straight_anchorage: bool
+    bars_bundled: bool
+    bars_spliced: bool
+    bars_curtailed: bool
+    reinforcement_schedule_approved: bool
+    effective_depth_basis_approved: bool
+    durability_cover_basis_approved: bool
+    detailing_basis_reference: str
+    durability_basis_reference: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "top_bar_count",
+            "bottom_bar_count",
+            "side_face_bar_count_each_face",
+            "stirrup_leg_count",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise StrapFootingContractError(f"{name} must be an integer")
+            if value < 2:
+                raise StrapFootingContractError(
+                    f"{name} must be at least 2 for the represented layout"
+                )
+        for name in (
+            "top_bar_diameter_mm",
+            "bottom_bar_diameter_mm",
+            "side_face_bar_diameter_mm",
+            "stirrup_diameter_mm",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _supported_discrete_value(
+                    getattr(self, name),
+                    name,
+                    "mm",
+                    _SUPPORTED_BAR_DIAMETERS_MM,
+                ),
+            )
+        for name in (
+            "side_face_vertical_spacing_mm",
+            "stirrup_spacing_mm",
+            "nominal_cover_mm",
+            "required_nominal_cover_mm",
+            "maximum_aggregate_size_mm",
+            "available_top_anchorage_exterior_mm",
+            "available_top_anchorage_interior_mm",
+            "available_bottom_anchorage_exterior_mm",
+            "available_bottom_anchorage_interior_mm",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _positive_finite(getattr(self, name), name, "mm"),
+            )
+        for name in (
+            "vertical_closed_stirrups",
+            "straight_anchorage",
+            "reinforcement_schedule_approved",
+            "effective_depth_basis_approved",
+            "durability_cover_basis_approved",
+        ):
+            _require_bool(getattr(self, name), name, True)
+        for name in ("bars_bundled", "bars_spliced", "bars_curtailed"):
+            _require_bool(getattr(self, name), name, False)
+        for name in ("detailing_basis_reference", "durability_basis_reference"):
+            object.__setattr__(
+                self,
+                name,
+                _non_blank(getattr(self, name), name),
+            )
+
+
+@dataclass(frozen=True)
+class StrapFootingDesignInput:
+    """Complete input to the bounded strap strength composition."""
+
+    analysis: StrapFootingAnalysisInput
+    material: StrapFootingMaterialInput
+    reinforcement: StrapFootingReinforcementInput
+
+    def __post_init__(self) -> None:
+        for name, expected_type in (
+            ("analysis", StrapFootingAnalysisInput),
+            ("material", StrapFootingMaterialInput),
+            ("reinforcement", StrapFootingReinforcementInput),
+        ):
+            if not isinstance(getattr(self, name), expected_type):
+                raise StrapFootingContractError(
+                    f"{name} must be a {expected_type.__name__}"
+                )

--- a/Python/structural_lib/codes/is456/strap_footing/strength.py
+++ b/Python/structural_lib/codes/is456/strap_footing/strength.py
@@ -1,0 +1,574 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Pravin Surawase
+"""Strength and detailing checks for the bounded property-line strap."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+
+from structural_lib.codes.is456 import materials
+from structural_lib.codes.is456.beam.detailing import get_bond_stress
+from structural_lib.codes.is456.slab._flexure import (
+    calculate_ast_from_rectangular_stress_block,
+)
+from structural_lib.codes.is456.strap_footing.analysis import (
+    StrapFootingAnalysisResult,
+    StrapFootingTensionFace,
+    analyze_property_line_strap_footing,
+)
+from structural_lib.codes.is456.strap_footing.models import (
+    StrapFootingContractError,
+    StrapFootingDesignInput,
+)
+from structural_lib.codes.is456.tables import get_tc_max_value, get_tc_value
+from structural_lib.codes.is456.traceability import clause
+
+__all__ = [
+    "StrapFootingDesignDisposition",
+    "StrapFootingFlexureResult",
+    "StrapFootingShearResult",
+    "StrapFootingSideFaceResult",
+    "StrapFootingStrengthResult",
+    "check_property_line_strap_footing_strength",
+]
+
+
+_SOURCE_REFS = (
+    "IS456-2000-A5:sha256:964e270593392a0dea28b8c7c9ff1e0e730bbea912f8a903e8a86c7bb34d9264",
+    "IS456-AMD6-2024:sha256:4fc24999d133d6197088d6998da4ac4020f08bfd24c7bbcf9c24e8aa1a388881",
+    "NPTEL-AFE-C3-STRAP Section 3.6.1 and Fig. 3.2",
+    "INDIA-2-STRAP-HAND-01",
+)
+_CLAUSE_REFS = (
+    "IS 456:2000 Cl. 26.2.1, 26.2.1.1, 26.3.2 and 26.4",
+    "IS 456:2000 Cl. 26.5.1.1, 26.5.1.3, 26.5.1.5 and 26.5.1.6",
+    "IS 456:2000 Cl. 38.1 and Annex G-1.1",
+    "IS 456:2000 Cl. 40.1, 40.2 and 40.4; Tables 19 and 20",
+)
+_LIMITATIONS = (
+    "Only the G0-frozen property-line two-footing equal-pressure system is represented.",
+    "Footing slabs, transfer regions, soil capacity, settlement and connections remain externally verified.",
+    "No coated, bundled, spliced, curtailed or automatically selected reinforcement.",
+    "Vertical closed stirrups and straight anchorage into both footings only.",
+    "Qualified engineering review is required; software output is not professional approval.",
+)
+_SIDE_FACE_RATIO_TOTAL = 0.001
+_SIDE_FACE_DEPTH_THRESHOLD_MM = 750.0
+_MAX_SIDE_FACE_SPACING_MM = 300.0
+
+
+class StrapFootingDesignDisposition(StrEnum):
+    """Aggregate outcomes admitted by the bounded strength workflow."""
+
+    PASS = "PASS"  # nosec B105 - engineering disposition, not a credential
+    FAIL = "FAIL"
+
+
+@dataclass(frozen=True)
+class StrapFootingFlexureResult:
+    """Exact stress-block, minimum steel, spacing, cover and anchorage checks."""
+
+    governing_tension_face: StrapFootingTensionFace
+    factored_moment_demand_kn_m: float
+    limiting_singly_reinforced_moment_kn_m: float
+    exact_flexural_steel_required_mm2: float | None
+    exact_neutral_axis_depth_mm: float | None
+    beam_minimum_steel_required_mm2: float
+    top_steel_required_mm2: float | None
+    bottom_steel_required_mm2: float | None
+    top_steel_provided_mm2: float
+    bottom_steel_provided_mm2: float
+    top_neutral_axis_depth_mm: float
+    bottom_neutral_axis_depth_mm: float
+    top_moment_capacity_kn_m: float
+    bottom_moment_capacity_kn_m: float
+    top_clear_spacing_mm: float
+    bottom_clear_spacing_mm: float
+    minimum_top_clear_spacing_mm: float
+    minimum_bottom_clear_spacing_mm: float
+    nominal_cover_mm: float
+    required_nominal_cover_mm: float
+    tension_design_bond_stress_nmm2: float
+    top_development_length_required_mm: float
+    bottom_development_length_required_mm: float
+    top_anchorage_exterior_available_mm: float
+    top_anchorage_interior_available_mm: float
+    bottom_anchorage_exterior_available_mm: float
+    bottom_anchorage_interior_available_mm: float
+    singly_reinforced_capacity_is_sufficient: bool
+    top_area_is_safe: bool
+    bottom_area_is_safe: bool
+    top_section_is_under_reinforced: bool
+    bottom_section_is_under_reinforced: bool
+    top_clear_spacing_is_safe: bool
+    bottom_clear_spacing_is_safe: bool
+    nominal_cover_is_safe: bool
+    top_anchorage_is_safe: bool
+    bottom_anchorage_is_safe: bool
+    is_safe: bool
+
+
+@dataclass(frozen=True)
+class StrapFootingSideFaceResult:
+    """Side-face steel and vertical spacing check for the deep strap web."""
+
+    required: bool
+    required_total_area_mm2: float
+    required_area_each_face_mm2: float
+    provided_area_each_face_mm2: float
+    provided_total_area_mm2: float
+    provided_vertical_spacing_mm: float
+    maximum_vertical_spacing_mm: float
+    area_is_safe: bool
+    spacing_is_safe: bool
+    is_safe: bool
+
+
+@dataclass(frozen=True)
+class StrapFootingShearResult:
+    """Table 19/20 shear and supplied vertical-stirrup check."""
+
+    factored_shear_demand_kn: float
+    tension_reinforcement_area_mm2: float
+    tension_reinforcement_percent: float
+    table_19_lookup_reinforcement_percent: float
+    nominal_shear_stress_nmm2: float
+    concrete_design_shear_strength_nmm2: float
+    maximum_design_shear_stress_nmm2: float
+    concrete_shear_capacity_kn: float
+    stirrup_carried_shear_required_kn: float
+    stirrup_area_provided_mm2: float
+    minimum_stirrup_area_at_provided_spacing_mm2: float
+    stirrup_shear_capacity_provided_kn: float
+    provided_stirrup_spacing_mm: float
+    maximum_stirrup_spacing_mm: float
+    maximum_stress_is_safe: bool
+    minimum_stirrup_area_is_safe: bool
+    stirrup_strength_is_safe: bool
+    stirrup_spacing_is_safe: bool
+    is_safe: bool
+
+
+@dataclass(frozen=True)
+class StrapFootingStrengthResult:
+    """Composed service, strength and detailing disposition."""
+
+    input: StrapFootingDesignInput
+    actions: StrapFootingAnalysisResult
+    flexure: StrapFootingFlexureResult
+    side_face: StrapFootingSideFaceResult
+    shear: StrapFootingShearResult
+    disposition: StrapFootingDesignDisposition
+    reasons: tuple[str, ...]
+    clause_refs: tuple[str, ...]
+    source_refs: tuple[str, ...]
+    limitations: tuple[str, ...]
+    qualified_review_required: bool = True
+    complete_engineering_approval: bool = False
+
+    @property
+    def is_safe_within_supported_scope(self) -> bool:
+        """Return whether every represented comparison passes."""
+
+        return self.disposition is StrapFootingDesignDisposition.PASS
+
+
+def _bar_area_mm2(diameter_mm: float) -> float:
+    return math.pi * diameter_mm**2 / 4.0
+
+
+def _section_capacity(
+    *,
+    steel_area_mm2: float,
+    width_mm: float,
+    effective_depth_mm: float,
+    fck_nmm2: float,
+    fy_nmm2: float,
+) -> tuple[float, float]:
+    neutral_axis = 0.87 * fy_nmm2 * steel_area_mm2 / (0.36 * fck_nmm2 * width_mm)
+    capacity = (
+        0.36
+        * fck_nmm2
+        * width_mm
+        * neutral_axis
+        * (effective_depth_mm - 0.42 * neutral_axis)
+        / 1_000_000.0
+    )
+    return neutral_axis, capacity
+
+
+def _clear_spacing(
+    *,
+    width_mm: float,
+    count: int,
+    diameter_mm: float,
+    cover_mm: float,
+    stirrup_diameter_mm: float,
+) -> float:
+    return (width_mm - 2.0 * (cover_mm + stirrup_diameter_mm) - count * diameter_mm) / (
+        count - 1
+    )
+
+
+def _development_length(
+    *, diameter_mm: float, fck_nmm2: float, fy_nmm2: float
+) -> tuple[float, float]:
+    bond_stress = get_bond_stress(fck_nmm2, "deformed")
+    return bond_stress, diameter_mm * 0.87 * fy_nmm2 / (4.0 * bond_stress)
+
+
+def _check_flexure(
+    footing_input: StrapFootingDesignInput, actions: StrapFootingAnalysisResult
+) -> StrapFootingFlexureResult:
+    geometry = footing_input.analysis.geometry
+    material = footing_input.material
+    reinforcement = footing_input.reinforcement
+    width = geometry.strap_width_mm
+    depth = geometry.strap_effective_depth_mm
+    fck = material.strap_concrete_grade_nmm2
+    fy = material.steel_grade_nmm2
+    demand = actions.factored_clear_strap.governing_moment_demand_kn_m
+    tension_face = actions.factored_clear_strap.governing_tension_face
+    xu_max = materials.get_xu_max_d(fy) * depth
+    limiting_moment = (
+        0.36 * fck * width * xu_max * (depth - 0.42 * xu_max) / 1_000_000.0
+    )
+    capacity_is_sufficient = demand <= limiting_moment
+    required_flexural: float | None = None
+    required_xu: float | None = None
+    if capacity_is_sufficient and demand > 0.0:
+        required_flexural, required_xu = calculate_ast_from_rectangular_stress_block(
+            b_mm=width,
+            d_mm=depth,
+            factored_moment_knm=demand,
+            fck_n_per_mm2=fck,
+            fy_n_per_mm2=fy,
+        )
+    minimum_area = 0.85 * width * depth / fy
+    top_required = minimum_area
+    bottom_required = minimum_area
+    if required_flexural is not None:
+        if tension_face is StrapFootingTensionFace.TOP:
+            top_required = max(top_required, required_flexural)
+        elif tension_face is StrapFootingTensionFace.BOTTOM:
+            bottom_required = max(bottom_required, required_flexural)
+    if not capacity_is_sufficient:
+        top_required_result: float | None = None
+        bottom_required_result: float | None = None
+    else:
+        top_required_result = top_required
+        bottom_required_result = bottom_required
+
+    top_area = reinforcement.top_bar_count * _bar_area_mm2(
+        reinforcement.top_bar_diameter_mm
+    )
+    bottom_area = reinforcement.bottom_bar_count * _bar_area_mm2(
+        reinforcement.bottom_bar_diameter_mm
+    )
+    top_xu, top_capacity = _section_capacity(
+        steel_area_mm2=top_area,
+        width_mm=width,
+        effective_depth_mm=depth,
+        fck_nmm2=fck,
+        fy_nmm2=fy,
+    )
+    bottom_xu, bottom_capacity = _section_capacity(
+        steel_area_mm2=bottom_area,
+        width_mm=width,
+        effective_depth_mm=depth,
+        fck_nmm2=fck,
+        fy_nmm2=fy,
+    )
+    top_clear = _clear_spacing(
+        width_mm=width,
+        count=reinforcement.top_bar_count,
+        diameter_mm=reinforcement.top_bar_diameter_mm,
+        cover_mm=reinforcement.nominal_cover_mm,
+        stirrup_diameter_mm=reinforcement.stirrup_diameter_mm,
+    )
+    bottom_clear = _clear_spacing(
+        width_mm=width,
+        count=reinforcement.bottom_bar_count,
+        diameter_mm=reinforcement.bottom_bar_diameter_mm,
+        cover_mm=reinforcement.nominal_cover_mm,
+        stirrup_diameter_mm=reinforcement.stirrup_diameter_mm,
+    )
+    top_min_clear = max(
+        reinforcement.top_bar_diameter_mm,
+        reinforcement.maximum_aggregate_size_mm + 5.0,
+        25.0,
+    )
+    bottom_min_clear = max(
+        reinforcement.bottom_bar_diameter_mm,
+        reinforcement.maximum_aggregate_size_mm + 5.0,
+        25.0,
+    )
+    bond_stress, top_ld = _development_length(
+        diameter_mm=reinforcement.top_bar_diameter_mm,
+        fck_nmm2=fck,
+        fy_nmm2=fy,
+    )
+    _, bottom_ld = _development_length(
+        diameter_mm=reinforcement.bottom_bar_diameter_mm,
+        fck_nmm2=fck,
+        fy_nmm2=fy,
+    )
+    top_area_safe = top_required_result is not None and top_area >= top_required_result
+    bottom_area_safe = (
+        bottom_required_result is not None and bottom_area >= bottom_required_result
+    )
+    top_under_reinforced = top_xu <= xu_max
+    bottom_under_reinforced = bottom_xu <= xu_max
+    top_anchor_safe = (
+        min(
+            reinforcement.available_top_anchorage_exterior_mm,
+            reinforcement.available_top_anchorage_interior_mm,
+        )
+        >= top_ld
+    )
+    bottom_anchor_safe = (
+        min(
+            reinforcement.available_bottom_anchorage_exterior_mm,
+            reinforcement.available_bottom_anchorage_interior_mm,
+        )
+        >= bottom_ld
+    )
+    cover_safe = (
+        reinforcement.nominal_cover_mm >= reinforcement.required_nominal_cover_mm
+    )
+    top_spacing_safe = top_clear >= top_min_clear
+    bottom_spacing_safe = bottom_clear >= bottom_min_clear
+    is_safe = all(
+        (
+            capacity_is_sufficient,
+            top_area_safe,
+            bottom_area_safe,
+            top_under_reinforced,
+            bottom_under_reinforced,
+            top_spacing_safe,
+            bottom_spacing_safe,
+            cover_safe,
+            top_anchor_safe,
+            bottom_anchor_safe,
+        )
+    )
+    return StrapFootingFlexureResult(
+        governing_tension_face=tension_face,
+        factored_moment_demand_kn_m=demand,
+        limiting_singly_reinforced_moment_kn_m=limiting_moment,
+        exact_flexural_steel_required_mm2=required_flexural,
+        exact_neutral_axis_depth_mm=required_xu,
+        beam_minimum_steel_required_mm2=minimum_area,
+        top_steel_required_mm2=top_required_result,
+        bottom_steel_required_mm2=bottom_required_result,
+        top_steel_provided_mm2=top_area,
+        bottom_steel_provided_mm2=bottom_area,
+        top_neutral_axis_depth_mm=top_xu,
+        bottom_neutral_axis_depth_mm=bottom_xu,
+        top_moment_capacity_kn_m=top_capacity,
+        bottom_moment_capacity_kn_m=bottom_capacity,
+        top_clear_spacing_mm=top_clear,
+        bottom_clear_spacing_mm=bottom_clear,
+        minimum_top_clear_spacing_mm=top_min_clear,
+        minimum_bottom_clear_spacing_mm=bottom_min_clear,
+        nominal_cover_mm=reinforcement.nominal_cover_mm,
+        required_nominal_cover_mm=reinforcement.required_nominal_cover_mm,
+        tension_design_bond_stress_nmm2=bond_stress,
+        top_development_length_required_mm=top_ld,
+        bottom_development_length_required_mm=bottom_ld,
+        top_anchorage_exterior_available_mm=(
+            reinforcement.available_top_anchorage_exterior_mm
+        ),
+        top_anchorage_interior_available_mm=(
+            reinforcement.available_top_anchorage_interior_mm
+        ),
+        bottom_anchorage_exterior_available_mm=(
+            reinforcement.available_bottom_anchorage_exterior_mm
+        ),
+        bottom_anchorage_interior_available_mm=(
+            reinforcement.available_bottom_anchorage_interior_mm
+        ),
+        singly_reinforced_capacity_is_sufficient=capacity_is_sufficient,
+        top_area_is_safe=top_area_safe,
+        bottom_area_is_safe=bottom_area_safe,
+        top_section_is_under_reinforced=top_under_reinforced,
+        bottom_section_is_under_reinforced=bottom_under_reinforced,
+        top_clear_spacing_is_safe=top_spacing_safe,
+        bottom_clear_spacing_is_safe=bottom_spacing_safe,
+        nominal_cover_is_safe=cover_safe,
+        top_anchorage_is_safe=top_anchor_safe,
+        bottom_anchorage_is_safe=bottom_anchor_safe,
+        is_safe=is_safe,
+    )
+
+
+def _check_side_face(
+    footing_input: StrapFootingDesignInput,
+) -> StrapFootingSideFaceResult:
+    geometry = footing_input.analysis.geometry
+    reinforcement = footing_input.reinforcement
+    required = geometry.strap_overall_depth_mm > _SIDE_FACE_DEPTH_THRESHOLD_MM
+    required_total = (
+        _SIDE_FACE_RATIO_TOTAL
+        * geometry.strap_width_mm
+        * geometry.strap_overall_depth_mm
+        if required
+        else 0.0
+    )
+    required_each = required_total / 2.0
+    provided_each = reinforcement.side_face_bar_count_each_face * _bar_area_mm2(
+        reinforcement.side_face_bar_diameter_mm
+    )
+    area_safe = provided_each >= required_each
+    spacing_safe = (
+        not required
+        or reinforcement.side_face_vertical_spacing_mm <= _MAX_SIDE_FACE_SPACING_MM
+    )
+    return StrapFootingSideFaceResult(
+        required=required,
+        required_total_area_mm2=required_total,
+        required_area_each_face_mm2=required_each,
+        provided_area_each_face_mm2=provided_each,
+        provided_total_area_mm2=2.0 * provided_each,
+        provided_vertical_spacing_mm=reinforcement.side_face_vertical_spacing_mm,
+        maximum_vertical_spacing_mm=(_MAX_SIDE_FACE_SPACING_MM if required else 0.0),
+        area_is_safe=area_safe,
+        spacing_is_safe=spacing_safe,
+        is_safe=area_safe and spacing_safe,
+    )
+
+
+def _check_shear(
+    footing_input: StrapFootingDesignInput,
+    actions: StrapFootingAnalysisResult,
+    flexure: StrapFootingFlexureResult,
+) -> StrapFootingShearResult:
+    geometry = footing_input.analysis.geometry
+    material = footing_input.material
+    reinforcement = footing_input.reinforcement
+    width = geometry.strap_width_mm
+    depth = geometry.strap_effective_depth_mm
+    fy = material.steel_grade_nmm2
+    fck = material.strap_concrete_grade_nmm2
+    demand = actions.factored_clear_strap.governing_shear_demand_kn
+    tension_area = (
+        flexure.top_steel_provided_mm2
+        if actions.factored_clear_strap.governing_tension_face
+        is StrapFootingTensionFace.TOP
+        else flexure.bottom_steel_provided_mm2
+    )
+    steel_percent = 100.0 * tension_area / (width * depth)
+    lookup_percent = min(max(steel_percent, 0.15), 3.0)
+    tau_v = demand * 1000.0 / (width * depth)
+    tau_c = get_tc_value(fck, lookup_percent)
+    tau_c_max = get_tc_max_value(fck)
+    concrete_capacity = tau_c * width * depth / 1000.0
+    required_stirrup_shear = max(demand - concrete_capacity, 0.0)
+    stirrup_area = reinforcement.stirrup_leg_count * _bar_area_mm2(
+        reinforcement.stirrup_diameter_mm
+    )
+    minimum_area = 0.4 * width * reinforcement.stirrup_spacing_mm / (0.87 * fy)
+    provided_capacity = (
+        0.87 * fy * stirrup_area * depth / reinforcement.stirrup_spacing_mm / 1000.0
+    )
+    maximum_spacing = min(0.75 * depth, 300.0)
+    maximum_safe = tau_v <= tau_c_max
+    minimum_safe = stirrup_area >= minimum_area
+    strength_safe = provided_capacity >= required_stirrup_shear
+    spacing_safe = reinforcement.stirrup_spacing_mm <= maximum_spacing
+    return StrapFootingShearResult(
+        factored_shear_demand_kn=demand,
+        tension_reinforcement_area_mm2=tension_area,
+        tension_reinforcement_percent=steel_percent,
+        table_19_lookup_reinforcement_percent=lookup_percent,
+        nominal_shear_stress_nmm2=tau_v,
+        concrete_design_shear_strength_nmm2=tau_c,
+        maximum_design_shear_stress_nmm2=tau_c_max,
+        concrete_shear_capacity_kn=concrete_capacity,
+        stirrup_carried_shear_required_kn=required_stirrup_shear,
+        stirrup_area_provided_mm2=stirrup_area,
+        minimum_stirrup_area_at_provided_spacing_mm2=minimum_area,
+        stirrup_shear_capacity_provided_kn=provided_capacity,
+        provided_stirrup_spacing_mm=reinforcement.stirrup_spacing_mm,
+        maximum_stirrup_spacing_mm=maximum_spacing,
+        maximum_stress_is_safe=maximum_safe,
+        minimum_stirrup_area_is_safe=minimum_safe,
+        stirrup_strength_is_safe=strength_safe,
+        stirrup_spacing_is_safe=spacing_safe,
+        is_safe=all((maximum_safe, minimum_safe, strength_safe, spacing_safe)),
+    )
+
+
+@clause(
+    "26.2.1",
+    "26.2.1.1",
+    "26.3.2",
+    "26.4",
+    "26.5.1.1",
+    "26.5.1.3",
+    "26.5.1.5",
+    "26.5.1.6",
+    "38.1",
+    "G-1.1",
+    "40.1",
+    "40.2",
+    "40.4",
+)
+def check_property_line_strap_footing_strength(
+    footing_input: StrapFootingDesignInput,
+) -> StrapFootingStrengthResult:
+    """Check the G0-frozen strap reinforcement and detailing schedule.
+
+    Valid but inadequate provision returns ``FAIL``. Inputs outside the frozen
+    geometry, action, material, or detailing contract raise the typed contract
+    error without producing a disposition.
+    """
+
+    if not isinstance(footing_input, StrapFootingDesignInput):
+        raise StrapFootingContractError(
+            "footing_input must be a StrapFootingDesignInput"
+        )
+    actions = analyze_property_line_strap_footing(footing_input.analysis)
+    flexure = _check_flexure(footing_input, actions)
+    side_face = _check_side_face(footing_input)
+    shear = _check_shear(footing_input, actions, flexure)
+    reasons: list[str] = []
+    if not actions.gross_service_bearing_within_allowable:
+        reasons.append("Approved gross service bearing pressure is exceeded.")
+    if not flexure.is_safe:
+        reasons.append("Supplied longitudinal flexure/detailing is inadequate.")
+    if not side_face.is_safe:
+        reasons.append("Supplied side-face reinforcement is inadequate.")
+    if not shear.is_safe:
+        reasons.append("Supplied vertical shear reinforcement is inadequate.")
+    if not reasons:
+        reasons.append(
+            "Every represented service, strength and detailing check passes."
+        )
+    disposition = (
+        StrapFootingDesignDisposition.PASS
+        if actions.gross_service_bearing_within_allowable
+        and flexure.is_safe
+        and side_face.is_safe
+        and shear.is_safe
+        else StrapFootingDesignDisposition.FAIL
+    )
+    return StrapFootingStrengthResult(
+        input=footing_input,
+        actions=actions,
+        flexure=flexure,
+        side_face=side_face,
+        shear=shear,
+        disposition=disposition,
+        reasons=tuple(reasons),
+        clause_refs=_CLAUSE_REFS,
+        source_refs=_SOURCE_REFS
+        + (
+            footing_input.material.material_basis_reference,
+            footing_input.reinforcement.detailing_basis_reference,
+            footing_input.reinforcement.durability_basis_reference,
+        ),
+        limitations=_LIMITATIONS,
+    )

--- a/Python/tests/codes/is456/strap_footing/index.json
+++ b/Python/tests/codes/is456/strap_footing/index.json
@@ -3,7 +3,7 @@
   "type": "python-package",
   "description": "",
   "last_updated": "2026-08-16",
-  "file_count": 2,
+  "file_count": 3,
   "files": [
     {
       "name": "__init__.py",
@@ -86,9 +86,80 @@
         }
       ],
       "content_hash": "20a93ab4eb7a"
+    },
+    {
+      "name": "test_strength.py",
+      "type": "python",
+      "size_lines": 337,
+      "last_updated": "2026-08-16",
+      "description": "INDIA-2-FOUNDATION-STRAP-B strength and detailing tests.",
+      "functions": [
+        {
+          "name": "test_frozen_benchmark_passes_with_review_boundary"
+        },
+        {
+          "name": "test_exact_stress_block_and_longitudinal_steel_benchmark"
+        },
+        {
+          "name": "test_clear_spacing_cover_and_anchorage_benchmark"
+        },
+        {
+          "name": "test_side_face_reinforcement_benchmark"
+        },
+        {
+          "name": "test_table_shear_and_vertical_stirrup_benchmark"
+        },
+        {
+          "name": "test_valid_inadequate_flexure_or_detailing_returns_fail",
+          "params": [
+            "reinforcement",
+            "field"
+          ]
+        },
+        {
+          "name": "test_valid_inadequate_side_face_provision_returns_fail",
+          "params": [
+            "reinforcement",
+            "field"
+          ]
+        },
+        {
+          "name": "test_valid_inadequate_shear_provision_returns_fail",
+          "params": [
+            "reinforcement",
+            "field"
+          ]
+        },
+        {
+          "name": "test_valid_service_bearing_failure_composes_to_fail"
+        },
+        {
+          "name": "test_valid_singly_reinforced_capacity_exceedance_returns_fail"
+        },
+        {
+          "name": "test_out_of_domain_material_and_layout_fail_closed",
+          "params": [
+            "factory",
+            "message"
+          ]
+        },
+        {
+          "name": "test_wrong_top_level_types_fail_closed"
+        },
+        {
+          "name": "test_result_is_frozen_deterministic_and_finite"
+        },
+        {
+          "name": "test_clause_and_source_traceability_are_exact"
+        },
+        {
+          "name": "test_cover_and_beam_minimum_metadata_are_semantically_correct"
+        }
+      ],
+      "content_hash": "bf57c7030520"
     }
   ],
   "subfolders": [],
   "has_init": true,
-  "content_hash": "4ead26f666195df4"
+  "content_hash": "42213422ac05a140"
 }

--- a/Python/tests/codes/is456/strap_footing/index.md
+++ b/Python/tests/codes/is456/strap_footing/index.md
@@ -2,7 +2,7 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-16
-**Files:** 2
+**Files:** 3
 
 ## Python Files
 
@@ -10,3 +10,4 @@
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | Tests for the bounded INDIA-2 strap-footing workflow. | 0 | 0 | 2 |
 | [test_analysis.py](test_analysis.py) | INDIA-2-FOUNDATION-STRAP-A benchmark and boundary tests. | 0 | 16 | 364 |
+| [test_strength.py](test_strength.py) | INDIA-2-FOUNDATION-STRAP-B strength and detailing tests. | 0 | 15 | 337 |

--- a/Python/tests/codes/is456/strap_footing/test_strength.py
+++ b/Python/tests/codes/is456/strap_footing/test_strength.py
@@ -1,0 +1,336 @@
+"""INDIA-2-FOUNDATION-STRAP-B strength and detailing tests."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from structural_lib.codes.is456.strap_footing import (
+    StrapFootingDesignDisposition,
+    StrapFootingDesignInput,
+    StrapFootingMaterialInput,
+    StrapFootingReinforcementInput,
+    StrapFootingTensionFace,
+    check_property_line_strap_footing_strength,
+)
+from structural_lib.codes.is456.strap_footing.models import StrapFootingContractError
+from structural_lib.codes.is456.traceability import get_clause_info, get_clause_refs
+
+from .test_analysis import _actions, _input
+
+
+def _material(**overrides: object) -> StrapFootingMaterialInput:
+    values: dict[str, object] = {
+        "strap_concrete_grade_nmm2": 30.0,
+        "steel_grade_nmm2": 500.0,
+        "uncoated_deformed_bars": True,
+        "material_basis_reference": "INDIA-2-STRAP-HAND-01-MATERIAL",
+    }
+    values.update(overrides)
+    return StrapFootingMaterialInput(**values)  # type: ignore[arg-type]
+
+
+def _reinforcement(**overrides: object) -> StrapFootingReinforcementInput:
+    values: dict[str, object] = {
+        "top_bar_count": 6,
+        "top_bar_diameter_mm": 25.0,
+        "bottom_bar_count": 4,
+        "bottom_bar_diameter_mm": 16.0,
+        "side_face_bar_count_each_face": 4,
+        "side_face_bar_diameter_mm": 12.0,
+        "side_face_vertical_spacing_mm": 250.0,
+        "stirrup_leg_count": 2,
+        "stirrup_diameter_mm": 10.0,
+        "stirrup_spacing_mm": 250.0,
+        "nominal_cover_mm": 50.0,
+        "required_nominal_cover_mm": 50.0,
+        "maximum_aggregate_size_mm": 20.0,
+        "available_top_anchorage_exterior_mm": 1200.0,
+        "available_top_anchorage_interior_mm": 1200.0,
+        "available_bottom_anchorage_exterior_mm": 1200.0,
+        "available_bottom_anchorage_interior_mm": 1200.0,
+        "vertical_closed_stirrups": True,
+        "straight_anchorage": True,
+        "bars_bundled": False,
+        "bars_spliced": False,
+        "bars_curtailed": False,
+        "reinforcement_schedule_approved": True,
+        "effective_depth_basis_approved": True,
+        "durability_cover_basis_approved": True,
+        "detailing_basis_reference": "INDIA-2-STRAP-HAND-01-DETAILING",
+        "durability_basis_reference": "INDIA-2-STRAP-HAND-01-DURABILITY",
+    }
+    values.update(overrides)
+    return StrapFootingReinforcementInput(**values)  # type: ignore[arg-type]
+
+
+def _design_input(**overrides: object) -> StrapFootingDesignInput:
+    values: dict[str, object] = {
+        "analysis": _input(),
+        "material": _material(),
+        "reinforcement": _reinforcement(),
+    }
+    values.update(overrides)
+    return StrapFootingDesignInput(**values)  # type: ignore[arg-type]
+
+
+def test_frozen_benchmark_passes_with_review_boundary() -> None:
+    result = check_property_line_strap_footing_strength(_design_input())
+
+    assert result.disposition is StrapFootingDesignDisposition.PASS
+    assert result.is_safe_within_supported_scope is True
+    assert result.qualified_review_required is True
+    assert result.complete_engineering_approval is False
+    assert result.reasons == (
+        "Every represented service, strength and detailing check passes.",
+    )
+
+
+def test_exact_stress_block_and_longitudinal_steel_benchmark() -> None:
+    result = check_property_line_strap_footing_strength(_design_input()).flexure
+
+    assert result.governing_tension_face is StrapFootingTensionFace.TOP
+    assert result.factored_moment_demand_kn_m == pytest.approx(916.6875)
+    assert result.limiting_singly_reinforced_moment_kn_m == pytest.approx(1447.955892)
+    assert result.exact_flexural_steel_required_mm2 == pytest.approx(2788.774499810215)
+    assert result.exact_neutral_axis_depth_mm == pytest.approx(224.651279151378)
+    assert result.beam_minimum_steel_required_mm2 == pytest.approx(722.5)
+    assert result.top_steel_required_mm2 == pytest.approx(2788.774499810215)
+    assert result.bottom_steel_required_mm2 == pytest.approx(722.5)
+    assert result.top_steel_provided_mm2 == pytest.approx(2945.243112740431)
+    assert result.bottom_steel_provided_mm2 == pytest.approx(804.247719318987)
+    assert result.top_moment_capacity_kn_m == pytest.approx(961.337320139164)
+    assert result.top_area_is_safe is True
+    assert result.bottom_area_is_safe is True
+
+
+def test_clear_spacing_cover_and_anchorage_benchmark() -> None:
+    result = check_property_line_strap_footing_strength(_design_input()).flexure
+
+    assert result.top_clear_spacing_mm == pytest.approx(46.0)
+    assert result.bottom_clear_spacing_mm == pytest.approx(105.333333333333)
+    assert result.minimum_top_clear_spacing_mm == pytest.approx(25.0)
+    assert result.nominal_cover_is_safe is True
+    assert result.tension_design_bond_stress_nmm2 == pytest.approx(2.4)
+    assert result.top_development_length_required_mm == pytest.approx(1132.8125)
+    assert result.bottom_development_length_required_mm == pytest.approx(725.0)
+    assert result.top_anchorage_is_safe is True
+    assert result.bottom_anchorage_is_safe is True
+
+
+def test_side_face_reinforcement_benchmark() -> None:
+    result = check_property_line_strap_footing_strength(_design_input()).side_face
+
+    assert result.required is True
+    assert result.required_total_area_mm2 == pytest.approx(475.0)
+    assert result.required_area_each_face_mm2 == pytest.approx(237.5)
+    assert result.provided_area_each_face_mm2 == pytest.approx(452.38934211693)
+    assert result.provided_total_area_mm2 == pytest.approx(904.77868423386)
+    assert result.maximum_vertical_spacing_mm == pytest.approx(300.0)
+    assert result.is_safe is True
+
+
+def test_table_shear_and_vertical_stirrup_benchmark() -> None:
+    result = check_property_line_strap_footing_strength(_design_input()).shear
+
+    assert result.factored_shear_demand_kn == pytest.approx(261.65625)
+    assert result.tension_reinforcement_percent == pytest.approx(0.692998379468337)
+    assert result.nominal_shear_stress_nmm2 == pytest.approx(0.615661764705882)
+    assert result.concrete_design_shear_strength_nmm2 == pytest.approx(
+        0.569479416608601
+    )
+    assert result.maximum_design_shear_stress_nmm2 == pytest.approx(3.5)
+    assert result.stirrup_carried_shear_required_kn == pytest.approx(19.6274979428445)
+    assert result.stirrup_area_provided_mm2 == pytest.approx(157.07963267949)
+    assert result.minimum_stirrup_area_at_provided_spacing_mm2 == pytest.approx(
+        114.942528735632
+    )
+    assert result.stirrup_shear_capacity_provided_kn == pytest.approx(232.320776807564)
+    assert result.maximum_stirrup_spacing_mm == pytest.approx(300.0)
+    assert result.is_safe is True
+
+
+@pytest.mark.parametrize(
+    ("reinforcement", "field"),
+    (
+        (_reinforcement(top_bar_count=5), "top_area_is_safe"),
+        (_reinforcement(bottom_bar_count=3), "bottom_area_is_safe"),
+        (_reinforcement(nominal_cover_mm=49.0), "nominal_cover_is_safe"),
+        (
+            _reinforcement(available_top_anchorage_exterior_mm=1132.0),
+            "top_anchorage_is_safe",
+        ),
+        (
+            _reinforcement(available_bottom_anchorage_interior_mm=724.0),
+            "bottom_anchorage_is_safe",
+        ),
+    ),
+)
+def test_valid_inadequate_flexure_or_detailing_returns_fail(
+    reinforcement: StrapFootingReinforcementInput,
+    field: str,
+) -> None:
+    result = check_property_line_strap_footing_strength(
+        _design_input(reinforcement=reinforcement)
+    )
+
+    assert result.disposition is StrapFootingDesignDisposition.FAIL
+    assert getattr(result.flexure, field) is False
+
+
+@pytest.mark.parametrize(
+    ("reinforcement", "field"),
+    (
+        (_reinforcement(side_face_bar_count_each_face=2), "area_is_safe"),
+        (_reinforcement(side_face_vertical_spacing_mm=301.0), "spacing_is_safe"),
+    ),
+)
+def test_valid_inadequate_side_face_provision_returns_fail(
+    reinforcement: StrapFootingReinforcementInput,
+    field: str,
+) -> None:
+    result = check_property_line_strap_footing_strength(
+        _design_input(reinforcement=reinforcement)
+    )
+
+    assert result.disposition is StrapFootingDesignDisposition.FAIL
+    assert getattr(result.side_face, field) is False
+
+
+@pytest.mark.parametrize(
+    ("reinforcement", "field"),
+    (
+        (_reinforcement(stirrup_diameter_mm=8.0), "minimum_stirrup_area_is_safe"),
+        (_reinforcement(stirrup_spacing_mm=301.0), "stirrup_spacing_is_safe"),
+    ),
+)
+def test_valid_inadequate_shear_provision_returns_fail(
+    reinforcement: StrapFootingReinforcementInput,
+    field: str,
+) -> None:
+    result = check_property_line_strap_footing_strength(
+        _design_input(reinforcement=reinforcement)
+    )
+
+    assert result.disposition is StrapFootingDesignDisposition.FAIL
+    assert getattr(result.shear, field) is False
+
+
+def test_valid_service_bearing_failure_composes_to_fail() -> None:
+    result = check_property_line_strap_footing_strength(
+        _design_input(
+            analysis=_input(
+                actions=_actions(allowable_gross_bearing_pressure_kn_per_m2=210.0)
+            )
+        )
+    )
+
+    assert result.disposition is StrapFootingDesignDisposition.FAIL
+    assert result.actions.gross_service_bearing_within_allowable is False
+
+
+def test_valid_singly_reinforced_capacity_exceedance_returns_fail() -> None:
+    actions = _actions(
+        service_exterior_column_load_kn=2051.125,
+        service_interior_column_load_kn=3482.875,
+        factored_exterior_column_load_kn=3076.6875,
+        factored_interior_column_load_kn=5224.3125,
+        service_clear_strap_line_load_kn_per_m=24.0,
+        factored_clear_strap_line_load_kn_per_m=36.0,
+        allowable_gross_bearing_pressure_kn_per_m2=500.0,
+    )
+    result = check_property_line_strap_footing_strength(
+        _design_input(analysis=_input(actions=actions))
+    )
+
+    assert result.disposition is StrapFootingDesignDisposition.FAIL
+    assert result.flexure.singly_reinforced_capacity_is_sufficient is False
+    assert result.flexure.exact_flexural_steel_required_mm2 is None
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    (
+        (lambda: _material(strap_concrete_grade_nmm2=45.0), "strap_concrete"),
+        (lambda: _material(steel_grade_nmm2=550.0), "steel_grade"),
+        (lambda: _material(uncoated_deformed_bars=False), "uncoated_deformed_bars"),
+        (lambda: _reinforcement(vertical_closed_stirrups=False), "vertical_closed"),
+        (lambda: _reinforcement(bars_bundled=True), "bars_bundled"),
+        (
+            lambda: _reinforcement(reinforcement_schedule_approved=False),
+            "reinforcement_schedule_approved",
+        ),
+        (lambda: _reinforcement(top_bar_count=True), "top_bar_count"),
+        (lambda: _reinforcement(stirrup_diameter_mm=math.inf), "stirrup_diameter"),
+    ),
+)
+def test_out_of_domain_material_and_layout_fail_closed(
+    factory: object, message: str
+) -> None:
+    with pytest.raises(StrapFootingContractError, match=message):
+        factory()  # type: ignore[operator]
+
+
+def test_wrong_top_level_types_fail_closed() -> None:
+    with pytest.raises(StrapFootingContractError, match="analysis"):
+        StrapFootingDesignInput(  # type: ignore[arg-type]
+            analysis=object(), material=_material(), reinforcement=_reinforcement()
+        )
+    with pytest.raises(StrapFootingContractError, match="footing_input"):
+        check_property_line_strap_footing_strength(object())  # type: ignore[arg-type]
+
+
+def test_result_is_frozen_deterministic_and_finite() -> None:
+    first = check_property_line_strap_footing_strength(_design_input())
+    second = check_property_line_strap_footing_strength(_design_input())
+
+    assert first == second
+    with pytest.raises(FrozenInstanceError):
+        first.disposition = StrapFootingDesignDisposition.FAIL  # type: ignore[misc]
+    assert all(
+        math.isfinite(value)
+        for value in (
+            first.flexure.exact_flexural_steel_required_mm2,
+            first.shear.nominal_shear_stress_nmm2,
+            first.side_face.provided_total_area_mm2,
+        )
+        if value is not None
+    )
+
+
+def test_clause_and_source_traceability_are_exact() -> None:
+    refs = get_clause_refs(check_property_line_strap_footing_strength)
+    result = check_property_line_strap_footing_strength(_design_input())
+
+    assert refs == [
+        "26.2.1",
+        "26.2.1.1",
+        "26.3.2",
+        "26.4",
+        "26.5.1.1",
+        "26.5.1.3",
+        "26.5.1.5",
+        "26.5.1.6",
+        "38.1",
+        "G-1.1",
+        "40.1",
+        "40.2",
+        "40.4",
+    ]
+    assert result.source_refs[0].startswith("IS456-2000-A5:sha256:")
+    assert result.source_refs[1].startswith("IS456-AMD6-2024:sha256:")
+    assert "INDIA-2-STRAP-HAND-01" in result.source_refs
+    assert any("Qualified engineering review" in item for item in result.limitations)
+
+
+def test_cover_and_beam_minimum_metadata_are_semantically_correct() -> None:
+    cover = get_clause_info("26.4")
+    minimum = get_clause_info("26.5.1.1")
+
+    assert cover is not None
+    assert cover["title"] == "Nominal Cover to Reinforcement"
+    assert minimum is not None
+    assert minimum["title"] == "Minimum Tension Reinforcement in Beams"
+    assert minimum["category"] == "detailing"

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,79 @@
 
 ---
 
+## 2026-08-16 — Session: INDIA-2-FOUNDATION-STRAP-B
+
+**Agent:** Codex (`structural-math`, sole writer; one bounded independent
+exact-head audit after the candidate is committed)
+
+**Branch:** `codex/india-2-foundation-strap-b` from merged STRAP-A
+`c410b28024e44e3e2670c8b359b69ae29165f2ae`
+
+**Git handoff receipt:** `docs/verification/india-2-foundation-strap-b-git-handoff-receipt.json`
+
+**Focus:** Implement only exact strap flexure, shear/stirrups, minimum and
+side-face steel, spacing, cover, anchorage, and composed disposition. Public
+Python/FastAPI, React, broad Python, and the full 30-check gate remain outside B.
+
+### Summary
+
+- Added strict material/reinforcement/design contracts and immutable strength
+  result types over STRAP-A.
+- Used the shared exact rectangular stress-block root with direct capacity,
+  beam minimum/side-face steel, Table 19/20 shear, supplied vertical stirrups,
+  caller-approved cover, clear spacing, and both-footing anchorage checks.
+- Preserved valid inadequate provision as `FAIL`, unsupported inputs as typed
+  contract errors, and public strap capability as held until C/D/acceptance.
+
+### Issues encountered
+
+- The initial worktree-creation command continued its onboarding commands in
+  the primary checkout, so its first status/brief described dirty primary main
+  instead of the new B lane.
+- Black could not parse `models.py` after the first contract patch because a
+  new helper block split the exterior-column validation statement.
+- The first focused Ruff run stopped on an unused `overall_depth` local in the
+  flexure helper.
+- The first cumulative manifest test classified Clause `26.4` as
+  registration-only. Inspection also reactivated the previously recorded
+  Clause `26.5.1.1` metadata defect because B now uses that clause directly.
+
+### Root causes and resolutions
+
+- Root cause: creating a linked worktree does not change the shell or tool
+  working directory. Resolution: invoke all subsequent commands with B's exact
+  worktree as `workdir` and re-run Git state, source diagnosis, session brief,
+  and session start there. Evidence: B reports clean `READY_LOCAL`, exact A
+  base, and `source_bound=true`; primary remains untouched.
+  ⚠️ TERMINAL ISSUE: onboarding ran in the creation checkout -> explicit B
+  workdir produced the correct trusted session.
+- Root cause: the patch anchor matched repeated geometry text and inserted
+  `_supported_discrete_value` inside a multi-line method rather than beside the
+  other scalar helpers. Resolution: move the complete helper above the first
+  dataclass and restore the uninterrupted column-face calculation. Evidence:
+  Black parses/formats the package and all direct/cumulative B tests pass.
+- Root cause: the flexure draft retained a dimension local after the final
+  beam-minimum formula used effective depth directly. Resolution: remove the
+  dead assignment without changing arithmetic. Evidence: Ruff, mypy, direct
+  tests, and all focused gates pass.
+- Confirmed root cause: parent Clause `26.4` had no normalized metadata, while
+  Clause `26.5.1.1` was incorrectly labelled as minimum shear reinforcement
+  instead of beam minimum tension reinforcement. The latter had been deferred
+  until a packet used it; STRAP-B is that reactivation boundary. Resolution:
+  add the bounded `26.4` identity and correct `26.5.1.1` title/category/keywords
+  without changing formulas or capability. Evidence: deterministic manifest
+  generation, zero IS 456 registration-only references, semantic metadata
+  assertions, and all focused gates pass.
+- Root cause: adding the A/B clause identities increased the registry by two,
+  but the manual `metadata.total_clauses` counter remained at 173; the first
+  semantic correction also used the natural label `beams`, while the registry
+  schema permits the broader `detailing` category. Resolution: update the
+  counter to 175 and use the permitted detailing category while retaining the
+  exact beam-minimum title/keywords. Evidence: the complete clause-registry
+  schema suite and direct semantic regression pass.
+
+---
+
 ## 2026-08-16 — Session: INDIA-2-FOUNDATION-STRAP-A
 
 **Agent:** Codex (`structural-math`, sole writer; one bounded independent

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-16 — STRAP-A analysis complete; STRAP-B is next after merge
+**Updated:** 2026-08-16 — STRAP-B strength complete; STRAP-C is next after merge
 
 ---
 
@@ -133,7 +133,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-2-FOUNDATION-STRAP-B | Implement exact strap flexure, shear, detailing, anchorage, and composed disposition | Main Agent + structural math | focused strength packet | P0 | 🚧 NEXT after STRAP-A merges unchanged; publication remains held |
+| INDIA-2-FOUNDATION-STRAP-C | Publish the typed property-line strap Python composition, stable provenance/result types, executable benchmark, canonical exports, and public docs | Main Agent + backend | focused Python-publication packet | P0 | 🚧 NEXT after STRAP-B merges unchanged; FastAPI/capability remain held |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 
 ## Backlog
@@ -159,6 +159,7 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-2-FOUNDATION-STRAP-B | Implemented exact stress-block flexure, minimum/provided and side-face steel, Table 19/20 shear and vertical stirrups, spacing, cover, anchorage, and composed disposition | Main Agent + structural math | ✅ COMPLETE — frozen PASS, valid FAIL, exact-helper regression, and fail-closed boundaries pass; public composition/publication remain held |
 | INDIA-2-FOUNDATION-STRAP-A | Implemented typed strap geometry/action/approval contracts, equal-pressure/common-factor eligibility, reactions, bearing, clear-strap actions, and equilibrium | Main Agent + structural math | ✅ COMPLETE — frozen benchmark, source-equation reduction, valid bearing failure, and fail-closed boundaries pass; strength/publication remain held |
 | INDIA-2-FOUNDATION-STRAP-G0 | Froze one property-line two-footing system with equal uniform pressure, an explicit no-soil-contact strap model, independent benchmark, and externally verified footing-slab prerequisites | Main Agent + structural engineer | ✅ GO — STRAP-A-D and focused acceptance activated; public capability remains held |
 | INDIA-2-FOUNDATION-COMBINED | Implemented, published, and focused-accepted one bounded symmetric equal-load two-column rigid rectangular combined-footing workflow | Main Agent + structural engineer | ✅ DONE — G0/A-D integrated; 84 family tests, 339 focused public-contract tests, frozen and non-frozen benchmarks, exact-head audit, and hosted checks pass; qualified review and excluded systems remain held |

--- a/docs/planning/india-2-next-session-publication-and-closeout-plan.md
+++ b/docs/planning/india-2-next-session-publication-and-closeout-plan.md
@@ -16,8 +16,9 @@ COMBINED-C/D and focused family acceptance are integrated. STRAP-G0 returned
 GO for one source-bound property-line two-footing model with equal uniform net
 pressure, a straight no-soil-contact strap, explicit service/factored actions,
 and externally verified footing slabs. STRAP-A implements its bounded statics,
-bearing, clear-strap actions, and exact equilibrium. The next packet is
-`INDIA-2-FOUNDATION-STRAP-B` after A merges unchanged with required checks
+bearing, clear-strap actions, and exact equilibrium; STRAP-B implements exact
+strap strength and detailing. The next packet is
+`INDIA-2-FOUNDATION-STRAP-C` after B merges unchanged with required checks
 green.
 
 Finish the bounded strap sequence A -> B -> C -> D -> focused acceptance, one

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,11 +4,12 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-16
-- Focus: Merge STRAP-A unchanged, then begin only STRAP-B strength
+- Focus: Merge STRAP-B unchanged, then begin only STRAP-C public Python workflow
 - Combined acceptance: PR #792 squash-merged as 8e039b112e38436fcae36326b46afa9c436fb970; tree=873aea4cdca8aa9633b30a7c9b74138e5a73a6ce
 - STRAP-G0: PR #793 squash-merged as 70cd2894485d88b72d22544ee18533733789d0f1; audited tree=60d5636265e157e723236909b1de7f582791b297
-- STRAP-A: bounded statics, bearing, actions, and equilibrium implemented; strength/publication remain held
-- Next action: START_STRAP_B_ONLY_AFTER_A_MERGE
+- STRAP-A: PR #794 squash-merged as c410b28024e44e3e2670c8b359b69ae29165f2ae; audited tree=08899dbedd35e3d0b0e2c9ba2e78813d87be1f70
+- STRAP-B: exact strap strength/detailing composition implemented; public Python/FastAPI remain held
+- Next action: START_STRAP_C_ONLY_AFTER_B_MERGE
 <!-- HANDOFF:END -->
 
 **Date:** 2026-08-16
@@ -17,7 +18,7 @@
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; INDIA-0, INDIA-1, and the INDIA-2-STAIR family are complete |
 | **Program** | Umbrella INDIA-2 remains in progress; INDIA-3 and INDIA-4 remain planned |
-| **Next** | Begin `INDIA-2-FOUNDATION-STRAP-B` only after STRAP-A merges unchanged |
+| **Next** | Begin `INDIA-2-FOUNDATION-STRAP-C` only after STRAP-B merges unchanged |
 
 ## Required Reading
 
@@ -120,8 +121,8 @@ authorization, or cleanup authority.
 
 ## Exact next action
 
-After verifying STRAP-A merged unchanged into current `origin/main`, create a
-fresh STRAP-B lane. Implement only exact strap flexure, minimum/provided and
-side-face steel, shear/stirrups, cover/spacing, anchorage, and the composed
-strength disposition. Public Python, FastAPI, capability promotion, React,
-broad Python, and the 30-check gate remain outside STRAP-B.
+After verifying STRAP-B merged unchanged into current `origin/main`, create a
+fresh STRAP-C lane. Publish only the typed Python composition, immutable
+provenance/result/status types, canonical exports, executable frozen benchmark,
+and public API documentation over A/B. FastAPI, capability promotion, React,
+broad Python, and the 30-check gate remain outside STRAP-C.

--- a/docs/verification/india-2-foundation-strap-b-git-handoff-receipt.json
+++ b/docs/verification/india-2-foundation-strap-b-git-handoff-receipt.json
@@ -1,0 +1,155 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-16T10:55:32Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2:user-request-finish-strap-footing",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-16T10:55:32Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-foundation-strap-b",
+      "head_sha": "7b6a4094e56b56dc15ab8c2ceb3a1c492a723feb",
+      "task_id": "INDIA-2-FOUNDATION-STRAP-B"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "b31c2cad534cb48cadcf2a6345bef4caf4dea8fd96c84262823418130e06535b",
+    "state": {
+      "branch": "codex/india-2-foundation-strap-b",
+      "default_base": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "c410b28024e44e3e2670c8b359b69ae29165f2ae",
+        "status": "ahead"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 83.99,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-india-2-foundation-strap-b",
+      "head_sha": "7b6a4094e56b56dc15ab8c2ceb3a1c492a723feb",
+      "hold_reasons": [
+        "changed paths: 1"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-16T10:55:58.129773+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-foundation-strap-b",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 1,
+        "modified_paths": [],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/india-2-foundation-strap-b-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "c410b28024e44e3e2670c8b359b69ae29165f2ae",
+        "status": "ahead"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-2-foundation-strap-b"
+    }
+  },
+  "local_state_receipt_hash": "sha256:b31c2cad534cb48cadcf2a6345bef4caf4dea8fd96c84262823418130e06535b",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-16T10:55:58.129920+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-16T10:55:32Z",
+    "owner": "Main Agent under user instruction to preserve Git state",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "fastapi_app",
+      "react_app",
+      "private_sources",
+      "pyproject.toml",
+      "CHANGELOG.md"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "Python/structural_lib/codes/is456/strap_footing",
+      "Python/tests/codes/is456/strap_footing",
+      "docs/verification/india-2-foundation-strap-b-strength-evidence.md",
+      "docs/verification/india-2-foundation-strap-b-git-handoff-source-evidence.json"
+    ],
+    "shared_paths": [
+      "Python/structural_lib/codes/is456/clauses.json",
+      "scripts/_lib/indian_code_manifest.py",
+      "docs/verification/indian-code-capability-coverage.json",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "INDIA-2-FOUNDATION-STRAP-B"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-2-foundation-strap-b-git-handoff-source-evidence.json
+++ b/docs/verification/india-2-foundation-strap-b-git-handoff-source-evidence.json
@@ -1,0 +1,53 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-16T10:55:32Z",
+      "query_status": "OK",
+      "reference": "task:INDIA-2:user-request-finish-strap-footing",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-16T10:55:32Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/india-2-foundation-strap-b",
+      "head_sha": "7b6a4094e56b56dc15ab8c2ceb3a1c492a723feb",
+      "task_id": "INDIA-2-FOUNDATION-STRAP-B"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-16T10:55:32Z",
+    "owner": "Main Agent under user instruction to preserve Git state",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-2-foundation-strap-b-strength-evidence.md
+++ b/docs/verification/india-2-foundation-strap-b-strength-evidence.md
@@ -1,0 +1,60 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-16
+doc_type: verification
+task: INDIA-2-FOUNDATION-STRAP-B
+---
+
+# INDIA-2 Foundation Strap B Strength Evidence
+
+## Scope and retained boundary
+
+This packet composes A actions with caller-supplied M20-M40 concrete, Fe415/
+Fe500 uncoated deformed bars, longitudinal/side-face reinforcement, vertical
+closed stirrups, approved cover, and straight anchorage into both footings. It
+checks exact rectangular stress-block flexure, Clause 26.5.1.1 beam minimum
+steel, side-face steel, clear spacing, cover, development length, Table 19/20
+shear, minimum stirrups, stirrup strength/spacing, and gross service bearing.
+
+Footing slabs, column/strap transfer, soil capacity, settlement, connections,
+automatic reinforcement, public Python composition, FastAPI, capability
+promotion, React, release, broad Python, and the full 30-check gate remain
+outside B.
+
+## Frozen benchmark
+
+`INDIA-2-STRAP-HAND-01` returns `PASS` with qualified review required and
+complete engineering approval false. The exact physical stress-block root is
+`2788.774499810215 mm2` with `xu = 224.651279151378 mm`; direct substitution
+returns the `916.6875 kN m` demand, while six 25 mm top bars provide
+`2945.243112740431 mm2` and `961.337320139164 kN m` resistance. Four 16 mm
+bottom bars exceed the `722.5 mm2` beam minimum.
+
+Eight 12 mm side-face bars provide `904.77868423386 mm2` total against
+`475 mm2`. Table 19 interpolation gives `tau_c = 0.569479416608601 N/mm2`
+against `tau_v = 0.615661764705882 N/mm2`; the stirrup-carried demand is
+`19.6274979428445 kN`. Two-leg 10 mm stirrups at 250 mm provide
+`157.07963267949 mm2`, exceed the `114.942528735632 mm2` minimum, and resist
+`232.320776807564 kN`. Required 25 mm top-bar development is `1132.8125 mm`;
+`1200 mm` is supplied into both footings.
+
+## Dispositions and provenance
+
+Valid inadequate bearing, longitudinal/side-face steel, stirrups, spacing,
+cover, anchorage, singly reinforced capacity, or maximum shear produces
+`FAIL`. Unsupported grades/layouts/approvals, coated/bundled/spliced/curtailed
+bars, invalid values, or an invalid A contract fail closed without a result.
+The result carries normalized clause/source IDs, controlled source hashes,
+the public IISc/NPTEL model ID, hand-benchmark ID, and caller references. No
+source scans or protected prose are committed.
+
+## Verification
+
+- Direct STRAP-B tests, cumulative A/B tests, exact-helper regression, Ruff,
+  Black, mypy, architecture/import, manifest/parity, links/indexes, source
+  binding, and quick gate pass.
+- Capability remains held at `12 supported / 9 held`; it now truthfully states
+  that G0/A/B exist while public composition/publication remain pending.
+- Exact candidate commit/tree, independent audit, hosted checks, and merge
+  identity are bound by the packet Git handoff receipt.

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -279,7 +279,7 @@
           "claim": "Strap-footing design is not implemented.",
           "workflows": [],
           "limitations": [
-            "G0 and the bounded analysis kernel are implemented; strap strength and publication remain pending."
+            "G0 plus bounded analysis and strap-strength kernels are implemented; public composition and publication remain pending."
           ],
           "evidence": [],
           "qualified_review_required": true
@@ -312,11 +312,11 @@
         }
       ],
       "registration_summary": {
-        "known_references": 174,
-        "registered_known_references": 96,
-        "metadata_only_references": 78,
+        "known_references": 175,
+        "registered_known_references": 98,
+        "metadata_only_references": 77,
         "registration_only_references": 0,
-        "registration_pct": 55.2
+        "registration_pct": 56.0
       },
       "references": [
         {
@@ -523,7 +523,8 @@
             "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength",
             "structural_lib.codes.is456.deep_beam.reinforcement.check_simply_supported_deep_beam_reinforcement",
             "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
-            "structural_lib.codes.is456.footing.load_transfer.check_isolated_footing_load_transfer"
+            "structural_lib.codes.is456.footing.load_transfer.check_isolated_footing_load_transfer",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -536,7 +537,8 @@
           "functions": [
             "structural_lib.codes.is456.beam.detailing.get_bond_stress",
             "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength",
-            "structural_lib.codes.is456.deep_beam.reinforcement.check_simply_supported_deep_beam_reinforcement"
+            "structural_lib.codes.is456.deep_beam.reinforcement.check_simply_supported_deep_beam_reinforcement",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -614,7 +616,8 @@
           "registration_status": "REGISTERED",
           "functions": [
             "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength",
-            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel"
+            "structural_lib.codes.is456.footing.detailing.detail_isolated_footing_bottom_steel",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -633,6 +636,17 @@
           ]
         },
         {
+          "reference_id": "IS456:2000:26.4",
+          "reference": "26.4",
+          "reference_type": "clause",
+          "title": "Nominal Cover to Reinforcement",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
+          ]
+        },
+        {
           "reference_id": "IS456:2000:26.4.2.2",
           "reference": "26.4.2.2",
           "reference_type": "clause",
@@ -647,10 +661,12 @@
           "reference_id": "IS456:2000:26.5.1.1",
           "reference": "26.5.1.1",
           "reference_type": "clause",
-          "title": "Minimum Shear Reinforcement",
-          "category": "shear",
-          "registration_status": "METADATA_ONLY",
-          "functions": []
+          "title": "Minimum Tension Reinforcement in Beams",
+          "category": "detailing",
+          "registration_status": "REGISTERED",
+          "functions": [
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
+          ]
         },
         {
           "reference_id": "IS456:2000:26.5.1.2",
@@ -669,7 +685,8 @@
           "category": "detailing",
           "registration_status": "REGISTERED",
           "functions": [
-            "structural_lib.codes.is456.beam.detailing.check_side_face_reinforcement"
+            "structural_lib.codes.is456.beam.detailing.check_side_face_reinforcement",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -680,7 +697,8 @@
           "category": "shear",
           "registration_status": "REGISTERED",
           "functions": [
-            "structural_lib.codes.is456.beam.shear.design_shear"
+            "structural_lib.codes.is456.beam.shear.design_shear",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -691,7 +709,8 @@
           "category": "shear",
           "registration_status": "REGISTERED",
           "functions": [
-            "structural_lib.codes.is456.beam.shear.design_shear"
+            "structural_lib.codes.is456.beam.shear.design_shear",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -1540,7 +1559,8 @@
             "structural_lib.codes.is456.slab.one_way.design_simply_supported_one_way_slab_flexure",
             "structural_lib.codes.is456.slab.one_way_continuous.design_continuous_one_way_slab_flexure",
             "structural_lib.codes.is456.slab.two_way.design_supported_interior_two_way_slab_flexure",
-            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -1686,7 +1706,8 @@
             "structural_lib.codes.is456.beam.shear.design_shear",
             "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength",
             "structural_lib.codes.is456.slab.shear.check_solid_slab_one_way_shear",
-            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -1701,7 +1722,8 @@
             "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength",
             "structural_lib.codes.is456.slab.shear.check_solid_slab_one_way_shear",
             "structural_lib.codes.is456.slab.two_way_complete.design_two_way_slab_panel",
-            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase"
+            "structural_lib.codes.is456.staircase.design.design_straight_flight_staircase",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -1723,7 +1745,8 @@
           "category": "shear",
           "registration_status": "REGISTERED",
           "functions": [
-            "structural_lib.codes.is456.beam.shear.design_shear"
+            "structural_lib.codes.is456.beam.shear.design_shear",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {
@@ -2118,7 +2141,8 @@
           "registration_status": "REGISTERED",
           "functions": [
             "structural_lib.codes.is456.beam.flexure.design_doubly_reinforced",
-            "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength"
+            "structural_lib.codes.is456.combined_footing.strength.check_symmetric_combined_footing_strength",
+            "structural_lib.codes.is456.strap_footing.strength.check_property_line_strap_footing_strength"
           ]
         },
         {

--- a/scripts/_lib/indian_code_manifest.py
+++ b/scripts/_lib/indian_code_manifest.py
@@ -110,7 +110,7 @@ _HELD_FAMILIES: dict[str, tuple[dict[str, Any], ...]] = {
             "family": "strap_footing",
             "claim": "Strap-footing design is not implemented.",
             "limitations": [
-                "G0 and the bounded analysis kernel are implemented; strap strength and publication remain pending."
+                "G0 plus bounded analysis and strap-strength kernels are implemented; public composition and publication remain pending."
             ],
         },
         {


### PR DESCRIPTION
## Scope\n- add exact strap flexure, beam minimum and side-face reinforcement checks\n- add Table 19/20 shear, vertical stirrup, spacing, cover, and anchorage checks\n- correct Clause 26.5.1.1 metadata and retain strap capability as held\n\n## Validation\n- 28 direct STRAP-B tests; 71 cumulative strap tests\n- 262 focused strap/combined/manifest/traceability tests\n- Ruff, Black, mypy\n- architecture 0/197; imports 0/642; circular imports clean; links 1,258\n- parity 12 supported / 9 held and 80/80 endpoints\n- quick gate 10/10\n\nBroad Python and the 30-check gate remain deferred to final INDIA-2 closeout per the accepted cadence.