### PR TITLE
docs(governance): batch verification after implementation

### DIFF
--- a/.github/skills/quality-gate/SKILL.md
+++ b/.github/skills/quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-gate
-description: "Apply the project verification ladder without duplicating gates: narrow checks while editing, one quick pre-commit gate, the required PR Gate, one full closeout gate, and release preflight only for releases."
+description: "Apply the project verification ladder without duplicating gates: implementation first, necessary narrow diagnostics, one consolidated focused selection, one quick pre-commit gate, the required PR Gate, one cumulative full gate, and release preflight only for releases."
 ---
 
 # Quality Gate
@@ -16,9 +16,17 @@ Use the repository's canonical gates from the workspace root. Do not recreate th
 
 ## Verification Ladder
 
-### 1. While editing: narrow evidence
+### 1. Implement the bounded scope first
 
-Run only the smallest existing check that exercises the changed main process. Examples:
+Complete the scoped code, tests, documentation, evidence, and other intended
+writes before the routine verification sequence. Do not treat every saved edit
+as a gate boundary.
+
+### 2. While editing: diagnose only when needed
+
+When a current question or failure requires evidence, run only the smallest
+existing check that exercises the changed main process. Do not rerun a check
+merely because another edit was made. Examples:
 
 ```bash
 ./scripts/python_runtime.sh -m pytest Python/tests/path/to/test_file.py -q
@@ -29,7 +37,14 @@ npm --prefix react_app run lint
 
 Choose commands from the affected component's skill or existing project automation. Do not add tests during a review-only task.
 
-### 2. Before commit: quick gate once
+### 3. After content freeze: focused evidence together
+
+After all intended versioned writes are complete, run the affected focused
+tests, benchmarks, and architecture/import checks as one consolidated
+selection. Refresh maintained indexes once before this selection when they are
+affected.
+
+### 4. Before commit: quick gate once
 
 ```bash
 ./run.sh check --quick
@@ -37,19 +52,23 @@ Choose commands from the affected component's skill or existing project automati
 
 If it fails, diagnose the first relevant failure, fix its root cause, rerun that narrow check, then rerun the quick gate once.
 
-### 3. PR acceptance: required CI
+### 5. PR acceptance: required CI
 
 The GitHub check named `PR Gate` is the authoritative merge gate. Inspect the check for the current commit. Do not rerun an equivalent local suite merely because CI already passed it. A failing or stale check blocks acceptance; bypass flags and admin merges are forbidden.
 
-### 4. Implementation closeout: full gate once
+### 6. Cumulative implementation closeout: full gate once
 
 ```bash
 ./run.sh check
 ```
 
-Run the full gate once after the scoped implementation is stable. After a failure, rerun only the failed check while repairing it; repeat the full gate only when the fix can affect other categories or to establish the final green result.
+Run the full gate once after all intended packets in the milestone are integrated.
+Run it earlier only when repository-wide risk makes that necessary. After a
+failure, rerun only the failed check while repairing it; repeat the full gate
+only when the fix can affect other categories or to establish the final green
+result.
 
-### 5. Release only
+### 7. Release only
 
 For an actual release candidate, use the release skill and its canonical preflight:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,15 @@ The canonical policy is [docs/guidelines/ai-token-efficiency.md](docs/guidelines
 - The orchestrator must add non-goals, likely pitfalls, measurable acceptance criteria, narrow tests, and a return format to each packet, then independently inspect and verify the result before acceptance.
 - Named handoff chains below are quality roles, not mandatory agent processes. The parent normally performs implementation, testing, documentation, and operations passes itself.
 - Start with `./run.sh session brief --agent <role>`, folder indexes, and targeted `rg`; do not load full agent files or large logs unless required.
+- Use implementation-first, batched verification for each agreed bounded packet.
+  Complete the scoped code, tests, documentation, and other intended writes
+  before the routine verification sequence. While implementing, run only a
+  narrow reproducer, test, or diagnostic that is needed to guide or debug the
+  current change; do not rerun quick, full, or unchanged suites after each
+  edit. After content freezes, run the affected focused checks together, the
+  quick gate once, normal commit hooks, and the required hosted checks. If an
+  outcome-changing repair alters the frozen candidate, rerun the affected
+  focused evidence and then the consolidated gate once.
 - For a multi-packet milestone, run focused tests, independent benchmarks,
   architecture/import checks, `./run.sh check --quick`, normal commit hooks,
   and every required hosted PR check for each packet. Run the broad Python

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -12,8 +12,7 @@
 **Branch:** `codex/implementation-first-verification-policy` from freshly
 fetched `origin/main = 55104e11257937b0a42fb06f931a70b8484cef39`
 
-**Git handoff receipt:**
-`docs/verification/implementation-first-verification-policy-git-handoff-receipt.json`
+**Git handoff receipt:** `docs/verification/implementation-first-verification-policy-git-handoff-receipt.json`
 
 **Focus:** Make the owner's implementation-first, batched-verification cadence
 durable for future repository chats. Preserve the clean Packet A candidate and
@@ -38,6 +37,8 @@ adapters, release behavior, or the active LIB-PRO-002 handoff.
   duplicated gates, but did not explicitly say that routine verification
   starts only after the whole bounded packet is implemented and frozen. That
   ambiguity could make future chats rerun unchanged checks after small edits.
+- The first session-end check did not discover the committed handoff receipt
+  because its path was wrapped onto the line after the bold label.
 
 ### Root causes and resolutions
 
@@ -49,6 +50,12 @@ adapters, release behavior, or the active LIB-PRO-002 handoff.
   checks, and one cumulative full gate. Evidence: the efficiency policy check,
   documentation checks, affected indexes, quick gate, session-end contract,
   and normal commit hooks complete after content freeze.
+- Confirmed root cause: the session-end parser requires the receipt path on the
+  same line as the bold `Git handoff receipt` label. Resolution: place the
+  committed path on that label line and retain this exact format for future
+  entries. Evidence: the repaired session-end check discovers and validates
+  the receipt. ⚠️ TERMINAL ISSUE: session end reported a missing receipt ->
+  matched the maintained same-line parser contract.
 
 ### Validation through content freeze
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,62 @@
 
 ---
 
+## 2026-08-17 — Session: Implementation-First Verification Policy
+
+**Agent:** Codex (`governance`, sole writer)
+
+**Branch:** `codex/implementation-first-verification-policy` from freshly
+fetched `origin/main = 55104e11257937b0a42fb06f931a70b8484cef39`
+
+**Git handoff receipt:**
+`docs/verification/implementation-first-verification-policy-git-handoff-receipt.json`
+
+**Focus:** Make the owner's implementation-first, batched-verification cadence
+durable for future repository chats. Preserve the clean Packet A candidate and
+all unrelated worktrees; do not change structural calculations, APIs, React,
+adapters, release behavior, or the active LIB-PRO-002 handoff.
+
+### Summary
+
+- Made one bounded packet, rather than each edit, the routine verification
+  boundary.
+- Limited during-implementation checks to narrow evidence needed to guide or
+  debug a live question.
+- Consolidated focused checks, the single quick gate, commit hooks, hosted
+  checks, and the cumulative full gate into an explicit non-duplicative
+  cadence shared by top-level instructions, canonical efficiency policy, and
+  the quality-gate skill.
+- Kept required safety, independent-review, hosted-CI, and release gates intact.
+
+### Issues encountered
+
+- Existing guidance said to use targeted checks while editing and to avoid
+  duplicated gates, but did not explicitly say that routine verification
+  starts only after the whole bounded packet is implemented and frozen. That
+  ambiguity could make future chats rerun unchanged checks after small edits.
+
+### Root causes and resolutions
+
+- Confirmed root cause: the intended cadence was split across `AGENTS.md`, the
+  canonical token-efficiency guide, and the quality-gate skill, while the phrase
+  “while editing” lacked a necessity condition. Resolution: align all three
+  surfaces on implementation first, necessary diagnostics only, one
+  consolidated post-freeze focused selection, one quick gate, required hosted
+  checks, and one cumulative full gate. Evidence: the efficiency policy check,
+  documentation checks, affected indexes, quick gate, session-end contract,
+  and normal commit hooks complete after content freeze.
+
+### Validation through content freeze
+
+- Startup evidence: fresh fetch equality at
+  `55104e11257937b0a42fb06f931a70b8484cef39`, a clean isolated policy lane,
+  and current-worktree Python source binding.
+- Packet A remains a separate clean `READY_LOCAL` worktree at
+  `22066d0d83f84995b898a58b43993f621ec2d8d0`; the unrelated dirty detached
+  worktree remains untouched.
+- No task-board or next-session-brief update is required because this policy
+  change does not alter the active LIB-PRO-002 packet sequence or handoff.
+
 ## 2026-08-17 — Session: Pre-Release Input-Safety Contract Freeze
 
 **Agent:** Codex (`orchestrator` and `doc-master`, sole writer; two bounded

--- a/docs/guidelines/ai-token-efficiency.md
+++ b/docs/guidelines/ai-token-efficiency.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-15
+last_updated: 2026-08-17
 doc_type: guide
 ---
 
@@ -144,18 +144,32 @@ Then:
 
 ## Verification Ladder
 
+The default cadence is implementation first, then one batched verification
+sequence for the agreed bounded packet. A diagnostic check during implementation
+is an exception used to guide or debug the change, not a ritual after each edit.
+
 1. Inspect only affected files and existing patterns.
-2. Implement one bounded issue.
-3. Run the narrowest relevant test or lint command while iterating.
-4. Add one or two independent reviews only when risk justifies them.
-5. Run `./run.sh check --quick` before committing.
-6. For a multi-packet milestone, keep each packet to focused tests, independent
-   benchmarks, architecture/import checks, the quick gate, normal commit hooks,
-   and all required hosted PR checks.
-7. After all intended packets are integrated, run the broad Python suite and
+2. Complete the bounded implementation, its tests, documentation, evidence,
+   and other intended versioned writes.
+3. While implementing, run only the narrowest reproducer, test, lint, or
+   diagnostic needed to answer a current question or repair a failure. Do not
+   rerun quick, full, or unchanged suites after each edit.
+4. Freeze the packet content, including its single maintained-index refresh
+   when indexes are affected.
+5. Run the affected focused tests, benchmarks, and architecture/import checks
+   together as one consolidated selection.
+6. Add one or two independent reviews only when risk justifies them, then run
+   `./run.sh check --quick` once before committing and allow normal hooks to run.
+7. If verification exposes an outcome-changing defect, repair its root cause,
+   rerun the failed or affected narrow evidence, and repeat the consolidated
+   gate once for the new frozen candidate.
+8. For a multi-packet milestone, keep each completed packet to focused tests,
+   independent benchmarks, architecture/import checks, the quick gate, normal
+   commit hooks, and all required hosted PR checks.
+9. After all intended packets are integrated, run the broad Python suite and
    `./run.sh check` (currently 30 checks) once at the cumulative closeout.
    Repeat only a failed portion unless the fix can affect other categories.
-8. Run either broad gate before cumulative closeout only when an
+10. Run either broad gate before cumulative closeout only when an
    outcome-changing failure or repository-wide surface makes it necessary.
    Required hosted checks are never deferred or bypassed.
 
@@ -233,8 +247,11 @@ authority. Default to no
 subagents; use no more than two only for independent,
 bounded work. Give each a concise packet with objective, exact files, non-goals,
 pitfalls, acceptance criteria, tests, and return format—never full conversation
-history. Verify every result before accepting it. Run targeted tests during
-development and the full gate once at closeout. Close subagents and stop when done.
+history. Verify every result before accepting it. Complete the bounded
+implementation first; use a narrow diagnostic during editing only when needed,
+then run one consolidated focused selection and one quick gate after content
+freezes. Run the full gate once at cumulative closeout. Close subagents and stop
+when done.
 ```
 
 ## Official References

--- a/docs/guidelines/index.json
+++ b/docs/guidelines/index.json
@@ -2,14 +2,14 @@
   "folder": "docs/guidelines",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-15",
+  "last_updated": "2026-08-17",
   "file_count": 16,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
       "size_lines": 74,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "title": "Guidelines Index",
       "description": "Development standards and best practices for the structural engineering library. | Need To... | Read This |",
       "content_hash": "33a845020aca"
@@ -17,16 +17,16 @@
     {
       "name": "ai-token-efficiency.md",
       "type": "documentation",
-      "size_lines": 241,
-      "last_updated": "2026-08-15",
+      "size_lines": 265,
+      "last_updated": "2026-08-17",
       "description": "This is the canonical low-token operating policy for AI-assisted work in this repository. It controls avoidable context and agent fan-out without weakening",
-      "content_hash": "3f488ba304f9"
+      "content_hash": "c65df56ad83d"
     },
     {
       "name": "api-design-guidelines.md",
       "type": "documentation",
       "size_lines": 2626,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "This document consolidates all Phase 1 and Phase 2 API research into a **single, actionable reference** for developing structural_engineering_lib APIs. Use this as the \"north star\" for all API design ",
       "content_hash": "69b32bfec1a0"
     },
@@ -34,7 +34,7 @@
       "name": "api-evolution-standard.md",
       "type": "documentation",
       "size_lines": 1691,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "> **Standard for API versioning, deprecation, and backward compatibility** > Part of: API Improvement Research (TASK-207)",
       "content_hash": "5816feab7380"
     },
@@ -42,7 +42,7 @@
       "name": "blog-writing-guide.md",
       "type": "documentation",
       "size_lines": 860,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "| Audience | Tone | Example | |----------|------|---------|",
       "content_hash": "b7c4234e5431"
     },
@@ -50,7 +50,7 @@
       "name": "doc-naming-conventions.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "Reduce duplication, improve findability, and ensure every topic has a clear canonical home. 1. **One topic = one canonical file.** Check docs/docs-canonical.json first.",
       "content_hash": "e9614c2283ad"
     },
@@ -58,7 +58,7 @@
       "name": "documentation-standard.md",
       "type": "documentation",
       "size_lines": 1614,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "> **Standard for documentation, docstrings, and API discoverability** > Part of: API Improvement Research (TASK-206)",
       "content_hash": "6931309770e9"
     },
@@ -66,7 +66,7 @@
       "name": "error-handling-standard.md",
       "type": "documentation",
       "size_lines": 1935,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "> **Standard for exception design, error messages, and validation patterns** > Part of: API Improvement Research (TASK-204)",
       "content_hash": "5e23a429bea3"
     },
@@ -74,7 +74,7 @@
       "name": "file-operations-safety-guide.md",
       "type": "documentation",
       "size_lines": 308,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "File operations (delete, move, rename) can break: - Internal markdown links",
       "content_hash": "3bdf4e50bb20"
     },
@@ -82,7 +82,7 @@
       "name": "folder-cleanup-workflow.md",
       "type": "documentation",
       "size_lines": 294,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "This workflow provides a systematic approach to cleaning up folders: 1. **Audit** - Identify cleanup candidates",
       "content_hash": "e5e2eca12a9f"
     },
@@ -90,7 +90,7 @@
       "name": "folder-structure-governance.md",
       "type": "documentation",
       "size_lines": 530,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "1. **Progressive Disclosure** - Short entry docs, detailed content one level down 2. **Clear Ownership** - Every folder has a clear purpose and maintainer",
       "content_hash": "6aed96cb759b"
     },
@@ -98,14 +98,14 @@
       "name": "function-signature-standard.md",
       "type": "documentation",
       "size_lines": 1352,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "This document defines the standard for function signatures in the structural_engineering_lib to ensure: - **Discoverability**: IDE autocomplete and type checkers work effectively",
       "content_hash": "4feea637cd31"
     },
     {
       "name": "governance-limits.json",
       "type": "config",
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "top_level_keys": [
         "root",
         "docs_root",
@@ -118,7 +118,7 @@
       "name": "migration-preflight-checklist.md",
       "type": "documentation",
       "size_lines": 284,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "bash .venv/bin/python scripts/pre_migration_check.py",
       "content_hash": "be5802ce0399"
     },
@@ -126,7 +126,7 @@
       "name": "migration-workflow-guide.md",
       "type": "documentation",
       "size_lines": 460,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "bash ./scripts/python_runtime.sh scripts/pre_migration_check.py",
       "content_hash": "cc62b460fc3e"
     },
@@ -134,11 +134,11 @@
       "name": "result-object-standard.md",
       "type": "documentation",
       "size_lines": 1437,
-      "last_updated": "2026-08-15",
+      "last_updated": "2026-08-17",
       "description": "This document defines standards for result objects returned by functions in structural_engineering_lib. Result objects replace primitive returns (tuples, dicts) with structured, self-documenting, type",
       "content_hash": "c613ac1f4ae5"
     }
   ],
   "subfolders": [],
-  "content_hash": "fed1ed5c5ef2e933"
+  "content_hash": "61d0b04873ccc845"
 }

--- a/docs/guidelines/index.md
+++ b/docs/guidelines/index.md
@@ -1,7 +1,7 @@
 # Guidelines
 
 **Type:** Documentation
-**Last Updated:** 2026-08-15
+**Last Updated:** 2026-08-17
 **Files:** 16
 
 ## Config Files
@@ -13,7 +13,7 @@
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Guidelines Index | Development standards and best practices for the structural  | 74 |
-| [ai-token-efficiency.md](ai-token-efficiency.md) |  | This is the canonical low-token operating policy for AI-assi | 241 |
+| [ai-token-efficiency.md](ai-token-efficiency.md) |  | This is the canonical low-token operating policy for AI-assi | 265 |
 | [api-design-guidelines.md](api-design-guidelines.md) |  | This document consolidates all Phase 1 and Phase 2 API resea | 2626 |
 | [api-evolution-standard.md](api-evolution-standard.md) |  | > **Standard for API versioning, deprecation, and backward c | 1691 |
 | [blog-writing-guide.md](blog-writing-guide.md) |  | | Audience | Tone | Example | |----------|------|---------| | 860 |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 1267,
+      "size_lines": 1274,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "ed9918f47758"
+      "content_hash": "d425aa92854e"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "60d37d41faae8256"
+  "content_hash": "b030cafd55d1197e"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 1211,
+      "size_lines": 1267,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "25be8783d678"
+      "content_hash": "ed9918f47758"
     },
     {
       "name": "TASKS.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 159,
+      "file_count": 160,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "938e8e9e867e86ed"
+  "content_hash": "60d37d41faae8256"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1211 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1267 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 702 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1792 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 159 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 160 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1267 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1274 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 702 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/verification/implementation-first-verification-policy-git-handoff-receipt.json
+++ b/docs/verification/implementation-first-verification-policy-git-handoff-receipt.json
@@ -1,0 +1,125 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "83347f7acf80750f0d45b0eff94c782b4d759c468601ec7cffd0fdeaa1c744f1",
+    "state": {
+      "branch": "codex/implementation-first-verification-policy",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "55104e11257937b0a42fb06f931a70b8484cef39",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 89.04,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-implementation-first-verification-policy",
+      "head_sha": "55104e11257937b0a42fb06f931a70b8484cef39",
+      "hold_reasons": [
+        "changed paths: 4"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-16T19:33:38.850004+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-implementation-first-verification-policy",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 4,
+        "modified_paths": [
+          ".github/skills/quality-gate/SKILL.md",
+          "AGENTS.md",
+          "docs/SESSION_LOG.md",
+          "docs/guidelines/ai-token-efficiency.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "55104e11257937b0a42fb06f931a70b8484cef39",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-implementation-first-verification-policy"
+    }
+  },
+  "local_state_receipt_hash": "sha256:83347f7acf80750f0d45b0eff94c782b4d759c468601ec7cffd0fdeaa1c744f1",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-16T19:33:38.850181+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/",
+      "fastapi_app/",
+      "react_app/"
+    ],
+    "integration_owner": "Codex",
+    "owned_paths": [
+      "AGENTS.md",
+      "docs/guidelines/ai-token-efficiency.md",
+      ".github/skills/quality-gate/SKILL.md",
+      "docs/verification/implementation-first-verification-policy-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/guidelines/index.json",
+      "docs/guidelines/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md"
+    ],
+    "task_id": "GOV-IMPLEMENTATION-FIRST-VERIFICATION"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-17",
-  "file_count": 157,
+  "file_count": 158,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -149,6 +149,24 @@
         "task_archive"
       ],
       "content_hash": "46faa81c1af4"
+    },
+    {
+      "name": "implementation-first-verification-policy-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-17",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "402ef1894c3b"
     },
     {
       "name": "india-1-cumulative-gate-evidence.md",
@@ -1963,5 +1981,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "a344e1a833c1ba25"
+  "content_hash": "4af650572448d4b1"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-17
-**Files:** 157
+**Files:** 158
 
 ## Config Files
 
@@ -14,6 +14,7 @@ Benchmark examples and verification packs for validating library calculations ag
 - [git-001-phase-8-reconciliation-git-handoff-source-evidence.json](git-001-phase-8-reconciliation-git-handoff-source-evidence.json)
 - [git-primary-session-log-reconcile-handoff-receipt.json](git-primary-session-log-reconcile-handoff-receipt.json)
 - [git-primary-session-log-reconcile-handoff-source-evidence.json](git-primary-session-log-reconcile-handoff-source-evidence.json)
+- [implementation-first-verification-policy-git-handoff-receipt.json](implementation-first-verification-policy-git-handoff-receipt.json)
 - [india-2-closeout-git-handoff-receipt.json](india-2-closeout-git-handoff-receipt.json)
 - [india-2-closeout-git-handoff-source-evidence.json](india-2-closeout-git-handoff-source-evidence.json)
 - [india-2-cumulative-git-handoff-receipt.json](india-2-cumulative-git-handoff-receipt.json)


### PR DESCRIPTION
## What changed

- make the agreed bounded packet, rather than each edit, the routine verification boundary
- allow narrow checks during implementation only when they are needed to guide or debug a live question
- run one consolidated focused selection and one quick gate after content freeze
- retain required per-PR hosted checks and one broad gate at cumulative milestone closeout
- align `AGENTS.md`, the canonical token-efficiency policy, and the `quality-gate` skill

## Why

The intended non-duplicative cadence was split across several instruction surfaces. The phrase “targeted checks while editing” could therefore be interpreted as permission to rerun unchanged checks after every small edit, wasting time without improving the main-process outcome.

## Impact

Future repository chats inherit an explicit implementation-first workflow without weakening structural-safety, independent-review, CI, or release gates. The existing Packet A candidate and unrelated worktrees are unchanged.

## Validation

- `./run.sh efficiency check` — PASS
- `./run.sh check --quick` — 10/10 PASS on the final repair candidate
- normal commit hooks — PASS for both commits
- `./run.sh session end --agent governance` — PASS
- handoff receipt validation — valid expected `HOLD`
