### PR TITLE
docs(planning): close remaining publication blockers

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,131 @@
 
 ---
 
+## 2026-08-17 — Session: LIB-PRO-002 Post-Fix Usability Re-Audit
+
+**Agent:** Codex (`library-expert`, documentation/evidence owner)
+
+**Branch:** `codex/lib-pro-002-usability-refresh` from A-G merge
+`fe4ab025419b834c6d0f840e9492c0604ae74201` (PR #815)
+
+**Git handoff receipt:** `docs/verification/lib-pro-002-post-fix-recheck-git-handoff-receipt.json`
+
+**Focus:** Re-run the synthetic one-storey user workflow and manual comparison,
+verify whether A-G fixed the original usability hazards, audit professional API
+and publication surfaces, and update the active plan without changing runtime
+behavior or authorizing publication/professional use.
+
+### Summary
+
+- Confirmed that the A-G fixes are material: canonical and compatibility beam
+  services block malformed/empty inputs; named imports account rows/fields;
+  column materials are explicit; beam/slab/column/footing results retain
+  qualified-review truth; the current candidate wheel passes its declared
+  19-case negative UAT.
+- Recomputed a linked one-storey slab-to-beam-to-column-to-footing gravity
+  example. The library matches the independent load, action, flexure, shear,
+  column, footing pressure/moment/punching, and development-length arithmetic.
+  The footing correctly remains `FAIL` for inadequate dowel anchorage and
+  retains HOLD reasons for assumed load/soil/supporting-area bases.
+- Reproduced one unresolved advertised-path defect: the `design` CLI skipped a
+  malformed row, printed its warning to stdout, exited `0`, and emitted a
+  one-of-one PASS summary. Its old intake also supplies cover/effective-depth
+  assumptions outside the lossless/strict boundary.
+- Confirmed that the published PyPI `0.23.1a1` is the pre-A-G artifact: its page
+  has the wrong `0.23.0` pin and its displayed batch example raises
+  `AttributeError` against the exact installed wheel. No claim was made that
+  current source repairs the immutable old artifact.
+- Updated the active plan, task board, planning handoff, and planning README.
+  New Packet I owns CLI intake convergence, a versioned machine-readable output
+  contract, retained `design -> bbs/detail/dxf` compatibility or explicit
+  deprecation, advertised-entry-point inventory, and exact-wheel CLI negatives.
+  Packet H whole-building planning remains inactive.
+
+### Verification
+
+- Current source binding: `source_bound=true`; exact audit base
+  `fe4ab025419b834c6d0f840e9492c0604ae74201`.
+- Manual/library comparison matched the Section 2.4 values for slab, beam,
+  column, and footing, including `Ast_slab=207.012 mm2`,
+  `Ast_beam=465.092 mm2`, `Pu_column=68.789063 kN`,
+  `q_footing=89.027778 kPa`, `Mu_footing=1.533643 kNm`, punching utilization
+  `0.023010`, and required dowel `Ld=644.732 mm`.
+- Built the current wheel into a temporary directory, installed it into a clean
+  temporary environment, and ran `structural_lib.release_uat
+  --require-installed-wheel`: `PASS`, 19/19 declared cases, installed origin.
+- Focused current-source selection: 79/79 passed across batch, imports, column
+  project contract, result contract, release UAT, and Excel-integration edges.
+- Exact published-wheel replay: installed PyPI `0.23.1a1` into an isolated
+  environment; the displayed `GenericCSVAdapter` example failed with
+  `AttributeError: 'BeamGeometry' object has no attribute 'b_mm'`.
+- API audit: root `__all__` 187 symbols; service facade 168 symbols (91
+  functions, 77 classes); 28 service functions expose at least one audited
+  unit-ambiguous name requiring canonical/compatibility disposition before a
+  stable promise.
+- Independent structural reviewer: ACCEPT; independently reproduced every
+  Section 2.4 value and ran 101 focused tests, with no clause/claim
+  contradiction. Independent release reviewer initially rejected two plan
+  gaps; both the CLI output/downstream contract and post-plan-merge base wording
+  were corrected, and the focused follow-up returned ACCEPT before closeout.
+
+### Issues encountered
+
+- The advertised CLI retained the original row-loss/defaulting class after A-G
+  merged, even though the declared 19-case wheel UAT passed.
+- The first isolated PyPI replay inherited the repository `PYTHONPATH`, so it
+  imported current source rather than the installed wheel and then failed on a
+  missing dependency. That attempt was not accepted as package evidence.
+- The first synthetic footing call used human-readable basis text where the
+  strict contract requires exact controlled tokens. It blocked correctly before
+  calculation.
+- Independent release review found that a direct switch from the old CLI
+  `beams` artifact to the strict service `members` envelope could silently break
+  advertised `bbs`, `detail`, and `dxf` consumers, and that the handoff's exact
+  `fe4ab025…` future base would become stale after this plan merges.
+
+### Root causes and resolutions
+
+- Confirmed CLI root cause: A-G's route inventory covered service,
+  imports, HTTP/SSE/React, and selected package examples, but not every
+  advertised calculation entry point. The historical CLI therefore continued
+  calling `services.excel_integration.load_beam_data_from_csv`, which catches
+  parse errors, prints a warning, and continues with surviving rows. Resolution
+  in this documentation packet: add RC-7, CLI-01/CLI-02/REL-UAT-02, and Packet I
+  with whole-file blocking, row/field conservation, non-zero exit, stderr-only
+  diagnostics, versioned output compatibility, downstream workflow tests, and
+  an advertised-entry-point inventory. Evidence: mixed-row live replay and
+  direct source trace.
+- Confirmed UAT root cause: the packaged matrix proves its handler set is
+  complete relative to its data file, not complete relative to public docs/CLI
+  surfaces. Resolution: Packet I binds matrix coverage to the advertised
+  entry-point inventory and adds exact-wheel CLI cases. Evidence: 19/19 UAT PASS
+  alongside the reproduced CLI failure.
+- Confirmed installed-package evidence root cause: worktree-bound launchers set
+  source routing that is unsuitable for an isolation proof. Resolution: remove
+  `PYTHONPATH`/`PYTHONHOME`, install dependencies and the exact wheel in a fresh
+  temporary environment, verify `structural_lib.__file__`, then accept the
+  replay. Evidence: installed origin under temporary `site-packages` for both
+  current candidate and published-wheel runs.
+- The footing token failures were correct fail-closed validation, not product
+  defects. Resolution: use the maintained exact values
+  `includes_footing_self_weight_and_overburden` and
+  `largest_frustum_1v_2h`; the corrected call then matched manual arithmetic.
+- The independent review defects were plan incompleteness, not style issues.
+  Resolution: freeze the CLI output/downstream contract and treat `fe4ab025…`
+  as the required A-G ancestor while binding Packet I to exact fetched
+  `origin/main` after this reviewed plan merges.
+
+### Limitations and handoff
+
+- This session changed documentation and work state only; it did not implement
+  Packet I or alter structural calculations.
+- The one-storey replay is a synthetic component/load-path regression, not a
+  building analysis, source acceptance, geotechnical verification, qualified
+  review, code-compliant deliverable, or professional approval.
+- Next routine action: implement only Packet I from the exact fetched
+  post-plan-merge `origin/main`, with `fe4ab025…` as required ancestor. Keep
+  publication and Packet H held.
+
 ## 2026-08-17 — Session: LIB-PRO-002 B-G Cumulative Safety Integration
 
 **Agent:** Codex (`orchestrator`, sole writer)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -44,6 +44,10 @@ behavior or authorizing publication/professional use.
   contract, retained `design -> bbs/detail/dxf` compatibility or explicit
   deprecation, advertised-entry-point inventory, and exact-wheel CLI negatives.
   Packet H whole-building planning remains inactive.
+- A follow-up publication-readiness replay added Packet J rather than widening
+  Packet I: scheduled/tag full suites must bind the setup-python interpreter,
+  and pre-bump, technical-candidate, and authorized-publication modes must emit
+  different verdicts. No version bump or release action was authorized.
 
 ### Verification
 
@@ -71,6 +75,17 @@ behavior or authorizing publication/professional use.
   contradiction. Independent release reviewer initially rejected two plan
   gaps; both the CLI output/downstream contract and post-plan-merge base wording
   were corrected, and the focused follow-up returned ACCEPT before closeout.
+- Provisional `./run.sh release preflight 0.23.1a2`: 6,387 Python tests passed,
+  446 FastAPI tests passed, and the React build passed; it also reported no
+  candidate wheel and still printed `READY TO RELEASE`, so it is accepted only
+  as green pre-bump local health—not publication readiness.
+- Hosted Weekly Verification run `31988837003` at exact A-G merge
+  `fe4ab025...`: Docker, locked dependency, and clean-wheel jobs passed; the
+  full suite failed six governance/session tests because recursive repository
+  launchers could not find a project interpreter, and the summary failed.
+- Publication authorization checks for provisional `0.23.1a2` correctly
+  returned non-zero for TestPyPI, PyPI, and GitHub Release because decision,
+  version, tag, targets, owner, time, and exact review receipt remain unset.
 
 ### Issues encountered
 
@@ -86,6 +101,17 @@ behavior or authorizing publication/professional use.
   `beams` artifact to the strict service `members` envelope could silently break
   advertised `bbs`, `detail`, and `dxf` consumers, and that the handoff's exact
   `fe4ab025…` future base would become stale after this plan merges.
+- The scheduled full workflow and publish full-suite step do not export the
+  selected setup-python interpreter, although their tests can recursively call
+  `run.sh`/`python_runtime.sh`; the scheduled run failed six such tests.
+- Pre-bump preflight uses the same success label as publication readiness even
+  when it has no exact wheel and does not evaluate immutable review, hosted
+  receipts, or exact target authorization.
+- ⚠️ TERMINAL ISSUE: a targeted workflow search included an unmatched
+  `.github/workflows/*.yaml` zsh glob and stopped that compound command; running
+  `rg` directly on `.github/workflows` produced the intended evidence.
+- The first I-J handoff draft duplicated detailed-plan history and commands,
+  reached 200 lines, and failed the repository's 150-line brief gate.
 
 ### Root causes and resolutions
 
@@ -118,6 +144,26 @@ behavior or authorizing publication/professional use.
   Resolution: freeze the CLI output/downstream contract and treat `fe4ab025…`
   as the required A-G ancestor while binding Packet I to exact fetched
   `origin/main` after this reviewed plan merges.
+- Confirmed hosted-interpreter root cause: setup-python selects an executable
+  but creates neither the repository `.venv` nor `VIRTUAL_ENV`; the launcher is
+  intentionally fail-closed, and nightly/publish full suites omitted the
+  supported `STRUCTURAL_LIB_PYTHON` binding already used by PR control-plane
+  checks. Resolution in the plan: Packet J exports the exact
+  `command -v python` path for recursive full suites, preserves strict launcher
+  selection, adds workflow-contract tests, and requires a fresh manual Weekly
+  Verification pass on the immutable J head.
+- Confirmed preflight-verdict root cause: local pre-bump, exact-wheel technical,
+  and authorized publication states share one `errors == 0` success label;
+  missing wheel is only a warning and authorization is a separate command.
+  Resolution in the plan: Packet J introduces mode-specific verdicts and
+  reserves `READY_TO_PUBLISH` for exact wheel/UAT, review, hosted receipts, and
+  target authorization. Evidence: the green provisional preflight coexisted
+  with the reproduced CLI failure, failed hosted full run, and three rejected
+  authorization checks.
+- Confirmed brief-length root cause: the handoff repeated A-G history and full
+  command blocks already owned by the detailed plan. Resolution: retain exact
+  branches, I/J ownership, evidence, and stop rules while linking execution
+  details to the plan; the brief is 141 lines and the brief-length gate passes.
 
 ### Limitations and handoff
 
@@ -126,9 +172,10 @@ behavior or authorizing publication/professional use.
 - The one-storey replay is a synthetic component/load-path regression, not a
   building analysis, source acceptance, geotechnical verification, qualified
   review, code-compliant deliverable, or professional approval.
-- Next routine action: implement only Packet I from the exact fetched
-  post-plan-merge `origin/main`, with `fe4ab025…` as required ancestor. Keep
-  publication and Packet H held.
+- Next routine action: merge this plan, implement and merge Packet I from exact
+  fetched post-plan `origin/main`, then implement Packet J from exact post-I
+  `origin/main`. Run broad/exact-wheel/full hosted evidence at J, stop before a
+  version bump, and keep publication and Packet H held.
 
 ## 2026-08-17 — Session: LIB-PRO-002 B-G Cumulative Safety Integration
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -112,6 +112,11 @@ behavior or authorizing publication/professional use.
   `rg` directly on `.github/workflows` produced the intended evidence.
 - The first I-J handoff draft duplicated detailed-plan history and commands,
   reached 200 lines, and failed the repository's 150-line brief gate.
+- Normal commit hooks accepted the plan but warned that the descriptive status
+  `In Progress — Packets I-J Planned` was outside the canonical metadata enum.
+- ⚠️ TERMINAL ISSUE: the first repair check guessed the nonexistent
+  `scripts/check_doc_metadata.py`; `./run.sh find "doc metadata"` resolved the
+  maintained command to `scripts/check_docs.py --metadata --strict`.
 
 ### Root causes and resolutions
 
@@ -164,6 +169,9 @@ behavior or authorizing publication/professional use.
   command blocks already owned by the detailed plan. Resolution: retain exact
   branches, I/J ownership, evidence, and stop rules while linking execution
   details to the plan; the brief is 141 lines and the brief-length gate passes.
+- Confirmed metadata root cause: a descriptive suffix was placed in the strict
+  `Status` field instead of plan prose. Resolution: restore canonical
+  `In Progress`; validate through the discovered consolidated metadata command.
 
 ### Limitations and handoff
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-17 — LIB-PRO-002 A-G cumulative candidate integrated; acceptance and publication authorization held
+**Updated:** 2026-08-17 — A-G merged; post-fix replay opened CLI convergence Packet I and retained publication HOLD
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-002-B-G | Integrate lossless imports, route/client convergence, result/review truth, evidence identity, API/doc truth, and exact-wheel negative UAT | backend + tester + API + frontend + release | cumulative | P0 | 🚧 REPAIR CANDIDATE — first exact-head review rejected presence-only publication receipt validation at `c66160c7`; bind the actual receipt to reviewed Git/package identity, then restart exact review and hosted checks |
+| LIB-PRO-002-I | Converge the advertised `design` CLI on lossless/strict intake, freeze its JSON/downstream compatibility contract, and add every advertised calculation entry point to exact-wheel negative UAT | backend + tester + release | M | P0 | 📋 READY — post-fix replay at `fe4ab025` reproduced partial-success CLI row loss: one malformed row skipped, warning contaminated stdout, exit 0, remaining row reported PASS |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. INDIA-3, dependency, release execution, further cleanup, and
@@ -136,14 +136,15 @@ professional approval remain separately held.
 `LIB-PRO-002-G0` was independently accepted and merged through PR #812 at
 `55104e11257937b0a42fb06f931a70b8484cef39`. Packet A was independently
 accepted and merged through PR #814 at
-`3986935ecb473c1f9d56dec44aeb4218d9192f84`. The next publication remains held
-through cumulative A-G acceptance and a separate exact owner authorization.
+`3986935ecb473c1f9d56dec44aeb4218d9192f84`; Packets B-G merged through PR #815
+at `fe4ab025419b834c6d0f840e9492c0604ae74201`. The next publication remains
+held through Packet I acceptance and a separate exact owner authorization.
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-002-H | Decide whether to activate a separately source-backed whole-building workflow planning program | repository owner | decision gate | P2 | ⏸ NOT ACTIVATED — component-only claims remain; no whole-building implementation is authorized |
+| LIB-PRO-002-H | Decide whether to activate a separately source-backed whole-building workflow planning program after Packet I | repository owner | decision gate | P2 | ⏸ NOT ACTIVATED — component-only claims remain; no whole-building implementation is authorized |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 
 ## Backlog

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-17 — A-G merged; post-fix replay opened CLI convergence Packet I and retained publication HOLD
+**Updated:** 2026-08-17 — A-G merged; next session closes CLI Packet I and release-signal Packet J before any release preparation
 
 ---
 
@@ -128,6 +128,7 @@
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
 | LIB-PRO-002-I | Converge the advertised `design` CLI on lossless/strict intake, freeze its JSON/downstream compatibility contract, and add every advertised calculation entry point to exact-wheel negative UAT | backend + tester + release | M | P0 | 📋 READY — post-fix replay at `fe4ab025` reproduced partial-success CLI row loss: one malformed row skipped, warning contaminated stdout, exit 0, remaining row reported PASS |
+| LIB-PRO-002-J | Bind hosted full suites to the selected Python interpreter and replace warning-compatible `READY TO RELEASE` pre-bump output with mode-accurate candidate/publication verdicts | ops + tester + release | S | P0 | 📋 BLOCKED BY I — Weekly Verification `31988837003` failed six launcher-dependent tests; pre-bump `0.23.1a2` checks passed locally without a wheel but overstated release readiness |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. INDIA-3, dependency, release execution, further cleanup, and
@@ -138,13 +139,14 @@ professional approval remain separately held.
 accepted and merged through PR #814 at
 `3986935ecb473c1f9d56dec44aeb4218d9192f84`; Packets B-G merged through PR #815
 at `fe4ab025419b834c6d0f840e9492c0604ae74201`. The next publication remains
-held through Packet I acceptance and a separate exact owner authorization.
+held through Packets I-J, an exact versioned release candidate, immutable
+review/hosted evidence, and a separate exact owner authorization.
 
 ## Up Next
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-002-H | Decide whether to activate a separately source-backed whole-building workflow planning program after Packet I | repository owner | decision gate | P2 | ⏸ NOT ACTIVATED — component-only claims remain; no whole-building implementation is authorized |
+| LIB-PRO-002-H | Decide whether to activate a separately source-backed whole-building workflow planning program after Packets I-J | repository owner | decision gate | P2 | ⏸ NOT ACTIVATED — component-only claims remain; no whole-building implementation is authorized |
 | SPARK-001-G0 | Review the Spark master plan and accept, revise, or reject Wave 0 | repository owner | review gate | P1 | ⏸ OWNER REVIEW |
 
 ## Backlog

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 1855,
+      "size_lines": 1902,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "06a016ef16a7"
+      "content_hash": "243e3fe58653"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 709,
+      "size_lines": 711,
       "last_updated": "2026-08-17",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "6bf5324656b3"
+      "content_hash": "47ddfa02e0fd"
     },
     {
       "name": "WORKLOG.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "c5590034ee7b1a3e"
+  "content_hash": "e541f354e5e771fa"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 1902,
+      "size_lines": 1910,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "243e3fe58653"
+      "content_hash": "b37a6435dd7e"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "e541f354e5e771fa"
+  "content_hash": "4b278bb5788ac849"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -9,7 +9,7 @@
       "name": "README.md",
       "type": "documentation",
       "size_lines": 253,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "title": "Docs Index (Start Here)",
       "description": "Guides, references, evidence, and contributor material for the structural-lib-is456 Python package and the React/FastAPI workbench.",
       "content_hash": "09e22d932251"
@@ -17,33 +17,33 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 1730,
+      "size_lines": 1855,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "d0afae34c2ce"
+      "content_hash": "06a016ef16a7"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 708,
+      "size_lines": 709,
       "last_updated": "2026-08-17",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "58bced7e91f7"
+      "content_hash": "6bf5324656b3"
     },
     {
       "name": "WORKLOG.md",
       "type": "documentation",
       "size_lines": 354,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "description": "> **One line per item. Compact. Append-only.** > Format: DATE | TASK-ID | what changed | commit",
       "content_hash": "99219f077170"
     },
     {
       "name": "docs-canonical.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-04-06",
       "top_level_keys": [
         "_comment",
         "_updated",
@@ -57,7 +57,7 @@
     {
       "name": "docs-index.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "version",
         "generated",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 169,
+      "file_count": 170,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "cd941b60eb4aab20"
+  "content_hash": "c5590034ee7b1a3e"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1902 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1910 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 711 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1730 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 708 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1855 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 709 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1793 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 169 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 170 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1855 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 709 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 1902 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 711 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -33,8 +33,8 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
-| `next-session-brief.md` | 2026-08-17 | 📋 LIB-PRO-002-G0 is the planning candidate; Packet A is the exact next implementation boundary |
-| `pre-release-input-safety-and-professional-readiness-plan.md` | 2026-08-17 | 🚧 G0 contract freeze complete; next publication held through Packet G |
+| `next-session-brief.md` | 2026-08-17 | 📋 LIB-PRO-002-I CLI convergence is the exact next implementation boundary |
+| `pre-release-input-safety-and-professional-readiness-plan.md` | 2026-08-17 | 🚧 A-G merged; post-fix CLI gap keeps publication held through Packet I |
 | `is456-solid-slabs-master-plan.md` | 2026-08-10 | 📋 Master plan ready; implementation has not started |
 | `ui-experience-foundation-master-plan.md` | 2026-08-10 | ✅ Two-session P0-P15 workbench/capability program accepted |
 | `compact-modernization-plan.md` | 2026-08-09 | 📋 Ready after PR #676 |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -33,8 +33,8 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
-| `next-session-brief.md` | 2026-08-17 | 📋 LIB-PRO-002-I CLI convergence is the exact next implementation boundary |
-| `pre-release-input-safety-and-professional-readiness-plan.md` | 2026-08-17 | 🚧 A-G merged; post-fix CLI gap keeps publication held through Packet I |
+| `next-session-brief.md` | 2026-08-17 | 📋 LIB-PRO-002-I CLI closure then J release-signal convergence are the exact next sequence |
+| `pre-release-input-safety-and-professional-readiness-plan.md` | 2026-08-17 | 🚧 A-G merged; CLI, hosted-interpreter, preflight-verdict, and authorization holds remain through I-J |
 | `is456-solid-slabs-master-plan.md` | 2026-08-10 | 📋 Master plan ready; implementation has not started |
 | `ui-experience-foundation-master-plan.md` | 2026-08-10 | ✅ Two-session P0-P15 workbench/capability program accepted |
 | `compact-modernization-plan.md` | 2026-08-09 | 📋 Ready after PR #676 |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -12,7 +12,7 @@
       "last_updated": "2026-08-17",
       "title": "Planning",
       "description": "Internal planning documents and research notes. | Document | Purpose |",
-      "content_hash": "adcf8d6c4483"
+      "content_hash": "d73132ea428c"
     },
     {
       "name": "adoption-trust-surface-plan.md",
@@ -131,11 +131,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 98,
+      "size_lines": 142,
       "last_updated": "2026-08-17",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-17",
-      "content_hash": "68687706ebe5"
+      "content_hash": "0413e4cbd7d6"
     },
     {
       "name": "pre-release-checklist.md",
@@ -149,11 +149,11 @@
     {
       "name": "pre-release-input-safety-and-professional-readiness-plan.md",
       "type": "documentation",
-      "size_lines": 651,
+      "size_lines": 732,
       "last_updated": "2026-08-17",
       "title": "Pre-Release Input Safety and Professional Readiness Plan",
       "description": "fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G merged through PR #815",
-      "content_hash": "7182a9a01427"
+      "content_hash": "408a2d1c6bf2"
     },
     {
       "name": "professional-library-remediation-plan.md",
@@ -182,5 +182,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "b4daa2c979a3d3bf"
+  "content_hash": "82f07a057bbf0649"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -12,13 +12,13 @@
       "last_updated": "2026-08-17",
       "title": "Planning",
       "description": "Internal planning documents and research notes. | Document | Purpose |",
-      "content_hash": "82a8554d66b4"
+      "content_hash": "adcf8d6c4483"
     },
     {
       "name": "adoption-trust-surface-plan.md",
       "type": "documentation",
       "size_lines": 380,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "description": "Make the released Alpha straightforward to evaluate from four perspectives: - a user can copy every public quick start and receive the documented result;",
       "content_hash": "ce4b11ed46d5"
     },
@@ -26,7 +26,7 @@
       "name": "compact-modernization-plan.md",
       "type": "documentation",
       "size_lines": 794,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "description": "Modernize the repository's CI, maintenance controls, and agent-facing workflow without changing the structural-engineering product outcome. The finished repository must have:",
       "content_hash": "b0efe5bf80fd"
     },
@@ -34,7 +34,7 @@
       "name": "democratization-vision.md",
       "type": "documentation",
       "size_lines": 273,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-04-07",
       "description": "> **\"What was not possible few years back, or only possible for big firms — now everyone can use them free.\"** This project is not just about building a structural engineering library. It's about **de",
       "content_hash": "248d22c61e51"
     },
@@ -42,7 +42,7 @@
       "name": "dependency-security-baseline.md",
       "type": "documentation",
       "size_lines": 69,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-09",
       "description": "This record makes MAINT-003 reproducible. It separates confirmed vulnerabilities from transferred-environment residue and records every temporary exception.",
       "content_hash": "7870e2a5028a"
     },
@@ -50,7 +50,7 @@
       "name": "etabs-killer-masterplan.md",
       "type": "documentation",
       "size_lines": 2855,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-09",
       "title": "Project BHEEM: Open-Source Structural Design Software Masterplan",
       "description": "> **BHEEM** — **B**uilding **H**olistic **E**ngineering **E**nvironment with **M**achine-intelligence > An open-source, AI-native structural design platform that aims to surpass ETABS in usability, tr",
       "content_hash": "88e3dfd24f78"
@@ -59,7 +59,7 @@
       "name": "gpt-5-3-codex-spark-work-program.md",
       "type": "documentation",
       "size_lines": 614,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "description": "Use GPT-5.3-Codex-Spark as a high-throughput implementation lane for small, explicit, rapidly verifiable tasks. The program targets truthful documentation,",
       "content_hash": "4160ef25ca5e"
     },
@@ -67,7 +67,7 @@
       "name": "india-2-next-session-publication-and-closeout-plan.md",
       "type": "documentation",
       "size_lines": 529,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "Combined-footing and strap-footing G0/A-D plus focused family acceptance are integrated within their recorded bounded cases. GIT-001 Phase 8, the",
       "content_hash": "654fe82a8d12"
     },
@@ -75,7 +75,7 @@
       "name": "india-2-remaining-is456-elements-plan.md",
       "type": "documentation",
       "size_lines": 396,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "INDIA-2 finishes a practical, explicitly limited set of IS 456 reinforced concrete elements that are still missing from the library.",
       "content_hash": "ddd15751140c"
     },
@@ -83,7 +83,7 @@
       "name": "indian-code-completion-plan.md",
       "type": "documentation",
       "size_lines": 140,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "This is the canonical finish plan for the repository's Indian-code program. It defines the meaning and order of INDIA-0 through INDIA-4 without claiming",
       "content_hash": "9f7bd8b461a2"
     },
@@ -91,7 +91,7 @@
       "name": "is456-library-first-master-plan.md",
       "type": "documentation",
       "size_lines": 1507,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "The Python package is the product. FastAPI, React, command-line workflows, reports, ETABS adapters, and future integrations are consumers of that product.",
       "content_hash": "8f28361ce673"
     },
@@ -99,7 +99,7 @@
       "name": "is456-solid-slabs-master-plan.md",
       "type": "documentation",
       "size_lines": 1123,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "description": "The next element program will complete a useful, evidence-backed solid-slab workflow under IS 456 without pretending to solve every slab system.",
       "content_hash": "bcd3ec19ce4d"
     },
@@ -107,7 +107,7 @@
       "name": "library-expansion-blueprint-v5.md",
       "type": "documentation",
       "size_lines": 1121,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "title": "Library Expansion Blueprint v5.0 — Multi-Code, Multi-Element",
       "description": "> Master plan for expanding structural_engineering_lib from single-code beam-only (IS 456) to multi-code (IS 456, ACI 318-19, EC2), multi-element (beam, column, slab, footing, wall, stair) with comple",
       "content_hash": "c03aeee26b45"
@@ -116,7 +116,7 @@
       "name": "memory.md",
       "type": "documentation",
       "size_lines": 411,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "description": "- Development resumed after a four-month pause and a Mac laptop → Mac Mini transfer. - Git history, reachable objects, sample data, package source, and ARM64 Python environment transferred intact.",
       "content_hash": "78a539f85b53"
     },
@@ -124,24 +124,24 @@
       "name": "next-phase-improvements-plan.md",
       "type": "documentation",
       "size_lines": 1445,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-03-30",
       "description": "> This document is a result of a full audit of the beam library, FastAPI layer, and React app. > Nothing here assumes — it traces every suggestion back to what already exists and what is missing.",
       "content_hash": "9be9935445ee"
     },
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 79,
+      "size_lines": 98,
       "last_updated": "2026-08-17",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-17",
-      "content_hash": "3839f54b788b"
+      "content_hash": "68687706ebe5"
     },
     {
       "name": "pre-release-checklist.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "title": "Pre-Release Checklist",
       "description": "Release-ready source metadata: 0.23.1a1 Current public release: v0.23.1a1 Alpha",
       "content_hash": "aa14481f9a4b"
@@ -149,17 +149,17 @@
     {
       "name": "pre-release-input-safety-and-professional-readiness-plan.md",
       "type": "documentation",
-      "size_lines": 537,
+      "size_lines": 651,
       "last_updated": "2026-08-17",
       "title": "Pre-Release Input Safety and Professional Readiness Plan",
-      "description": "3986935ecb473c1f9d56dec44aeb4218d9192f84 after Packet A merged through PR #814",
-      "content_hash": "0a8af285bff1"
+      "description": "fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G merged through PR #815",
+      "content_hash": "7182a9a01427"
     },
     {
       "name": "professional-library-remediation-plan.md",
       "type": "documentation",
       "size_lines": 562,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "title": "Professional Library Remediation Plan",
       "description": "This document is no longer the active implementation plan. T0 and R1-R8 are complete, and their findings, packet definitions, and verification remain here",
       "content_hash": "31095ffcf998"
@@ -168,7 +168,7 @@
       "name": "react-ux-improvement-plan.md",
       "type": "documentation",
       "size_lines": 709,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "description": "> **Historical implementation record.** Execution status in this document is > superseded by",
       "content_hash": "706c92bd3f7a"
     },
@@ -176,11 +176,11 @@
       "name": "ui-experience-foundation-master-plan.md",
       "type": "documentation",
       "size_lines": 2408,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "description": "The product will move from a collection of equally weighted pages to one compact, professional structural workbench.",
       "content_hash": "fc8042fee46a"
     }
   ],
   "subfolders": [],
-  "content_hash": "8ee32063172cfd00"
+  "content_hash": "b4daa2c979a3d3bf"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -153,7 +153,7 @@
       "last_updated": "2026-08-17",
       "title": "Pre-Release Input Safety and Professional Readiness Plan",
       "description": "fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G merged through PR #815",
-      "content_hash": "408a2d1c6bf2"
+      "content_hash": "09958672d44d"
     },
     {
       "name": "professional-library-remediation-plan.md",
@@ -182,5 +182,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "82f07a057bbf0649"
+  "content_hash": "85ef4adb488c4201"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -23,9 +23,9 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-17 | 79 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-17 | 98 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
-| [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | 3986935ecb473c1f9d56dec44aeb4218d9192f84 after Packet A merg | 537 |
+| [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 651 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |
 | [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2408 |

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -23,9 +23,9 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-17 | 98 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-17 | 142 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
-| [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 651 |
+| [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 732 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |
 | [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2408 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,20 +4,22 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-17
-- Focus: LIB-PRO-002 post-fix usability replay and advertised CLI safety gap
-- Required ancestor: A-G merge `fe4ab025419b834c6d0f840e9492c0604ae74201` (PR #815); Packet I starts from the exact fetched `origin/main` after this reviewed plan merges
+- Focus: LIB-PRO-002 Packets I-J advertised CLI and release-signal closure
+- Required ancestor: A-G merge `fe4ab025419b834c6d0f840e9492c0604ae74201` (PR #815); Packet I starts from exact fetched `origin/main` after this reviewed plan merges, and Packet J starts only after Packet I merges
 - Lane: `codex/lib-pro-002-usability-refresh`; documentation/evidence owner only; unrelated worktrees preserved
 - Accepted improvement: strict batch/import/HTTP/SSE/React, cross-element review truth, evidence identity, API classification, and the declared 19-case exact-wheel UAT pass the reproduced cases
 - New blocker: advertised `python -m structural_lib design` still skips malformed CSV rows, exits 0, and reports a partial PASS; the 19-case exact-wheel matrix omits the CLI
+- Hosted blocker: Weekly Verification run `31988837003` failed six full-suite governance/session tests because the scheduled workflow did not export the selected setup-python interpreter; the publish full-suite step has the same environment gap
+- Verdict blocker: pre-bump `release preflight 0.23.1a2` passed 6,387 Python tests, 446 FastAPI tests, and the React build but incorrectly printed `READY TO RELEASE` with no exact wheel while authorization remained `HOLD`
 - Release: HOLD; `docs/verification/release-publication-authorization.json` contains no exact version/tag/target authorization
 - Whole-building workflow: Packet H is not activated and component-only claims remain
-- Exact next action: implement Packet I CLI convergence and advertised-entry-point exact-wheel UAT, then repeat immutable review and hosted checks
+- Exact next action: merge this planning packet; implement and merge Packet I; then implement Packet J, run the cumulative broad/exact-wheel gates and a manually dispatched full hosted workflow, and merge only unchanged accepted heads
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; no stable, professional-approval, or whole-building claim |
-| **Next** | LIB-PRO-002-I advertised CLI convergence and exact-wheel entry-point closure |
+| **Next** | LIB-PRO-002-I then LIB-PRO-002-J; no release-candidate mutation or publication |
 | **Held** | Publication, professional approval, Packet H, INDIA-3, dependency work, branch/worktree cleanup, and unrelated retained lanes |
 
 ## Required Reading
@@ -30,9 +32,12 @@
 
 ## Resume safely
 
-Start Packet I in one fresh source-bound lane from the exact fetched
-`origin/main` after this reviewed plan merges. Do not mutate primary `main`,
-reuse the historical A-G candidate lane, or clean unrelated worktrees.
+Start Packet I in fresh source-bound lane `codex/lib-pro-002-i-cli` from exact
+fetched `origin/main` after this reviewed plan merges. After Packet I's exact
+head is accepted, passes hosted checks, and merges, start Packet J in a second
+fresh lane `codex/lib-pro-002-j-release-signal` from the new exact
+`origin/main`. Never keep both packets as active writers. Do not mutate primary
+`main`, reuse historical candidate lanes, or clean unrelated worktrees.
 
 ```bash
 ./run.sh session brief --agent orchestrator
@@ -41,34 +46,16 @@ reuse the historical A-G candidate lane, or clean unrelated worktrees.
 ./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
 
-Require `fe4ab025…` as an ancestor, record the actual fetched base/head,
+Require `fe4ab025…` as an ancestor, record each actual fetched base/head,
 `source_bound=true`, no operation marker, and no new overlapping writer before
-mutation. Preserve every unrelated lane.
-
-## Integrated A-G boundary
-
-- strict canonical beam input, explicit effective depth, stable blocking issues,
-  no calculation call for blocked inputs, and accounted empty/mixed batches;
-- explicit/unique adapter selection, every-row/every-field normalization ledger,
-  and blocking malformed, dropped, duplicate, or unmatched records;
-- one canonical service orchestration shared by HTTP/SSE/React, with old routes
-  delegating or deprecated and no client structural fallback;
-- orthogonal intake/calculation/engineering/review truth across beam, slab,
-  column, and footing, retaining the correct insufficient-dowel FAIL;
-- calculation, library, controlled-source, amendment, artifact, ledger,
-  assumption, provenance, and replay identity;
-- complete Alpha API classification, corrected version/claim/example surfaces,
-  and installed-package preflight;
-- source-free exact-wheel negative UAT plus an explicit per-version/tag/target
-  owner authorization stop before publication; the repair resolves and hashes
-  an actual independent-review JSON receipt, verifies reviewed Git/Python
-  identity and permits only an evidence-only descendant delta.
-
-The post-fix replay did not invalidate these improvements. It found that their
-route inventory was incomplete.
+mutation. Before Packet J starts, prove Packet I is integrated and compare all
+open task-owned candidate paths. Preserve every unrelated lane.
 
 ## Packet I boundary
 
+- freeze the default valid output as the existing versioned `beams` envelope
+  before replacing orchestration; migrate by a compatibility adapter rather
+  than silently switching downstream consumers to the service `members` shape;
 - replace the `design` CLI's row-skipping/defaulting intake with the lossless
   ledger and strict project command;
 - block the whole CLI project on any malformed, missing, non-finite, unknown,
@@ -81,16 +68,73 @@ route inventory was incomplete.
 - add valid, malformed-only, mixed-validity, empty, missing-depth/cover,
   duplicate, unknown-field, and ambiguous-format CLI cases to exact-wheel UAT;
 - bind all advertised calculation entry points to a generated or validated
-  inventory so a future route cannot be omitted silently;
+  inventory classifying calculation entry, result consumer, inspection,
+  compatibility, deprecated, and held surfaces so a future route cannot be
+  omitted silently;
 - retain the corrected one-storey beam result for complete canonical input.
+
+Packet I owns only CLI/import/service/UAT and directly affected docs/tests. It
+does not own workflow interpreter policy, release verdict labels, dependency
+updates, new formulas, whole-building work, version bump, or publication.
+
+## Packet J boundary
+
+- reuse `STRUCTURAL_LIB_PYTHON="$(command -v python)"` in the Weekly
+  Verification and publish full-suite steps so recursive repository launchers
+  inherit the exact setup-python interpreter;
+- preserve `python_runtime.sh` fail-closed selection; do not add a bare-system-
+  Python fallback;
+- add workflow-contract tests that fail if a hosted full suite can invoke
+  `run.sh`/`python_runtime.sh` without the interpreter binding;
+- replace the single preflight success label with
+  `READY_TO_PREPARE_CANDIDATE`, `CANDIDATE_TECHNICALLY_READY` plus explicit
+  holds, and `READY_TO_PUBLISH` only after exact authorization;
+- keep pre-bump validation read-only and allow it to run before authorization,
+  but never describe missing wheel/review/hosted/authorization evidence as a
+  warning-compatible release-ready state;
+- manually dispatch Weekly Verification on Packet J's exact remote head and
+  require every full Python/FastAPI/React/docs/summary job to pass.
+
+Packet J owns only `.github/workflows/nightly.yml`, the directly affected
+publish validation step, `scripts/release.py`, focused workflow/release tests,
+and directly affected release guidance. It does not bump a version, create a
+tag, authorize targets, upload a package, or activate Packet H.
+
+## Next-session execution order
+
+1. Fetch `origin/main`; inspect all worktrees/open task-owned PRs and require a
+   clean fresh Packet I lane with `source_bound=true`.
+2. Freeze Packet I tests before orchestration changes: valid legacy `beams`
+   output/downstream compatibility, whole-file blocking, stdout/stderr, exit
+   code, row/field conservation, and advertised-entry-point inventory.
+3. Implement all Packet I writes, then run its consolidated CLI, Excel-edge,
+   import, batch, release-UAT, and quick checks listed in the detailed plan.
+4. Complete Packet I session/handoff/index writes, hooks, immutable review,
+   hosted PR checks, and unchanged-head merge. Do not start J before merge.
+5. Create the fresh Packet J lane from fetched post-I `origin/main`; freeze
+   workflow/preflight verdict tests, then implement all J writes.
+6. Run Packet J's workflow-contract, release-script, release-environment, and
+   quick checks listed in the detailed plan.
+7. Freeze Packet J documentation/evidence/indexes, run normal hooks, then run
+   Python, FastAPI, React, and the full canonical gate once cumulatively.
+8. Build one clean technical-acceptance wheel for the unchanged current source,
+   run expanded source-free UAT/public examples and exact-wheel preflight, then
+   obtain immutable review, required PR checks, and the manual Weekly
+   Verification receipt. This wheel is evidence for I-J, not authority to
+   republish `0.23.1a1`.
+9. Merge only the unchanged accepted J head, synchronize clean primary `main`,
+   and stop. A later owner-authorized release-preparation session selects and
+   bumps the next version, writes release notes, builds the final versioned
+   wheel, repeats exact review/hosted gates, and requests exact target
+   authorization.
 
 ## Acceptance and stop rules
 
-After Packet I freezes, run its focused CLI/import/service tests, the complete
-negative matrix, public examples, broad Python, complete FastAPI/React, full
-canonical, packaging, protected-source, and exact-wheel gates once. Bind the
-immutable commit/tree to an independent software/release-evidence review and
-all required hosted checks before merge.
+Required final evidence is: Packet I and J base/head/tree receipts; source-
+bound diagnostics; focused counts; exact wheel filename and SHA-256; expanded
+entry-point matrix identity and result; public-example result; independent
+review decision; PR check URLs; Weekly Verification URL; and a publication
+authorization check that still returns `HOLD` until the owner separately acts.
 
 Do not publish a package, create a tag or GitHub Release, claim professional
 approval, activate Packet H, close issues/PRs, delete branches, or clean retained

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,24 +4,25 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-17
-- Focus: LIB-PRO-002 cumulative A-G input safety and professional-readiness integration
-- Base: Packet A merge `3986935ecb473c1f9d56dec44aeb4218d9192f84` (PR #814)
-- Lane: `codex/lib-pro-002-b-lossless-import`; one isolated writer; unrelated worktrees preserved
-- Candidate: Packets B-G integrated; first exact-head review rejected a bypassable presence-only publication receipt check after all local/hosted gates passed
+- Focus: LIB-PRO-002 post-fix usability replay and advertised CLI safety gap
+- Required ancestor: A-G merge `fe4ab025419b834c6d0f840e9492c0604ae74201` (PR #815); Packet I starts from the exact fetched `origin/main` after this reviewed plan merges
+- Lane: `codex/lib-pro-002-usability-refresh`; documentation/evidence owner only; unrelated worktrees preserved
+- Accepted improvement: strict batch/import/HTTP/SSE/React, cross-element review truth, evidence identity, API classification, and the declared 19-case exact-wheel UAT pass the reproduced cases
+- New blocker: advertised `python -m structural_lib design` still skips malformed CSV rows, exits 0, and reports a partial PASS; the 19-case exact-wheel matrix omits the CLI
 - Release: HOLD; `docs/verification/release-publication-authorization.json` contains no exact version/tag/target authorization
 - Whole-building workflow: Packet H is not activated and component-only claims remain
-- Exact next action: finish the receipt head/tree/package/version/tag/target binding repair, then create one repaired immutable head and restart exact review plus hosted checks
+- Exact next action: implement Packet I CLI convergence and advertised-entry-point exact-wheel UAT, then repeat immutable review and hosted checks
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
 | **Current** | `v0.23.1a1` Alpha; no stable, professional-approval, or whole-building claim |
-| **Next** | LIB-PRO-002 A-G cumulative input/import/result/evidence/API/release-safety acceptance |
+| **Next** | LIB-PRO-002-I advertised CLI convergence and exact-wheel entry-point closure |
 | **Held** | Publication, professional approval, Packet H, INDIA-3, dependency work, branch/worktree cleanup, and unrelated retained lanes |
 
 ## Required Reading
 
-1. [Active A-G plan](pre-release-input-safety-and-professional-readiness-plan.md)
+1. [Active post-fix plan](pre-release-input-safety-and-professional-readiness-plan.md)
 2. [Current task board](../TASKS.md)
 3. [Git workflow single source](../git-automation/git-workflow-single-source.md)
 4. [Publication authorization record](../verification/release-publication-authorization.json)
@@ -29,9 +30,9 @@
 
 ## Resume safely
 
-Use only the existing cumulative worktree. Do not recreate the branch, move its
-changes to a retained lane, or mutate primary `main` while the candidate is
-open.
+Start Packet I in one fresh source-bound lane from the exact fetched
+`origin/main` after this reviewed plan merges. Do not mutate primary `main`,
+reuse the historical A-G candidate lane, or clean unrelated worktrees.
 
 ```bash
 ./run.sh session brief --agent orchestrator
@@ -40,12 +41,9 @@ open.
 ./scripts/python_runtime.sh scripts/git_state.py --json --worktrees
 ```
 
-Require the expected branch/head/diff, `source_bound=true`, no operation marker,
-and no new overlapping writer before mutation. The earlier Packet A Git issue
-was not an unclean-start failure: a later side packet advanced shared refs and
-overlapped closeout/index files after the original start check. The durable
-active-candidate dependency/path-overlap gate in `AGENTS.md` and the canonical
-Git workflow now covers that whole candidate lifetime.
+Require `fe4ab025…` as an ancestor, record the actual fetched base/head,
+`source_bound=true`, no operation marker, and no new overlapping writer before
+mutation. Preserve every unrelated lane.
 
 ## Integrated A-G boundary
 
@@ -66,12 +64,33 @@ Git workflow now covers that whole candidate lifetime.
   an actual independent-review JSON receipt, verifies reviewed Git/Python
   identity and permits only an evidence-only descendant delta.
 
+The post-fix replay did not invalidate these improvements. It found that their
+route inventory was incomplete.
+
+## Packet I boundary
+
+- replace the `design` CLI's row-skipping/defaulting intake with the lossless
+  ledger and strict project command;
+- block the whole CLI project on any malformed, missing, non-finite, unknown,
+  duplicate, ambiguous, or unaccounted design-bearing record;
+- require explicit effective-depth or complete derivation basis; do not supply
+  hidden cover/material/load/identity values;
+- freeze a versioned CLI output contract before migration; keep stdout/output
+  JSON parseable, send diagnostics to stderr, and prove retained `bbs`, `detail`,
+  and `dxf` consumers accept valid `design` output;
+- add valid, malformed-only, mixed-validity, empty, missing-depth/cover,
+  duplicate, unknown-field, and ambiguous-format CLI cases to exact-wheel UAT;
+- bind all advertised calculation entry points to a generated or validated
+  inventory so a future route cannot be omitted silently;
+- retain the corrected one-storey beam result for complete canonical input.
+
 ## Acceptance and stop rules
 
-Run the broad Python, complete FastAPI/React, full canonical, packaging,
-protected-source, and exact-wheel gates once at this cumulative boundary. Bind
-the immutable commit/tree to an independent software/release-evidence review
-and all required hosted checks before merge.
+After Packet I freezes, run its focused CLI/import/service tests, the complete
+negative matrix, public examples, broad Python, complete FastAPI/React, full
+canonical, packaging, protected-source, and exact-wheel gates once. Bind the
+immutable commit/tree to an independent software/release-evidence review and
+all required hosted checks before merge.
 
 Do not publish a package, create a tag or GitHub Release, claim professional
 approval, activate Packet H, close issues/PRs, delete branches, or clean retained

--- a/docs/planning/pre-release-input-safety-and-professional-readiness-plan.md
+++ b/docs/planning/pre-release-input-safety-and-professional-readiness-plan.md
@@ -3,7 +3,7 @@
 **Task:** LIB-PRO-002
 **Type:** Decision
 **Audience:** Maintainers
-**Status:** In Progress — Packets I-J Planned
+**Status:** In Progress
 **Created:** 2026-08-17
 **Last Updated:** 2026-08-17
 **Importance:** Critical

--- a/docs/planning/pre-release-input-safety-and-professional-readiness-plan.md
+++ b/docs/planning/pre-release-input-safety-and-professional-readiness-plan.md
@@ -3,7 +3,7 @@
 **Task:** LIB-PRO-002
 **Type:** Decision
 **Audience:** Maintainers
-**Status:** In Progress — Post-Fix Re-Audit
+**Status:** In Progress — Packets I-J Planned
 **Created:** 2026-08-17
 **Last Updated:** 2026-08-17
 **Importance:** Critical
@@ -40,6 +40,18 @@ declared cases because it does not execute this CLI path. The current PyPI
 and non-executable batch example. Therefore the current source is much safer,
 but the advertised package surface is not yet publication-ready.
 
+A subsequent publication-readiness replay found two independent release-signal
+defects. The scheduled full verification at A-G merge `fe4ab025...` failed six
+governance/session tests because `actions/setup-python` installs an interpreter
+without creating the `.venv` or `VIRTUAL_ENV` contract required by
+`scripts/python_runtime.sh`; the workflow did not export the already-supported
+`STRUCTURAL_LIB_PYTHON` path. The provisional next-Alpha command
+`./run.sh release preflight 0.23.1a2` then passed 6,387 Python tests, 446 FastAPI
+tests, and the React build, yet printed `READY TO RELEASE` while also reporting
+that no exact wheel was supplied. It does not evaluate the separate
+authorization record, which remains `HOLD`, or the omitted CLI negative. Local
+pre-bump health is therefore green, but the release verdict is not.
+
 The decision is:
 
 - Hold every next public package publication until the Alpha safety gate in
@@ -48,8 +60,11 @@ The decision is:
 - Do not claim whole-building design, professional approval, codewide formula
   certification, or project fitness from the pilot.
 - Complete Packet I CLI convergence and expand exact-wheel UAT to every
-  advertised calculation entry point before expanding formulas, load cases,
-  structural systems, or UI capability.
+  advertised calculation entry point.
+- Complete Packet J release-signal convergence so scheduled/tag workflows use
+  the selected interpreter and preflight reports mode-accurate readiness.
+- Finish I-J before expanding formulas, load cases, structural systems, or UI
+  capability.
 - Preserve the completed `LIB-PRO-001` ledger. This is a new remediation
   program caused by new end-user workflow evidence, not a reopening or rewrite
   of the completed historical packet.
@@ -112,6 +127,8 @@ or partial improvement.
 | API inventory | 187 root exports and 168 service-facade exports are machine-classified; no callable leakage is accepted | **Improved substantially** |
 | Exact-wheel negative UAT | A clean temporary environment installed the current built wheel and passed all 19 declared cases | **Improved but incomplete**; CLI is absent |
 | Advertised `design` CLI | One malformed row was skipped; warning text contaminated stdout; process exited `0`; output reported one of one beams passed | **Still blocking** |
+| Scheduled full verification | Weekly run `31988837003` on `fe4ab025...` failed six launcher-dependent tests because the workflow did not export the selected setup-python executable | **Still blocking**; PR checks alone are insufficient |
+| Pre-bump release verdict | Provisional `0.23.1a2` local tests/build passed, but preflight printed `READY TO RELEASE` with no exact wheel and while authorization remained `HOLD` | **Still blocking**; verdict conflates preparation with publication |
 | Published PyPI `0.23.1a1` | [Published on 2026-08-11](https://pypi.org/project/structural-lib-is456/0.23.1a1/) before A-G; page still says pin `0.23.0`, and its batch example raises `AttributeError` against the installed wheel | **Known old artifact; not fixed retroactively** |
 | Whole-building workflow | No controlled model generates or reconciles the complete slab-to-foundation load path | **Still not implemented** |
 
@@ -149,7 +166,7 @@ checks, lateral loads, geotechnical verification, or professional approval.
 
 ## 3. Confirmed root-cause map
 
-The apparent list of many failures reduces to seven root causes. Fixing symptoms
+The apparent list of many failures reduces to nine root causes. Fixing symptoms
 independently would create more formats and more drift.
 
 | Root cause | Confirmed mechanism | Main-process consequence | Required correction |
@@ -161,6 +178,8 @@ independently would create more formats and more drift.
 | RC-5: result/review semantics are not one contract | PASS/FAIL/HOLD, calculation success, review status, errors, and slab wording vary by element | A consumer can confuse software completion with engineering acceptance or professional review | One result envelope with orthogonal intake, calculation, engineering, and review states |
 | RC-6: release truth tests happy paths, not the advertised product | Version surfaces, examples, export classifications, exact-wheel negative paths, and source identity are not one gate | Green CI can coexist with stale or unsafe published guidance | Machine-checked API inventory, executable documentation, negative UAT, and exact artifact evidence |
 | RC-7: advertised-entry-point inventory was incomplete | A-G covered service, imports, HTTP/SSE/React, and selected exact-wheel examples but did not bind `python -m structural_lib design` to the same acceptance matrix | A public CLI can retain the original row-loss/defaulting hazard while all declared A-G checks pass | Generate the advertised entry-point inventory from docs/CLI/API surfaces and require every calculation-bearing entry point to delegate to the canonical boundary or be explicitly held |
+| RC-8: workflow interpreter identity was implicit | Full scheduled/tag suites invoke tests that recursively call `run.sh`/`python_runtime.sh`, but `actions/setup-python` creates neither a repository `.venv` nor `VIRTUAL_ENV`; the affected workflows omit the supported `STRUCTURAL_LIB_PYTHON` binding | Exact source can pass PR checks while the broader scheduled or publication suite deterministically fails before exercising its intended controls | Export the exact `command -v python` path for every full-suite workflow step that can invoke repository launchers; retain fail-closed launcher behavior and enforce the workflow contract in tests |
+| RC-9: release modes share one verdict label | Pre-bump validation may have no wheel, exact review, hosted receipt, or authorization, yet zero local test errors prints `READY TO RELEASE` | A maintainer can mistake permission to prepare a candidate for permission to publish | Give pre-bump, exact-candidate, and publication modes distinct machine-readable verdicts; only the final mode may report publication readiness |
 
 ## 4. Outcome-changing issue register
 
@@ -194,6 +213,8 @@ Rows from G0 preserve the original defect wording; Section 2.3 and each packet's
 | CLI-01 | P0 | Advertised `python -m structural_lib design` bypasses the lossless import and strict project command; its CSV reader applies hidden cover/depth assumptions and skips malformed rows | `Python/structural_lib/__main__.py`, `services/excel_integration.py` | CLI delegates to the lossless ledger plus strict project command; every source row is accepted or blocked, hidden structural defaults are absent, and any blocked row makes the command non-zero with no PASS summary |
 | CLI-02 | P0 | The current `design` CLI writes a `beams` artifact consumed by `bbs`, `detail`, and `dxf`, while the strict project service returns a different `members` envelope; warnings also contaminate stdout | `Python/structural_lib/__main__.py` and downstream CLI commands | Freeze a versioned CLI output/compatibility contract; diagnostics use stderr; valid JSON remains machine-readable; blocked input emits no partial-success artifact; exact-wheel tests prove advertised downstream consumers or explicitly deprecate/hold them |
 | REL-UAT-02 | P0 | The 19-case matrix passes without executing the advertised design CLI, so it cannot detect CLI-01 | `services/release_uat.py`, packaged matrix, publish workflow | Exact-wheel UAT discovers all advertised calculation entry points and runs valid, malformed, mixed-validity, empty, and unknown-field CLI cases in a source-free environment |
+| REL-CI-01 | P0 | Weekly Verification run `31988837003` failed six full-suite tests at A-G merge `fe4ab025...`: repository subprocesses could not find a project interpreter because the workflow did not export `STRUCTURAL_LIB_PYTHON`; the publish workflow has the same full-suite environment gap | `.github/workflows/nightly.yml`, `.github/workflows/publish.yml`, `scripts/python_runtime.sh`, workflow-contract tests | Scheduled and tag-publication full suites inherit the exact setup-python executable through the supported environment contract; no `.venv` assumption is introduced; workflow-contract tests and a fresh hosted full run pass |
+| REL-PREFLIGHT-01 | P0 | Pre-bump `release preflight 0.23.1a2` printed `READY TO RELEASE` with no exact wheel while exact authorization remained `HOLD` and the CLI negative was outside UAT | `scripts/release.py`, release-script tests, release-preflight skill | Pre-bump success says only `READY_TO_PREPARE_CANDIDATE`; exact-wheel success says `CANDIDATE_TECHNICALLY_READY` plus explicit remaining holds; `READY_TO_PUBLISH` requires exact wheel/UAT, immutable review and hosted receipts, and exact target authorization |
 | PUBLISHED-01 | P0 | PyPI `0.23.1a1` predates A-G, displays the wrong exact pin, and advertises a batch example that fails against its own wheel | [live PyPI 0.23.1a1 page](https://pypi.org/project/structural-lib-is456/0.23.1a1/) and installed-wheel replay | Do not imply A-G fixed the old artifact; the next separately authorized version must publish the corrected executable description and pass exact-wheel examples before upload |
 | INSTALL-01 | P1 | Repository operation depends on the selected `.venv`, while beginner guidance does not provide one decisive preflight and repair path | setup docs/runtime guidance | One documented command reports interpreter, installed extras, package origin/version, and a clear install command without repository-only assumptions |
 | API-NAME-01 | P1 | The 168-symbol service facade still includes 28 functions with unit-ambiguous parameter names such as `b`, `d`, `fck`, `fy`, `cover`, or `span`; several are compatibility aliases mixed into recommended functions | installed-facade signature audit | Each symbol is classified as canonical explicit-unit, compatibility-only, or internal; recommended APIs use unit-bearing names and compatibility aliases have a removal/migration policy |
@@ -217,8 +238,9 @@ for another public Alpha:
    IMPORT-03, EMPTY-01, COLUMN-01, REVIEW-01, RESULT-01, and PROV-01 are
    accepted.
 2. REL-TRUTH-01, REL-EXAMPLE-01, REL-UAT-01, CLI-01, CLI-02, REL-UAT-02,
-   PUBLISHED-01, and CLAIM-01 are accepted against the exact candidate wheel in
-   a source-free environment.
+   REL-CI-01, REL-PREFLIGHT-01, PUBLISHED-01, and CLAIM-01 are accepted against
+   the exact candidate wheel in a source-free environment and the matching
+   hosted source commit.
 3. The candidate describes only its bounded component capabilities. A missing
    whole-building workflow is an explicit limitation, not an implied feature.
 4. Focused, quick, cumulative Python/FastAPI/React, packaging, protected-source,
@@ -227,8 +249,12 @@ for another public Alpha:
    exact-head software/release-evidence review receipt are bound in release
    evidence. This Alpha review is not qualified structural-engineering review
    or professional approval.
-6. The repository owner separately authorizes the exact version/tag/package
-   publication. This plan is not that authorization.
+6. Pre-bump validation reports only readiness to prepare a candidate. Exact-
+   wheel validation reports technical candidate readiness and every remaining
+   hold. Neither state is publication readiness.
+7. The repository owner separately authorizes the exact version/tag/package
+   publication after immutable review. Only then may the final gate report
+   `READY_TO_PUBLISH`. This plan is not that authorization.
 
 ### 5.2 Stable or engineering-use gate
 
@@ -359,13 +385,25 @@ cannot omit cases.
 | Insufficient footing dowel length | VALID | COMPLETED | FAIL retained |
 | Safe supported calculation | VALID | COMPLETED | PASS plus qualified review required |
 
+Release-control cases are orthogonal to structural input cases and must also
+fail closed:
+
+| Release-control case | Required verdict | Required evidence |
+|---|---|---|
+| Pre-bump checks, no exact wheel | `READY_TO_PREPARE_CANDIDATE` | Valid version upgrade and green affected local suites; wheel/review/hosted/authorization explicitly pending |
+| Exact wheel, UAT or public example fails | `NOT_READY` | Exact failing artifact and case; no publication action |
+| Exact wheel passes, authorization absent or `HOLD` | `CANDIDATE_TECHNICALLY_READY` plus `PUBLICATION_HOLD` | Wheel/source identities, exact UAT, independent receipt, hosted receipts, and missing authorization fields |
+| Scheduled/full hosted interpreter unresolved | `NOT_READY` | Failing workflow/job and interpreter-resolution diagnostic |
+| Exact version/tag/targets authorized after immutable review | `READY_TO_PUBLISH` | Authorization JSON and SHA-bound review receipt match version, tag, targets, source/Python trees, reviewer, chronology, and hosted checks |
+
 ## 8. Dependency-ordered implementation packets
 
 WIP remains at most two, but these packets are implemented by one writer in
 dependency order wherever files overlap. Parallel agents are most useful for
 read-only audit and immutable review, not competing edits.
-Packet H was already reserved for the whole-building decision; the newly found
-Packet I is listed before H because it is now H's prerequisite.
+Packet H was already reserved for the whole-building decision. Newly found
+Packets I and J are listed before H because both are publication prerequisites;
+J also becomes H's immediate predecessor.
 
 ### G0 — Contract and claim freeze (`LIB-PRO-002-G0`, S)
 
@@ -530,19 +568,55 @@ source and exact-wheel environments. The old PyPI batch example is explicitly
 recorded as historical/broken; stdout JSON is parsed; valid `design` output is
 passed through every retained downstream command; and the next package
 description is executed from the candidate wheel.
-**Accept:** CLI-01, CLI-02, REL-UAT-02, and PUBLISHED-01 close. Re-run the complete
-Section 7 matrix, public examples, quick/full release gates, immutable review,
-and hosted checks on one exact candidate. Publication still requires separate
+**Accept:** CLI-01, CLI-02, REL-UAT-02, and PUBLISHED-01 close. Run the affected
+CLI/import/service/downstream tests together, the expanded matrix, quick gate,
+normal hooks, immutable review, and required hosted PR checks on the frozen
+Packet I head. Defer the next broad Python/FastAPI/React and full canonical run
+to the Packet J cumulative boundary. Publication still requires J and separate
 owner authorization.
 **Rollback:** retain publication HOLD; do not restore row skipping or hidden
 defaults for compatibility.
 
+### J — Release signal convergence (`LIB-PRO-002-J`, S)
+
+**State:** required after Packet I because live hosted and local preflight
+evidence currently disagree about publication readiness.
+
+**Depends on:** I.
+**Owns:** full-suite interpreter binding in scheduled/tag workflows,
+mode-specific release-preflight verdicts, workflow/release-script contract
+tests, and directly affected release guidance.
+**Deliver:** reuse the already-supported
+`STRUCTURAL_LIB_PYTHON="$(command -v python)"` contract in every hosted full-
+suite step that can recursively invoke repository launchers, including Weekly
+Verification and publish validation. Do not weaken `python_runtime.sh` to trust
+an arbitrary system interpreter. Split pre-bump, exact-wheel, and final
+publication states: pre-bump may report only `READY_TO_PREPARE_CANDIDATE`;
+exact-wheel success reports `CANDIDATE_TECHNICALLY_READY` and explicit holds;
+only exact authorization after immutable review can report
+`READY_TO_PUBLISH`.
+**Focused proof:** workflow-contract tests fail if a full suite lacks the
+interpreter binding; release-script tests cover every verdict/exit-code
+combination for missing wheel, failed UAT, absent review, `HOLD` authorization,
+wrong version/tag/target, and complete exact authorization. Run Weekly
+Verification by manual dispatch on the exact remote Packet J head and require
+the full Python, FastAPI, React, documentation, and summary jobs to pass.
+**Accept:** REL-CI-01 and REL-PREFLIGHT-01 close. After focused evidence freezes,
+run quick, hooks, broad Python, complete FastAPI/React, full canonical,
+packaging, protected-source, expanded exact-wheel UAT/public examples,
+immutable review, all required hosted PR checks, and the manually dispatched
+full workflow. Publication remains `HOLD` until an exact release candidate and
+separate owner authorization exist.
+**Rollback:** keep the strict launcher and publication HOLD; never recover a
+green label by bypassing interpreter identity, wheel evidence, review, hosted
+checks, or authorization.
+
 ### H — Whole-building workflow decision (`LIB-PRO-002-H`, planning only, L)
 
-**State:** not activated. Completing A-I does not activate this packet or
+**State:** not activated. Completing A-J does not activate this packet or
 authorize whole-building implementation.
 
-**Depends on:** I and separate owner activation.
+**Depends on:** J and separate owner activation.
 **Owns:** a new source-backed plan—not calculation code.
 **Deliver:** supported structural model, load provenance/takedown, combinations,
 equilibrium/load-path checks, element result aggregation, detailing/review
@@ -568,15 +642,18 @@ The fastest safe path is contract-first and evidence-last:
    for behavior the packet changes; avoid generic hardening.
 5. Run focused tests while editing. Run architecture/import checks when a layer
    boundary changes, then quick once on the frozen candidate.
-6. Reserve the next broad Python/FastAPI/React and full canonical gates for the
-   frozen Packet I cumulative repair unless an outcome-changing failure proves
-   repository-wide risk earlier.
+6. Packet I runs its focused/quick/hosted packet gates after content freeze.
+   Reserve the next broad Python/FastAPI/React and full canonical gates for the
+   frozen Packet J cumulative boundary unless an outcome-changing failure
+   proves repository-wide risk earlier.
 7. Use one candidate and at most one repair candidate. A material post-push
    defect creates a new reviewed candidate; status prose does not mutate the
    immutable head.
 8. Finish task, session, handoff, evidence, and pre-commit receipt first. Write
    affected indexes last, then validate without rewriting them.
-9. Independently review exact commit/tree and bind hosted checks before merge.
+9. Independently review each exact commit/tree and bind hosted checks before
+   merge. For J, manually dispatch Weekly Verification on the exact remote head
+   and bind that full-workflow receipt as well.
 10. Report total wall time including CI and closeout so later estimates improve.
 
 For a future publication, review the complete package candidate first. The
@@ -622,10 +699,11 @@ ledger and blocking rules are accepted.
 G0 has now frozen:
 
 - the bounded interpretation of the one-storey pilot;
-- seven root causes and an outcome-changing issue register;
+- nine root causes and an outcome-changing issue register;
 - canonical input, import-ledger, result, and compatibility contracts;
 - Alpha/stable/whole-building release boundaries;
-- a nine-packet dependency order and cumulative test cadence.
+- an implementation order through Packet J followed by the held Packet H
+  decision, with an implementation-first cumulative test cadence.
 
 Packet A merged through PR #814 and Packets B-G merged through PR #815 at
 `fe4ab025419b834c6d0f840e9492c0604ae74201`. The post-fix replay accepts the
@@ -634,17 +712,20 @@ one-storey arithmetic, but it rejects publication readiness because the public
 design CLI still skips malformed rows and the exact-wheel matrix omits that
 entry point.
 
-The exact next implementation packet is `LIB-PRO-002-I`. It converges the
-advertised CLI on the lossless/strict boundary, adds CLI cases to source-free
-exact-wheel UAT, and proves the candidate package description. This is a repair
-of acceptance scope, not evidence that A-G failed everywhere.
+The exact next implementation sequence is `LIB-PRO-002-I` followed by
+`LIB-PRO-002-J`. Packet I converges the advertised CLI on the lossless/strict
+boundary, adds CLI cases to source-free exact-wheel UAT, and proves the
+candidate package description. Packet J binds the selected interpreter in
+scheduled/tag full suites and makes release-preflight verdicts accurately name
+pre-bump, technical-candidate, and authorized-publication states. These repair
+acceptance and release-signal scope; they do not imply A-G failed everywhere.
 
 Packet H remains inactive because the owner has not separately activated a
-whole-building planning program. Even after Packet I acceptance, publication
+whole-building planning program. Even after Packets I-J are accepted, publication
 remains blocked until the owner separately authorizes the exact future version,
 tag, and publication targets recorded by
 `docs/verification/release-publication-authorization.json`.
 
-While Packet I is unresolved, the release state is:
+While Packets I-J are unresolved, the release state is:
 
-`NEXT_PUBLICATION = HOLD_ADVERTISED_CLI_AND_OWNER_AUTHORIZATION`
+`NEXT_PUBLICATION = HOLD_ADVERTISED_CLI_HOSTED_SIGNAL_AND_OWNER_AUTHORIZATION`

--- a/docs/planning/pre-release-input-safety-and-professional-readiness-plan.md
+++ b/docs/planning/pre-release-input-safety-and-professional-readiness-plan.md
@@ -3,15 +3,15 @@
 **Task:** LIB-PRO-002
 **Type:** Decision
 **Audience:** Maintainers
-**Status:** Review
+**Status:** In Progress — Post-Fix Re-Audit
 **Created:** 2026-08-17
 **Last Updated:** 2026-08-17
 **Importance:** Critical
 **Prepared:** 2026-08-17
 **Planning source base:** `origin/main` at `904a2f8cf0ea5d4595f57c46dac06e2e837bba45`
 **Cumulative implementation base:** `origin/main` at
-`3986935ecb473c1f9d56dec44aeb4218d9192f84` after Packet A merged through
-PR #814
+`fe4ab025419b834c6d0f840e9492c0604ae74201` after Packets A-G merged through
+PR #815
 **Scope:** Public/project input, import accounting, orchestration, result truth,
 API classification, evidence identity, documentation, and release gates
 **Source bound:** `true`
@@ -24,13 +24,21 @@ recomputed arithmetic matched the library outputs. The footing dowel
 development-length failure was also reproduced and is a legitimate failure,
 not a software defect.
 
-That evidence does **not** establish that the library is safe as a project or
-whole-building workflow. Live code inspection confirms that multiple public
-paths can replace missing or malformed structural values with plausible
-defaults, discard recognized fields, select an unintended CSV adapter, drop
-invalid rows, or manufacture zero forces before the calculation core runs. A
-calculation can therefore be arithmetically correct for values the user did not
-provide.
+The A-G remediation merged through PR #815 materially improved the library.
+The strict service, named lossless import, HTTP/SSE/React, result/review,
+evidence, API-classification, and release-authorization paths now fail closed
+for the original reproduced cases. Those corrections are real and the
+one-storey member arithmetic remains unchanged.
+
+The post-fix user replay nevertheless found one advertised path outside that
+accepted boundary. `python -m structural_lib design` still uses the historical
+Excel/CSV reader. In a two-row file containing one valid beam and one malformed
+beam, it skipped the malformed row, exited `0`, and wrote a summary saying the
+one remaining beam passed. The exact-wheel negative UAT passed all 19 of its
+declared cases because it does not execute this CLI path. The current PyPI
+`0.23.1a1` artifact also predates A-G and still carries the old incorrect pin
+and non-executable batch example. Therefore the current source is much safer,
+but the advertised package surface is not yet publication-ready.
 
 The decision is:
 
@@ -39,8 +47,9 @@ The decision is:
 - Continue describing the current release as Alpha/development software.
 - Do not claim whole-building design, professional approval, codewide formula
   certification, or project fitness from the pilot.
-- Repair the canonical input and accounting boundary before expanding formulas,
-  load cases, structural systems, or UI capability.
+- Complete Packet I CLI convergence and expand exact-wheel UAT to every
+  advertised calculation entry point before expanding formulas, load cases,
+  structural systems, or UI capability.
 - Preserve the completed `LIB-PRO-001` ledger. This is a new remediation
   program caused by new end-user workflow evidence, not a reopening or rewrite
   of the completed historical packet.
@@ -86,9 +95,61 @@ The `1.5` factor and soil pressure in the pilot remain user-supplied
 assumptions. An approval flag records a workflow state; it cannot convert an
 assumption into verified source data.
 
+### 2.3 Post-fix recheck at `fe4ab025…`
+
+The following classifications distinguish a real correction from a test-only
+or partial improvement.
+
+| Area rechecked | Post-fix observation | Classification |
+|---|---|---|
+| Canonical beam batch | Complete explicit-unit input evaluated; malformed numeric input blocked with `PROJECT_BEAM_INVALID_NUMBER`; empty input blocked and evaluated zero members | **Fixed for this service** |
+| Compatibility beam batch | Malformed width returned a structured error and did not call the calculation core | **Fixed for this service** |
+| Direct Excel-style headings | The strict service rejected them with named unknown/missing-field issues instead of guessing | **Fixed behavior**; use a named adapter |
+| Named Generic CSV import | Ordinary headings were accepted with one accounted source row and a normalization ledger | **Fixed for the tested adapter case** |
+| Adapter ambiguity and row loss | Ambiguity, malformed rows, unmatched records, and injected row loss block in the 19-case UAT | **Fixed for covered routes** |
+| Column materials | Omitting `fck_nmm2` or `fy_nmm2` blocks instead of supplying 25/415 | **Fixed** |
+| Result/review truth | Beam, slab, column, and footing results retain `QUALIFIED_REVIEW_REQUIRED`; assumed footing bases remain assumed | **Fixed for covered results** |
+| API inventory | 187 root exports and 168 service-facade exports are machine-classified; no callable leakage is accepted | **Improved substantially** |
+| Exact-wheel negative UAT | A clean temporary environment installed the current built wheel and passed all 19 declared cases | **Improved but incomplete**; CLI is absent |
+| Advertised `design` CLI | One malformed row was skipped; warning text contaminated stdout; process exited `0`; output reported one of one beams passed | **Still blocking** |
+| Published PyPI `0.23.1a1` | [Published on 2026-08-11](https://pypi.org/project/structural-lib-is456/0.23.1a1/) before A-G; page still says pin `0.23.0`, and its batch example raises `AttributeError` against the installed wheel | **Known old artifact; not fixed retroactively** |
+| Whole-building workflow | No controlled model generates or reconciles the complete slab-to-foundation load path | **Still not implemented** |
+
+### 2.4 One-storey load-path and manual side calculation
+
+This is a synthetic regression model, not a real design: one 2.5 m by 5.5 m
+one-way slab panel, one exterior simply supported 5.5 m beam taking a 1.25 m
+tributary width, one 400 mm square 3 m column, and one concentric square
+footing. Materials are M25 and Fe415. Loads, support conditions, soil pressure,
+and the `1.5` factor are declared test assumptions rather than generated or
+verified project facts.
+
+| Check | Hand calculation and maintained clause/formula basis | Library | Result |
+|---|---|---:|---|
+| Slab factored load | `1.5 × (0.15×25 + 1.0 + 3.0) = 11.625 kN/m²` | 11.625 | Match |
+| Slab moment | `wu L²/8 = 11.625×2.5²/8 = 9.082031 kN·m/m`; rectangular equilibrium `C=0.36 fck b xu`, `z=d-0.42xu` | 9.082031 | Match |
+| Slab steel | Exact Cl. 38.1/Annex-G equilibrium at `b=1000 mm`, `d=125 mm` gives `Ast=207.012 mm²/m` | 207.012 | Match |
+| Slab supplied bars | 10 mm at 250 mm gives 314.159 mm²/m; 8 mm distribution at 250 mm gives 201.062 mm²/m against 180 mm²/m minimum | Adequate; qualified review required | Match |
+| Beam line load | `1.5 × [7.75×1.25 + 0.30×(0.50-0.15)×25] = 18.46875 kN/m` | caller input | Match |
+| Beam actions | `Mu=wuL²/8=69.834961 kN·m`; `Vu=wuL/2=50.789063 kN` | same | Match |
+| Beam flexure/shear | Cl. 38.1/Annex G gives `Ast=465.092 mm²`; Cl. 40.1 gives `tau_v=Vu/(bd)=0.383025 N/mm²` | same | Match |
+| Column factored load | Beam reaction 50.789063 + `1.5×0.4×0.4×3×25` column self-weight = 68.789063 kN | 68.789063 | Match |
+| Column axial capacity | Cl. 39.3: `0.4 fck Ac + 0.67 fy Asc = 2031.157 kN` for eight 16 mm bars | 2031.157 | Match |
+| Column minimum moment | Cl. 25.4: `e_min=max(l/500+D/30,20)=20 mm`; `Pu e=1.375781 kN·m` | 1.375781 in each axis | Match |
+| Linked footing service load | Beam reaction 33.859375 + column self-weight 12.0 + 750×750×300 mm footing self-weight 4.21875 = 50.078125 kN | caller input, marked assumed | Reconciled test load |
+| Footing sizing/pressure | Cl. 34.1 basis: 750×750 mm gives `q=50.078125/0.75²=89.027778 kPa < 100 kPa` | 750×750; 89.027778 | Match |
+| Footing moment | Cl. 34.2.3.1/34.3.1 basis: `qu=133.541667 kPa`, projection 0.175 m, `Mu=qu×0.75×0.175²/2=1.533643 kN·m` | 1.533643 | Match |
+| Footing punching | Cl. 31.6.1/34.2.4.1(b): at `d/2`, `b0=4×(400+250)=2600 mm`; `tau_v=0.028763 N/mm²`, `tau_c=0.25√25=1.25 N/mm²`, utilization 0.023010 | 0.023010 | Match |
+| Footing dowel anchorage | Cl. 26.2.1: `Ld=16×(0.87×415)/(4×2.24)=644.732 mm`; only 300/600 mm supplied | 644.732; aggregate `FAIL` | Correct failure |
+
+The chained loads now reconcile for this narrow gravity example, which is an
+improvement over the earlier unrelated 60/90 kN footing probe. It still does
+not provide analysis, combinations, continuity, direct slab deflection/crack
+checks, lateral loads, geotechnical verification, or professional approval.
+
 ## 3. Confirmed root-cause map
 
-The apparent list of many failures reduces to six root causes. Fixing symptoms
+The apparent list of many failures reduces to seven root causes. Fixing symptoms
 independently would create more formats and more drift.
 
 | Root cause | Confirmed mechanism | Main-process consequence | Required correction |
@@ -99,14 +160,17 @@ independently would create more formats and more drift.
 | RC-4: orchestration is duplicated | Service batch, streaming, import batch design, React preparation, and column routes each normalize or derive values | Effective depth, materials, identity, and errors differ by route | Transports delegate to one service boundary and never derive structural values |
 | RC-5: result/review semantics are not one contract | PASS/FAIL/HOLD, calculation success, review status, errors, and slab wording vary by element | A consumer can confuse software completion with engineering acceptance or professional review | One result envelope with orthogonal intake, calculation, engineering, and review states |
 | RC-6: release truth tests happy paths, not the advertised product | Version surfaces, examples, export classifications, exact-wheel negative paths, and source identity are not one gate | Green CI can coexist with stale or unsafe published guidance | Machine-checked API inventory, executable documentation, negative UAT, and exact artifact evidence |
+| RC-7: advertised-entry-point inventory was incomplete | A-G covered service, imports, HTTP/SSE/React, and selected exact-wheel examples but did not bind `python -m structural_lib design` to the same acceptance matrix | A public CLI can retain the original row-loss/defaulting hazard while all declared A-G checks pass | Generate the advertised entry-point inventory from docs/CLI/API surfaces and require every calculation-bearing entry point to delegate to the canonical boundary or be explicitly held |
 
 ## 4. Outcome-changing issue register
 
 Priority means publication impact, not code size. `P0` blocks the next public
 package. `P1` blocks stable/professional-readiness claims or a claimed product
 surface. `P2` is required before the related capability is advertised.
+Rows from G0 preserve the original defect wording; Section 2.3 and each packet's
+`State` line own the current post-fix classification.
 
-| ID | Pri | Confirmed issue | Evidence location | Exit condition |
+| ID | Pri | Original or current confirmed issue | Evidence location | Exit condition |
 |---|---:|---|---|---|
 | INPUT-01 | P0 | Batch aliases omit ordinary headings such as `BeamID`, `Mu (kN-m)`, and `Cover (mm)` and silently substitute dimensions, actions, materials, cover, and identity | `Python/structural_lib/services/batch.py` | Missing, unknown, malformed, empty, and non-finite project inputs produce stable blocking errors; no calculation is invoked |
 | CLIENT-01 | P0 | React replaces absent moment/shear with zero and materials/cover with 25/500/40 before transport | `react_app/src/hooks/useBatchDesign.ts` | Client sends only source-derived canonical values; missing fields remain missing and block at the shared boundary |
@@ -127,7 +191,14 @@ surface. `P2` is required before the related capability is advertised.
 | REL-TRUTH-01 | P0 | Root README still advertises 0.23.0 while package docs advertise 0.23.1a1; release version checks omit these README surfaces | READMEs and `scripts/release.py` | All maintained current-version surfaces are checked against the candidate version or explicitly historical |
 | REL-EXAMPLE-01 | P0 | The Python README batch example uses fields not returned by the shown import result; public examples are not executed from the exact wheel | `Python/README.md`, publish workflow | Every advertised quickstart/example runs in a source-free temporary environment against the exact built wheel |
 | REL-UAT-01 | P0 | Exact-wheel UAT covers happy paths but not silent-default, row-loss, empty, unknown-field, or review-language cases | `.github/workflows/publish.yml`, release checks | Candidate wheel passes the negative acceptance matrix in Section 7 and the supported end-to-end workflows |
+| CLI-01 | P0 | Advertised `python -m structural_lib design` bypasses the lossless import and strict project command; its CSV reader applies hidden cover/depth assumptions and skips malformed rows | `Python/structural_lib/__main__.py`, `services/excel_integration.py` | CLI delegates to the lossless ledger plus strict project command; every source row is accepted or blocked, hidden structural defaults are absent, and any blocked row makes the command non-zero with no PASS summary |
+| CLI-02 | P0 | The current `design` CLI writes a `beams` artifact consumed by `bbs`, `detail`, and `dxf`, while the strict project service returns a different `members` envelope; warnings also contaminate stdout | `Python/structural_lib/__main__.py` and downstream CLI commands | Freeze a versioned CLI output/compatibility contract; diagnostics use stderr; valid JSON remains machine-readable; blocked input emits no partial-success artifact; exact-wheel tests prove advertised downstream consumers or explicitly deprecate/hold them |
+| REL-UAT-02 | P0 | The 19-case matrix passes without executing the advertised design CLI, so it cannot detect CLI-01 | `services/release_uat.py`, packaged matrix, publish workflow | Exact-wheel UAT discovers all advertised calculation entry points and runs valid, malformed, mixed-validity, empty, and unknown-field CLI cases in a source-free environment |
+| PUBLISHED-01 | P0 | PyPI `0.23.1a1` predates A-G, displays the wrong exact pin, and advertises a batch example that fails against its own wheel | [live PyPI 0.23.1a1 page](https://pypi.org/project/structural-lib-is456/0.23.1a1/) and installed-wheel replay | Do not imply A-G fixed the old artifact; the next separately authorized version must publish the corrected executable description and pass exact-wheel examples before upload |
 | INSTALL-01 | P1 | Repository operation depends on the selected `.venv`, while beginner guidance does not provide one decisive preflight and repair path | setup docs/runtime guidance | One documented command reports interpreter, installed extras, package origin/version, and a clear install command without repository-only assumptions |
+| API-NAME-01 | P1 | The 168-symbol service facade still includes 28 functions with unit-ambiguous parameter names such as `b`, `d`, `fck`, `fy`, `cover`, or `span`; several are compatibility aliases mixed into recommended functions | installed-facade signature audit | Each symbol is classified as canonical explicit-unit, compatibility-only, or internal; recommended APIs use unit-bearing names and compatibility aliases have a removal/migration policy |
+| RETURN-01 | P1 | Several recommended exports still return generic dictionaries or positional tuples, including the unified column workflow | installed-facade signature audit and `api-levels.md` | Public workflow results use named typed contracts with schema/version/issue/review metadata; compatibility shapes are isolated and documented |
+| SERVICE-01 | P1 | The tested slab result passes only the basic span/depth screen and explicitly holds direct deflection, cracking, shear, load combinations, continuity, cantilevers, and patterns | one-way slab result limitations | Stable/engineering-use claims name these holds prominently or add separately source-backed implementations and benchmarks |
 | CLAIM-01 | P0 | A 12-value pilot match can be overgeneralized into “library formulas are accurate” | publication language | Claims name exact cases, evidence, exclusions, and independent-review status; codewide/professional claims are prohibited without their own evidence |
 | BUILDING-01 | P2 | There is no controlled slab-to-foundation project orchestration or load-path reconciliation | service/product architecture | Separate owner-approved packet defines model, load provenance, combinations, equilibrium checks, supported systems, and review dossier before implementation |
 
@@ -145,8 +216,9 @@ for another public Alpha:
 1. INPUT-01, CLIENT-01, ROUTE-01, DEPTH-01, FIELD-01, IMPORT-01 through
    IMPORT-03, EMPTY-01, COLUMN-01, REVIEW-01, RESULT-01, and PROV-01 are
    accepted.
-2. REL-TRUTH-01, REL-EXAMPLE-01, REL-UAT-01, and CLAIM-01 are accepted against
-   the exact candidate wheel in a source-free environment.
+2. REL-TRUTH-01, REL-EXAMPLE-01, REL-UAT-01, CLI-01, CLI-02, REL-UAT-02,
+   PUBLISHED-01, and CLAIM-01 are accepted against the exact candidate wheel in
+   a source-free environment.
 3. The candidate describes only its bounded component capabilities. A missing
    whole-building workflow is an explicit limitation, not an implied feature.
 4. Focused, quick, cumulative Python/FastAPI/React, packaging, protected-source,
@@ -162,7 +234,8 @@ for another public Alpha:
 
 In addition to the Alpha gate, stable or engineering-use language requires:
 
-- API-CLASS-01, API-DOC-01, ASSUME-01, and INSTALL-01 acceptance;
+- API-CLASS-01, API-DOC-01, ASSUME-01, INSTALL-01, API-NAME-01, RETURN-01,
+  and SERVICE-01 acceptance;
 - cumulative independent numerical benchmarks for every claimed supported
   family, not extrapolation from this pilot;
 - explicit serviceability, detailing, load-combination, and applicability
@@ -278,6 +351,9 @@ cannot omit cases.
 | Empty batch or all rows blocked | BLOCKED | NOT_EVALUATED | zero PASS; summary HOLD/BLOCKED |
 | Ambiguous adapter detection | BLOCKED | NOT_EVALUATED | candidates reported |
 | Invalid import row | row BLOCKED and accounted | no calculation for row | batch cannot hide loss |
+| CLI file with one valid and one invalid row | file BLOCKED and both rows accounted | no project verdict is emitted | non-zero exit; never a partial PASS summary |
+| CLI file missing cover or effective-depth basis | BLOCKED | NOT_EVALUATED | no hidden 40 mm cover or `D-cover` depth |
+| Valid CLI `design` artifact | VALID and versioned | COMPLETED | JSON is parseable and accepted by each advertised downstream command, or that command is explicitly held/deprecated |
 | Geometry without forces / forces without geometry | BLOCKED unless explicit exclusion | NOT_EVALUATED | unresolved identity listed |
 | Unapproved footing basis | BLOCKED/HOLD | per bounded contract | never promoted by a flag alone |
 | Insufficient footing dowel length | VALID | COMPLETED | FAIL retained |
@@ -288,6 +364,8 @@ cannot omit cases.
 WIP remains at most two, but these packets are implemented by one writer in
 dependency order wherever files overlap. Parallel agents are most useful for
 read-only audit and immutable review, not competing edits.
+Packet H was already reserved for the whole-building decision; the newly found
+Packet I is listed before H because it is now H's prerequisite.
 
 ### G0 — Contract and claim freeze (`LIB-PRO-002-G0`, S)
 
@@ -305,8 +383,7 @@ remains held.
 
 ### A — Strict service intake (`LIB-PRO-002-A`, M)
 
-**Candidate state:** merged through PR #814; included in the cumulative A-G
-acceptance boundary.
+**State:** merged through PR #814 and retained in the A-G merge at PR #815.
 
 **Depends on:** G0.
 **Owns:** new project input/result types, `services/batch.py`, focused service
@@ -321,8 +398,8 @@ blocked inputs never call the core; valid pilot beam remains numerically equal.
 
 ### B — Lossless import boundary (`LIB-PRO-002-B`, L)
 
-**Candidate state:** integrated in the cumulative A-G candidate; cumulative
-gates and exact-head review remain.
+**State:** merged through PR #815; post-fix replay accepted the covered import
+cases.
 
 **Depends on:** A.
 **Owns:** import models, adapter selection, adapter parsers, matching/accounting,
@@ -338,8 +415,8 @@ packet rather than restoring implicit first-match behavior.
 
 ### C — Transport and client convergence (`LIB-PRO-002-C`, L)
 
-**Candidate state:** integrated in the cumulative A-G candidate; cumulative
-gates and exact-head review remain.
+**State:** merged through PR #815 for HTTP/SSE/React. The advertised CLI was
+outside Packet C and is now assigned to Packet I.
 
 **Depends on:** A and B.
 **Owns:** streaming/import batch endpoints, OpenAPI, React batch hook, focused
@@ -355,8 +432,8 @@ normalization to keep an endpoint alive.
 
 ### D — Cross-element result and review truth (`LIB-PRO-002-D`, M)
 
-**Candidate state:** integrated in the cumulative A-G candidate; cumulative
-gates and exact-head review remain.
+**State:** merged through PR #815; post-fix slab, column, beam, and footing
+replays retained required-review and fail-closed semantics.
 
 **Depends on:** A. May be developed after A while B is under independent
 review, provided owned files do not overlap.
@@ -373,8 +450,8 @@ field names, but missing status always maps to HOLD—not PASS.
 
 ### E — Evidence and assumption identity (`LIB-PRO-002-E`, M)
 
-**Candidate state:** integrated in the cumulative A-G candidate; cumulative
-gates and exact-head review remain.
+**State:** merged through PR #815; post-fix replay retained assumed basis and
+identity separation.
 
 **Depends on:** A, B, and D.
 **Owns:** evidence envelopes, project provenance models, controlled-source
@@ -389,8 +466,8 @@ amendment state remains UNKNOWN/HOLD.
 
 ### F — Public API and documentation truth (`LIB-PRO-002-F`, M)
 
-**Candidate state:** integrated in the cumulative A-G candidate; cumulative
-gates and exact-head review remain.
+**State:** merged through PR #815. Export classification is substantially
+better; API naming and typed-return closure remain stable-release work.
 
 **Depends on:** A and D; can inventory in read-only mode earlier.
 **Owns:** API classification registry/generator, API reference docs, README
@@ -405,9 +482,9 @@ documentation portions close.
 
 ### G — Exact-wheel negative UAT and publication policy (`LIB-PRO-002-G`, L)
 
-**Candidate state:** repair candidate after exact-head review rejected the
-presence-only review-receipt check; immutable re-review and hosted checks must
-restart on the repaired head.
+**State:** merged through PR #815 after the exact-review-receipt repair. The
+post-fix replay found a separate scope gap: the 19-case matrix does not execute
+the advertised design CLI.
 
 **Depends on:** A through F.
 **Owns:** release preflight, publish workflow, source-free example runner,
@@ -428,12 +505,44 @@ boundary.
 **Rollback:** release remains held; never weaken the negative matrix to make a
 candidate pass.
 
+### I — Advertised CLI convergence (`LIB-PRO-002-I`, M)
+
+**State:** required next repair packet after the post-fix user replay.
+
+**Depends on:** A through G.
+**Owns:** the `design` CLI intake/orchestration path, its CSV/JSON compatibility
+boundary, packaged negative-UAT entry-point inventory, focused CLI tests, and
+directly affected documentation.
+**Deliver:** `python -m structural_lib design` delegates to the lossless import
+ledger and strict project command; every row and calculation-bearing field is
+accounted; no cover, effective depth, material, load, or identity is silently
+created; mixed-validity and empty files return non-zero without a partial PASS
+summary. Freeze a versioned CLI output/compatibility contract before changing
+orchestration: JSON output remains machine-readable, diagnostics go only to
+stderr, and valid `design` artifacts remain consumable by advertised `bbs`,
+`detail`, and `dxf` commands unless a command is explicitly deprecated and held.
+Generate or validate one advertised calculation-entry-point inventory so future
+CLI/API/transport additions cannot be omitted from exact-wheel UAT.
+**Focused proof:** canonical valid CLI input preserves the one-storey beam
+result; malformed-only, mixed valid/invalid, empty, missing-cover/depth,
+non-finite, unknown-field, duplicate-ID, and ambiguous-format files block in
+source and exact-wheel environments. The old PyPI batch example is explicitly
+recorded as historical/broken; stdout JSON is parsed; valid `design` output is
+passed through every retained downstream command; and the next package
+description is executed from the candidate wheel.
+**Accept:** CLI-01, CLI-02, REL-UAT-02, and PUBLISHED-01 close. Re-run the complete
+Section 7 matrix, public examples, quick/full release gates, immutable review,
+and hosted checks on one exact candidate. Publication still requires separate
+owner authorization.
+**Rollback:** retain publication HOLD; do not restore row skipping or hidden
+defaults for compatibility.
+
 ### H — Whole-building workflow decision (`LIB-PRO-002-H`, planning only, L)
 
-**State:** not activated. Completing A-G does not activate this packet or
+**State:** not activated. Completing A-I does not activate this packet or
 authorize whole-building implementation.
 
-**Depends on:** G and separate owner activation.
+**Depends on:** I and separate owner activation.
 **Owns:** a new source-backed plan—not calculation code.
 **Deliver:** supported structural model, load provenance/takedown, combinations,
 equilibrium/load-path checks, element result aggregation, detailing/review
@@ -459,8 +568,9 @@ The fastest safe path is contract-first and evidence-last:
    for behavior the packet changes; avoid generic hardening.
 5. Run focused tests while editing. Run architecture/import checks when a layer
    boundary changes, then quick once on the frozen candidate.
-6. Reserve broad Python/FastAPI/React and full canonical gates for cumulative
-   Packet G unless a packet exposes repository-wide risk.
+6. Reserve the next broad Python/FastAPI/React and full canonical gates for the
+   frozen Packet I cumulative repair unless an outcome-changing failure proves
+   repository-wide risk earlier.
 7. Use one candidate and at most one repair candidate. A material post-push
    defect creates a new reviewed candidate; status prose does not mutate the
    immutable head.
@@ -512,25 +622,29 @@ ledger and blocking rules are accepted.
 G0 has now frozen:
 
 - the bounded interpretation of the one-storey pilot;
-- six root causes and an outcome-changing issue register;
+- seven root causes and an outcome-changing issue register;
 - canonical input, import-ledger, result, and compatibility contracts;
 - Alpha/stable/whole-building release boundaries;
-- an eight-packet dependency order and cumulative test cadence.
+- a nine-packet dependency order and cumulative test cadence.
 
-Packet A merged through PR #814. Packets B-G are now integrated as one
-cumulative candidate in a single isolated writer lane based on that merge.
-The next action is to freeze its task/session/handoff evidence, run the Section
-7 exact-wheel matrix and the cumulative local gates, then obtain immutable
-exact-head review and required hosted checks. Any outcome-changing failure
-repairs the same cumulative candidate; it does not weaken the contract or split
-acceptance into undocumented partial states.
+Packet A merged through PR #814 and Packets B-G merged through PR #815 at
+`fe4ab025419b834c6d0f840e9492c0604ae74201`. The post-fix replay accepts the
+original covered service/import/transport/result/evidence/API cases and the
+one-storey arithmetic, but it rejects publication readiness because the public
+design CLI still skips malformed rows and the exact-wheel matrix omits that
+entry point.
+
+The exact next implementation packet is `LIB-PRO-002-I`. It converges the
+advertised CLI on the lossless/strict boundary, adds CLI cases to source-free
+exact-wheel UAT, and proves the candidate package description. This is a repair
+of acceptance scope, not evidence that A-G failed everywhere.
 
 Packet H remains inactive because the owner has not separately activated a
-whole-building planning program. Even after A-G acceptance, publication remains
-blocked until the owner separately authorizes the exact future version, tag,
-and publication targets recorded by
+whole-building planning program. Even after Packet I acceptance, publication
+remains blocked until the owner separately authorizes the exact future version,
+tag, and publication targets recorded by
 `docs/verification/release-publication-authorization.json`.
 
-While the cumulative candidate is under acceptance, the release state is:
+While Packet I is unresolved, the release state is:
 
-`NEXT_PUBLICATION = HOLD_CUMULATIVE_ACCEPTANCE_AND_OWNER_AUTHORIZATION`
+`NEXT_PUBLICATION = HOLD_ADVERTISED_CLI_AND_OWNER_AUTHORIZATION`

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,12 +3,12 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-17",
-  "file_count": 167,
+  "file_count": 168,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -27,7 +27,7 @@
       "name": "README.md",
       "type": "documentation",
       "size_lines": 64,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "title": "Verification",
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards. | Document | Description |",
       "content_hash": "4763d5ab8b48"
@@ -36,7 +36,7 @@
       "name": "alpha-0231-local-prepublication-rehearsal.md",
       "type": "documentation",
       "size_lines": 72,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "title": "v0.23.1a1 Local Prepublication Rehearsal",
       "description": "not a CI artifact identity, tag, or publication approval | Artifact | Bytes | Members | SHA-256 |",
       "content_hash": "d6a173859f50"
@@ -45,7 +45,7 @@
       "name": "bundled-sample-boq-evidence.md",
       "type": "documentation",
       "size_lines": 58,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "description": "This is the reproducible software record for the bundled ETABS sample. It is not a bill approved for procurement or construction and is not professional",
       "content_hash": "78b84b5474bc"
     },
@@ -53,7 +53,7 @@
       "name": "column-pmm-benchmark.md",
       "type": "documentation",
       "size_lines": 107,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "description": "This record independently checks the experimental rectangular-column fiber kernel at an oblique neutral-axis orientation. It is a calculation benchmark,",
       "content_hash": "fcc6aaad58e3"
     },
@@ -74,7 +74,7 @@
       "name": "examples.md",
       "type": "documentation",
       "size_lines": 1550,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "description": "This document provides benchmark examples that engineers can use to verify the library's calculations against: - Hand calculations",
       "content_hash": "79cb3add7cbe"
     },
@@ -82,7 +82,7 @@
       "name": "external-cli-test.md",
       "type": "documentation",
       "size_lines": 98,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-03-30",
       "description": "Purpose: capture a repeatable, human-run CLI test from a fresh user. Preferred: use the automated smoke script so the output is consistent and easy to share.",
       "content_hash": "a81223e8c701"
     },
@@ -107,7 +107,7 @@
     {
       "name": "git-001-phase-8-reconciliation-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -125,7 +125,7 @@
     {
       "name": "git-001-phase-8-reconciliation-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -137,7 +137,7 @@
     {
       "name": "git-primary-session-log-reconcile-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -155,7 +155,7 @@
     {
       "name": "git-primary-session-log-reconcile-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -186,7 +186,7 @@
       "name": "india-1-cumulative-gate-evidence.md",
       "type": "documentation",
       "size_lines": 56,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "INDIA-1A through INDIA-1D are integrated on main as four independently gated packets:",
       "content_hash": "06bfd83e531d"
     },
@@ -194,7 +194,7 @@
       "name": "india-1a-beam-route-evidence.md",
       "type": "documentation",
       "size_lines": 85,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "design_flanged_beam_is456() composes one monolithic sagging T-beam case from already-factored supplied actions. It calculates the effective flange width,",
       "content_hash": "97194ff486b7"
     },
@@ -202,7 +202,7 @@
       "name": "india-1b-column-decision-evidence.md",
       "type": "documentation",
       "size_lines": 73,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "The stable IS 456 column decision remains bounded to solid rectangular tied sections. design_column_is456() and design_long_column_is456() accept one",
       "content_hash": "5ed855d6483f"
     },
@@ -210,7 +210,7 @@
       "name": "india-1c-isolated-footing-workflow-evidence.md",
       "type": "documentation",
       "size_lines": 53,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "INDIA-1C publishes the existing bounded concentric isolated-footing composition through structural_lib.services.api and the package root. No footing structural",
       "content_hash": "e6ec5ffc6d7b"
     },
@@ -218,14 +218,14 @@
       "name": "india-1d-slab-boundary-evidence.md",
       "type": "documentation",
       "size_lines": 71,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "INDIA-1D closes the decision boundary around already supported solid-slab serviceability, shear, and loading behavior. It does not add or promote new",
       "content_hash": "76b8e456fffe"
     },
     {
       "name": "india-2-closeout-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -243,7 +243,7 @@
     {
       "name": "india-2-closeout-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -256,14 +256,14 @@
       "name": "india-2-cumulative-gate-evidence.md",
       "type": "documentation",
       "size_lines": 71,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "INDIA-2A-D are integrated through exact origin/main 18da6c112e67af49d8adf32bf0babf65285e2cd4. The cumulative gate packet ran",
       "content_hash": "e72e21fb5707"
     },
     {
       "name": "india-2-cumulative-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -281,7 +281,7 @@
     {
       "name": "india-2-cumulative-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -294,14 +294,14 @@
       "name": "india-2-deep-a-geometry-evidence.md",
       "type": "documentation",
       "size_lines": 73,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "DEEP-A implements the typed pure-math foundation for the G0-approved case: one simply supported, top-loaded, solid rectangular deep beam without openings,",
       "content_hash": "6e1bf2ca5125"
     },
     {
       "name": "india-2-deep-a-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -319,7 +319,7 @@
     {
       "name": "india-2-deep-a-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -331,7 +331,7 @@
     {
       "name": "india-2-deep-acceptance-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -349,7 +349,7 @@
     {
       "name": "india-2-deep-acceptance-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -361,7 +361,7 @@
     {
       "name": "india-2-deep-b-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -379,7 +379,7 @@
     {
       "name": "india-2-deep-b-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -392,14 +392,14 @@
       "name": "india-2-deep-b-reinforcement-evidence.md",
       "type": "documentation",
       "size_lines": 75,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "DEEP-B implements the remaining pure-math checks for the G0-approved simply supported solid rectangular top-loaded deep beam. It accepts one caller-",
       "content_hash": "82c98695be8a"
     },
     {
       "name": "india-2-deep-c-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -417,7 +417,7 @@
     {
       "name": "india-2-deep-c-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -430,14 +430,14 @@
       "name": "india-2-deep-c-public-workflow-evidence.md",
       "type": "documentation",
       "size_lines": 61,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "design_simply_supported_deep_beam_is456 is the single typed Python workflow for the G0-approved case. It is exported identically from",
       "content_hash": "076377ad8318"
     },
     {
       "name": "india-2-deep-d-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -455,7 +455,7 @@
     {
       "name": "india-2-deep-d-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -468,7 +468,7 @@
       "name": "india-2-deep-d-publication-evidence.md",
       "type": "documentation",
       "size_lines": 73,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "POST /api/v1/design/deep-beam/simply-supported is a thin typed transport over the canonical design_simply_supported_deep_beam_is456 service. Its request",
       "content_hash": "e9f0ce8f804f"
     },
@@ -476,14 +476,14 @@
       "name": "india-2-deep-family-acceptance-evidence.md",
       "type": "documentation",
       "size_lines": 93,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "exact integrated G0/A-D starting head was ce45e22032ea234f588ce88c601db5f6a42af166. The supported public route remains",
       "content_hash": "6f058b49b1ea"
     },
     {
       "name": "india-2-deep-g0-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -501,7 +501,7 @@
     {
       "name": "india-2-deep-g0-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -514,7 +514,7 @@
       "name": "india-2-deep-g0-scope-evidence.md",
       "type": "documentation",
       "size_lines": 166,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "supported, solid rectangular, top-loaded deep beam without openings, under one caller-supplied governing positive factored moment. The route checks the",
       "content_hash": "300737e95db2"
     },
@@ -522,7 +522,7 @@
       "name": "india-2-final-closeout-evidence.md",
       "type": "documentation",
       "size_lines": 91,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "families are accepted only for the cases recorded below: wall, staircase, deep beam, flat slab with column punching, combined footing, and strap footing.",
       "content_hash": "d0a2995909c6"
     },
@@ -530,14 +530,14 @@
       "name": "india-2-flat-a-geometry-evidence.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "FLAT-A implements the typed pure-math foundation for the G0-approved case: one solid square interior panel in an equal-span orthogonal column grid, using the",
       "content_hash": "900cb6f84a05"
     },
     {
       "name": "india-2-flat-a-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -555,7 +555,7 @@
     {
       "name": "india-2-flat-a-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -567,7 +567,7 @@
     {
       "name": "india-2-flat-acceptance-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -585,7 +585,7 @@
     {
       "name": "india-2-flat-acceptance-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -597,7 +597,7 @@
     {
       "name": "india-2-flat-b-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -615,7 +615,7 @@
     {
       "name": "india-2-flat-b-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -628,14 +628,14 @@
       "name": "india-2-flat-b-moment-evidence.md",
       "type": "documentation",
       "size_lines": 80,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "FLAT-B adds only the gravity moment calculation approved by FLAT-G0. The input must first satisfy the FLAT-A equal-span square interior-panel, direct-design,",
       "content_hash": "2ef4c61ac9d3"
     },
     {
       "name": "india-2-flat-c-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -653,7 +653,7 @@
     {
       "name": "india-2-flat-c-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -666,14 +666,14 @@
       "name": "india-2-flat-c-reinforcement-evidence.md",
       "type": "documentation",
       "size_lines": 85,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "FLAT-C consumes the FLAT-A/B panel and moment contracts and adds only bounded singly reinforced flexure, caller-provided straight-bar checks, the frozen",
       "content_hash": "b3348eb6b4bc"
     },
     {
       "name": "india-2-flat-d-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -691,7 +691,7 @@
     {
       "name": "india-2-flat-d-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -704,14 +704,14 @@
       "name": "india-2-flat-d-punching-evidence.md",
       "type": "documentation",
       "size_lines": 82,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "FLAT-D adds the centred concentric punching check for the G0-frozen square interior column. It consumes the fail-closed FLAT-A panel contract and requires",
       "content_hash": "102df860ad9f"
     },
     {
       "name": "india-2-flat-e-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -729,7 +729,7 @@
     {
       "name": "india-2-flat-e-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -742,7 +742,7 @@
       "name": "india-2-flat-e-publication-evidence.md",
       "type": "documentation",
       "size_lines": 93,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "FLAT-E composes the integrated FLAT-A-D calculations into the sole public design_regular_interior_flat_slab_is456 service and exposes the same workflow",
       "content_hash": "ef60f1ec9135"
     },
@@ -750,14 +750,14 @@
       "name": "india-2-flat-family-acceptance-evidence.md",
       "type": "documentation",
       "size_lines": 100,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "exact integrated G0/A-E starting head was b04d80653484a8dc43e8ff73936d8171e4b65d40. The supported public route remains",
       "content_hash": "ac0c238727b4"
     },
     {
       "name": "india-2-flat-g0-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -775,7 +775,7 @@
     {
       "name": "india-2-flat-g0-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -788,7 +788,7 @@
       "name": "india-2-flat-g0-scope-evidence.md",
       "type": "documentation",
       "size_lines": 215,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "interior panel in an equal-span orthogonal grid, designed by the direct design method for uniform gravity loading, with one centred square interior-column",
       "content_hash": "6b3a77310a78"
     },
@@ -796,14 +796,14 @@
       "name": "india-2-foundation-combined-a-analysis-evidence.md",
       "type": "documentation",
       "size_lines": 114,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "COMBINED-A implements only the G0-frozen pure IS 456 analysis layer for two identical square columns carrying equal concentric axial compression on one",
       "content_hash": "6e5b36a832d2"
     },
     {
       "name": "india-2-foundation-combined-a-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -821,7 +821,7 @@
     {
       "name": "india-2-foundation-combined-a-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -833,7 +833,7 @@
     {
       "name": "india-2-foundation-combined-acceptance-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -851,7 +851,7 @@
     {
       "name": "india-2-foundation-combined-acceptance-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -863,7 +863,7 @@
     {
       "name": "india-2-foundation-combined-acceptance-nonfrozen-replay.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "case_id",
         "footing",
@@ -874,7 +874,7 @@
     {
       "name": "india-2-foundation-combined-b-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -892,7 +892,7 @@
     {
       "name": "india-2-foundation-combined-b-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -905,14 +905,14 @@
       "name": "india-2-foundation-combined-b-strength-evidence.md",
       "type": "documentation",
       "size_lines": 152,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "COMBINED-B implements only the G0-frozen pure IS 456 strength composition for two identical square columns carrying equal concentric axial compression on one",
       "content_hash": "8aec93e9e535"
     },
     {
       "name": "india-2-foundation-combined-c-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -930,7 +930,7 @@
     {
       "name": "india-2-foundation-combined-c-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -943,14 +943,14 @@
       "name": "india-2-foundation-combined-c-public-workflow-evidence.md",
       "type": "documentation",
       "size_lines": 146,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "COMBINED-C publishes one typed Python workflow, design_symmetric_combined_footing_is456, over the already accepted",
       "content_hash": "8d7b847e8992"
     },
     {
       "name": "india-2-foundation-combined-d-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -968,7 +968,7 @@
     {
       "name": "india-2-foundation-combined-d-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -981,7 +981,7 @@
       "name": "india-2-foundation-combined-d-publication-evidence.md",
       "type": "documentation",
       "size_lines": 92,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "POST /api/v1/design/combined-footing/symmetric is a thin typed transport over the canonical design_symmetric_combined_footing_is456 service accepted in",
       "content_hash": "d4c9e869bffd"
     },
@@ -989,14 +989,14 @@
       "name": "india-2-foundation-combined-family-acceptance-evidence.md",
       "type": "documentation",
       "size_lines": 176,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "The exact integrated G0/A-D starting head is 079ca22b00744ca9b01f859be0b64333b5830fcb, tree",
       "content_hash": "c89171222f11"
     },
     {
       "name": "india-2-foundation-combined-g0-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1014,7 +1014,7 @@
     {
       "name": "india-2-foundation-combined-g0-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1027,14 +1027,14 @@
       "name": "india-2-foundation-combined-g0-scope-evidence.md",
       "type": "documentation",
       "size_lines": 226,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "square reinforced-concrete columns carrying equal concentric axial compression, located symmetrically on the longitudinal centreline of one rigid rectangular,",
       "content_hash": "1f4ee33aff2e"
     },
     {
       "name": "india-2-foundation-pile-cap-g0-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1052,7 +1052,7 @@
     {
       "name": "india-2-foundation-pile-cap-g0-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1065,14 +1065,14 @@
       "name": "india-2-foundation-pile-cap-g0-hold-evidence.md",
       "type": "documentation",
       "size_lines": 176,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "implementation files. The frozen candidate remains one constant-depth rectangular reinforced-",
       "content_hash": "1f0c1c3d968b"
     },
     {
       "name": "india-2-foundation-raft-g0-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1090,7 +1090,7 @@
     {
       "name": "india-2-foundation-raft-g0-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1103,7 +1103,7 @@
       "name": "india-2-foundation-raft-g0-hold-evidence.md",
       "type": "documentation",
       "size_lines": 187,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "implementation files. The frozen candidate remains one regular rectangular constant-depth rigid raft",
       "content_hash": "2051564fc5cb"
     },
@@ -1111,14 +1111,14 @@
       "name": "india-2-foundation-strap-a-analysis-evidence.md",
       "type": "documentation",
       "size_lines": 56,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "This packet implements only the G0-frozen two-footing property-line analysis: strict typed topology/action/approval inputs, reaction statics, equal uniform",
       "content_hash": "d8aa9a13773d"
     },
     {
       "name": "india-2-foundation-strap-a-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1136,7 +1136,7 @@
     {
       "name": "india-2-foundation-strap-a-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1148,7 +1148,7 @@
     {
       "name": "india-2-foundation-strap-acceptance-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1166,7 +1166,7 @@
     {
       "name": "india-2-foundation-strap-acceptance-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1178,7 +1178,7 @@
     {
       "name": "india-2-foundation-strap-acceptance-nonfrozen-replay.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "case_id",
         "footing",
@@ -1189,7 +1189,7 @@
     {
       "name": "india-2-foundation-strap-b-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1207,7 +1207,7 @@
     {
       "name": "india-2-foundation-strap-b-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1220,14 +1220,14 @@
       "name": "india-2-foundation-strap-b-strength-evidence.md",
       "type": "documentation",
       "size_lines": 61,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "This packet composes A actions with caller-supplied M20-M40 concrete, Fe415/ Fe500 uncoated deformed bars, longitudinal/side-face reinforcement, vertical",
       "content_hash": "1c995a8306f6"
     },
     {
       "name": "india-2-foundation-strap-c-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1245,7 +1245,7 @@
     {
       "name": "india-2-foundation-strap-c-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1258,14 +1258,14 @@
       "name": "india-2-foundation-strap-c-public-workflow-evidence.md",
       "type": "documentation",
       "size_lines": 52,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "design_property_line_strap_footing_is456 is the sole canonical public Python composition over STRAP-A/B. It accepts one immutable case wrapper around the",
       "content_hash": "0f31237bfd01"
     },
     {
       "name": "india-2-foundation-strap-d-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1283,7 +1283,7 @@
     {
       "name": "india-2-foundation-strap-d-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1296,7 +1296,7 @@
       "name": "india-2-foundation-strap-d-publication-evidence.md",
       "type": "documentation",
       "size_lines": 95,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "POST /api/v1/design/strap-footing/property-line is a thin typed transport over the canonical design_property_line_strap_footing_is456 service accepted",
       "content_hash": "ad70699f818c"
     },
@@ -1304,14 +1304,14 @@
       "name": "india-2-foundation-strap-family-acceptance-evidence.md",
       "type": "documentation",
       "size_lines": 192,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "The exact integrated G0/A-D starting head is b75daa970b2976cbd5d51e9a951926a7946d5fa6, tree",
       "content_hash": "abe4929e3c8c"
     },
     {
       "name": "india-2-foundation-strap-g0-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1329,7 +1329,7 @@
     {
       "name": "india-2-foundation-strap-g0-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1342,14 +1342,14 @@
       "name": "india-2-foundation-strap-g0-scope-evidence.md",
       "type": "documentation",
       "size_lines": 267,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "rectangular constant-depth footings on soil, one exterior square column eccentric to its footing centroid and one interior square column centred on its",
       "content_hash": "8704b0e57f8a"
     },
     {
       "name": "india-2-next-agent-plan-refresh-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1367,7 +1367,7 @@
     {
       "name": "india-2-next-agent-plan-refresh-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1379,7 +1379,7 @@
     {
       "name": "india-2-plan-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1397,7 +1397,7 @@
     {
       "name": "india-2-plan-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1410,14 +1410,14 @@
       "name": "india-2-truth-hygiene-38-2-evidence.md",
       "type": "documentation",
       "size_lines": 122,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "The controlled IS 456 source has Clause 38.1 and Annex G beam/section cases, but no Clause 38.2, 38.3, or 38.4. Independently replayed equilibrium also",
       "content_hash": "50b5fff40345"
     },
     {
       "name": "india-2-truth-hygiene-38-2-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1435,7 +1435,7 @@
     {
       "name": "india-2-truth-hygiene-38-2-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1448,14 +1448,14 @@
       "name": "india-2-wall-a-axial-kernel-evidence.md",
       "type": "documentation",
       "size_lines": 83,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "WALL-A implements the pure IS 456 layer for the accepted Clause 32.2 braced wall case. It resolves effective height, enforces the maximum effective-height",
       "content_hash": "f64b2ddf2842"
     },
     {
       "name": "india-2-wall-acceptance-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1473,7 +1473,7 @@
     {
       "name": "india-2-wall-acceptance-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1486,7 +1486,7 @@
       "name": "india-2-wall-b-reinforcement-evidence.md",
       "type": "documentation",
       "size_lines": 82,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "WALL-B adds one pure IS 456 provided-reinforcement check to the accepted Clause 32.2 braced-wall case. It does not select bars. The caller supplies one",
       "content_hash": "dccc2142b26b"
     },
@@ -1494,7 +1494,7 @@
       "name": "india-2-wall-c-public-workflow-evidence.md",
       "type": "documentation",
       "size_lines": 80,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "WALL-C publishes one canonical typed Python function, design_braced_wall_is456, through structural_lib.services.api, the",
       "content_hash": "6a75d034217a"
     },
@@ -1502,7 +1502,7 @@
       "name": "india-2-wall-d-publication-evidence.md",
       "type": "documentation",
       "size_lines": 80,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "WALL-D publishes the integrated design_braced_wall_is456 workflow through POST /api/v1/design/wall/braced-axial and promotes exactly one bounded wall",
       "content_hash": "3e70433c516b"
     },
@@ -1510,7 +1510,7 @@
       "name": "india-2-wall-family-acceptance-evidence.md",
       "type": "documentation",
       "size_lines": 82,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "integrated A-D starting head was 46094a8c35c75fcfb0644f23a851087cc3297c60. The supported public route remains one regular 100-200 mm thick, one-grid,",
       "content_hash": "fafe9e88fdce"
     },
@@ -1518,7 +1518,7 @@
       "name": "india-2-wall-g0-scope-evidence.md",
       "type": "documentation",
       "size_lines": 125,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "activated the remaining INDIA-2 work on 2026-08-16 by asking that INDIA-2 be implemented and finished. Each later family still has to pass its own G0 source,",
       "content_hash": "a5addb19fbc4"
     },
@@ -1526,7 +1526,7 @@
       "name": "india-2a-staircase-scope-evidence.md",
       "type": "documentation",
       "size_lines": 111,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "activated INDIA-2A through INDIA-2D on 2026-08-15 by requesting that INDIA-2 be started and finished. This decision selects only the case below; it does not",
       "content_hash": "6d6defbea3ed"
     },
@@ -1534,7 +1534,7 @@
       "name": "india-2b-staircase-actions-evidence.md",
       "type": "documentation",
       "size_lines": 70,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "INDIA-2B implements only the typed geometry, concrete self-weight, and three-segment simply supported action contract selected by INDIA-2A. It adds no",
       "content_hash": "1f9680c591ed"
     },
@@ -1542,14 +1542,14 @@
       "name": "india-2c-staircase-design-evidence.md",
       "type": "documentation",
       "size_lines": 66,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "INDIA-2C composes the accepted INDIA-2B per-metre actions into one bounded waist-slab design check. It does not add public consumers or promote staircase",
       "content_hash": "ccbd767ff6fb"
     },
     {
       "name": "india-2d-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1567,7 +1567,7 @@
     {
       "name": "india-2d-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1580,14 +1580,14 @@
       "name": "india-2d-staircase-publication-evidence.md",
       "type": "documentation",
       "size_lines": 85,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "description": "INDIA-2D publishes one typed Python service and one thin FastAPI transport for the bounded straight-flight staircase developed in INDIA-2A-C. It does not add",
       "content_hash": "be7ac2e157a6"
     },
     {
       "name": "india-completion-plan-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1605,7 +1605,7 @@
     {
       "name": "india-completion-plan-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1617,7 +1617,7 @@
     {
       "name": "indian-code-capability-coverage.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "manifest_id",
@@ -1634,7 +1634,7 @@
       "name": "indian-code-truth-baseline.md",
       "type": "documentation",
       "size_lines": 93,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "title": "INDIA-0 Indian-Code Truth Baseline",
       "description": "was squash-merged as 0373de68; INDIA-1 packets now update the generated manifest from fresh integrated-main lanes",
       "content_hash": "e8d850af25d8"
@@ -1643,7 +1643,7 @@
       "name": "insights-verification-pack.md",
       "type": "documentation",
       "size_lines": 101,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-09",
       "description": "This pack provides benchmark test cases for the insights module to ensure accuracy and prevent regressions. Tests are automatically run in CI on every PR. Run all insights benchmark tests:",
       "content_hash": "62116e5ed5fe"
     },
@@ -1651,7 +1651,7 @@
       "name": "is456-library-first-evidence.md",
       "type": "documentation",
       "size_lines": 169,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "title": "IS 456 Library-First Evidence and Claim Crosswalk",
       "description": "| Source | SHA-256 | Pages | Use | |---|---|---:|---|",
       "content_hash": "3a47d498ba82"
@@ -1659,7 +1659,7 @@
     {
       "name": "is456-public-distribution-permission.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "top_level_keys": [
         "schema_version",
         "record_id",
@@ -1677,7 +1677,7 @@
       "name": "is456-slab-evidence.md",
       "type": "documentation",
       "size_lines": 125,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-15",
       "title": "IS 456 Solid Slab Source and Benchmark Ledger",
       "description": "| ID | Identity | Permitted implementation use | State | |---|---|---|---|",
       "content_hash": "087b5c252695"
@@ -1812,9 +1812,27 @@
       "content_hash": "ff996d87bfcb"
     },
     {
-      "name": "next-session-git-issues-plan-git-handoff-receipt.json",
+      "name": "lib-pro-002-post-fix-recheck-git-handoff-receipt.json",
       "type": "config",
       "last_updated": "2026-08-17",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "2ae22416068d"
+    },
+    {
+      "name": "next-session-git-issues-plan-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1832,7 +1850,7 @@
     {
       "name": "next-session-git-issues-plan-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1845,7 +1863,7 @@
       "name": "pack.md",
       "type": "documentation",
       "size_lines": 56,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-03-30",
       "description": "This repo’s unit tests validate correctness and edge cases, but they don’t always answer the question: **“did the numerical design outputs change?”** The **Verification Pack** is a small set of **pinn",
       "content_hash": "fa4fe75b3d05"
     },
@@ -1853,14 +1871,14 @@
       "name": "post-india2-cleanup-authorization-proposal.md",
       "type": "documentation",
       "size_lines": 162,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "description": "Exact candidate set POST-INDIA2-2499DF4ADE0DF704 contains **71 branches** and **193 separately bound actions**. Its worktree actions are expected to recover approximately **7.8 GiB**. The repository o",
       "content_hash": "2ff7f7bd38c7"
     },
     {
       "name": "post-india2-cleanup-disposition-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "audit_branch",
         "audit_head_sha",
@@ -1878,7 +1896,7 @@
     {
       "name": "post-india2-cleanup-execution-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1896,7 +1914,7 @@
     {
       "name": "post-india2-cleanup-execution-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1908,7 +1926,7 @@
     {
       "name": "post-india2-cleanup-execution-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "packet",
@@ -1926,7 +1944,7 @@
     {
       "name": "post-india2-index-determinism-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "packet",
@@ -1944,7 +1962,7 @@
     {
       "name": "post-india2-index-determinism-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -1962,7 +1980,7 @@
     {
       "name": "post-india2-index-determinism-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -1974,7 +1992,7 @@
     {
       "name": "post-india2-index-local-artifact-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "packet",
@@ -1992,7 +2010,7 @@
     {
       "name": "post-india2-index-local-artifact-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -2010,7 +2028,7 @@
     {
       "name": "post-india2-index-local-artifact-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -2022,7 +2040,7 @@
     {
       "name": "post-india2-maintenance-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "schema_version",
         "packet",
@@ -2040,7 +2058,7 @@
     {
       "name": "post-india2-maintenance-git-handoff-receipt.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "holds",
@@ -2058,7 +2076,7 @@
     {
       "name": "post-india2-maintenance-git-handoff-source-evidence.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-16",
       "top_level_keys": [
         "authorization",
         "integration",
@@ -2098,7 +2116,7 @@
       "name": "ui-experience-session-2-acceptance.md",
       "type": "documentation",
       "size_lines": 70,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-10",
       "description": "This is the software acceptance record for UIX-001 P9-P15. It does not certify the formulas, approve a structural design, or authorize professional use.",
       "content_hash": "82dbbd6cae09"
     },
@@ -2106,11 +2124,11 @@
       "name": "validation-pack.md",
       "type": "documentation",
       "size_lines": 396,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-12",
       "description": "This pack provides 5 benchmark beams and 3 benchmark columns with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trust",
       "content_hash": "63fd4822c78c"
     }
   ],
   "subfolders": [],
-  "content_hash": "a4f47ff966ac598e"
+  "content_hash": "9c28378289aba05c"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-17
-**Files:** 167
+**Files:** 168
 
 ## Config Files
 
@@ -98,6 +98,7 @@ Benchmark examples and verification packs for validating library calculations ag
 - [lib-pro-002-a-git-handoff-source-evidence.json](lib-pro-002-a-git-handoff-source-evidence.json)
 - [lib-pro-002-g0-git-handoff-receipt.json](lib-pro-002-g0-git-handoff-receipt.json)
 - [lib-pro-002-g0-git-handoff-source-evidence.json](lib-pro-002-g0-git-handoff-source-evidence.json)
+- [lib-pro-002-post-fix-recheck-git-handoff-receipt.json](lib-pro-002-post-fix-recheck-git-handoff-receipt.json)
 - [next-session-git-issues-plan-git-handoff-receipt.json](next-session-git-issues-plan-git-handoff-receipt.json)
 - [next-session-git-issues-plan-git-handoff-source-evidence.json](next-session-git-issues-plan-git-handoff-source-evidence.json)
 - [post-india2-cleanup-disposition-evidence.json](post-india2-cleanup-disposition-evidence.json)

--- a/docs/verification/lib-pro-002-post-fix-recheck-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-002-post-fix-recheck-git-handoff-receipt.json
@@ -1,0 +1,126 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "1931760c665a10e1ffd69029beeab94ace42c72fe38349b82f8b189a018480dc",
+    "state": {
+      "branch": "codex/lib-pro-002-usability-refresh",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "fe4ab025419b834c6d0f840e9492c0604ae74201",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 73.947,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "head_sha": "fe4ab025419b834c6d0f840e9492c0604ae74201",
+      "hold_reasons": [
+        "changed paths: 9"
+      ],
+      "linked_worktree": false,
+      "locks": [],
+      "observed_at_utc": "2026-08-17T03:31:53.572065+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 9,
+        "modified_paths": [
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/README.md",
+          "docs/planning/index.json",
+          "docs/planning/index.md",
+          "docs/planning/next-session-brief.md",
+          "docs/planning/pre-release-input-safety-and-professional-readiness-plan.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:1931760c665a10e1ffd69029beeab94ace42c72fe38349b82f8b189a018480dc",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-17T03:31:53.572232+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [],
+    "integration_owner": "Codex",
+    "owned_paths": [
+      "docs/planning/pre-release-input-safety-and-professional-readiness-plan.md",
+      "docs/planning/next-session-brief.md",
+      "docs/planning/README.md"
+    ],
+    "shared_paths": [
+      "docs/TASKS.md",
+      "docs/SESSION_LOG.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/index.json",
+      "docs/index.md"
+    ],
+    "task_id": "LIB-PRO-002-POST-FIX-RECHECK"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}


### PR DESCRIPTION
## Summary
- record the post-A-G advertised CLI safety gap and preserve the valid legacy output/downstream contract
- add Packet J for hosted interpreter binding and mode-accurate release verdicts
- freeze the next-session I then J branch order, focused/cumulative verification cadence, evidence receipts, and publication stop rules

## Verification
- ./run.sh check --quick (10/10)
- affected docs/planning and docs indexes current
- 1,348 internal links checked; zero broken
- normal commit hooks passed
- strict documentation metadata passed

## Holds
- no runtime implementation, version bump, tag, package upload, GitHub Release, professional approval, Packet H activation, branch deletion, or worktree cleanup
- publication remains held through Packets I-J, exact versioned candidate review/hosted evidence, and separate owner authorization