### PR TITLE
fix(docs): enforce frontmatter validation

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,95 @@
 
 ---
 
+## 2026-08-16 — Session: Documentation Frontmatter Contract Repair
+
+**Agent:** Codex (`doc-master`, sole writer)
+
+**Branch:** `codex/doc-frontmatter-contract` from freshly fetched
+`origin/main = c8fcd2f0f9b933eb8e8787dc901ee440e05ae984`, tree
+`41d878c0681e5e51d159615d14290d5c3964c822`
+
+**Focus:** Make machine-readable frontmatter validation fail whenever invalid
+records exist, add direct valid/invalid regressions, and repair exactly the
+eight frozen lifecycle/type records. Do not bulk-add frontmatter to 60
+permitted legacy documents or start Clause 38.2, pile-cap, raft, cleanup,
+release, React, dependency, or broad-gate work.
+
+### Summary
+
+- Reproduced the defect on the clean source-bound lane: JSON mode reported
+  `342` checked, `282` with frontmatter, `60` without frontmatter, and `8`
+  invalid, but exited `0`; text mode exited `1` on the same records.
+- Made JSON mode return the same invalid-count result as text mode without
+  changing the report object, and added direct valid/invalid payload-and-exit
+  regressions.
+- Changed only the eight frozen metadata values: the closed library-first plan
+  is `archived`; live combined/flat/deep/wall evidence is `active`; strap A/B/C
+  evidence uses `doc_type: reference`. Narrative engineering outcomes remain
+  unchanged.
+- Reconciled the task board, execution plan, and compact handoff so
+  `INDIA-2-TRUTH-HYGIENE-38-2` is the sole next packet after merge.
+
+### Issues encountered
+
+- JSON validation visibly printed eight invalid records but returned success,
+  allowing a machine consumer to accept an invalid documentation state.
+- Eight documents used completion/acceptance/evidence words as schema lifecycle
+  or type values, conflating narrative engineering outcome with maintained
+  document metadata.
+- The first normal commit-hook run stopped because the compact brief used
+  `## Required reading` instead of the exact required heading
+  `## Required Reading`, blocking candidate publication.
+
+### Root causes and resolutions
+
+- Confirmed root cause: `check_frontmatter()` returned `0` unconditionally
+  immediately after printing its JSON report, before applying the invalid-count
+  rule used by text mode. Resolution: return `1` when
+  `report["invalid_frontmatter"]` is nonzero in that branch. Evidence: the
+  direct invalid fixture preserves the full report and returns `1`; the direct
+  valid fixture preserves its report and returns `0`; both tests pass.
+- Confirmed root cause: record authors used `completed`, `complete`, `accepted`,
+  and `verification` to describe the body outcome/purpose even though the
+  maintained schema defines document lifecycle as active, draft, deprecated,
+  or archived and type as guide, reference, tutorial, index, spec, or log.
+  Resolution:
+  map the closed plan to `archived`, live evidence to `active`, and strap
+  evidence to `reference`, without changing any engineering statement.
+  Evidence: live JSON and text modes both exit `0`, report zero invalid, and
+  retain exactly 60 permitted no-frontmatter records.
+- Confirmed root cause: the handoff rewrite normalized heading capitalization
+  without first checking the exact string contract enforced by
+  `check_session_docs.py`; generic link, brief-length, and quick checks did not
+  exercise that constraint. Resolution: restore the exact required heading and
+  retain normal hooks as the publication guard. Evidence: the repaired hook
+  run must pass before the candidate commit is accepted. ⚠️ TERMINAL ISSUE:
+  normal commit hooks rejected the compact brief heading -> restored the exact
+  maintained heading and reran the candidate gates.
+
+### Validation through content freeze
+
+- Startup: `source_bound=true`, `READY_LOCAL`, no operation marker, exact base
+  equality with fetched `origin/main`, and a clean fresh lane.
+- Focused regressions: `2 passed`; Ruff and Black pass for the checker and new
+  test module.
+- Live replay: JSON reports `invalid_frontmatter: 0` with `files_invalid: []`;
+  JSON and text both exit `0`; total/with/without/skipped counts remain
+  `342/282/60/462`.
+- Maintained indexes, links, quick `10/10`, normal hooks, hosted checks, and
+  merge-tree equality complete during candidate/publication closeout.
+
+### Timing through content freeze
+
+- Orientation and source binding: `14:23:14Z` to `14:24:24Z` — 1 minute 10
+  seconds.
+- Reproduction, implementation, and focused validation: `14:24:24Z` to
+  `14:26:36Z` — 2 minutes 12 seconds.
+- Task/plan/handoff reconciliation: `14:26:36Z` to `14:28:30Z` — 1 minute 54
+  seconds.
+- Generator/gates, hosted CI wait, merge closeout, and total wall time are
+  reported by the final closeout observation.
+
 ## 2026-08-16 — Session: GIT-001 Phase 8 Adoption and Reconciliation
 
 **Agent:** Codex (`orchestrator` and `ops`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-16 — GIT-001 Phase 8 closes with retained holds; the sole next packet is the bounded frontmatter contract/data repair
+**Updated:** 2026-08-16 — frontmatter contract/data repair closes on merge; Clause 38.2 truth hygiene is the sole next packet
 
 ---
 
@@ -125,15 +125,14 @@
 
 ## Active
 
-No implementation packet is active after Phase 8 closeout. Start only the
-next bounded packet below from refreshed `origin/main`.
+No implementation packet is active after the frontmatter candidate closes.
+Start only the next bounded packet below from refreshed `origin/main`.
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| DOC-FRONTMATTER-CONTRACT | Fix JSON-mode false success and the eight currently invalid frontmatter records | Main Agent + doc-master | one packet | P0 | ⏭️ NEXT — repair only the exit-code contract and exactly eight invalid records |
-| INDIA-2-TRUTH-HYGIENE-38-2 | Source-audit and correct live Clause 38.2 flexure metadata, decorators, provenance, and any benchmark-proven arithmetic defect | Main Agent + structural engineer | one bounded packet | P0 | ⏸ AFTER DOC CONTRACT |
+| INDIA-2-TRUTH-HYGIENE-38-2 | Source-audit and correct live Clause 38.2 flexure metadata, decorators, provenance, and any benchmark-proven arithmetic defect | Main Agent + structural engineer | one bounded packet | P0 | ⏭️ NEXT — audit source identity and equilibrium before deciding metadata-only versus arithmetic repair |
 | INDIA-2-FOUNDATION-PILE-CAP-G0 | Decide one source-bound pile-cap case or retain an explicit hold before any implementation | Main Agent + structural engineer | decision only | P0 | ⏸ AFTER ISSUE REPAIRS — investigate one centred axial two-pile cap; controlled companion source and benchmark remain prerequisites |
 | INDIA-2-FOUNDATION-RAFT-G0 | Decide one source-bound non-FEM raft case or retain an explicit hold before any implementation | Main Agent + structural engineer | decision only | P0 | ⏸ AFTER PILE-CAP DECISION — not started |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
@@ -147,10 +146,11 @@ INDIA-0 through INDIA-4, and the dedicated
 defines the remaining family packets. INDIA-0 and INDIA-1 are complete. The
 historical INDIA-2A-D packets form the completed `INDIA-2-STAIR` family. Bounded
 wall, deep-beam, flat-slab/punching, combined-footing, and strap-footing
-families are accepted, but umbrella INDIA-2 remains in progress while the
-frontmatter contract repair, Clause 38.2 truth hygiene, and pile-cap/raft G0
-decisions remain pending. Git/status reconciliation is complete with retained
-lanes explicitly held and no cleanup authority.
+families are accepted, but umbrella INDIA-2 remains in progress while Clause
+38.2 truth hygiene and pile-cap/raft G0 decisions remain pending. The
+frontmatter contract repair closes on merge with 60 permitted legacy records
+unchanged. Git/status reconciliation is complete with retained lanes explicitly
+held and no cleanup authority.
 The v0.23.1a1 Alpha is published.
 UIX-001 P0-P15 is accepted: the revision-safe workbench, authoritative
 3D inspection, versioned capability catalogue, curated renderer, bounded
@@ -163,6 +163,7 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| DOC-FRONTMATTER-CONTRACT | Made JSON frontmatter validation fail on invalid records, added direct valid/invalid report regressions, and repaired exactly eight invalid lifecycle/type records | Main Agent + doc-master | ✅ COMPLETE ON MERGE — live JSON/text modes pass with zero invalid and 60 permitted legacy records unchanged |
 | GIT-001-P8-RECONCILIATION | Verified GIT-7E adoption, corrected transition-versus-closeout receipt semantics, reconciled current ledgers, and refreshed preservation holds | Main Agent + ops | ✅ COMPLETE ON MERGE — primary/e54a retained; Excel and all other pre-existing lanes remain `UNKNOWN/HOLD`; no cleanup performed |
 | GIT-001 | Researched and implemented the evidence-backed Git operating model through adoption closeout | Main Agent + repository owner | ✅ COMPLETE ON MERGE — Phases 0-8 close with fail-closed maintenance/reactivation rules and preserved unknown lanes |
 | INDIA-2-FOUNDATION-STRAP | Implemented, published, and focused-accepted one bounded property-line two-footing equal-pressure no-soil-contact strap workflow | Main Agent + structural engineer | ✅ DONE — G0/A-D integrated; frozen and non-frozen benchmarks, exact-head audit, focused gates, and hosted checks pass; qualified review and excluded systems remain held |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 9483,
+      "size_lines": 9572,
       "last_updated": "2026-08-16",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "d8de4684733a"
+      "content_hash": "023181df758b"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 736,
+      "size_lines": 737,
       "last_updated": "2026-08-16",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "533130b0c275"
+      "content_hash": "d96afee4be36"
     },
     {
       "name": "WORKLOG.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "d5a066a0b1ab49e4"
+  "content_hash": "db787632623fedbf"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 9483 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 736 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 9572 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 737 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -66,10 +66,10 @@
     {
       "name": "india-2-next-session-publication-and-closeout-plan.md",
       "type": "documentation",
-      "size_lines": 477,
+      "size_lines": 485,
       "last_updated": "2026-08-16",
-      "description": "Combined-footing and strap-footing G0/A-D plus focused family acceptance are integrated within their recorded bounded cases. GIT-001 Phase 8 closes through",
-      "content_hash": "765b5a9d9d5d"
+      "description": "Combined-footing and strap-footing G0/A-D plus focused family acceptance are integrated within their recorded bounded cases. GIT-001 Phase 8 is integrated,",
+      "content_hash": "72ea3444a492"
     },
     {
       "name": "india-2-remaining-is456-elements-plan.md",
@@ -93,7 +93,7 @@
       "size_lines": 1507,
       "last_updated": "2026-08-16",
       "description": "The Python package is the product. FastAPI, React, command-line workflows, reports, ETABS adapters, and future integrations are consumers of that product.",
-      "content_hash": "a4fd1d2c1971"
+      "content_hash": "8f28361ce673"
     },
     {
       "name": "is456-solid-slabs-master-plan.md",
@@ -131,11 +131,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 114,
+      "size_lines": 112,
       "last_updated": "2026-08-16",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-16",
-      "content_hash": "bb5a4603d46d"
+      "content_hash": "9bfc93ac9fd4"
     },
     {
       "name": "pre-release-checklist.md",
@@ -173,5 +173,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "d4d7cc0c27996f68"
+  "content_hash": "06431246243bc566"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -15,7 +15,7 @@
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
 | [etabs-killer-masterplan.md](etabs-killer-masterplan.md) | Project BHEEM: Open-Source Structural De | > **BHEEM** — **B**uilding **H**olistic **E**ngineering **E* | 2855 |
 | [gpt-5-3-codex-spark-work-program.md](gpt-5-3-codex-spark-work-program.md) |  | Use GPT-5.3-Codex-Spark as a high-throughput implementation  | 614 |
-| [india-2-next-session-publication-and-closeout-plan.md](india-2-next-session-publication-and-closeout-plan.md) |  | Combined-footing and strap-footing G0/A-D plus focused famil | 477 |
+| [india-2-next-session-publication-and-closeout-plan.md](india-2-next-session-publication-and-closeout-plan.md) |  | Combined-footing and strap-footing G0/A-D plus focused famil | 485 |
 | [india-2-remaining-is456-elements-plan.md](india-2-remaining-is456-elements-plan.md) |  | INDIA-2 finishes a practical, explicitly limited set of IS 4 | 392 |
 | [indian-code-completion-plan.md](indian-code-completion-plan.md) |  | This is the canonical finish plan for the repository's India | 133 |
 | [is456-library-first-master-plan.md](is456-library-first-master-plan.md) |  | The Python package is the product. FastAPI, React, command-l | 1507 |
@@ -23,7 +23,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 114 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-16 | 112 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/india-2-next-session-publication-and-closeout-plan.md
+++ b/docs/planning/india-2-next-session-publication-and-closeout-plan.md
@@ -13,9 +13,10 @@ doc_type: spec
 ## 1. Outcome and stop boundary
 
 Combined-footing and strap-footing G0/A-D plus focused family acceptance are
-integrated within their recorded bounded cases. GIT-001 Phase 8 closes through
-its adoption packet; the next session starts with the confirmed frontmatter
-contract/data repair before any new foundation decision.
+integrated within their recorded bounded cases. GIT-001 Phase 8 is integrated,
+and the frontmatter contract/data repair closes on merge of its unchanged
+candidate. The next session starts with Clause 38.2 truth hygiene before any
+new foundation decision.
 
 This document remains the sequence plan. Phase 8 execution is recorded in
 [`GIT-001-phase-8-adoption-closeout.md`](../research/git-governance/GIT-001-phase-8-adoption-closeout.md).
@@ -29,9 +30,9 @@ time:
 1. `GIT-001-P8-RECONCILIATION` — complete on merge of its unchanged adoption
    packet; primary/e54a are retained and all other pre-existing lanes remain
    `UNKNOWN/HOLD` without cleanup.
-2. `DOC-FRONTMATTER-CONTRACT` — next; repair the JSON-mode exit-code defect and
-   the eight currently invalid frontmatter records.
-3. `INDIA-2-TRUTH-HYGIENE-38-2` — source-audit every live `38.2` consumer,
+2. `DOC-FRONTMATTER-CONTRACT` — complete on merge; JSON/text modes agree, the
+   eight invalid records are repaired, and 60 permitted legacy records remain.
+3. `INDIA-2-TRUTH-HYGIENE-38-2` — next; source-audit every live `38.2` consumer,
    correct provenance, and change arithmetic only if an independently checked
    benchmark proves an outcome defect.
 4. `INDIA-2-FOUNDATION-PILE-CAP-G0` — decision and benchmark only.
@@ -75,10 +76,10 @@ Live inspection for this plan established:
   still register `38.2` for three beam-flexure functions even though the prior
   controlled-source review found the relevant identities under Clause `38.1`
   and Annex G;
-- `scripts/check_docs.py --frontmatter --json` currently reports 341 scanned
-  documents, 281 with frontmatter, 60 permitted legacy/no-frontmatter records,
-  and eight invalid records, but exits `0`; code inspection confirms JSON mode
-  returns before applying the invalid-count failure rule;
+- before repair, `scripts/check_docs.py --frontmatter --json` reported 342
+  scanned documents, 282 with frontmatter, 60 permitted legacy/no-frontmatter
+  records, and eight invalid records while exiting `0`; the bounded repair now
+  makes JSON/text modes agree and reports zero invalid without changing the 60;
 - the controlled private source set currently retains IS 456:2000 through
   Amendment 5 and Amendment 6 only. It contains no retained IS 2911/IS 2950
   companion source and no accepted pile-cap or raft structural benchmark.
@@ -200,13 +201,13 @@ If that path is absent in a later checkout, rediscover the replacement with
 `rg --files scripts | rg 'check.*git.*workflow'` and record the changed
 entrypoint instead of guessing or using an archived script.
 
-## 4. Packet 2 — frontmatter checker and record repair
+## 4. Packet 2 — frontmatter checker and record repair (complete on merge)
 
 ### Confirmed root cause
 
-`check_frontmatter()` correctly computes `invalid_frontmatter`, but its
-`json_output` branch prints the report and returns `0` unconditionally. The
-normal text branch applies `return 1 if invalid_frontmatter else 0`. This makes
+`check_frontmatter()` correctly computed `invalid_frontmatter`, but its
+`json_output` branch printed the report and returned `0` unconditionally. The
+normal text branch applied `return 1 if invalid_frontmatter else 0`. This made
 machine-readable validation say “passed” while returning eight invalid records.
 
 The eight records are separate data defects:
@@ -221,7 +222,7 @@ and are not automatically in scope because current policy permits their legacy
 metadata/no-frontmatter forms. Expand scope only if a maintained gate proves a
 main-process failure.
 
-### Fix and acceptance
+### Implemented fix and acceptance
 
 1. Make JSON mode return the same pass/fail result as text mode without changing
    its JSON payload.
@@ -233,6 +234,11 @@ main-process failure.
 4. Require live JSON output to report `invalid_frontmatter: 0`, text mode to
    pass, focused checker tests, links/indexes, quick `10/10`, normal hooks, and
    hosted documentation checks to pass.
+
+The bounded candidate implements items 1-3: JSON preserves its report and now
+shares text-mode failure semantics, two direct valid/invalid payload-and-exit
+regressions pass, and exactly the eight named records use schema-valid lifecycle
+or reference values. Item 4 completes through candidate and hosted closeout.
 
 ## 5. Packet 3 — Clause 38.2 flexure truth hygiene
 
@@ -356,40 +362,42 @@ benchmark means `HOLD`, not an improvised model.
 
 ## 7. Next-agent execution card
 
-The next agent starts and finishes only `DOC-FRONTMATTER-CONTRACT`.
+The next agent starts and finishes only `INDIA-2-TRUTH-HYGIENE-38-2`.
 
 ### First 15 minutes
 
 1. Fetch `origin/main`; record the exact commit and tree.
-2. Create `codex/doc-frontmatter-contract` from that ref; never write on
-   primary or reuse Phase 8 or another retained lane.
+2. Create `codex/india-2-truth-hygiene-38-2` from that ref; never write on
+   primary or reuse the frontmatter or another retained lane.
 3. Run the compact brief's four start commands and require
    `source_bound=true` plus `READY_LOCAL`.
-4. Read only this plan, the compact brief, `scripts/check_docs.py`, the nearest
-   script-level test layout discovered with `rg --files`, and the eight named
-   invalid records.
-5. Reproduce JSON exit `0` with eight invalid records and freeze the exact
-   payload plus the text-mode result before editing.
+4. Read only this plan, the compact brief, the controlled-source registry and
+   clause database, the beam flexure/decorator/provenance paths discovered with
+   `rg --files`, and their nearest focused tests.
+5. Freeze every live `38.2` consumer and independently replay the supported
+   rectangular stress-block equilibrium before editing.
 
 ### Work loop
 
-1. Freeze the checker, focused tests, and exactly eight record paths before
-   edits; the 60 permitted legacy records are non-goals.
-2. Make JSON mode return the same pass/fail result as text mode without changing
-   its JSON payload.
-3. Add direct valid/invalid exit-code regressions and give only the eight named
-   records schema-valid lifecycle/doc types without rewriting evidence.
-4. Generate maintained indexes once after human-owned content freezes.
-5. Run focused tests, live JSON/text replay, links/indexes, one quick gate, one
-   candidate review, one push, and one hosted-check cycle.
+1. Freeze source identities, live consumers, supported beam cases, public
+   signatures, and focused tests before edits.
+2. Bind each formula/provenance identity to Clause 38.1 or Annex G evidence;
+   never mass-replace labels or copy protected prose.
+3. Compare legacy approximation and exact equilibrium on independently checked
+   benchmarks. Change arithmetic only if a supported outcome can change.
+4. Add semantic regressions against unsupported `38.2` identities and generate
+   the maintained manifest once after executable truth freezes.
+5. Run focused flexure/traceability/manifest/public-contract gates, links and
+   indexes, one quick gate, one candidate review, one push, and one hosted-check
+   cycle.
 6. Merge only the unchanged reviewed head, verify squash-tree equality and
    refreshed `origin/main`, retain the lane, and stop.
 
 ### Stop and handoff
 
-Stop after `DOC-FRONTMATTER-CONTRACT` merges. Name
-`INDIA-2-TRUTH-HYGIENE-38-2` as the sole next packet. Do not use remaining time
-to start Clause 38.2 work in the frontmatter lane.
+Stop after `INDIA-2-TRUTH-HYGIENE-38-2` merges. Name decision-only
+`INDIA-2-FOUNDATION-PILE-CAP-G0` as the sole next packet. Do not use remaining
+time to start pile-cap work in the Clause 38.2 lane.
 
 ## 8. Efficiency and speed controls
 
@@ -426,7 +434,7 @@ repository-wide mutation, or a second repair cycle breaks that boundary.
 |---|---|---|
 | Primary output-detail drift | Confirmed and resolved | Codex persisted a project output-detail selection into tracked `.codex/config.toml`; keep repository `low`, verify primary clean, and do not publish personal preference drift |
 | Stale primary/config wording in this plan and brief | Confirmed and resolved here | PR #799 described the pre-cleanup snapshot; refresh current mutable facts at packet start and do not treat a planning receipt as live state |
-| JSON frontmatter exits zero with eight invalid records | Confirmed, open | Fix the early JSON return, add direct valid/invalid exit-code tests, and repair only the eight invalid records |
+| JSON frontmatter exits zero with eight invalid records | Confirmed and resolved on merge | JSON now returns the invalid-count result; direct valid/invalid payload tests pass; exactly eight records were repaired while 60 permitted legacy records stayed unchanged |
 | Live `38.2` identities | Origin and arithmetic impact unconfirmed | Source-audit every consumer and benchmark exact equilibrium before deciding metadata-only versus arithmetic repair |
 | Pydantic-version OpenAPI drift | Confirmed and already guarded | Preserve explicit schema mode and the cross-version regression in every future D packet |
 | Public-call wrapper mismatch | Confirmed and already guarded | Discover the maintained signature; construct the typed request wrapper before calling the service in acceptance replays |

--- a/docs/planning/is456-library-first-master-plan.md
+++ b/docs/planning/is456-library-first-master-plan.md
@@ -1,7 +1,7 @@
 ---
 task: LIB-IS456-V1
 title: IS 456 Library-First Completion and PyPI Master Plan
-status: completed
+status: archived
 owner: Main Agent and repository owner
 created: 2026-08-09
 last_updated: 2026-08-16

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,41 +4,40 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-16
-- Focus: frontmatter checker contract and exactly eight invalid records
-- Baseline: GIT-001 Phase 8 started from fetched origin/main 86f92ed16164a97b7cbb1edacd64a50a5a71e13d, tree 1bb7e448fd26208ba2227b1d9e2f3f0f976ed46e
+- Focus: Clause 38.2 beam-flexure truth hygiene
+- Baseline: DOC-FRONTMATTER-CONTRACT started from fetched origin/main c8fcd2f0f9b933eb8e8787dc901ee440e05ae984, tree 41d878c0681e5e51d159615d14290d5c3964c822
 - Truth: 13 supported / 8 held; 81/81 endpoints directly tested
-- Git outcome: Phases 0-8 close on merge of the unchanged adoption packet; transition receipts are time-bound and final merge facts require a fresh successor observation
-- Primary/e54a: primary was clean/equal at packet start; detached dirty e54a remains retained and untouched
-- Other lanes: Excel is HOLD_UNKNOWN_OWNER; every other pre-existing lane remains UNKNOWN/HOLD; no cleanup authority exists
-- Confirmed next defect: frontmatter JSON mode reports eight invalid records but exits zero because it returns before applying the text-mode failure rule
-- Scope guard: repair only that exit-code contract, its direct regression tests, and the eight named lifecycle/doc-type records; leave 60 permitted legacy records alone
-- Next action: begin only DOC-FRONTMATTER-CONTRACT in a fresh fetched-current-main lane
+- Frontmatter outcome: JSON and text modes agree; zero invalid records; 60 permitted legacy/no-frontmatter records unchanged; two direct payload/exit regressions pass
+- Scope guard: source-audit every live 38.2 consumer and independently benchmark equilibrium before deciding metadata-only versus arithmetic repair
+- Retained lanes: primary, detached dirty e54a, Excel HOLD_UNKNOWN_OWNER, and every other pre-existing lane remain untouched; no cleanup authority exists
+- Next action: begin only INDIA-2-TRUTH-HYGIENE-38-2 in a fresh fetched-current-main lane after the frontmatter candidate merges
 <!-- HANDOFF:END -->
 
 **Date:** 2026-08-16
 
 | State | Boundary |
 |---|---|
-| **Current** | `v0.23.1a1` Alpha; GIT-001 adoption closes with retained holds and no cleanup |
-| **Next** | `DOC-FRONTMATTER-CONTRACT` only |
-| **Later** | Clause 38.2 truth hygiene, pile-cap G0, raft G0, accepted GO packets, INDIA-2 broad closeout |
+| **Current** | `v0.23.1a1` Alpha; frontmatter contract repair complete on merge |
+| **Next** | `INDIA-2-TRUTH-HYGIENE-38-2` only |
+| **Later** | Pile-cap G0, raft G0, accepted GO packets, INDIA-2 broad closeout |
 | **Held** | Cleanup/deletion, release, React expansion, professional approval, dependency majors |
 
 ## Required Reading
 
 1. [Next-session Git/issues/INDIA-2 plan](india-2-next-session-publication-and-closeout-plan.md)
 2. [Current task board](../TASKS.md)
-3. [Phase 8 adoption closeout](../research/git-governance/GIT-001-phase-8-adoption-closeout.md)
-4. [`check_docs.py`](../../scripts/check_docs.py)
+3. [IS 456 public-distribution permission](../verification/is456-public-distribution-permission.json)
+4. Discover the live clause database, beam flexure, decorator, provenance,
+   manifest, and nearest focused-test paths with `rg --files` before reading.
 
 ## Exact start
 
 Fetch and verify `origin/main`, then create one fresh
-`codex/doc-frontmatter-contract` worktree. Do not write on primary, reuse the
-Phase 8 lane, or touch retained worktrees.
+`codex/india-2-truth-hygiene-38-2` worktree. Do not write on primary, reuse the
+frontmatter lane, or touch retained worktrees.
 
 ```bash
-./run.sh session brief --agent doc-master
+./run.sh session brief --agent structural-engineer
 ./run.sh session start
 ./scripts/python_runtime.sh --diagnose
 ./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
@@ -49,65 +48,64 @@ equality with fetched `origin/main` before editing.
 
 ## Packet order
 
-1. `DOC-FRONTMATTER-CONTRACT`
-   - make JSON mode return nonzero whenever `invalid_frontmatter` is nonzero;
-   - preserve the JSON payload exactly;
-   - add direct invalid/valid exit-code regressions;
-   - repair exactly the eight already identified status/doc-type records;
-   - do not bulk-add frontmatter to 60 permitted legacy documents.
-2. `INDIA-2-TRUTH-HYGIENE-38-2`
-   - trace live metadata/decorator/provenance/arithmetic consumers;
-   - rebind supported source identities;
-   - change arithmetic only if an independent benchmark proves an outcome
-     defect.
-3. Decision-only `PILE-CAP-G0`, then its A-D/acceptance chain only after `GO`.
-4. Decision-only `RAFT-G0`, then any owner-accepted chain.
-5. `INDIA-2-CLOSEOUT` with broad Python and the full 30-check gate once.
-6. Post-INDIA-2 dependency-major compatibility packets only afterward.
+1. `INDIA-2-TRUTH-HYGIENE-38-2`
+   - enumerate every live `38.2` metadata, decorator, result-provenance, test,
+     documentation, and generated-manifest consumer;
+   - bind each supported identity to the controlled Clause 38.1 or Annex G
+     evidence actually used;
+   - independently replay rectangular stress-block equilibrium and compare the
+     legacy `4.6` approximation with the shared exact helper;
+   - change arithmetic only if benchmark evidence proves a supported outcome
+     can change.
+2. Decision-only `PILE-CAP-G0`, then A-D/acceptance only after accepted `GO`.
+3. Decision-only `RAFT-G0`, then any owner-accepted chain.
+4. `INDIA-2-CLOSEOUT` with broad Python and the full 30-check gate once.
+5. Post-INDIA-2 dependency-major compatibility packets only afterward.
 
-## Frozen frontmatter scope
+## Frozen Clause 38.2 scope
 
-The confirmed root cause is the early unconditional JSON return in
-`check_frontmatter()`. The eight data defects are:
+The open defect is a source/provenance contradiction, not permission to delete
+a label mechanically. The clause database, beam decorators,
+`calculate_ast_required`, singly/doubly reinforced design, serialized
+`sources_used`, tests, docs, and generated manifest must be traced together.
 
-- invalid `status`: the library-first master plan, combined-C public-workflow
-  evidence, and wall/deep/flat family-acceptance evidence; and
-- invalid `doc_type: verification`: strap A, B, and C evidence.
+Back-substitute required steel into the exact equilibrium independently. If
+the legacy approximation cannot change a supported PASS/FAIL or public result,
+leave arithmetic stable and repair only unsupported identities. If it can,
+fix the shared root cause with compatibility and benchmark evidence.
 
-Give each record a schema-valid lifecycle/doc type while preserving its
-narrative completion/acceptance meaning. Do not rewrite engineering evidence,
-expand the schema, or sweep unrelated legacy metadata.
+Do not copy protected clause prose, mass-replace `38.2`, change unrelated beam
+behavior, infer approval from metadata, or expand supported cases.
 
 ## Owner-decision boundaries
 
-- Primary, `e54a`, Excel, Phase 8, and every other retained lane stay untouched.
-- Historical task-to-Git receipts are time-bound evidence; do not rewrite them
-  to suppress stale holds.
-- Closing dependency PRs, deleting branches/worktrees, release/tag/package
-  publication, and professional approval require separate authority.
+- Primary, `e54a`, Excel, the frontmatter lane, and every other retained lane
+  stay untouched.
+- Public-source distribution permission is already recorded; do not reopen it.
+- Pile-cap/raft implementation, cleanup/deletion, release/tag/package
+  publication, and professional approval remain separately gated.
 
 ## Gate cadence
 
-Run focused checker tests, both live JSON and text modes, exact eight-record
-replay, links/indexes, quick `10/10`, normal hooks, exact-head review, hosted
-documentation checks, and merge-tree verification. Broad Python and the full
-30-check gate remain deferred to final INDIA-2 closeout unless a confirmed
-repository-wide failure forces them earlier.
+Run focused flexure, traceability, manifest, public-contract, architecture, and
+import gates; generate the maintained manifest/indexes once; then run links,
+quick `10/10`, normal hooks, exact-head review, hosted checks, and merge-tree
+verification. Broad Python and the full 30-check gate remain deferred to final
+INDIA-2 closeout unless a repository-wide failure forces them earlier.
 
 The session entry must contain `Issues encountered` and `Root causes and
-resolutions`, including visible symptom, main-process impact, confirmed cause,
-implemented correction, and executable proof.
+resolutions`, with executable evidence for the corrected outcome.
 
 ## Efficiency card
 
-- Freeze the eight paths and checker/test paths before editing.
+- Freeze consumers, source identities, benchmark cases, tests, and public
+  signatures before editing.
 - Use one writer, one candidate, one generator pass, one quick gate, one push,
   and one hosted-check cycle.
-- Preserve the JSON payload while changing only the exit status.
 - Record orientation, implementation, repair, CI wait, closeout, and total
   elapsed workflow time separately.
 
 ## Stop rule
 
-Start and finish only `DOC-FRONTMATTER-CONTRACT`. Do not begin Clause 38.2,
-pile-cap, raft, dependency, broad-gate, or cleanup work in that lane.
+Start and finish only `INDIA-2-TRUTH-HYGIENE-38-2`. Do not begin pile-cap,
+raft, dependency, broad-gate, cleanup, release, or React work in that lane.

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -416,7 +416,7 @@
       "size_lines": 93,
       "last_updated": "2026-08-16",
       "description": "exact integrated G0/A-D starting head was ce45e22032ea234f588ce88c601db5f6a42af166. The supported public route remains",
-      "content_hash": "bec54ccc855d"
+      "content_hash": "6f058b49b1ea"
     },
     {
       "name": "india-2-deep-g0-git-handoff-receipt.json",
@@ -682,7 +682,7 @@
       "size_lines": 100,
       "last_updated": "2026-08-16",
       "description": "exact integrated G0/A-E starting head was b04d80653484a8dc43e8ff73936d8171e4b65d40. The supported public route remains",
-      "content_hash": "4a42ec953539"
+      "content_hash": "ac0c238727b4"
     },
     {
       "name": "india-2-flat-g0-git-handoff-receipt.json",
@@ -875,7 +875,7 @@
       "size_lines": 146,
       "last_updated": "2026-08-16",
       "description": "COMBINED-C publishes one typed Python workflow, design_symmetric_combined_footing_is456, over the already accepted",
-      "content_hash": "b1b71be9bb1e"
+      "content_hash": "8d7b847e8992"
     },
     {
       "name": "india-2-foundation-combined-d-git-handoff-receipt.json",
@@ -967,7 +967,7 @@
       "size_lines": 56,
       "last_updated": "2026-08-16",
       "description": "This packet implements only the G0-frozen two-footing property-line analysis: strict typed topology/action/approval inputs, reaction statics, equal uniform",
-      "content_hash": "5b631211d8f0"
+      "content_hash": "d8aa9a13773d"
     },
     {
       "name": "india-2-foundation-strap-a-git-handoff-receipt.json",
@@ -1076,7 +1076,7 @@
       "size_lines": 61,
       "last_updated": "2026-08-16",
       "description": "This packet composes A actions with caller-supplied M20-M40 concrete, Fe415/ Fe500 uncoated deformed bars, longitudinal/side-face reinforcement, vertical",
-      "content_hash": "24f166c00a95"
+      "content_hash": "1c995a8306f6"
     },
     {
       "name": "india-2-foundation-strap-c-git-handoff-receipt.json",
@@ -1114,7 +1114,7 @@
       "size_lines": 52,
       "last_updated": "2026-08-16",
       "description": "design_property_line_strap_footing_is456 is the sole canonical public Python composition over STRAP-A/B. It accepts one immutable case wrapper around the",
-      "content_hash": "d01514c18565"
+      "content_hash": "0f31237bfd01"
     },
     {
       "name": "india-2-foundation-strap-d-git-handoff-receipt.json",
@@ -1328,7 +1328,7 @@
       "size_lines": 82,
       "last_updated": "2026-08-16",
       "description": "integrated A-D starting head was 46094a8c35c75fcfb0644f23a851087cc3297c60. The supported public route remains one regular 100-200 mm thick, one-grid,",
-      "content_hash": "086e03bbc9b8"
+      "content_hash": "fafe9e88fdce"
     },
     {
       "name": "india-2-wall-g0-scope-evidence.md",
@@ -1563,5 +1563,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "765267657eb82d2a"
+  "content_hash": "a9d9827377aa90c8"
 }

--- a/docs/verification/india-2-deep-family-acceptance-evidence.md
+++ b/docs/verification/india-2-deep-family-acceptance-evidence.md
@@ -1,6 +1,6 @@
 ---
 owner: Main Agent
-status: accepted
+status: active
 last_updated: 2026-08-16
 doc_type: reference
 task: INDIA-2-DEEP-ACCEPTANCE

--- a/docs/verification/india-2-flat-family-acceptance-evidence.md
+++ b/docs/verification/india-2-flat-family-acceptance-evidence.md
@@ -1,6 +1,6 @@
 ---
 owner: Main Agent
-status: accepted
+status: active
 last_updated: 2026-08-16
 doc_type: reference
 task: INDIA-2-FLAT-ACCEPTANCE

--- a/docs/verification/india-2-foundation-combined-c-public-workflow-evidence.md
+++ b/docs/verification/india-2-foundation-combined-c-public-workflow-evidence.md
@@ -1,6 +1,6 @@
 ---
 owner: Main Agent
-status: complete
+status: active
 last_updated: 2026-08-16
 doc_type: reference
 task: INDIA-2-FOUNDATION-COMBINED-C

--- a/docs/verification/india-2-foundation-strap-a-analysis-evidence.md
+++ b/docs/verification/india-2-foundation-strap-a-analysis-evidence.md
@@ -2,7 +2,7 @@
 owner: Main Agent
 status: active
 last_updated: 2026-08-16
-doc_type: verification
+doc_type: reference
 task: INDIA-2-FOUNDATION-STRAP-A
 ---
 

--- a/docs/verification/india-2-foundation-strap-b-strength-evidence.md
+++ b/docs/verification/india-2-foundation-strap-b-strength-evidence.md
@@ -2,7 +2,7 @@
 owner: Main Agent
 status: active
 last_updated: 2026-08-16
-doc_type: verification
+doc_type: reference
 task: INDIA-2-FOUNDATION-STRAP-B
 ---
 

--- a/docs/verification/india-2-foundation-strap-c-public-workflow-evidence.md
+++ b/docs/verification/india-2-foundation-strap-c-public-workflow-evidence.md
@@ -2,7 +2,7 @@
 owner: Main Agent
 status: active
 last_updated: 2026-08-16
-doc_type: verification
+doc_type: reference
 task: INDIA-2-FOUNDATION-STRAP-C
 ---
 

--- a/docs/verification/india-2-wall-family-acceptance-evidence.md
+++ b/docs/verification/india-2-wall-family-acceptance-evidence.md
@@ -1,6 +1,6 @@
 ---
 owner: Main Agent
-status: accepted
+status: active
 last_updated: 2026-08-16
 doc_type: reference
 task: INDIA-2-WALL-ACCEPTANCE

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -184,7 +184,7 @@ def check_frontmatter(add_missing: bool = False, json_output: bool = False) -> i
 
     if json_output:
         print(json.dumps(report, indent=2))
-        return 0
+        return 1 if report["invalid_frontmatter"] else 0
 
     print("\n📊 Front-Matter Report")
     print(f"{'=' * 40}")

--- a/tests/test_check_docs.py
+++ b/tests/test_check_docs.py
@@ -1,0 +1,77 @@
+"""Focused regressions for the unified documentation checker."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import check_docs
+
+
+def _write_frontmatter_doc(path: Path, *, status: str) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "---",
+                "owner: Main Agent",
+                f"status: {status}",
+                "last_updated: 2026-08-16",
+                "doc_type: reference",
+                "---",
+                "",
+                "# Fixture",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_frontmatter_json_returns_nonzero_with_unchanged_invalid_report(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_frontmatter_doc(tmp_path / "invalid.md", status="completed")
+    monkeypatch.setattr(check_docs, "DOCS_DIR", tmp_path)
+
+    result = check_docs.check_frontmatter(json_output=True)
+
+    report = json.loads(capsys.readouterr().out)
+    assert result == 1
+    assert report == {
+        "total": 1,
+        "with_frontmatter": 1,
+        "without_frontmatter": 0,
+        "invalid_frontmatter": 1,
+        "skipped": 0,
+        "files_without": [],
+        "files_invalid": [
+            {
+                "file": "invalid.md",
+                "errors": [
+                    "Invalid status: 'completed' "
+                    "(valid: ['active', 'draft', 'deprecated', 'archived'])"
+                ],
+            }
+        ],
+    }
+
+
+def test_frontmatter_json_returns_zero_with_unchanged_valid_report(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_frontmatter_doc(tmp_path / "valid.md", status="active")
+    monkeypatch.setattr(check_docs, "DOCS_DIR", tmp_path)
+
+    result = check_docs.check_frontmatter(json_output=True)
+
+    report = json.loads(capsys.readouterr().out)
+    assert result == 0
+    assert report == {
+        "total": 1,
+        "with_frontmatter": 1,
+        "without_frontmatter": 0,
+        "invalid_frontmatter": 0,
+        "skipped": 0,
+        "files_without": [],
+        "files_invalid": [],
+    }


### PR DESCRIPTION
## Summary
- make frontmatter JSON mode return failure whenever invalid records exist without changing its report
- add direct valid and invalid payload/exit regressions
- repair exactly eight invalid lifecycle/type records while retaining 60 permitted legacy records
- hand off only INDIA-2-TRUTH-HYGIENE-38-2 as the next packet

## Verification
- 2 focused checker tests passed
- live JSON and text frontmatter checks passed with zero invalid records
- exact eight-record one-line replay passed
- three maintained index checks passed
- 1,261 internal links passed
- quick gate passed 10/10
- normal commit hooks passed