### PR TITLE
docs(git): close phase 8 adoption

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -58,6 +58,9 @@ not start the frontmatter repair.
 - The first exact JSON assertion captured the frontmatter checker's trailing
   success banner after the root JSON object, so `jq` parsed the correct payload
   and then stopped on the non-JSON trailer before the quick gate ran.
+- The immutable audit passed all six PR identity rows, then the Excel assertion
+  stopped because its 15-minute caller-evidence window expired during candidate
+  preparation and added stale-observation reason codes.
 
 ### Root causes and resolutions
 
@@ -101,6 +104,14 @@ not start the frontmatter repair.
   assertion proves exactly eight invalid and 60 permitted no-frontmatter
   records before the quick gate. ⚠️ TERMINAL ISSUE: broad JSON extraction fed a
   trailing banner to `jq` -> exact root-object delimiters produced valid JSON.
+- Confirmed root cause: the classifier intentionally rejects remote, PR, and
+  retention observations older than 15 minutes; the first candidate crossed
+  that boundary before immutable audit reached Excel. Resolution: perform one
+  fresh read-only `ls-remote`/GitHub observation, refresh only the timestamp-
+  bound caller/adoption evidence and current task handoff, then create the
+  single allowed repair candidate. Evidence: the refreshed classifier returns
+  only `OWNER_UNKNOWN` and `RETENTION_EVIDENCE_UNKNOWN`, preserving
+  `HOLD_UNKNOWN_OWNER`; no lane or remote state changed.
 
 ### Validation
 
@@ -130,6 +141,8 @@ not start the frontmatter repair.
 - Consolidated repair and content freeze: `13:53:59Z` to `13:58:57Z` —
   4 minutes 58 seconds.
 - Final local candidate gate: `13:58:57Z` to `13:59:56Z` — 59 seconds.
+- Initial immutable audit and freshness-triggered repair start: `13:59:56Z` to
+  `14:01:46Z` — 1 minute 50 seconds.
 - Hosted CI wait, merge closeout, and total wall time are reported by the
   successor closeout observation because they occur after the unchanged
   candidate is frozen.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,135 @@
 
 ---
 
+## 2026-08-16 — Session: GIT-001 Phase 8 Adoption and Reconciliation
+
+**Agent:** Codex (`orchestrator` and `ops`, sole writer)
+
+**Branch:** `codex/git-001-phase8-reconciliation` from freshly fetched
+`origin/main = 86f92ed16164a97b7cbb1edacd64a50a5a71e13d`, tree
+`1bb7e448fd26208ba2227b1d9e2f3f0f976ed46e`
+
+**Git handoff receipt:** `docs/verification/git-001-phase-8-reconciliation-git-handoff-receipt.json`
+
+**Focus:** Verify GIT-7E adoption from one bounded recent sample, reconcile
+current GIT-001/task/handoff truth, and refresh only outcome-changing retained-
+lane disposition evidence. Do not mutate any pre-existing branch, worktree,
+dirty path, stash, issue, pull request, GitHub setting, or cleanup target; do
+not start the frontmatter repair.
+
+### Summary
+
+- Created one fresh source-bound `READY_LOCAL` lane from fetched current main;
+  primary remained clean/equal and detached dirty `e54a` remained untouched.
+- Bound PRs #751/#752 plus recent PRs #792/#797/#798/#799 to their exact bases,
+  reviewed heads, hosted checks, squash commits, equal reviewed/merged trees,
+  and current-main reachability.
+- Confirmed that recent packets adopted `git_state.py`, source binding, hosted
+  exact-head checks, and post-merge tree equivalence. Corrected the evidence
+  boundary between time-bound transition receipts and a fresh successor
+  closeout observation.
+- Captured one 62-worktree census including the new packet lane. Classified
+  only the outcome-changing Excel anomaly; it remains `HOLD_UNKNOWN_OWNER`.
+  Primary and `e54a` are `RETAIN`; all other pre-existing lanes are aggregate
+  `UNKNOWN/HOLD`. No target is retirement-ready.
+- Published the Phase 8 human and machine-readable adoption records, closed
+  GIT-001 on merge with reactivation guards, and named
+  `DOC-FRONTMATTER-CONTRACT` as the sole next packet without starting it.
+
+### Issues encountered
+
+- All four named adoption-sample handoff receipts failed current validation
+  with stale authorization/retention hold-set errors, although live GitHub and
+  local object evidence proved their PRs merged at equal reviewed/merged trees.
+- The first Phase 8 frontmatter replay reported nine invalid records instead of
+  the frozen eight because the new closeout report used unsupported
+  `doc_type: verification`.
+- The first live index pass refused `docs/git-automation/` because that folder
+  has no maintained index, after dry-run had described hypothetical outputs;
+  the first handoff receipt had consequently named two nonexistent shared index
+  paths.
+- The first consolidated documentation closeout found one broken brief link to
+  a guessed `Python/tests/test_check_docs.py` and reported the planning/root
+  indexes stale after the final human-owned edits.
+- The first exact JSON assertion captured the frontmatter checker's trailing
+  success banner after the root JSON object, so `jq` parsed the correct payload
+  and then stopped on the non-JSON trailer before the quick gate ran.
+
+### Root causes and resolutions
+
+- Confirmed root cause: the sample JSON files are time-bound pre-publication
+  transition observations, but the execution plan treated them as permanent
+  final-closeout receipts. Their fail-closed validator correctly recomputes
+  stale external evidence, and an unchanged pre-merge tree cannot record its
+  future squash identity. Resolution: retain each historical receipt unchanged,
+  bind final PR/check/merge/tree facts in the fresh Phase 8 successor evidence,
+  and add the transition-versus-closeout rule to the canonical workflow.
+  Evidence: PRs #751/#752/#792/#797/#798/#799 have exact live reviewed heads,
+  zero failed checks, equal reviewed/merged trees, and merge commits reachable
+  from `86f92ed1`; the four historical validators fail only with the documented
+  stale-evidence hold-set errors.
+- Confirmed root cause: the new report copied the narrative evidence category
+  into `doc_type` instead of checking the maintained schema enum. Resolution:
+  use schema-valid `doc_type: reference` while retaining the report's evidence
+  purpose in its title/body. Evidence: live text mode returns to exactly eight
+  pre-existing invalid records and JSON again reports
+  `invalid_frontmatter: 8`; no deferred record was edited.
+- Confirmed root cause: dry-run previews the requested target even when a live
+  write would create a new index, while live mode correctly requires explicit
+  `--allow-new-index`; Phase 8 had no authority or need to create that topology.
+  Resolution: preserve the unmaintained folder, remove its nonexistent indexes
+  from the receipt path contract, regenerate the receipt, and refresh only the
+  maintained verification index. Evidence: receipt validation and all touched
+  maintained index checks pass. ⚠️ TERMINAL ISSUE: live generation refused the
+  unmaintained `docs/git-automation` target -> retained no-new-index scope and
+  regenerated only maintained targets.
+- Confirmed root cause: the next-packet brief inferred a future focused-test
+  filename before `rg --files` discovery, and the last plan/session edits
+  occurred after their earlier index generation. Resolution: remove the
+  nonexistent link, direct the next packet to discover the test layout, then
+  regenerate only the maintained planning and root indexes after all human
+  content freezes. Evidence: the repeated link scan, touched-index checks, and
+  quick gate complete on the repaired candidate.
+- Confirmed root cause: JSON mode prints a human progress prefix and success
+  suffix around its JSON object, while the assertion extracted from the first
+  opening brace through end of stream. Resolution: delimit extraction from the
+  root `{` line through the unindented root `}` line. Evidence: the corrected
+  assertion proves exactly eight invalid and 60 permitted no-frontmatter
+  records before the quick gate. ⚠️ TERMINAL ISSUE: broad JSON extraction fed a
+  trailing banner to `jq` -> exact root-object delimiters produced valid JSON.
+
+### Validation
+
+- Startup: `source_bound=true`, `READY_LOCAL`, no operation marker, exact base
+  equality, and zero worktree-census query failures.
+- Focused Git governance: 127 tests pass across state, handoff-receipt, and
+  disposition suites; `scripts/check_codex_git_workflow.py` passes.
+- Adoption: all six sampled PRs are merged/reachable with equal reviewed and
+  merged trees; applicable hosted checks passed and only intended jobs skipped.
+- Disposition: Excel classifier returns `HOLD_UNKNOWN_OWNER` with
+  `OWNER_UNKNOWN` and `RETENTION_EVIDENCE_UNKNOWN`; `e54a` exact head/blob/file
+  hashes and 119-insertion/7-deletion single-path diff are recorded without
+  mutation.
+- Documentation: compact brief is 114 lines; JSON and text frontmatter replay
+  retain exactly eight deferred invalid records after the packet-owned metadata
+  repair; all touched maintained indexes are hash-current.
+- Candidate documentation/index checks pass; all 1,262 internal links are
+  valid and the exact-head quick gate passes `10/10`. Normal hooks, hosted
+  checks, merge-tree verification, and total elapsed time complete during
+  publication closeout.
+
+### Timing through content freeze
+
+- Orientation: `13:40:07Z` to `13:46:29Z` — 6 minutes 22 seconds.
+- Evidence sampling and first writing pass: `13:46:29Z` to `13:53:59Z` —
+  7 minutes 30 seconds.
+- Consolidated repair and content freeze: `13:53:59Z` to `13:58:57Z` —
+  4 minutes 58 seconds.
+- Final local candidate gate: `13:58:57Z` to `13:59:56Z` — 59 seconds.
+- Hosted CI wait, merge closeout, and total wall time are reported by the
+  successor closeout observation because they occur after the unchanged
+  candidate is frozen.
+
 ## 2026-08-16 — Session: INDIA-2 Next-Agent Execution Plan Refresh
 
 **Agent:** Codex (`orchestrator` and `doc-master`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-16 — primary is clean at `339bad21`; next session starts with Git Phase 8 and confirmed issue repairs before new foundation work
+**Updated:** 2026-08-16 — GIT-001 Phase 8 closes with retained holds; the sole next packet is the bounded frontmatter contract/data repair
 
 ---
 
@@ -125,16 +125,14 @@
 
 ## Active
 
-| ID | Task | Owner | Status |
-|----|------|-------|--------|
-| GIT-001 | Research and implement an evidence-backed Git operating model for human/AI work, recovery, and lifecycle governance | Main Agent + repository owner | 🚧 PHASE 8 NEXT — Phases 1-7E are integrated through PRs #751/#752; verify adoption, reconcile stale status, and refresh preservation holds without cleanup |
+No implementation packet is active after Phase 8 closeout. Start only the
+next bounded packet below from refreshed `origin/main`.
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| GIT-001-P8-RECONCILIATION | Verify GIT-7E adoption, reconcile current ledgers, and classify retained lanes without mutation | Main Agent + ops | one packet | P0 | ⏭️ NEXT — primary is clean/current; sample recent receipts and inspect retained anomalies only; cleanup remains unauthorized |
-| DOC-FRONTMATTER-CONTRACT | Fix JSON-mode false success and the eight currently invalid frontmatter records | Main Agent + doc-master | one packet | P0 | ⏸ AFTER GIT P8 |
+| DOC-FRONTMATTER-CONTRACT | Fix JSON-mode false success and the eight currently invalid frontmatter records | Main Agent + doc-master | one packet | P0 | ⏭️ NEXT — repair only the exit-code contract and exactly eight invalid records |
 | INDIA-2-TRUTH-HYGIENE-38-2 | Source-audit and correct live Clause 38.2 flexure metadata, decorators, provenance, and any benchmark-proven arithmetic defect | Main Agent + structural engineer | one bounded packet | P0 | ⏸ AFTER DOC CONTRACT |
 | INDIA-2-FOUNDATION-PILE-CAP-G0 | Decide one source-bound pile-cap case or retain an explicit hold before any implementation | Main Agent + structural engineer | decision only | P0 | ⏸ AFTER ISSUE REPAIRS — investigate one centred axial two-pile cap; controlled companion source and benchmark remain prerequisites |
 | INDIA-2-FOUNDATION-RAFT-G0 | Decide one source-bound non-FEM raft case or retain an explicit hold before any implementation | Main Agent + structural engineer | decision only | P0 | ⏸ AFTER PILE-CAP DECISION — not started |
@@ -150,8 +148,9 @@ defines the remaining family packets. INDIA-0 and INDIA-1 are complete. The
 historical INDIA-2A-D packets form the completed `INDIA-2-STAIR` family. Bounded
 wall, deep-beam, flat-slab/punching, combined-footing, and strap-footing
 families are accepted, but umbrella INDIA-2 remains in progress while the
-Git/status reconciliation, frontmatter contract repair, Clause 38.2 truth
-hygiene, and pile-cap/raft G0 decisions remain pending.
+frontmatter contract repair, Clause 38.2 truth hygiene, and pile-cap/raft G0
+decisions remain pending. Git/status reconciliation is complete with retained
+lanes explicitly held and no cleanup authority.
 The v0.23.1a1 Alpha is published.
 UIX-001 P0-P15 is accepted: the revision-safe workbench, authoritative
 3D inspection, versioned capability catalogue, curated renderer, bounded
@@ -164,6 +163,8 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| GIT-001-P8-RECONCILIATION | Verified GIT-7E adoption, corrected transition-versus-closeout receipt semantics, reconciled current ledgers, and refreshed preservation holds | Main Agent + ops | ✅ COMPLETE ON MERGE — primary/e54a retained; Excel and all other pre-existing lanes remain `UNKNOWN/HOLD`; no cleanup performed |
+| GIT-001 | Researched and implemented the evidence-backed Git operating model through adoption closeout | Main Agent + repository owner | ✅ COMPLETE ON MERGE — Phases 0-8 close with fail-closed maintenance/reactivation rules and preserved unknown lanes |
 | INDIA-2-FOUNDATION-STRAP | Implemented, published, and focused-accepted one bounded property-line two-footing equal-pressure no-soil-contact strap workflow | Main Agent + structural engineer | ✅ DONE — G0/A-D integrated; frozen and non-frozen benchmarks, exact-head audit, focused gates, and hosted checks pass; qualified review and excluded systems remain held |
 | INDIA-2-FOUNDATION-STRAP-D | Published the strict nested FastAPI transport, exact OpenAPI contract, capability/semantic truth, and deterministic manifest promotion | Main Agent + API developer | ✅ COMPLETE — one bounded workflow is supported at 13/21 truth and all 81 routes have direct tests; family acceptance is separately complete |
 | INDIA-2-FOUNDATION-STRAP-C | Published the typed property-line strap Python composition, immutable provenance/result/status types, mapping builder, canonical exports, executable benchmark, and public docs | Main Agent + backend | ✅ COMPLETE — public Python PASS/FAIL/fail-closed/provenance tests pass; capability remains held until D |

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -149,6 +149,15 @@ identity summary into `next-session-brief.md`, and fails closed if the receipt
 is missing or invalid. The full JSON remains the audit contract; prose and PR
 numbers alone are not a durable Git receipt.
 
+A task-to-Git handoff receipt is a time-bound transition observation, not a
+permanent final-merge receipt. Its external authorization, retention, remote,
+review, and check evidence is expected to become stale and fail closed later;
+never rewrite the historical file merely to make it validate as current. A
+fresh successor closeout observation must bind the final reviewed head, hosted
+checks, merge commit, and merged tree. This separation is unavoidable for a
+squash merge because the unchanged pre-merge candidate cannot know its future
+merge identity.
+
 ## Verification before publication
 
 - Follow the compact audited-integration gates above when independent acceptance

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 9108,
+      "size_lines": 9470,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "ddeb865b3799"
+      "content_hash": "23d8ef957a4b"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 730,
+      "size_lines": 736,
       "last_updated": "2026-08-16",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "ff5b3bff9b75"
+      "content_hash": "533130b0c275"
     },
     {
       "name": "WORKLOG.md",
@@ -197,7 +197,7 @@
     {
       "name": "research",
       "path": "research/",
-      "file_count": 33
+      "file_count": 36
     },
     {
       "name": "specs",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 125,
+      "file_count": 131,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "aec5a2fbdca00828"
+  "content_hash": "5ab768ce9c7fdebf"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 9470,
+      "size_lines": 9483,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "23d8ef957a4b"
+      "content_hash": "d8de4684733a"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "5ab768ce9c7fdebf"
+  "content_hash": "d5a066a0b1ab49e4"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 9470 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 9483 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 736 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 9108 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 730 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 9470 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 736 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -46,6 +46,6 @@ Guides, references, evidence, and contributor material for the
 | [planning/](planning/) | 22 |  |
 | [publications/](publications/) | 11 | This directory contains blog posts, technical articles, and academic papers docu |
 | [reference/](reference/) | 1792 |  |
-| [research/](research/) | 33 |  |
+| [research/](research/) | 36 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 125 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 131 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -66,10 +66,10 @@
     {
       "name": "india-2-next-session-publication-and-closeout-plan.md",
       "type": "documentation",
-      "size_lines": 470,
+      "size_lines": 477,
       "last_updated": "2026-08-16",
-      "description": "Combined-footing and strap-footing G0/A-D plus focused family acceptance are integrated within their recorded bounded cases. The next session starts with",
-      "content_hash": "4a20e22c8a1f"
+      "description": "Combined-footing and strap-footing G0/A-D plus focused family acceptance are integrated within their recorded bounded cases. GIT-001 Phase 8 closes through",
+      "content_hash": "765b5a9d9d5d"
     },
     {
       "name": "india-2-remaining-is456-elements-plan.md",
@@ -131,11 +131,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 121,
+      "size_lines": 114,
       "last_updated": "2026-08-16",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-16",
-      "content_hash": "91a25abcf6d1"
+      "content_hash": "bb5a4603d46d"
     },
     {
       "name": "pre-release-checklist.md",
@@ -173,5 +173,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "c3471840015466f2"
+  "content_hash": "d4d7cc0c27996f68"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -15,7 +15,7 @@
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
 | [etabs-killer-masterplan.md](etabs-killer-masterplan.md) | Project BHEEM: Open-Source Structural De | > **BHEEM** — **B**uilding **H**olistic **E**ngineering **E* | 2855 |
 | [gpt-5-3-codex-spark-work-program.md](gpt-5-3-codex-spark-work-program.md) |  | Use GPT-5.3-Codex-Spark as a high-throughput implementation  | 614 |
-| [india-2-next-session-publication-and-closeout-plan.md](india-2-next-session-publication-and-closeout-plan.md) |  | Combined-footing and strap-footing G0/A-D plus focused famil | 470 |
+| [india-2-next-session-publication-and-closeout-plan.md](india-2-next-session-publication-and-closeout-plan.md) |  | Combined-footing and strap-footing G0/A-D plus focused famil | 477 |
 | [india-2-remaining-is456-elements-plan.md](india-2-remaining-is456-elements-plan.md) |  | INDIA-2 finishes a practical, explicitly limited set of IS 4 | 392 |
 | [indian-code-completion-plan.md](indian-code-completion-plan.md) |  | This is the canonical finish plan for the repository's India | 133 |
 | [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1507 |
@@ -23,7 +23,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 121 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 114 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/india-2-next-session-publication-and-closeout-plan.md
+++ b/docs/planning/india-2-next-session-publication-and-closeout-plan.md
@@ -13,23 +13,24 @@ doc_type: spec
 ## 1. Outcome and stop boundary
 
 Combined-footing and strap-footing G0/A-D plus focused family acceptance are
-integrated within their recorded bounded cases. The next session starts with
-Git and confirmed issue reconciliation before any new foundation decision.
+integrated within their recorded bounded cases. GIT-001 Phase 8 closes through
+its adoption packet; the next session starts with the confirmed frontmatter
+contract/data repair before any new foundation decision.
 
-This document is a plan only. Primary `main` was separately cleaned and
-fast-forwarded before this refresh. Publication does not authorize any further
-primary mutation, branch/worktree retirement, dependency-PR closure, pile-cap
-or raft implementation, release work, or professional approval. Stop after
-this planning packet merges.
+This document remains the sequence plan. Phase 8 execution is recorded in
+[`GIT-001-phase-8-adoption-closeout.md`](../research/git-governance/GIT-001-phase-8-adoption-closeout.md).
+Its publication does not authorize primary mutation, branch/worktree
+retirement, dependency-PR closure, pile-cap or raft implementation, release
+work, or professional approval.
 
 Execute later work in this order, one fresh lane and one active writer at a
 time:
 
-1. `GIT-001-P8-RECONCILIATION` — reconcile the completed GIT-7E work, prove
-   current adoption, classify retained lanes, and obtain any required owner
-   decisions without cleanup.
-2. `DOC-FRONTMATTER-CONTRACT` — repair the JSON-mode exit-code defect and the
-   eight currently invalid frontmatter records.
+1. `GIT-001-P8-RECONCILIATION` — complete on merge of its unchanged adoption
+   packet; primary/e54a are retained and all other pre-existing lanes remain
+   `UNKNOWN/HOLD` without cleanup.
+2. `DOC-FRONTMATTER-CONTRACT` — next; repair the JSON-mode exit-code defect and
+   the eight currently invalid frontmatter records.
 3. `INDIA-2-TRUTH-HYGIENE-38-2` — source-audit every live `38.2` consumer,
    correct provenance, and change arithmetic only if an independently checked
    benchmark proves an outcome defect.
@@ -95,6 +96,10 @@ Every fact above must be refreshed in the executing packet. A dated plan is not
 remote-freshness or mutation authority.
 
 ## 3. Packet 1 — GIT-001 Phase 8 reconciliation
+
+**Status:** complete on merge of the unchanged
+[Phase 8 adoption packet](../research/git-governance/GIT-001-phase-8-adoption-closeout.md).
+The contract below is retained as execution evidence, not as the next action.
 
 ### Objective
 
@@ -351,44 +356,46 @@ benchmark means `HOLD`, not an improvised model.
 
 ## 7. Next-agent execution card
 
-The next agent starts and finishes only `GIT-001-P8-RECONCILIATION`.
+The next agent starts and finishes only `DOC-FRONTMATTER-CONTRACT`.
 
 ### First 15 minutes
 
 1. Fetch `origin/main`; record the exact commit and tree.
-2. Create `codex/git-001-phase8-reconciliation` from that ref; never write on
-   primary or reuse a retained lane.
-3. Run the four required start commands in Section 3 and require
+2. Create `codex/doc-frontmatter-contract` from that ref; never write on
+   primary or reuse Phase 8 or another retained lane.
+3. Run the compact brief's four start commands and require
    `source_bound=true` plus `READY_LOCAL`.
-4. Read only this plan, the compact next-session brief, the GIT-001 index and
-   disposition plan, and the four adoption-sample receipts. Do not read the
-   full 9,000-line session log unless one exact fact is missing.
-5. Capture one census and one remote/PR evidence timestamp. Build a short
-   anomaly list before opening individual lane histories.
+4. Read only this plan, the compact brief, `scripts/check_docs.py`, the nearest
+   script-level test layout discovered with `rg --files`, and the eight named
+   invalid records.
+5. Reproduce JSON exit `0` with eight invalid records and freeze the exact
+   payload plus the text-mode result before editing.
 
 ### Work loop
 
-1. Freeze the outcome-changing questions and exact paths before edits.
-2. Batch independent read-only commands, but keep all shared documents,
-   receipts, indexes, and Git operations under one writer.
-3. Update the Phase 8 evidence/status/session/brief once after facts stabilize.
-4. Generate maintained indexes once, after `--dry-run` or targeted discovery.
-5. Run focused tests while editing, one quick gate on the frozen candidate, one
-   content commit, only the required versioned-receipt follow-up, one push, and
-   one hosted-check cycle.
-6. Merge only the unchanged reviewed head; verify the squash tree and refreshed
-   `origin/main`; retain the lane unless deletion is separately authorized.
+1. Freeze the checker, focused tests, and exactly eight record paths before
+   edits; the 60 permitted legacy records are non-goals.
+2. Make JSON mode return the same pass/fail result as text mode without changing
+   its JSON payload.
+3. Add direct valid/invalid exit-code regressions and give only the eight named
+   records schema-valid lifecycle/doc types without rewriting evidence.
+4. Generate maintained indexes once after human-owned content freezes.
+5. Run focused tests, live JSON/text replay, links/indexes, one quick gate, one
+   candidate review, one push, and one hosted-check cycle.
+6. Merge only the unchanged reviewed head, verify squash-tree equality and
+   refreshed `origin/main`, retain the lane, and stop.
 
 ### Stop and handoff
 
-Stop after Phase 8 merges. Name `DOC-FRONTMATTER-CONTRACT` as the sole next
-packet. Do not use remaining time to start its fix in the Phase 8 lane.
+Stop after `DOC-FRONTMATTER-CONTRACT` merges. Name
+`INDIA-2-TRUTH-HYGIENE-38-2` as the sole next packet. Do not use remaining time
+to start Clause 38.2 work in the frontmatter lane.
 
 ## 8. Efficiency and speed controls
 
 - **One packet, one context:** use the compact brief and exact packet files;
-  avoid broad historical searches after the anomaly list is frozen.
-- **No subagent by default:** the next packet is mostly evidence reconciliation.
+  avoid broad historical searches after the eight-path list is frozen.
+- **No subagent by default:** the next packet is a bounded contract/data repair.
   Do not spawn one unless the owner explicitly requests delegation; the parent
   performs the review and never duplicates orientation or shared-file work.
 - **One candidate ceiling:** review the complete diff before commit. If audit

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,117 +4,110 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-16
-- Focus: Git reconciliation and confirmed issue repairs before new foundation work
-- Baseline: fetched origin/main 339bad2128bc00b34a18827a8ac185ebcdb069fd; planning PR #799 merged, tree ecd7fe389409e4077afb37f17aee20fe5734cf0e
+- Focus: frontmatter checker contract and exactly eight invalid records
+- Baseline: GIT-001 Phase 8 started from fetched origin/main 86f92ed16164a97b7cbb1edacd64a50a5a71e13d, tree 1bb7e448fd26208ba2227b1d9e2f3f0f976ed46e
 - Truth: 13 supported / 8 held; 81/81 endpoints directly tested
-- Primary: clean and synchronized at 339bad2128bc; repository output-detail default restored to low
-- Preserved e54a: detached 0fdb48ed, only docs/SESSION_LOG.md dirty; no cleanup authorization
-- Git correction: GIT-7E PR #751 and orchestration PR #752 are merged; parent status is reconciled and Phase 8 must verify adoption/current disposition facts
-- Issue correction: Clause 26.5.1.1 metadata was already fixed in STRAP-B and is not future work
-- Confirmed issues: JSON frontmatter mode falsely exits zero; eight invalid records remain; live beam provenance still carries unsupported 38.2
-- Foundation readiness: no retained IS 2911/IS 2950 companion source or accepted pile-cap/raft benchmark; G0 must acquire/bind evidence or HOLD
-- Next action: begin only GIT-001-P8-RECONCILIATION in a fresh current-main lane; no cleanup
+- Git outcome: Phases 0-8 close on merge of the unchanged adoption packet; transition receipts are time-bound and final merge facts require a fresh successor observation
+- Primary/e54a: primary was clean/equal at packet start; detached dirty e54a remains retained and untouched
+- Other lanes: Excel is HOLD_UNKNOWN_OWNER; every other pre-existing lane remains UNKNOWN/HOLD; no cleanup authority exists
+- Confirmed next defect: frontmatter JSON mode reports eight invalid records but exits zero because it returns before applying the text-mode failure rule
+- Scope guard: repair only that exit-code contract, its direct regression tests, and the eight named lifecycle/doc-type records; leave 60 permitted legacy records alone
+- Next action: begin only DOC-FRONTMATTER-CONTRACT in a fresh fetched-current-main lane
 <!-- HANDOFF:END -->
 
 **Date:** 2026-08-16
 
 | State | Boundary |
 |---|---|
-| **Current** | `v0.23.1a1` Alpha; bounded wall, stair, deep, flat/punching, combined-footing, and strap-footing families complete |
-| **Next** | Git Phase 8 reconciliation, then issue repairs |
-| **Later** | Decision-only pile-cap G0, raft G0, accepted GO packets, INDIA-2 broad closeout |
+| **Current** | `v0.23.1a1` Alpha; GIT-001 adoption closes with retained holds and no cleanup |
+| **Next** | `DOC-FRONTMATTER-CONTRACT` only |
+| **Later** | Clause 38.2 truth hygiene, pile-cap G0, raft G0, accepted GO packets, INDIA-2 broad closeout |
 | **Held** | Cleanup/deletion, release, React expansion, professional approval, dependency majors |
 
 ## Required Reading
 
 1. [Next-session Git/issues/INDIA-2 plan](india-2-next-session-publication-and-closeout-plan.md)
-2. [Canonical Git workflow](../git-automation/git-workflow-single-source.md)
-3. [GIT-001 index](../research/git-governance/GIT-001-README.md)
-4. [GIT-001 disposition plan](../research/git-governance/GIT-001-next-agent-disposition-plan.md)
-5. [INDIA-2 remaining-elements plan](india-2-remaining-is456-elements-plan.md)
-6. [Strap family acceptance](../verification/india-2-foundation-strap-family-acceptance-evidence.md)
-7. [Current task board](../TASKS.md)
+2. [Current task board](../TASKS.md)
+3. [Phase 8 adoption closeout](../research/git-governance/GIT-001-phase-8-adoption-closeout.md)
+4. [`check_docs.py`](../../scripts/check_docs.py)
 
 ## Exact start
 
-Create a fresh `codex/git-001-phase8-reconciliation` worktree from fetched,
-verified `origin/main`; primary is the clean integration anchor, not a write
-lane, and retained `e54a` remains untouched.
+Fetch and verify `origin/main`, then create one fresh
+`codex/doc-frontmatter-contract` worktree. Do not write on primary, reuse the
+Phase 8 lane, or touch retained worktrees.
 
 ```bash
-./run.sh session brief --agent ops
+./run.sh session brief --agent doc-master
 ./run.sh session start
 ./scripts/python_runtime.sh --diagnose
 ./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
 
-Require `source_bound=true`, `READY_LOCAL`, no operation marker, and an exact
-current-main base. Refresh GitHub PR evidence before making a current claim.
+Require `source_bound=true`, `READY_LOCAL`, no operation marker, and exact base
+equality with fetched `origin/main` before editing.
 
 ## Packet order
 
-1. `GIT-001-P8-RECONCILIATION`
-   - bind PR #751/#752 and verify the reconciled GIT-7E/task status;
-   - prove adoption by sampling combined acceptance, STRAP-D, strap acceptance,
-     and planning PR #799 receipts rather than rereading every packet;
-   - capture one worktree census, then classify only outcome-changing anomalies;
-   - verify primary clean/equal and preserve `e54a` read-only;
-   - ask for explicit owner decisions where required;
-   - perform no synchronization, reset, stash, deletion, branch closure, or
-     worktree removal.
-2. `DOC-FRONTMATTER-CONTRACT`
-   - make JSON output return nonzero when invalid records exist;
-   - add direct regression coverage;
-   - repair exactly the eight currently invalid lifecycle/doc-type records;
+1. `DOC-FRONTMATTER-CONTRACT`
+   - make JSON mode return nonzero whenever `invalid_frontmatter` is nonzero;
+   - preserve the JSON payload exactly;
+   - add direct invalid/valid exit-code regressions;
+   - repair exactly the eight already identified status/doc-type records;
    - do not bulk-add frontmatter to 60 permitted legacy documents.
-3. `INDIA-2-TRUTH-HYGIENE-38-2`
-   - trace all live metadata/decorator/provenance/arithmetic consumers;
+2. `INDIA-2-TRUTH-HYGIENE-38-2`
+   - trace live metadata/decorator/provenance/arithmetic consumers;
    - rebind supported source identities;
-   - benchmark the legacy flexure approximation against exact equilibrium;
-   - change arithmetic only when main-process outcome evidence requires it.
-4. Decision-only `PILE-CAP-G0`: first test a centred axial two-pile cap and
-   choose one source-bound footing-critical-section or deep-region model; never
-   assume GO without a controlled source and independent benchmark.
-5. Decision-only `RAFT-G0`, then any owner-accepted GO chain.
-6. `INDIA-2-CLOSEOUT` with broad Python and the full 30-check gate once.
-7. Post-INDIA-2 dependency-major compatibility packets only afterward.
+   - change arithmetic only if an independent benchmark proves an outcome
+     defect.
+3. Decision-only `PILE-CAP-G0`, then its A-D/acceptance chain only after `GO`.
+4. Decision-only `RAFT-G0`, then any owner-accepted chain.
+5. `INDIA-2-CLOSEOUT` with broad Python and the full 30-check gate once.
+6. Post-INDIA-2 dependency-major compatibility packets only afterward.
+
+## Frozen frontmatter scope
+
+The confirmed root cause is the early unconditional JSON return in
+`check_frontmatter()`. The eight data defects are:
+
+- invalid `status`: the library-first master plan, combined-C public-workflow
+  evidence, and wall/deep/flat family-acceptance evidence; and
+- invalid `doc_type: verification`: strap A, B, and C evidence.
+
+Give each record a schema-valid lifecycle/doc type while preserving its
+narrative completion/acceptance meaning. Do not rewrite engineering evidence,
+expand the schema, or sweep unrelated legacy metadata.
 
 ## Owner-decision boundaries
 
-- Primary `main` is clean and current; do not write on it or revisit the
-  resolved output-detail preference unless new drift appears.
-- `e54a`: retain until named ownership/retention evidence and an exact
-  classifier receipt exist. Even pending approval does not authorize deletion.
+- Primary, `e54a`, Excel, Phase 8, and every other retained lane stay untouched.
+- Historical task-to-Git receipts are time-bound evidence; do not rewrite them
+  to suppress stale holds.
 - Closing dependency PRs, deleting branches/worktrees, release/tag/package
   publication, and professional approval require separate authority.
 
 ## Gate cadence
 
-Using the cadence quoted by the owner: focused gates per packet, with the broad
-Python and 30-check gates only at the final INDIA-2 integration boundary unless
-a repository-wide failure forces them earlier.
+Run focused checker tests, both live JSON and text modes, exact eight-record
+replay, links/indexes, quick `10/10`, normal hooks, exact-head review, hosted
+documentation checks, and merge-tree verification. Broad Python and the full
+30-check gate remain deferred to final INDIA-2 closeout unless a confirmed
+repository-wide failure forces them earlier.
 
-Each packet still requires focused tests, root-cause proof, architecture/import
-checks where relevant, quick `10/10`, normal hooks, exact-head review, hosted
-checks, merge-tree verification, and a session entry containing `Issues
-encountered` plus `Root causes and resolutions`.
+The session entry must contain `Issues encountered` and `Root causes and
+resolutions`, including visible symptom, main-process impact, confirmed cause,
+implemented correction, and executable proof.
 
 ## Efficiency card
 
-- Read this brief and the linked plan first; do not read the full session log
-  unless one exact fact is missing.
-- Capture Git/worktree state once, build an anomaly list, and inspect only lanes
-  that could change disposition.
-- Keep one writer, one frozen candidate, one generator pass, one quick gate,
-  one content commit plus required receipt follow-up, one push, and one hosted-
-  check cycle.
-- Parallelize independent reads; serialize Git writes, receipts, shared docs,
-  and generated artifacts.
-- Record orientation, local work, audit/repair, CI wait, closeout, and total
-  elapsed time so the next packet can remove real overhead.
+- Freeze the eight paths and checker/test paths before editing.
+- Use one writer, one candidate, one generator pass, one quick gate, one push,
+  and one hosted-check cycle.
+- Preserve the JSON payload while changing only the exit status.
+- Record orientation, implementation, repair, CI wait, closeout, and total
+  elapsed workflow time separately.
 
 ## Stop rule
 
-The next session starts only GIT-001 Phase 8 reconciliation. Do not begin the
-frontmatter fix, Clause 38.2 repair, pile-cap, raft, dependency update, broad
-gate, or cleanup in the same packet.
+Start and finish only `DOC-FRONTMATTER-CONTRACT`. Do not begin Clause 38.2,
+pile-cap, raft, dependency, broad-gate, or cleanup work in that lane.

--- a/docs/research/git-governance/GIT-001-README.md
+++ b/docs/research/git-governance/GIT-001-README.md
@@ -25,7 +25,10 @@ The follow-on eight-branch retirement proposal was integrated by PR #750 as
 `b91838f` and still holds all exact targets on unknown retention. GIT-7E
 semantic guidance and durable handoff integrated through PR #751 as
 `6bcbd9d3`; the compact audited orchestrator workflow followed through PR #752
-as `96f193bd`. Phase 8 adoption and closeout are next. No cleanup is authorized.
+as `96f193bd`. Phase 8 verifies current adoption, separates time-bound
+transition receipts from successor closeout evidence, and closes on merge of
+its unchanged packet. All retained lanes remain preserved; no cleanup is
+authorized.
 
 ## Objective
 
@@ -55,7 +58,7 @@ work, make recovery deterministic, and remain efficient during normal work.
 | 5 | Scenario validation | Complete for proposal | Disposable Git and live read-only checks reproduce current defects, validate primitives, and define falsifiable GIT-7B–7E gates |
 | 6 | Canonical policy proposal | Accepted 2026-08-13 | Owner accepted the operating model and authorized GIT-7B only |
 | 7 | Controlled implementation | Complete through GIT-7E | GIT-7D2 merged through PRs #747-#748; PR #750 integrated the held proposal; PR #751 integrated semantic guidance and durable handoff; PR #752 integrated compact audited orchestration; no deletion is authorized |
-| 8 | Adoption and closeout | Next, not started | Verify current use through recent exact-head receipts, reconcile superseded task text, refresh preservation holds, and establish maintenance without cleanup |
+| 8 | Adoption and closeout | Complete on merge of the unchanged Phase 8 packet | Recent packets use state/source/check/tree controls; successor closeout evidence corrects the transition-receipt boundary; primary/e54a are retained and all other lanes remain held without cleanup |
 
 ## Artifact map
 
@@ -80,7 +83,9 @@ work, make recovery deterministic, and remain efficient during normal work.
 - [Eight-branch machine-readable proposal receipt](GIT-001-eight-branch-retirement-authorization-proposal.json)
 - [Eight-branch classifier caller evidence](GIT-001-eight-branch-retirement-classifier-evidence.json)
 - [Phase 7E semantic coherence and durable handoff](GIT-001-phase-7E-semantic-handoff.md)
-- Phase 8 adoption/closeout report — planned
+- [Phase 8 adoption and preservation closeout](GIT-001-phase-8-adoption-closeout.md)
+- [Phase 8 machine-readable adoption evidence](GIT-001-phase-8-adoption-evidence.json)
+- [Phase 8 Excel classifier caller evidence](GIT-001-phase-8-excel-disposition-evidence.json)
 
 ## Ownership and non-goals
 

--- a/docs/research/git-governance/GIT-001-next-agent-disposition-plan.md
+++ b/docs/research/git-governance/GIT-001-next-agent-disposition-plan.md
@@ -37,14 +37,20 @@ workflow remains
   nine commits behind with only `.codex/config.toml` dirty; GIT-7E PR #751 and
   compact orchestration PR #752 are merged. The dated topology tables below
   remain historical evidence until Phase 8 refreshes them read-only.
+- Phase 8 refresh on 2026-08-16: fetched `origin/main = 86f92ed1`, tree
+  `1bb7e448`; primary is clean/equal, retained detached `e54a` still has only
+  its 119-insertion/7-deletion session-log patch, and the one fresh Excel
+  classifier result is `HOLD_UNKNOWN_OWNER`. The complete current snapshot is
+  [the Phase 8 closeout](GIT-001-phase-8-adoption-closeout.md); every older
+  topology table remains historical rather than mutation authority.
 
 ## Outcome first: the revised order
 
 The old list mixed completed recovery with future work. The current order is:
 
-1. **Complete GIT-001 Phase 8 from a fresh lane.** Phases 1-7E are integrated;
-   reconcile stale status text, verify adoption from recent exact-head task
-   receipts, and refresh preservation holds without mutating retained lanes.
+1. **GIT-001 Phase 8 closes on merge of its unchanged packet.** Phases 1-7E
+   remain integrated; adoption, stale status, transition-receipt semantics,
+   and preservation holds are reconciled without mutating retained lanes.
 2. **Decide Excel planning ownership.** It has no unique commits and no PR, so
    one owner decision determines whether it remains active or may enter a
    separately evidenced retirement assessment.
@@ -371,17 +377,17 @@ disposition. No single script answers the ownership and recoverability question.
 - **Editing shared surfaces from parallel lanes.** Generated indexes, task and
   session records, registries, routes, manifests, and lockfiles need one owner.
 
-## Completion definition for this plan
+## Phase 8 closeout and reactivation
 
-This plan is fulfilled when:
+Phase 8 is fulfilled when its unchanged adoption packet merges with focused,
+hosted, and exact-tree closeout evidence. Unknown retained topology is a safe
+closeout state, not an instruction to keep GIT-001 active indefinitely.
 
-- Phases 1-7E remain integrated and their preserved evidence is not reopened or
-  reconciled without new authorization;
-- Excel has a named active owner/next action or an approved retirement receipt;
-- the three Alpha worktrees are either explicitly retained or safely retired
-  under exact approval;
-- the eight-branch table has an owner decision and any approved actions have
-  post-action receipts;
-- each dependency group is completed, held with a named reason, or deliberately
-  superseded on a current base;
-- completed PMM and PR #723 recovery is not reopened without new evidence.
+Future disposition work reactivates only after new authority or evidence:
+
+- Excel needs a named owner/next action and exact retention decision;
+- Alpha and the historical branch table need fresh classifier inputs plus
+  separate exact-target approval before any action;
+- dependency groups remain separate compatibility packets after INDIA-2;
+- completed PMM and PR #723 recovery stays closed absent new evidence; and
+- no hold, candidate, or merged PR authorizes cleanup by itself.

--- a/docs/research/git-governance/GIT-001-phase-8-adoption-closeout.md
+++ b/docs/research/git-governance/GIT-001-phase-8-adoption-closeout.md
@@ -1,0 +1,127 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-16
+doc_type: reference
+task: GIT-001-P8-RECONCILIATION
+---
+
+# GIT-001 Phase 8 — Adoption and Preservation Closeout
+
+## Decision
+
+Phase 8 accepts the GIT-7E operating model as adopted with one closeout-
+evidence correction. Recent packets used the read-only Git-state authority,
+source-bound worktrees, exact-head hosted checks, and squash-tree comparison.
+Their final GitHub and tree outcomes are sound. Their stored task-to-Git JSON
+files are pre-publication transition snapshots, however, not permanent final-
+merge receipts. They correctly become invalid when their time-bound external
+observations become stale.
+
+The maintenance rule is therefore explicit: use a handoff receipt only for the
+decision boundary and observation time it records. A later closeout observer
+must bind the final PR head, hosted checks, merge commit, and merged tree from
+fresh evidence. Never rewrite a historical receipt to make it appear current.
+The complete machine-readable snapshot is
+[`GIT-001-phase-8-adoption-evidence.json`](GIT-001-phase-8-adoption-evidence.json).
+
+No cleanup decision is made. Primary and `e54a` are retained. Every other
+pre-existing lane remains `UNKNOWN/HOLD`; none is retirement-ready.
+
+## Exact Phase 7 integration
+
+| PR | Base | Reviewed head | Merge | Tree equality | Hosted result |
+|---|---|---|---|---|---|
+| #751 | `b91838f5` | `dd1b0ab9` | `6bcbd9d3` | `f1b38e17` = `f1b38e17` | 6 passed, 2 skipped, 0 failed |
+| #752 | `6bcbd9d3` | `0690f745` | `96f193bd` | `8f38c8d4` = `8f38c8d4` | 5 passed, 3 skipped, 0 failed |
+
+Both merge commits are reachable from fetched
+`origin/main = 86f92ed16164a97b7cbb1edacd64a50a5a71e13d`. This closes the
+stale parent claim that GIT-7E implementation remained active.
+
+## Adoption sample
+
+The bounded sample covers combined-family acceptance, STRAP-D, strap-family
+acceptance, and planning PR #799.
+
+| Task / PR | Reviewed head | Merge | Tree equality | Hosted result |
+|---|---|---|---|---|
+| Combined acceptance / #792 | `490b10a8` | `8e039b11` | `873aea4c` = `873aea4c` | 6 passed, 2 skipped, 0 failed |
+| STRAP-D / #797 | `c107993b` | `b75daa97` | `af2695a8` = `af2695a8` | 7 passed, 1 skipped, 0 failed |
+| Strap acceptance / #798 | `7f480cb5` | `f56e1ec3` | `28698a28` = `28698a28` | 6 passed, 2 skipped, 0 failed |
+| Planning / #799 | `81368eae` | `339bad21` | `ecd7fe38` = `ecd7fe38` | 5 passed, 3 skipped, 0 failed |
+
+Each session records `source_bound=true` and completion of exact-head review.
+GitHub independently confirms the exact final PR heads and successful required
+gates, and local object comparison proves reviewed/merged tree equality and
+current-main reachability.
+
+The durable gap is narrower: the session records do not persist an independent
+audit result bound to its exact final head and tree. The four named JSON
+receipts capture dirty pre-publication states and no final PR/integration
+section. Running their maintained validator now fails with the same stale-
+evidence hold-set errors. That is correct fail-closed behavior, not receipt
+corruption; it means these files cannot be presented as current or final
+closeout proof.
+
+## Preservation and disposition
+
+The single canonical worktree census at `2026-08-16T13:41:21Z` reported 62
+worktrees including this new packet lane, with no query failure.
+
+| Target | Current evidence | Decision |
+|---|---|---|
+| Primary `main` | clean at fetched `86f92ed1`, tree `1bb7e448`, exactly equal to `origin/main` | `RETAIN` integration anchor |
+| Detached `e54a` | `0fdb48ed`; only `docs/SESSION_LOG.md` dirty; 119 insertions/7 deletions; exact dirty blob differs from main | `RETAIN` untouched |
+| Excel planning | clean attached `a0e115e1`; 0 ahead/119 behind; no remote feature ref or PR | `HOLD_UNKNOWN_OWNER` |
+| All other pre-existing lanes | no new owner/retention evidence capable of changing prior holds | aggregate `UNKNOWN/HOLD` |
+| Phase 8 packet lane | fresh, source-bound, `READY_LOCAL` | retain after closeout unless separately authorized |
+
+For `e54a`, the exact worktree file SHA-256 is
+`35903e436ce2bf90752c62ef8e4ae3e162e23f7a4b6ebc97e1ddfbc0a6af3cb9`;
+current main is
+`9cf3f9c3ec0c321bd8ba25b53153f406e7dcf88be2e4c9915325b566f67c099b`.
+Main contains the material GIT-7C1/GIT-7C2 outcome, but the dirty blob is not
+identical and the owner explicitly required the lane to remain untouched.
+
+The only fresh classifier pass was therefore the outcome-changing Excel lane.
+The caller evidence is
+[`GIT-001-phase-8-excel-disposition-evidence.json`](GIT-001-phase-8-excel-disposition-evidence.json).
+The inspection-only classifier returned `HOLD_UNKNOWN_OWNER` with
+`OWNER_UNKNOWN` and `RETENTION_EVIDENCE_UNKNOWN`. The absence of unique commits,
+a remote branch, and a PR does not answer whether the external planning task
+still needs its worktree.
+
+## Root cause and recurrence guard
+
+### Historical transition receipts were treated as permanent closeout proof
+
+- Symptom: all four named sample receipts fail current validation, and none
+  records its final PR head, hosted checks, merge commit, or merged tree.
+- Main-process impact: a later agent could either describe stale evidence as
+  current or incorrectly conclude that a successful integration was invalid.
+- Confirmed root cause: the plan sampled time-bound pre-publication handoffs as
+  though they were immutable final-closeout receipts. The validator correctly
+  recomputes freshness and holds; a pre-merge tree also cannot know its future
+  squash identity.
+- Fix: bind final PR and tree facts in this fresh Phase 8 successor observation
+  and clarify the transition-versus-closeout rule in the canonical workflow.
+- Proof: PRs #751, #752, #792, #797, #798, and #799 have unchanged reviewed
+  heads, no failed hosted checks, equal reviewed/merged trees, and merge commits
+  reachable from current `origin/main`; all four old receipts fail only with
+  stale authorization/retention hold-set errors.
+- Recurrence control: never mutate a historical transition receipt to appear
+  current; create a new observation-bound closeout record and bind exact
+  hosted/merge identities there.
+
+## Closeout boundary
+
+This packet changes no product, structural arithmetic, capability, endpoint,
+release, or professional-approval claim. It mutates no pre-existing branch,
+worktree, dirty path, stash, issue, pull request, or GitHub setting. The only
+new lane is `codex/git-001-phase8-reconciliation` from fetched current main.
+
+After the unchanged candidate passes focused Git-governance tests, semantic
+guidance, links/indexes, quick `10/10`, normal hooks, hosted checks, and merge-
+tree verification, GIT-001 Phase 8 is complete with preserved holds. The sole
+next packet is `DOC-FRONTMATTER-CONTRACT`.

--- a/docs/research/git-governance/GIT-001-phase-8-adoption-evidence.json
+++ b/docs/research/git-governance/GIT-001-phase-8-adoption-evidence.json
@@ -1,0 +1,263 @@
+{
+  "schema_version": 1,
+  "task_id": "GIT-001-P8-RECONCILIATION",
+  "evidence_kind": "phase_8_adoption_and_preservation_snapshot",
+  "status": "CANDIDATE_READY_FOR_HOSTED_CLOSEOUT",
+  "observed_at_utc": "2026-08-16T13:46:29.152902+00:00",
+  "authorization_boundary": {
+    "authorized": [
+      "CREATE_FRESH_PACKET_BRANCH_AND_WORKTREE",
+      "READ_LOCAL_AND_GITHUB_STATE",
+      "UPDATE_PHASE_8_EVIDENCE_AND_CURRENT_STATUS",
+      "NORMAL_PACKET_PUBLICATION_AND_UNCHANGED_GREEN_MERGE"
+    ],
+    "prohibited": [
+      "MUTATE_PREEXISTING_BRANCH_OR_WORKTREE",
+      "RESET_OR_STASH",
+      "DELETE_BRANCH_REF_OR_WORKTREE",
+      "CLOSE_ISSUE_OR_PULL_REQUEST",
+      "CHANGE_GITHUB_SETTINGS",
+      "PUBLISH_RELEASE",
+      "START_NEXT_PACKET"
+    ],
+    "receipt_grants_authority": false
+  },
+  "baseline": {
+    "fetch_observation_window_utc": {
+      "after": "2026-08-16T13:40:14.557969Z",
+      "before": "2026-08-16T13:41:14.962417Z"
+    },
+    "origin_main_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+    "origin_main_tree_sha": "1bb7e448fd26208ba2227b1d9e2f3f0f976ed46e",
+    "primary": {
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib",
+      "branch": "main",
+      "head_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+      "tree_clean": true,
+      "equal_to_origin_main": true,
+      "decision": "RETAIN"
+    },
+    "packet_lane": {
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-git-001-p8",
+      "branch": "codex/git-001-phase8-reconciliation",
+      "base_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+      "derived_action": "READY_LOCAL",
+      "source_bound": true,
+      "operation": "none"
+    }
+  },
+  "phase_7_integration": [
+    {
+      "pull_request": 751,
+      "base_sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
+      "reviewed_head_sha": "dd1b0ab97d6900ee97e07d3ad66d716c576a787b",
+      "reviewed_tree_sha": "f1b38e17e932e8e84c06cca23061aec97351c699",
+      "merge_commit_sha": "6bcbd9d3e082ea41bcba1d3858fcfa7deb77fa75",
+      "merged_tree_sha": "f1b38e17e932e8e84c06cca23061aec97351c699",
+      "reviewed_tree_matches_merged_tree": true,
+      "reachable_from_origin_main": true,
+      "hosted_checks": {
+        "passed": 6,
+        "skipped": 2,
+        "failed": 0,
+        "required_gate": "SUCCESS"
+      }
+    },
+    {
+      "pull_request": 752,
+      "base_sha": "6bcbd9d3e082ea41bcba1d3858fcfa7deb77fa75",
+      "reviewed_head_sha": "0690f74504b780f7920828a7ea0cd0e0dda4149c",
+      "reviewed_tree_sha": "8f38c8d40033010a011e9eb38c9519f3347d381c",
+      "merge_commit_sha": "96f193bd45a21f05698cf64de47808a2e5f82640",
+      "merged_tree_sha": "8f38c8d40033010a011e9eb38c9519f3347d381c",
+      "reviewed_tree_matches_merged_tree": true,
+      "reachable_from_origin_main": true,
+      "hosted_checks": {
+        "passed": 5,
+        "skipped": 3,
+        "failed": 0,
+        "required_gate": "SUCCESS"
+      }
+    }
+  ],
+  "adoption_sample": [
+    {
+      "task_id": "INDIA-2-FOUNDATION-COMBINED-ACCEPTANCE",
+      "receipt_path": "docs/verification/india-2-foundation-combined-acceptance-git-handoff-receipt.json",
+      "receipt_observed_at_utc": "2026-08-16T09:29:28.309144+00:00",
+      "receipt_role": "PREPUBLICATION_TRANSITION_SNAPSHOT",
+      "receipt_current_validation": "EXPECTED_STALE_HOLD_SET_FAILURE",
+      "source_bound_session_evidence": true,
+      "immutable_audit_session_claim": "COMPLETED_WITHOUT_DURABLE_HEAD_TREE_BINDING",
+      "pull_request": 792,
+      "base_sha": "079ca22b00744ca9b01f859be0b64333b5830fcb",
+      "reviewed_head_sha": "490b10a8e567fb6af6fa0398c90f62388da555b4",
+      "reviewed_tree_sha": "873aea4cdca8aa9633b30a7c9b74138e5a73a6ce",
+      "merge_commit_sha": "8e039b112e38436fcae36326b46afa9c436fb970",
+      "merged_tree_sha": "873aea4cdca8aa9633b30a7c9b74138e5a73a6ce",
+      "reviewed_tree_matches_merged_tree": true,
+      "reachable_from_origin_main": true,
+      "hosted_checks": {
+        "passed": 6,
+        "skipped": 2,
+        "failed": 0,
+        "required_gate": "SUCCESS"
+      }
+    },
+    {
+      "task_id": "INDIA-2-FOUNDATION-STRAP-D",
+      "receipt_path": "docs/verification/india-2-foundation-strap-d-git-handoff-receipt.json",
+      "receipt_observed_at_utc": "2026-08-16T11:40:19.741865+00:00",
+      "receipt_role": "PREPUBLICATION_TRANSITION_SNAPSHOT",
+      "receipt_current_validation": "EXPECTED_STALE_HOLD_SET_FAILURE",
+      "source_bound_session_evidence": true,
+      "immutable_audit_session_claim": "COMPLETED_WITHOUT_DURABLE_HEAD_TREE_BINDING",
+      "pull_request": 797,
+      "base_sha": "e3e4b2ae5d6559472c2e6595ce05d36887b32a1c",
+      "reviewed_head_sha": "c107993b2a68cd7e92903424c89ebe3063f7f791",
+      "reviewed_tree_sha": "af2695a815bb0a71898d58e98a70109b7dd5c2b4",
+      "merge_commit_sha": "b75daa970b2976cbd5d51e9a951926a7946d5fa6",
+      "merged_tree_sha": "af2695a815bb0a71898d58e98a70109b7dd5c2b4",
+      "reviewed_tree_matches_merged_tree": true,
+      "reachable_from_origin_main": true,
+      "hosted_checks": {
+        "passed": 7,
+        "skipped": 1,
+        "failed": 0,
+        "required_gate": "SUCCESS"
+      }
+    },
+    {
+      "task_id": "INDIA-2-FOUNDATION-STRAP-ACCEPTANCE",
+      "receipt_path": "docs/verification/india-2-foundation-strap-acceptance-git-handoff-receipt.json",
+      "receipt_observed_at_utc": "2026-08-16T11:55:32.244117+00:00",
+      "receipt_role": "PREPUBLICATION_TRANSITION_SNAPSHOT",
+      "receipt_current_validation": "EXPECTED_STALE_HOLD_SET_FAILURE",
+      "source_bound_session_evidence": true,
+      "immutable_audit_session_claim": "COMPLETED_WITHOUT_DURABLE_HEAD_TREE_BINDING",
+      "pull_request": 798,
+      "base_sha": "b75daa970b2976cbd5d51e9a951926a7946d5fa6",
+      "reviewed_head_sha": "7f480cb54d898797dab3856c2cb3972ce57a110f",
+      "reviewed_tree_sha": "28698a28d96f3e5cbad26fd6964cf835cda6e1b4",
+      "merge_commit_sha": "f56e1ec312902caf98e872c77ce8b71bdbc8440e",
+      "merged_tree_sha": "28698a28d96f3e5cbad26fd6964cf835cda6e1b4",
+      "reviewed_tree_matches_merged_tree": true,
+      "reachable_from_origin_main": true,
+      "hosted_checks": {
+        "passed": 6,
+        "skipped": 2,
+        "failed": 0,
+        "required_gate": "SUCCESS"
+      }
+    },
+    {
+      "task_id": "NEXT-SESSION-GIT-ISSUES-AND-INDIA-2",
+      "receipt_path": "docs/verification/next-session-git-issues-plan-git-handoff-receipt.json",
+      "receipt_observed_at_utc": "2026-08-16T12:18:25.088076+00:00",
+      "receipt_role": "PREPUBLICATION_TRANSITION_SNAPSHOT",
+      "receipt_current_validation": "EXPECTED_STALE_HOLD_SET_FAILURE",
+      "source_bound_session_evidence": true,
+      "immutable_audit_session_claim": "COMPLETED_WITHOUT_DURABLE_HEAD_TREE_BINDING",
+      "pull_request": 799,
+      "base_sha": "f56e1ec312902caf98e872c77ce8b71bdbc8440e",
+      "reviewed_head_sha": "81368eaeed3540ad8c2d356e89e5eef8bb4efbff",
+      "reviewed_tree_sha": "ecd7fe389409e4077afb37f17aee20fe5734cf0e",
+      "merge_commit_sha": "339bad2128bc00b34a18827a8ac185ebcdb069fd",
+      "merged_tree_sha": "ecd7fe389409e4077afb37f17aee20fe5734cf0e",
+      "reviewed_tree_matches_merged_tree": true,
+      "reachable_from_origin_main": true,
+      "hosted_checks": {
+        "passed": 5,
+        "skipped": 3,
+        "failed": 0,
+        "required_gate": "SUCCESS"
+      }
+    }
+  ],
+  "historical_receipt_validation": {
+    "command": "scripts/git_handoff_receipt.py validate <receipt>",
+    "sample_count": 4,
+    "currently_valid_count": 0,
+    "shared_errors": [
+      "HOLD_SET_MISMATCH",
+      "MISSING_REQUIRED_HOLD:AUTHORIZATION_SOURCE_STALE_EVIDENCE",
+      "MISSING_REQUIRED_HOLD:AUTHORIZATION_STALE_EVIDENCE",
+      "MISSING_REQUIRED_HOLD:RETENTION_STALE_EVIDENCE"
+    ],
+    "interpretation": "Expected fail-closed behavior for time-bound transition observations; these historical files are not current remote or final integration receipts"
+  },
+  "worktree_census": {
+    "observed_at_utc": "2026-08-16T13:41:21.294477+00:00",
+    "authority": "scripts/git_state.py --json --worktrees",
+    "total_worktrees_including_packet_lane": 62,
+    "preexisting_worktrees": 61,
+    "query_failures": [],
+    "decisions": {
+      "primary": "RETAIN",
+      "e54a": "RETAIN",
+      "other_preexisting_lanes": "UNKNOWN/HOLD",
+      "packet_lane": "RETAIN_AFTER_CLOSEOUT_UNLESS_SEPARATELY_AUTHORIZED"
+    }
+  },
+  "e54a_preservation": {
+    "path": "/Users/pravinsurawase/.codex/worktrees/e54a/structural_engineering_lib",
+    "head_sha": "0fdb48edbb73114288feb8a246d6f30b80ac4d95",
+    "branch": "DETACHED",
+    "operation": "none",
+    "dirty_paths": [
+      "docs/SESSION_LOG.md"
+    ],
+    "diff_insertions": 119,
+    "diff_deletions": 7,
+    "head_blob_sha": "bcdd9edaba84e920bb01f140d9a7301ae6f40a8d",
+    "worktree_blob_sha": "2c3d7ac8277953256c7c46d12b923180a99f9c14",
+    "worktree_file_sha256": "35903e436ce2bf90752c62ef8e4ae3e162e23f7a4b6ebc97e1ddfbc0a6af3cb9",
+    "origin_main_blob_sha": "11e82c4979c0c148f8ec25c98ff9f98f4ae88494",
+    "origin_main_file_sha256": "9cf3f9c3ec0c321bd8ba25b53153f406e7dcf88be2e4c9915325b566f67c099b",
+    "material_topic": "GIT-7C1 integration and GIT-7C2 settings proposal",
+    "material_outcome_present_on_main": true,
+    "exact_dirty_blob_matches_main": false,
+    "decision": "RETAIN",
+    "reason": "The owner directed that the lane remain untouched; it is detached and dirty, and no exact owner-backed retirement evidence or target authorization exists"
+  },
+  "excel_disposition": {
+    "evidence_path": "docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json",
+    "classifier_observed_at_utc": "2026-08-16T13:46:29.152902+00:00",
+    "branch": "codex/excel-product-planning",
+    "head_sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
+    "ahead_commit_count": 0,
+    "behind_commit_count": 119,
+    "remote_feature_ref": "ABSENT",
+    "pull_requests": "NONE_OPEN",
+    "attached_worktree_clean": true,
+    "disposition": "HOLD_UNKNOWN_OWNER",
+    "reason_codes": [
+      "OWNER_UNKNOWN",
+      "RETENTION_EVIDENCE_UNKNOWN"
+    ],
+    "next_action": "Hold until the repository owner names whether the external Excel planning task remains active and supplies an exact retention decision"
+  },
+  "adoption_decision": {
+    "git_state_used": true,
+    "source_binding_used": true,
+    "hosted_exact_head_checks_used": true,
+    "post_merge_tree_equivalence_used": true,
+    "immutable_review_claimed": true,
+    "immutable_review_durably_identity_bound": false,
+    "transition_receipts_mistaken_for_permanent_closeout_proof": true,
+    "outcome": "ADOPTED_WITH_CLOSEOUT_EVIDENCE_GUARD",
+    "maintenance_rule": "Use transition receipts only for their observed decision boundary; record final hosted and merge identity in a fresh successor closeout observation and never rewrite a historical receipt to appear current"
+  },
+  "mutation_summary": {
+    "created_packet_branch_and_worktree": true,
+    "fetched_origin_main_without_prune": true,
+    "preexisting_branches_mutated": 0,
+    "preexisting_worktrees_mutated": 0,
+    "preexisting_dirty_paths_mutated": 0,
+    "stashes_mutated": 0,
+    "github_settings_mutated": 0,
+    "issues_or_existing_pull_requests_mutated": 0,
+    "cleanup_or_deletion_actions": 0
+  },
+  "next_packet": "DOC-FRONTMATTER-CONTRACT"
+}

--- a/docs/research/git-governance/GIT-001-phase-8-adoption-evidence.json
+++ b/docs/research/git-governance/GIT-001-phase-8-adoption-evidence.json
@@ -3,7 +3,7 @@
   "task_id": "GIT-001-P8-RECONCILIATION",
   "evidence_kind": "phase_8_adoption_and_preservation_snapshot",
   "status": "CANDIDATE_READY_FOR_HOSTED_CLOSEOUT",
-  "observed_at_utc": "2026-08-16T13:46:29.152902+00:00",
+  "observed_at_utc": "2026-08-16T14:02:22.170580+00:00",
   "authorization_boundary": {
     "authorized": [
       "CREATE_FRESH_PACKET_BRANCH_AND_WORKTREE",
@@ -222,7 +222,7 @@
   },
   "excel_disposition": {
     "evidence_path": "docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json",
-    "classifier_observed_at_utc": "2026-08-16T13:46:29.152902+00:00",
+    "classifier_observed_at_utc": "2026-08-16T14:02:22.170580+00:00",
     "branch": "codex/excel-product-planning",
     "head_sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
     "ahead_commit_count": 0,

--- a/docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json
+++ b/docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "remote_freshness": {
+    "status": "OBSERVED_AT",
+    "observed_at_utc": "2026-08-16T13:45:19Z",
+    "default_ref": "origin/main",
+    "default_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d"
+  },
+  "authority_provenance": {
+    "source_task": "GIT-001-P8-RECONCILIATION",
+    "scope": "Read-only Phase 8 classification of the only retained lane whose current no-unique-commit evidence could otherwise change disposition",
+    "authorization_boundary": "No deletion, branch closure, ref removal, worktree removal, prune, cleanup, synchronization, or proposal-side authorization"
+  },
+  "branches": {
+    "codex/excel-product-planning": {
+      "owner": null,
+      "remote_ref": {
+        "status": "ABSENT",
+        "ref": "refs/heads/codex/excel-product-planning",
+        "sha": null
+      },
+      "pull_requests": {
+        "status": "NONE_OPEN",
+        "observed_at_utc": "2026-08-16T13:45:19Z",
+        "head_sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
+        "items": []
+      },
+      "retention": {
+        "status": "UNKNOWN",
+        "observed_at_utc": "2026-08-16T13:45:19Z",
+        "head_sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
+        "reason": "Git and GitHub prove no unique commit, remote feature ref, or pull request, but do not prove whether the external Excel planning task still needs the attached worktree"
+      }
+    }
+  }
+}

--- a/docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json
+++ b/docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "remote_freshness": {
     "status": "OBSERVED_AT",
-    "observed_at_utc": "2026-08-16T13:45:19Z",
+    "observed_at_utc": "2026-08-16T14:01:46Z",
     "default_ref": "origin/main",
     "default_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d"
   },
@@ -21,13 +21,13 @@
       },
       "pull_requests": {
         "status": "NONE_OPEN",
-        "observed_at_utc": "2026-08-16T13:45:19Z",
+        "observed_at_utc": "2026-08-16T14:01:46Z",
         "head_sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
         "items": []
       },
       "retention": {
         "status": "UNKNOWN",
-        "observed_at_utc": "2026-08-16T13:45:19Z",
+        "observed_at_utc": "2026-08-16T14:01:46Z",
         "head_sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
         "reason": "Git and GitHub prove no unique commit, remote feature ref, or pull request, but do not prove whether the external Excel planning task still needs the attached worktree"
       }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -2,21 +2,21 @@
   "folder": "docs/research/git-governance",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-15",
-  "file_count": 23,
+  "last_updated": "2026-08-16",
+  "file_count": 26,
   "files": [
     {
       "name": "GIT-001-README.md",
       "type": "documentation",
-      "size_lines": 107,
-      "last_updated": "2026-08-15",
+      "size_lines": 114,
+      "last_updated": "2026-08-16",
       "description": "This directory is the task-owned, non-normative research record for GIT-001. Its contents may describe official Git/GitHub/Codex facts, observed project",
-      "content_hash": "eb0ab1194fa8"
+      "content_hash": "202ae81df3dc"
     },
     {
       "name": "GIT-001-eight-branch-retirement-authorization-proposal.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "packet",
@@ -35,14 +35,14 @@
       "name": "GIT-001-eight-branch-retirement-authorization-proposal.md",
       "type": "documentation",
       "size_lines": 118,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "All eight exact targets remain held. The integrated classifier returned HOLD_UNKNOWN_OWNER with reason code RETENTION_EVIDENCE_UNKNOWN for every",
       "content_hash": "4dab788cb748"
     },
     {
       "name": "GIT-001-eight-branch-retirement-classifier-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "remote_freshness",
@@ -55,23 +55,23 @@
       "name": "GIT-001-lifecycle-research.md",
       "type": "documentation",
       "size_lines": 192,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This is a source-backed, non-normative map. It does not replace the canonical workflow and does not authorize policy, settings, cleanup, or release changes.",
       "content_hash": "8a2c9f510b77"
     },
     {
       "name": "GIT-001-next-agent-disposition-plan.md",
       "type": "documentation",
-      "size_lines": 384,
-      "last_updated": "2026-08-15",
+      "size_lines": 394,
+      "last_updated": "2026-08-16",
       "description": "This packet converts the original six-priority cleanup and recovery list into a current, evidence-backed handoff. It tells the next agent what is already done,",
-      "content_hash": "29d8c057cdc4"
+      "content_hash": "173f950b9d1c"
     },
     {
       "name": "GIT-001-official-evidence-register.md",
       "type": "documentation",
       "size_lines": 147,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Only primary, official sources belong in the source tables. A source supports a bounded external fact; it does not create project policy. Project observations,",
       "content_hash": "2fb0b91dbc96"
     },
@@ -79,7 +79,7 @@
       "name": "GIT-001-phase-0-preservation-baseline.md",
       "type": "documentation",
       "size_lines": 165,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "- Observation time: 2026-08-12T21:17:05+05:30 - Repository: Pravin-surawase/structural_engineering_lib",
       "content_hash": "6d737c63cb6d"
     },
@@ -87,7 +87,7 @@
       "name": "GIT-001-phase-2-incident-register.md",
       "type": "documentation",
       "size_lines": 350,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This register traces confirmed Git, worktree, automation, CI, release, and recovery failures from this repository. It is forensic evidence for the later",
       "content_hash": "e94fe169b0f7"
     },
@@ -95,7 +95,7 @@
       "name": "GIT-001-phase-3-gap-risk-matrix.md",
       "type": "documentation",
       "size_lines": 234,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "This matrix compares five evidence layers: 1. official Git/GitHub/Codex facts from Phase 1;",
       "content_hash": "c4c66d7f8b7e"
     },
@@ -103,7 +103,7 @@
       "name": "GIT-001-phase-4-operating-model.md",
       "type": "documentation",
       "size_lines": 429,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Use a **preservation-first, evidence-separated, Codex-native** operating model: - one task, one attached worktree, one branch, and one named integration owner;",
       "content_hash": "2648d526bef2"
     },
@@ -111,7 +111,7 @@
       "name": "GIT-001-phase-5-scenario-validation.md",
       "type": "documentation",
       "size_lines": 227,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "Phase 5 tests whether the proposed operating model is grounded in observable Git/GitHub behavior and whether every implementation packet has a falsifiable",
       "content_hash": "c58cdf2724e1"
     },
@@ -119,7 +119,7 @@
       "name": "GIT-001-phase-6-canonical-policy-proposal.md",
       "type": "documentation",
       "size_lines": 264,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "state and intake kernel, as the first implementation packet.** Do not yet authorize GitHub ruleset changes, CI topology changes, generated-data",
       "content_hash": "8bb49d830e7b"
     },
@@ -127,7 +127,7 @@
       "name": "GIT-001-phase-7A-preservation-workflow-recovery.md",
       "type": "documentation",
       "size_lines": 82,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "The repository owner authorized Git operations, merge/deletion when proven safe, parallel subagents, preservation of Column PMM, and selective recovery of",
       "content_hash": "3a5222567115"
     },
@@ -135,7 +135,7 @@
       "name": "GIT-001-phase-7B-state-intake-kernel.md",
       "type": "documentation",
       "size_lines": 149,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "The repository owner accepted Phase 6 and authorized GIT-7B on 2026-08-13. This packet implements only the read-only Git state authority, task intake,",
       "content_hash": "66c215280a81"
     },
@@ -143,7 +143,7 @@
       "name": "GIT-001-phase-7C1-required-ci-topology.md",
       "type": "documentation",
       "size_lines": 148,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "After GIT-7B merged through PR #744, the repository owner authorized the next planned workflow packet for publication as a draft PR on 2026-08-14. This",
       "content_hash": "bb370fb77675"
     },
@@ -151,14 +151,14 @@
       "name": "GIT-001-phase-7C2-server-enforcement.md",
       "type": "documentation",
       "size_lines": 93,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "The owner explicitly authorized the documented GIT-7C2 settings delta and autonomous verification/rollback on 2026-08-15. The change was applied only",
       "content_hash": "494e0c9d67de"
     },
     {
       "name": "GIT-001-phase-7D-cleanup-reconciliation.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "receipt_id",
@@ -177,7 +177,7 @@
       "name": "GIT-001-phase-7D-cleanup-reconciliation.md",
       "type": "documentation",
       "size_lines": 206,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "GIT-7D is complete as an inspection and control packet. GIT-7D1 targeted index generation is integrated through PR #746. GIT-7D2 inspection-only branch",
       "content_hash": "2644ecdaae12"
     },
@@ -185,7 +185,7 @@
       "name": "GIT-001-phase-7D1-targeted-index-generation.md",
       "type": "documentation",
       "size_lines": 93,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "GIT-7D is split so the incident-producing generator route can be corrected without combining it with branch/worktree disposition logic. This packet owns",
       "content_hash": "612cc39c216d"
     },
@@ -193,22 +193,22 @@
       "name": "GIT-001-phase-7D2-branch-disposition.md",
       "type": "documentation",
       "size_lines": 144,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "description": "GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale_branches.py path with",
       "content_hash": "a51ad88ca239"
     },
     {
       "name": "GIT-001-phase-7E-semantic-handoff.md",
       "type": "documentation",
-      "size_lines": 100,
-      "last_updated": "2026-08-15",
+      "size_lines": 109,
+      "last_updated": "2026-08-16",
       "description": "GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-semantic-handoff from freshly fetched and independently verified",
-      "content_hash": "f80001d77308"
+      "content_hash": "03f597b86a35"
     },
     {
       "name": "GIT-001-phase-7E-task-git-handoff.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -222,8 +222,46 @@
         "receipt_kind"
       ],
       "content_hash": "aab116932ebd"
+    },
+    {
+      "name": "GIT-001-phase-8-adoption-closeout.md",
+      "type": "documentation",
+      "size_lines": 128,
+      "last_updated": "2026-08-16",
+      "description": "Phase 8 accepts the GIT-7E operating model as adopted with one closeout- evidence correction. Recent packets used the read-only Git-state authority,",
+      "content_hash": "397428bac59f"
+    },
+    {
+      "name": "GIT-001-phase-8-adoption-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "schema_version",
+        "task_id",
+        "evidence_kind",
+        "status",
+        "observed_at_utc",
+        "authorization_boundary",
+        "baseline",
+        "phase_7_integration",
+        "adoption_sample",
+        "historical_receipt_validation"
+      ],
+      "content_hash": "30df35b9c712"
+    },
+    {
+      "name": "GIT-001-phase-8-excel-disposition-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "schema_version",
+        "remote_freshness",
+        "authority_provenance",
+        "branches"
+      ],
+      "content_hash": "48703659aa36"
     }
   ],
   "subfolders": [],
-  "content_hash": "8cdda2122458f974"
+  "content_hash": "738b0a5d10488c8b"
 }

--- a/docs/research/git-governance/index.json
+++ b/docs/research/git-governance/index.json
@@ -247,7 +247,7 @@
         "adoption_sample",
         "historical_receipt_validation"
       ],
-      "content_hash": "30df35b9c712"
+      "content_hash": "a98b1862c797"
     },
     {
       "name": "GIT-001-phase-8-excel-disposition-evidence.json",
@@ -259,9 +259,9 @@
         "authority_provenance",
         "branches"
       ],
-      "content_hash": "48703659aa36"
+      "content_hash": "fceac56fed5c"
     }
   ],
   "subfolders": [],
-  "content_hash": "738b0a5d10488c8b"
+  "content_hash": "e9c8a2caebf59c0d"
 }

--- a/docs/research/git-governance/index.md
+++ b/docs/research/git-governance/index.md
@@ -1,8 +1,8 @@
 # Git Governance
 
 **Type:** Documentation
-**Last Updated:** 2026-08-15
-**Files:** 23
+**Last Updated:** 2026-08-16
+**Files:** 26
 
 ## Config Files
 
@@ -10,15 +10,17 @@
 - [GIT-001-eight-branch-retirement-classifier-evidence.json](GIT-001-eight-branch-retirement-classifier-evidence.json)
 - [GIT-001-phase-7D-cleanup-reconciliation.json](GIT-001-phase-7D-cleanup-reconciliation.json)
 - [GIT-001-phase-7E-task-git-handoff.json](GIT-001-phase-7E-task-git-handoff.json)
+- [GIT-001-phase-8-adoption-evidence.json](GIT-001-phase-8-adoption-evidence.json)
+- [GIT-001-phase-8-excel-disposition-evidence.json](GIT-001-phase-8-excel-disposition-evidence.json)
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 107 |
+| [GIT-001-README.md](GIT-001-README.md) |  | This directory is the task-owned, non-normative research rec | 114 |
 | [GIT-001-eight-branch-retirement-authorization-proposal.md](GIT-001-eight-branch-retirement-authorization-proposal.md) |  | All eight exact targets remain held. The integrated classifi | 118 |
 | [GIT-001-lifecycle-research.md](GIT-001-lifecycle-research.md) |  | This is a source-backed, non-normative map. It does not repl | 192 |
-| [GIT-001-next-agent-disposition-plan.md](GIT-001-next-agent-disposition-plan.md) |  | This packet converts the original six-priority cleanup and r | 384 |
+| [GIT-001-next-agent-disposition-plan.md](GIT-001-next-agent-disposition-plan.md) |  | This packet converts the original six-priority cleanup and r | 394 |
 | [GIT-001-official-evidence-register.md](GIT-001-official-evidence-register.md) |  | Only primary, official sources belong in the source tables.  | 147 |
 | [GIT-001-phase-0-preservation-baseline.md](GIT-001-phase-0-preservation-baseline.md) |  | - Observation time: 2026-08-12T21:17:05+05:30 - Repository:  | 165 |
 | [GIT-001-phase-2-incident-register.md](GIT-001-phase-2-incident-register.md) |  | This register traces confirmed Git, worktree, automation, CI | 350 |
@@ -33,4 +35,5 @@
 | [GIT-001-phase-7D-cleanup-reconciliation.md](GIT-001-phase-7D-cleanup-reconciliation.md) |  | GIT-7D is complete as an inspection and control packet. GIT- | 206 |
 | [GIT-001-phase-7D1-targeted-index-generation.md](GIT-001-phase-7D1-targeted-index-generation.md) |  | GIT-7D is split so the incident-producing generator route ca | 93 |
 | [GIT-001-phase-7D2-branch-disposition.md](GIT-001-phase-7D2-branch-disposition.md) |  | GIT-7D2 replaces the deletion-oriented scripts/cleanup_stale | 144 |
-| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 100 |
+| [GIT-001-phase-7E-semantic-handoff.md](GIT-001-phase-7E-semantic-handoff.md) |  | GIT-7E started at 2026-08-15T09:12:34Z on codex/git-7e-seman | 109 |
+| [GIT-001-phase-8-adoption-closeout.md](GIT-001-phase-8-adoption-closeout.md) |  | Phase 8 accepts the GIT-7E operating model as adopted with o | 128 |

--- a/docs/verification/git-001-phase-8-reconciliation-git-handoff-receipt.json
+++ b/docs/verification/git-001-phase-8-reconciliation-git-handoff-receipt.json
@@ -1,0 +1,188 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-16T13:54:52Z",
+      "query_status": "OK",
+      "reference": "task:GIT-001-P8-RECONCILIATION:user-request-start-the-published-next-work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-16T13:54:52Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "MUTATE_PREEXISTING_BRANCH_OR_WORKTREE",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "DISCARD_USER_CHANGE",
+      "CLOSE_PULL_REQUEST",
+      "CHANGE_GITHUB_SETTINGS",
+      "PUBLISH_RELEASE",
+      "START_NEXT_PACKET"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/git-001-phase8-reconciliation",
+      "head_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+      "task_id": "GIT-001-P8-RECONCILIATION"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "9e029c7a421ccbdf78551340494dcd6b76f648195443af11f934e9c06c182247",
+    "state": {
+      "branch": "codex/git-001-phase8-reconciliation",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 90.797,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-git-001-p8",
+      "head_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+      "hold_reasons": [
+        "changed paths: 20"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-16T13:56:05.966320+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-git-001-p8",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 20,
+        "modified_paths": [
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/git-automation/git-workflow-single-source.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/index.json",
+          "docs/planning/index.md",
+          "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
+          "docs/planning/next-session-brief.md",
+          "docs/research/git-governance/GIT-001-README.md",
+          "docs/research/git-governance/GIT-001-next-agent-disposition-plan.md",
+          "docs/research/git-governance/index.json",
+          "docs/research/git-governance/index.md",
+          "docs/verification/index.json",
+          "docs/verification/index.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/research/git-governance/GIT-001-phase-8-adoption-closeout.md",
+          "docs/research/git-governance/GIT-001-phase-8-adoption-evidence.json",
+          "docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json",
+          "docs/verification/git-001-phase-8-reconciliation-git-handoff-receipt.json",
+          "docs/verification/git-001-phase-8-reconciliation-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-git-001-p8"
+    }
+  },
+  "local_state_receipt_hash": "sha256:9e029c7a421ccbdf78551340494dcd6b76f648195443af11f934e9c06c182247",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-16T13:56:05.966498+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-16T13:54:52Z",
+    "owner": "Main Agent under the repository owner's request to start only the published Phase 8 packet and preserve retained lanes",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib",
+      "fastapi_app",
+      "react_app",
+      "private_sources",
+      ".codex/config.toml",
+      "refs"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "docs/research/git-governance/GIT-001-phase-8-adoption-closeout.md",
+      "docs/research/git-governance/GIT-001-phase-8-adoption-evidence.json",
+      "docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json",
+      "docs/verification/git-001-phase-8-reconciliation-git-handoff-source-evidence.json",
+      "docs/verification/git-001-phase-8-reconciliation-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "docs/research/git-governance/GIT-001-README.md",
+      "docs/research/git-governance/GIT-001-next-agent-disposition-plan.md",
+      "docs/git-automation/git-workflow-single-source.md",
+      "docs/TASKS.md",
+      "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
+      "docs/planning/next-session-brief.md",
+      "docs/SESSION_LOG.md",
+      "docs/index.json",
+      "docs/index.md",
+      "docs/research/git-governance/index.json",
+      "docs/research/git-governance/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md"
+    ],
+    "task_id": "GIT-001-P8-RECONCILIATION"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/git-001-phase-8-reconciliation-git-handoff-receipt.json
+++ b/docs/verification/git-001-phase-8-reconciliation-git-handoff-receipt.json
@@ -2,7 +2,7 @@
   "authorization": {
     "authority_source": {
       "kind": "USER_DELEGATION",
-      "observed_at_utc": "2026-08-16T13:54:52Z",
+      "observed_at_utc": "2026-08-16T14:01:46Z",
       "query_status": "OK",
       "reference": "task:GIT-001-P8-RECONCILIATION:user-request-start-the-published-next-work",
       "status": "OBSERVED"
@@ -13,7 +13,7 @@
       "CREATE_OR_UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-16T13:54:52Z",
+    "observed_at_utc": "2026-08-16T14:01:46Z",
     "prohibited_actions": [
       "MERGE_BEFORE_REQUIRED_CHECKS",
       "MUTATE_PREEXISTING_BRANCH_OR_WORKTREE",
@@ -35,7 +35,7 @@
         "CREATE_OR_UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-001-phase8-reconciliation",
-      "head_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+      "head_sha": "25777a22807b2bb60ddd4e20eaa0d2469a26624b",
       "task_id": "GIT-001-P8-RECONCILIATION"
     }
   },
@@ -52,27 +52,27 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "9e029c7a421ccbdf78551340494dcd6b76f648195443af11f934e9c06c182247",
+    "receipt_sha256": "737815d0375b03266cc38164eaa10ee51d886485eb3167784859ad0c5cd15480",
     "state": {
       "branch": "codex/git-001-phase8-reconciliation",
       "default_base": {
-        "ahead": 0,
+        "ahead": 1,
         "behind": 0,
         "ref": "origin/main",
         "sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
-        "status": "equal"
+        "status": "ahead"
       },
       "derived_action": "HOLD_DIRTY",
-      "duration_ms": 90.797,
+      "duration_ms": 90.941,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-git-001-p8",
-      "head_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+      "head_sha": "25777a22807b2bb60ddd4e20eaa0d2469a26624b",
       "hold_reasons": [
-        "changed paths: 20"
+        "changed paths: 4"
       ],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-16T13:56:05.966320+00:00",
+      "observed_at_utc": "2026-08-16T14:03:01.907657+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -83,46 +83,29 @@
       "tree": {
         "clean": false,
         "conflicted_paths": [],
-        "dirty_count": 20,
+        "dirty_count": 4,
         "modified_paths": [
           "docs/SESSION_LOG.md",
-          "docs/TASKS.md",
-          "docs/git-automation/git-workflow-single-source.md",
-          "docs/index.json",
-          "docs/index.md",
-          "docs/planning/index.json",
-          "docs/planning/index.md",
-          "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
-          "docs/planning/next-session-brief.md",
-          "docs/research/git-governance/GIT-001-README.md",
-          "docs/research/git-governance/GIT-001-next-agent-disposition-plan.md",
-          "docs/research/git-governance/index.json",
-          "docs/research/git-governance/index.md",
-          "docs/verification/index.json",
-          "docs/verification/index.md"
-        ],
-        "staged_paths": [],
-        "untracked_paths": [
-          "docs/research/git-governance/GIT-001-phase-8-adoption-closeout.md",
           "docs/research/git-governance/GIT-001-phase-8-adoption-evidence.json",
           "docs/research/git-governance/GIT-001-phase-8-excel-disposition-evidence.json",
-          "docs/verification/git-001-phase-8-reconciliation-git-handoff-receipt.json",
           "docs/verification/git-001-phase-8-reconciliation-git-handoff-source-evidence.json"
-        ]
+        ],
+        "staged_paths": [],
+        "untracked_paths": []
       },
       "upstream": {
-        "ahead": 0,
+        "ahead": 1,
         "behind": 0,
         "ref": "origin/main",
         "sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
-        "status": "equal"
+        "status": "ahead"
       },
       "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-git-001-p8"
     }
   },
-  "local_state_receipt_hash": "sha256:9e029c7a421ccbdf78551340494dcd6b76f648195443af11f934e9c06c182247",
+  "local_state_receipt_hash": "sha256:737815d0375b03266cc38164eaa10ee51d886485eb3167784859ad0c5cd15480",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-16T13:56:05.966498+00:00",
+  "observed_at_utc": "2026-08-16T14:03:01.907827+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -137,7 +120,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-16T13:54:52Z",
+    "observed_at_utc": "2026-08-16T14:01:46Z",
     "owner": "Main Agent under the repository owner's request to start only the published Phase 8 packet and preserve retained lanes",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/verification/git-001-phase-8-reconciliation-git-handoff-source-evidence.json
+++ b/docs/verification/git-001-phase-8-reconciliation-git-handoff-source-evidence.json
@@ -2,7 +2,7 @@
   "authorization": {
     "authority_source": {
       "kind": "USER_DELEGATION",
-      "observed_at_utc": "2026-08-16T13:54:52Z",
+      "observed_at_utc": "2026-08-16T14:01:46Z",
       "query_status": "OK",
       "reference": "task:GIT-001-P8-RECONCILIATION:user-request-start-the-published-next-work",
       "status": "OBSERVED"
@@ -13,7 +13,7 @@
       "CREATE_OR_UPDATE_DRAFT_PR"
     ],
     "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
-    "observed_at_utc": "2026-08-16T13:54:52Z",
+    "observed_at_utc": "2026-08-16T14:01:46Z",
     "prohibited_actions": [
       "MERGE_BEFORE_REQUIRED_CHECKS",
       "MUTATE_PREEXISTING_BRANCH_OR_WORKTREE",
@@ -35,7 +35,7 @@
         "CREATE_OR_UPDATE_DRAFT_PR"
       ],
       "branch": "codex/git-001-phase8-reconciliation",
-      "head_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+      "head_sha": "25777a22807b2bb60ddd4e20eaa0d2469a26624b",
       "task_id": "GIT-001-P8-RECONCILIATION"
     }
   },
@@ -47,7 +47,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-16T13:54:52Z",
+    "observed_at_utc": "2026-08-16T14:01:46Z",
     "owner": "Main Agent under the repository owner's request to start only the published Phase 8 packet and preserve retained lanes",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/verification/git-001-phase-8-reconciliation-git-handoff-source-evidence.json
+++ b/docs/verification/git-001-phase-8-reconciliation-git-handoff-source-evidence.json
@@ -1,0 +1,58 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-16T13:54:52Z",
+      "query_status": "OK",
+      "reference": "task:GIT-001-P8-RECONCILIATION:user-request-start-the-published-next-work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_DRAFT_PR"
+    ],
+    "next_action": "WAIT_FOR_EXACT_HEAD_AUDIT",
+    "observed_at_utc": "2026-08-16T13:54:52Z",
+    "prohibited_actions": [
+      "MERGE_BEFORE_REQUIRED_CHECKS",
+      "MUTATE_PREEXISTING_BRANCH_OR_WORKTREE",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "DISCARD_USER_CHANGE",
+      "CLOSE_PULL_REQUEST",
+      "CHANGE_GITHUB_SETTINGS",
+      "PUBLISH_RELEASE",
+      "START_NEXT_PACKET"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_DRAFT_PR"
+      ],
+      "branch": "codex/git-001-phase8-reconciliation",
+      "head_sha": "86f92ed16164a97b7cbb1edacd64a50a5a71e13d",
+      "task_id": "GIT-001-P8-RECONCILIATION"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-16T13:54:52Z",
+    "owner": "Main Agent under the repository owner's request to start only the published Phase 8 packet and preserve retained lanes",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -106,7 +106,7 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "78a2e24e3cc2"
+      "content_hash": "21481a4e2dbd"
     },
     {
       "name": "git-001-phase-8-reconciliation-git-handoff-source-evidence.json",
@@ -118,7 +118,7 @@
         "retention",
         "task_archive"
       ],
-      "content_hash": "46be95b29e70"
+      "content_hash": "32a431082470"
     },
     {
       "name": "git-primary-session-log-reconcile-handoff-receipt.json",
@@ -1563,5 +1563,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "9f1bb8485021bff2"
+  "content_hash": "765267657eb82d2a"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-16",
-  "file_count": 126,
+  "file_count": 129,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -89,6 +89,36 @@
         "required_shared_markers"
       ],
       "content_hash": "e15f6ebeb790"
+    },
+    {
+      "name": "git-001-phase-8-reconciliation-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "78a2e24e3cc2"
+    },
+    {
+      "name": "git-001-phase-8-reconciliation-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "46be95b29e70"
     },
     {
       "name": "git-primary-session-log-reconcile-handoff-receipt.json",
@@ -1171,6 +1201,24 @@
       "content_hash": "8704b0e57f8a"
     },
     {
+      "name": "india-2-next-agent-plan-refresh-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "224af6655100"
+    },
+    {
       "name": "india-2-next-agent-plan-refresh-git-handoff-source-evidence.json",
       "type": "config",
       "last_updated": "2026-08-16",
@@ -1515,5 +1563,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "3720d9c0488be4c6"
+  "content_hash": "9f1bb8485021bff2"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,12 +4,14 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-16
-**Files:** 126
+**Files:** 129
 
 ## Config Files
 
 - [INDIA-0-git-handoff.json](INDIA-0-git-handoff.json)
 - [footing-release-inclusion.json](footing-release-inclusion.json)
+- [git-001-phase-8-reconciliation-git-handoff-receipt.json](git-001-phase-8-reconciliation-git-handoff-receipt.json)
+- [git-001-phase-8-reconciliation-git-handoff-source-evidence.json](git-001-phase-8-reconciliation-git-handoff-source-evidence.json)
 - [git-primary-session-log-reconcile-handoff-receipt.json](git-primary-session-log-reconcile-handoff-receipt.json)
 - [git-primary-session-log-reconcile-handoff-source-evidence.json](git-primary-session-log-reconcile-handoff-source-evidence.json)
 - [india-2-cumulative-git-handoff-receipt.json](india-2-cumulative-git-handoff-receipt.json)
@@ -66,6 +68,7 @@ Benchmark examples and verification packs for validating library calculations ag
 - [india-2-foundation-strap-d-git-handoff-source-evidence.json](india-2-foundation-strap-d-git-handoff-source-evidence.json)
 - [india-2-foundation-strap-g0-git-handoff-receipt.json](india-2-foundation-strap-g0-git-handoff-receipt.json)
 - [india-2-foundation-strap-g0-git-handoff-source-evidence.json](india-2-foundation-strap-g0-git-handoff-source-evidence.json)
+- [india-2-next-agent-plan-refresh-git-handoff-receipt.json](india-2-next-agent-plan-refresh-git-handoff-receipt.json)
 - [india-2-next-agent-plan-refresh-git-handoff-source-evidence.json](india-2-next-agent-plan-refresh-git-handoff-source-evidence.json)
 - [india-2-plan-git-handoff-receipt.json](india-2-plan-git-handoff-receipt.json)
 - [india-2-plan-git-handoff-source-evidence.json](india-2-plan-git-handoff-source-evidence.json)


### PR DESCRIPTION
## Summary

- close GIT-001 Phase 8 with exact adoption and preservation evidence
- distinguish time-bound transition receipts from fresh successor closeout observations
- retain primary and detached dirty e54a; keep Excel and all other pre-existing lanes held
- advance only DOC-FRONTMATTER-CONTRACT as the next packet

## Validation

- 127 focused Git-governance tests passed
- semantic Git workflow checker passed
- exact PR/head/base/merge/tree audit passed for #751, #752, #792, #797, #798, and #799
- Excel classifier: HOLD_UNKNOWN_OWNER
- 1,262 internal links, 0 broken
- quick gate: 10/10
- normal commit hooks passed

## Boundaries

No structural code, product capability, endpoint, release, GitHub setting, pre-existing branch/worktree, dirty path, stash, issue, PR, or cleanup target was changed. Historical transition receipts remain unchanged and fail closed when stale.