### PR TITLE
chore(release): prepare 0.23.1a2

### DIFF
--- a/.github/skills/release-preflight/SKILL.md
+++ b/.github/skills/release-preflight/SKILL.md
@@ -41,12 +41,14 @@ step 3, then establish the final green current-candidate preflight with:
 ./run.sh release preflight --wheel <exact-wheel-path>
 ```
 
-An owner-authorized release may carry its final dated CHANGELOG/CITATION
-metadata before the tag so that the tagged artifact is truthful. Record the
-checked owner authorization in `docs/planning/pre-release-checklist.md` first.
-The exact-wheel form accepts that release-ready state; preflight without an
-exact wheel continues to require unpublished-candidate wording and fails
-closed.
+A preparation-authorized candidate must retain explicit unpublished/on-hold
+CHANGELOG, release-ledger, and CITATION wording. Do not pre-check tag or
+publication authorization in `docs/planning/pre-release-checklist.md` before
+the immutable review. After that review, record exact target authorization only
+through the maintained authorization JSON and exact-candidate receipt flow;
+post-review changes remain limited to paths accepted by the release validator.
+The exact-wheel form accepts the historical candidate-freeze wording and fails
+closed unless those later evidence records authorize the selected target.
 
 This is read-only. Run it once. If local resource checks fail and Docker is the intended fallback, start Colima and run the Docker variant instead of running both full paths:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.23.1a2] — Prepared candidate (unreleased; on hold)
+
+Prepared Alpha candidate for strict project input safety, traceable result
+contracts, and additional bounded component workflows. At candidate freeze it
+is not tagged or published. Any later publication requires immutable review,
+hosted checks, and separate exact owner authorization. This is case-qualified
+software evidence, not whole-building safety or professional approval.
+
+### Added
+
+- Bounded public workflows for braced walls, straight-flight staircases,
+  simply supported deep beams, regular interior flat slabs, symmetric combined
+  footings, and property-line strap footings, with explicit limitations and
+  capability provenance.
+- Lossless import ledgers and versioned project/result envelopes that retain
+  every source row, normalization decision, blocked issue, source identity,
+  and qualified-review requirement.
+- Installed-wheel UAT covering 29 positive and negative cases across all 12
+  advertised commands, including the full `design` to `bbs`/`detail`/`dxf`
+  compatibility chain.
+
+### Fixed
+
+- Invalid, missing, conflicting, non-finite, or unknown project beam inputs no
+  longer receive structural defaults or produce partial-success results.
+- The advertised `design` command now fails the whole file on any blocked row,
+  exits non-zero, keeps stdout as clean JSON, and writes diagnostics to stderr.
+- Missing project column materials block calculation instead of silently using
+  concrete or steel defaults.
+- Result wording no longer equates successful arithmetic with qualified review
+  or professional approval.
+- Hosted full suites and local release preflight now use the selected Python
+  interpreter and emit mode-accurate preparation, candidate, and publication
+  verdicts.
+
+### Changed
+
+- Public API exports are classified by stability/compatibility level and
+  supported-case claims are separated from registration, evidence, review,
+  release, and professional approval.
+- Generated documentation indexes are content-derived, and release/session
+  closeout avoids cyclic or timestamp-only rewrites.
+
 ## [0.23.1a1] — 2026-08-11
 
 Alpha development preview of the bounded beam, column, isolated-footing, and
@@ -1442,6 +1485,8 @@ V3 Foundation release — everything built since v0.19.1. Full-stack maturity mi
 
 Format: Keep a section per release with Added/Changed/Fixed as needed. Tag releases as `vX.Y.Z`.
 
-[Unreleased]: https://github.com/Pravin-surawase/structural_engineering_lib/compare/v0.21.6...HEAD
+[Unreleased]: https://github.com/Pravin-surawase/structural_engineering_lib/compare/v0.23.1a2...HEAD
+[0.23.1a2]: https://github.com/Pravin-surawase/structural_engineering_lib/compare/v0.23.1a1...v0.23.1a2
+[0.23.1a1]: https://github.com/Pravin-surawase/structural_engineering_lib/compare/v0.23.0...v0.23.1a1
 [0.21.6]: https://github.com/Pravin-surawase/structural_engineering_lib/compare/v0.21.5...v0.21.6
 [0.21.4]: https://github.com/Pravin-surawase/structural_engineering_lib/compare/v0.21.3...v0.21.4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,7 @@
 cff-version: 1.2.0
 title: "Structural Engineering Library (IS 456)"
-version: 0.23.1a1
-date-released: 2026-08-11
-message: "Alpha development preview with case-qualified IS 456 workflows; independent verification and qualified professional approval remain required for engineering use."
+version: 0.23.1a2
+message: "Prepared Alpha candidate: not tagged or published at candidate freeze. Case-qualified IS 456 workflows still require independent verification and qualified professional review for engineering use."
 repository-code: "https://github.com/Pravin-surawase/structural_engineering_lib"
 url: "https://pypi.org/project/structural-lib-is456/"
 authors:

--- a/Python/README.md
+++ b/Python/README.md
@@ -2,7 +2,7 @@
 
 IS 456 RC Beam Design Library (Python package).
 
-**Version:** 0.23.1a1 (Alpha development preview)
+**Version:** 0.23.1a2 (Alpha development preview)
 **Status:** [![Weekly Verification](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/nightly.yml/badge.svg)](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/nightly.yml)
 
 > ⚠️ **Development Preview:** APIs may change until v1.0. For reproducible results, pin to a release tag.
@@ -12,18 +12,25 @@ IS 456 RC Beam Design Library (Python package).
 > qualified structural-engineering review. Use official standards as the
 > authoritative source.
 
-## New in v0.23.1a1
+## New in v0.23.1a2
 
-- **Security hardening:** 14 cross-field plausibility validators, error sanitization
-- **Code quality:** `check_code()` and `show_versions()` diagnostics
-- **Column API:** Full column design pipeline (axial, uniaxial, biaxial, slender, detailing)
-- **OpenAPI freeze:** Baseline drift detection in CI
+- **Fail-closed project intake:** malformed, missing, unknown, or mixed-validity
+  beam rows block the whole project instead of being defaulted or skipped.
+- **Safe public CLI:** `design` keeps JSON on stdout, sends diagnostics to stderr,
+  exits non-zero on blocked input, and preserves the `bbs`/`detail`/`dxf` chain.
+- **Traceable results:** import ledgers, input/result provenance, API classification,
+  and qualified-review boundaries are explicit and machine-readable.
+- **Additional bounded workflows:** braced walls, straight-flight staircases,
+  simply supported deep beams, regular interior flat slabs, symmetric combined
+  footings, and property-line strap footings expose case-qualified APIs.
+- **Release evidence:** exact-wheel UAT covers 29 positive and negative cases
+  across all 12 advertised commands, with hosted and local verdicts aligned.
 
 ## Install
 
 ```bash
-pip install structural-lib-is456===0.23.1a1       # current Alpha preview
-pip install "structural-lib-is456[dxf]===0.23.1a1" # Alpha with DXF export
+pip install structural-lib-is456===0.23.1a2       # current Alpha preview
+pip install "structural-lib-is456[dxf]===0.23.1a2" # Alpha with DXF export
 python -m structural_lib install-preflight          # interpreter/origin/extras
 ```
 

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "structural-lib-is456"
-version = "0.23.1a1"
+version = "0.23.1a2"
 description = "Supported-case IS 456 RC workflows for beams, columns, isolated footings, and solid slabs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -3432,7 +3432,7 @@
     {
       "name": "test_release_scripts.py",
       "type": "python",
-      "size_lines": 1030,
+      "size_lines": 1052,
       "last_updated": "2026-08-17",
       "description": "Tests for release scripts (bump_version.py, release.py).",
       "classes": [
@@ -3578,7 +3578,10 @@
           ]
         },
         {
-          "name": "test_release_publication_authorization_holds_by_default"
+          "name": "test_release_publication_authorization_holds_by_default",
+          "params": [
+            "tmp_path"
+          ]
         },
         {
           "name": "test_preflight_verdicts_are_mode_accurate",
@@ -3649,7 +3652,7 @@
         "RELEASE_SCRIPT",
         "VERSION_TRACKED_FILES"
       ],
-      "content_hash": "dd9f3b769715"
+      "content_hash": "6b60f771a6c9"
     },
     {
       "name": "test_release_uat.py",
@@ -4907,5 +4910,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "5d7c5e2836f6c5a4"
+  "content_hash": "ee18020d52909780"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -68,7 +68,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_pipeline_state.py](test_pipeline_state.py) | Tests for scripts/pipeline_state.py — Pipeline step tracking | 7 | 0 | 353 |
 | [test_private_source_boundary.py](test_private_source_boundary.py) | Protected engineering-source material stays local and outsid | 0 | 2 | 40 |
 | [test_release_environment.py](test_release_environment.py) | Regression tests for local release preflight environment sel | 0 | 13 | 281 |
-| [test_release_scripts.py](test_release_scripts.py) | Tests for release scripts (bump_version.py, release.py). | 15 | 11 | 1030 |
+| [test_release_scripts.py](test_release_scripts.py) | Tests for release scripts (bump_version.py, release.py). | 15 | 11 | 1052 |
 | [test_release_uat.py](test_release_uat.py) | The exact-wheel acceptance matrix remains data-driven and ex | 0 | 1 | 35 |
 | [test_report_edge_cases.py](test_report_edge_cases.py) | Edge case tests for report generation modules (TASK-520). | 4 | 0 | 303 |
 | [test_report_svg.py](test_report_svg.py) | Tests for the SVG report generation module. | 4 | 0 | 141 |

--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -205,10 +205,32 @@ class TestBumpVersionPatternMatch:
 # ─── release.py ──────────────────────────────────────────────────────────────
 
 
-def test_release_publication_authorization_holds_by_default() -> None:
+def test_release_publication_authorization_holds_by_default(tmp_path: Path) -> None:
+    authorization = tmp_path / "release-publication-authorization.json"
+    authorization.write_text(
+        json.dumps(
+            {
+                "schema_version": "release-publication-authorization/v1",
+                "decision": "HOLD",
+                "version": None,
+                "tag": None,
+                "authorized_targets": [],
+                "authorized_by": None,
+                "authorized_at_utc": None,
+                "exact_candidate_review_receipt": None,
+                "exact_candidate_review_receipt_sha256": None,
+                "qualified_structural_engineering_review": False,
+                "professional_approval": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
     errors = release._release_publication_authorization_errors(
         "0.23.1a1",
         "pypi",
+        authorization,
+        repo_root=tmp_path,
     )
 
     assert "release publication decision is HOLD, not AUTHORIZED" in errors

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An open-source Python library and visual workbench for supported beam, column,
 isolated-footing, and solid-slab workflows under IS 456:2000.
 
 [![PyPI version](https://img.shields.io/pypi/v/structural-lib-is456.svg)](https://pypi.org/project/structural-lib-is456/)
-[![Alpha](https://img.shields.io/badge/status-alpha-f59e0b)](https://github.com/Pravin-surawase/structural_engineering_lib/releases/tag/v0.23.1a1)
+[![Alpha](https://img.shields.io/badge/status-alpha-f59e0b)](https://github.com/Pravin-surawase/structural_engineering_lib/releases/tag/v0.23.1a2)
 [![PR Gate](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/fast-checks.yml/badge.svg)](https://github.com/Pravin-surawase/structural_engineering_lib/actions/workflows/fast-checks.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e)](LICENSE)
@@ -24,10 +24,11 @@ isolated-footing, and solid-slab workflows under IS 456:2000.
 ![StructLib beam inspector showing a 3D building model, reinforcement view, utilization, and IS 456 checks](docs/images/product/beam-inspector.jpg)
 
 > [!IMPORTANT]
-> **v0.23.1a1 is an Alpha development preview.** Support is case-qualified,
+> **v0.23.1a2 is an Alpha development preview.** Support is case-qualified,
 > not a claim of complete IS 456 coverage or professional design approval.
 > Outputs require independent review by a qualified structural engineer before
-> engineering or construction use.
+> engineering or construction use. This source is a prepared release candidate;
+> it has not yet been tagged or published.
 
 ## One workflow, four useful surfaces
 
@@ -85,14 +86,15 @@ reconciliation, or professional approval.
 ### Install the Python package
 
 ```bash
-python3 -m pip install "structural-lib-is456===0.23.1a1"
+python3 -m pip install "structural-lib-is456===0.23.1a2"
 ```
 
 The package is installed as `structural-lib-is456` and imported as
 `structural_lib`.
 
-`0.23.1a1` is the current published Alpha preview. Because it is a prerelease,
-use the exact PEP 440 pin above when reproducing an evaluation. See the
+`0.23.1a2` is the prepared, unpublished candidate. The current public Alpha is
+`0.23.1a1`; the exact `0.23.1a2` pin above becomes available only if this
+candidate is later authorized and published. See the
 [release policy](docs/getting-started/releases.md) before selecting a candidate.
 
 ```python

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,110 @@
 
 ---
 
+## 2026-08-17 — Session: v0.23.1a2 Release Candidate Preparation
+
+**Agent:** Codex (`ops`, sole writer)
+
+**Branch:** `codex/release-0231a2` from synchronized
+`main = 970a78c1931a3aa0439f487e6892a888bb113962`
+
+**Local evidence:** `docs/verification/alpha-0231a2-local-prepublication-rehearsal.md`
+
+**Git handoff receipt:** `docs/verification/release-0231a2-preparation-git-handoff-receipt.json`
+
+**Focus:** Prepare and locally verify the exact v0.23.1a2 Alpha candidate with
+one source-bound wheel, while keeping TestPyPI, PyPI, tag, GitHub Release,
+whole-building, professional-approval, and retained-lane actions explicitly
+unauthorized.
+
+### Summary
+
+- A fresh linked worktree was created from live GitHub `main`; it reported
+  `READY_LOCAL`, `source_bound=true`, and no open PR overlap. All retained
+  detached, dirty, and historical lanes were preserved unchanged.
+- The canonical release preparation changed source/package/documentation
+  version surfaces from `0.23.1a1` to `0.23.1a2`, retained the published
+  `v0.23.1a1` evidence, and added bounded candidate release notes.
+- The preparation gate passed 6,414 Python tests with 3 skipped and 6
+  deselected, then passed the repository-pinned Node 24 React production build.
+- Build anchor `c71e4e27749a9da58fe0d689bc1a1ba8b396f14d` produced one wheel and matching
+  sdist. The wheel is 665,658 bytes with SHA-256
+  `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19`.
+- The clean installed-wheel verifier passed 5,553 tests with 51 skipped and 2
+  deselected plus installed `job`, `critical`, and HTML `report` workflows.
+- The narrow exact candidate check passed the 29-case matrix, all 12 advertised
+  commands, public examples, content/version boundaries, and clean installed
+  package-origin assertion against the same wheel hash.
+- Candidate wording is historical and explicit: at freeze it is not tagged or
+  published. The current public Alpha remains `0.23.1a1`; publication and
+  professional approval remain separate holds.
+
+### Issues encountered
+
+- The release-preflight skill instructed maintainers to record a checked
+  publication authorization in the checklist before immutable review.
+- The general installed-wheel verifier passed its broad package suite and
+  legacy CLI workflows but did not execute the newer 29-case advertised-command
+  release matrix.
+- Version synchronization printed optional-pattern warnings for source files
+  that deliberately do not contain those optional tag/metadata forms.
+- The first direct index-generator command guessed the retired
+  `scripts/generate_folder_indexes.py` path and stopped before any write.
+
+### Root causes and resolutions
+
+- Confirmed root cause: the skill retained the earlier checklist-marker
+  authorization sequence after publication authority moved to the exact JSON
+  authorization plus immutable review-receipt flow. Resolution: candidate
+  preparation now requires unpublished/on-hold wording and forbids pre-checking
+  tag/publication approval; post-review authorization is routed only through
+  validator-permitted exact evidence. Proof: focused release-document checks,
+  14 release environment/version regressions, and normal commit hooks pass
+  while the v0.23.1a2 publication checkbox remains open.
+- Confirmed root cause: `release verify` and `release candidate-check` have
+  distinct maintained responsibilities; only the latter invokes packaged
+  `structural_lib.release_uat`. Resolution: run the broad verifier once, then
+  the narrow candidate check once without replaying manual CLI cases. Proof:
+  both commands exit zero against wheel SHA-256 `5bca57ba...cc19`; the packaged
+  matrix contains 29 cases and the advertised inventory contains 12 commands.
+- Confirmed root cause: the version synchronizer reports absent optional regex
+  forms even when all required candidate surfaces agree. Resolution: inspect
+  the intended surfaces once and rely on `--check-docs`, release-doc checks,
+  exact candidate validation, and commit hooks; no non-outcome tooling change
+  was added. Proof: every maintained check exits zero and the warnings identify
+  only non-applicable optional forms.
+- Confirmed root cause: the direct script name was guessed instead of using the
+  maintained `run.sh generate indexes <folder>` entry point documented by the
+  live launcher. Resolution: discover the current command with `rg --files`
+  and use only targeted dry-run/final refresh calls. Proof: the guessed command
+  made no write; final affected-folder index checks pass. ⚠️ TERMINAL ISSUE:
+  nonexistent direct generator path -> maintained targeted `run.sh` command.
+
+### Validation through local candidate freeze
+
+- Live base/GitHub: `main = 970a78c1`; no open PRs; release worktree
+  `READY_LOCAL`; `source_bound=true`.
+- Focused release environment/version regressions: 14 passed.
+- Canonical release preparation: 6,414 passed, 3 skipped, 6 deselected; React
+  production build passed.
+- Normal build-anchor commit hooks: all passed.
+- Exact installed wheel: 5,553 passed, 51 skipped, 2 deselected; installed CLI
+  workflows passed.
+- Exact candidate: 29/29 UAT cases and 12/12 advertised commands passed.
+- Final affected indexes, quick 10/10, immutable final commit, hosted checks,
+  and exact-head review complete in the next closeout stage. The exact-wheel
+  publication preflight is intentionally reserved for the reviewed and
+  authorized target identity.
+
+### Timing through local candidate freeze
+
+- Orientation, release controls, and lane creation: approximately 2 minutes.
+- Canonical preparation, release-document correction, and focused checks:
+  approximately 6 minutes.
+- Exact build, installed verification, candidate UAT, and evidence recording:
+  approximately 5 minutes.
+- Hosted CI/review wait and final closeout are not included here.
+
 ## 2026-08-17 — Session: LIB-PRO-002-J Release Signal Convergence
 
 **Agent:** Codex (`ops`, sole writer)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -54,6 +54,12 @@ unauthorized.
   that deliberately do not contain those optional tag/metadata forms.
 - The first direct index-generator command guessed the retired
   `scripts/generate_folder_indexes.py` path and stopped before any write.
+- Exact-head Weekly Verification run `32006071604` passed the clean-wheel,
+  Python, FastAPI, benchmark, Docker, and dependency stages, then stopped in
+  documentation drift because `fastapi_app/index.json` was stale; React was
+  skipped after that failure.
+- The first repair closeout invocation passed two folder arguments to the
+  single-folder index command; argument parsing stopped before either write.
 
 ### Root causes and resolutions
 
@@ -83,6 +89,17 @@ unauthorized.
   and use only targeted dry-run/final refresh calls. Proof: the guessed command
   made no write; final affected-folder index checks pass. ⚠️ TERMINAL ISSUE:
   nonexistent direct generator path -> maintained targeted `run.sh` command.
+- Confirmed root cause: release preparation changed `fastapi_app/__init__.py`,
+  `fastapi_app/config.py`, and `fastapi_app/openapi_baseline.json`, but the
+  affected-folder index refresh omitted `fastapi_app`. Resolution: regenerate
+  only `fastapi_app/index.json`; do not rebuild or repeat wheel UAT because the
+  Python package tree and exact wheel are unchanged. Proof: the exact failing
+  command, `scripts/generate_enhanced_index.py --all --check`, reports all
+  32 maintained indexes current before the single repair commit is pushed.
+- Confirmed root cause: the maintained targeted generator accepts one optional
+  positional folder, not a folder list. Resolution: invoke it once for `docs`
+  and once for `docs/verification`; both targeted refreshes pass. ⚠️ TERMINAL
+  ISSUE: combined two-folder index refresh -> separate maintained invocations.
 
 ### Validation through local candidate freeze
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -31,9 +31,9 @@ unauthorized.
   `v0.23.1a1` evidence, and added bounded candidate release notes.
 - The preparation gate passed 6,414 Python tests with 3 skipped and 6
   deselected, then passed the repository-pinned Node 24 React production build.
-- Build anchor `c71e4e27749a9da58fe0d689bc1a1ba8b396f14d` produced one wheel and matching
-  sdist. The wheel is 665,658 bytes with SHA-256
-  `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19`.
+- Repaired build anchor `a115b16efbb85db0459c79836f55b6c43a586470`
+  produced one wheel and matching sdist. The wheel is 665,658 bytes with
+  SHA-256 `34892d867845d044249236f32b700ab5e10ec558225407a47717fe3c3c2614bb`.
 - The clean installed-wheel verifier passed 5,553 tests with 51 skipped and 2
   deselected plus installed `job`, `critical`, and HTML `report` workflows.
 - The narrow exact candidate check passed the 29-case matrix, all 12 advertised
@@ -64,6 +64,9 @@ unauthorized.
   UAT, 6,413 Python tests, FastAPI, React, docs, and version checks, but one
   release test failed because it read the live authorization record after the
   owner correctly changed that record from `HOLD` to `AUTHORIZED`.
+- A read-only generated-artifact inspection loop used the zsh variable name
+  `path`, after which standard commands in that loop were reported as missing;
+  the failed inspection made no writes.
 
 ### Root causes and resolutions
 
@@ -79,7 +82,7 @@ unauthorized.
   distinct maintained responsibilities; only the latter invokes packaged
   `structural_lib.release_uat`. Resolution: run the broad verifier once, then
   the narrow candidate check once without replaying manual CLI cases. Proof:
-  both commands exit zero against wheel SHA-256 `5bca57ba...cc19`; the packaged
+  both commands exit zero against wheel SHA-256 `34892d86...14bb`; the packaged
   matrix contains 29 cases and the advertised inventory contains 12 commands.
 - Confirmed root cause: the version synchronizer reports absent optional regex
   forms even when all required candidate surfaces agree. Resolution: inspect
@@ -111,6 +114,15 @@ unauthorized.
   test and pass it explicitly to the validator. Evidence: the focused
   regression passes for the isolated HOLD state while the live three-target
   authorization checks remain reserved for the refreshed reviewed candidate.
+- Confirmed root cause: zsh reserves `path` as an array tied to `PATH`, so the
+  loop assignment replaced command lookup for that shell process. Resolution:
+  rerun the inspection with the task-specific variable `release_artifact` and
+  absolute command paths, then move only the inspected ignored, non-symlink
+  build directories recoverably before the clean rebuild. Evidence: the
+  corrected inspection identified exactly `Python/dist` and
+  `Python/structural_lib_is456.egg-info`; the clean build, candidate check, and
+  installed-wheel verifier all passed. ⚠️ TERMINAL ISSUE: zsh special variable
+  `path` shadowed `PATH` -> task-specific variable plus absolute commands.
 
 ### Validation through local candidate freeze
 
@@ -120,8 +132,8 @@ unauthorized.
 - Canonical release preparation: 6,414 passed, 3 skipped, 6 deselected; React
   production build passed.
 - Normal build-anchor commit hooks: all passed.
-- Exact installed wheel: 5,553 passed, 51 skipped, 2 deselected; installed CLI
-  workflows passed.
+- Rebuilt exact installed wheel: SHA-256 `34892d86...14bb`; 5,553 passed, 51
+  skipped, 2 deselected; installed CLI workflows passed.
 - Exact candidate: 29/29 UAT cases and 12/12 advertised commands passed.
 - Final affected indexes, quick 10/10, immutable final commit, hosted checks,
   and exact-head review complete in the next closeout stage. The exact-wheel

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -60,6 +60,10 @@ unauthorized.
   skipped after that failure.
 - The first repair closeout invocation passed two folder arguments to the
   single-folder index command; argument parsing stopped before either write.
+- The first authorized exact-wheel publication preflight passed clean-wheel
+  UAT, 6,413 Python tests, FastAPI, React, docs, and version checks, but one
+  release test failed because it read the live authorization record after the
+  owner correctly changed that record from `HOLD` to `AUTHORIZED`.
 
 ### Root causes and resolutions
 
@@ -100,6 +104,13 @@ unauthorized.
   positional folder, not a folder list. Resolution: invoke it once for `docs`
   and once for `docs/verification`; both targeted refreshes pass. ⚠️ TERMINAL
   ISSUE: combined two-folder index refresh -> separate maintained invocations.
+- Confirmed root cause: `test_release_publication_authorization_holds_by_default`
+  tested the mutable repository authorization record instead of an isolated
+  default-HOLD fixture, making a genuine authorization state fail the release
+  suite by construction. Resolution: create a temporary HOLD record inside the
+  test and pass it explicitly to the validator. Evidence: the focused
+  regression passes for the isolated HOLD state while the live three-target
+  authorization checks remain reserved for the refreshed reviewed candidate.
 
 ### Validation through local candidate freeze
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-17 — Packets I-J are software-complete; exact technical-acceptance artifact steps 3 and 4 are next, with publication still held
+**Updated:** 2026-08-17 — v0.23.1a2 is locally prepared and exact-wheel verified; hosted review and publication authorization remain held
 
 ---
 
@@ -127,21 +127,20 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-002-I | Converge the advertised `design` CLI on lossless/strict intake, freeze its JSON/downstream compatibility contract, and add every advertised calculation entry point to exact-wheel negative UAT | backend + tester + release | M | P0 | ✅ SOFTWARE COMPLETE — merged through PR #819; 150 focused tests prove strict whole-project blocking, retained `beams` compatibility, and expanded 29-case/12-command UAT contracts |
-| LIB-PRO-002-J | Bind hosted full suites to the selected Python interpreter, converge release verdicts, and remove cyclic closeout/index rewrites | ops + tester + release | S | P0 | ✅ SOFTWARE COMPLETE — full hosted suites inherit setup-python; only exact authorization can yield `READY_TO_PUBLISH`; index dates are content-stable and session closeout has no hidden index writes |
+| RELEASE-0231A2 | Prepare and review the exact v0.23.1a2 Alpha candidate without tagging or publishing | Main Agent + ops | M | P0 | 🔄 LOCAL CANDIDATE READY — source-bound wheel `5bca57ba…cc19`; 5,553 installed tests and 29/29 UAT pass; PR checks, Weekly Verification, independent review, exact receipt, and target authorization remain held |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
-boundary. INDIA-3, dependency, release execution, further cleanup, and
-professional approval remain separately held.
+boundary. INDIA-3, dependency work, tag/publication execution, further cleanup,
+and professional approval remain separately held.
 
 `LIB-PRO-002-G0` was independently accepted and merged through PR #812 at
 `55104e11257937b0a42fb06f931a70b8484cef39`. Packet A was independently
 accepted and merged through PR #814 at
 `3986935ecb473c1f9d56dec44aeb4218d9192f84`; Packets B-G merged through PR #815
-at `fe4ab025419b834c6d0f840e9492c0604ae74201`. The next publication remains
-held through exact technical-acceptance steps 3 and 4, a later exact versioned
-release candidate, immutable review/hosted evidence, and a separate exact owner
-authorization.
+at `fe4ab025419b834c6d0f840e9492c0604ae74201`. Packets I-J are software-
+complete, and the exact v0.23.1a2 local artifact now passes installed-package
+and advertised-command UAT. Publication remains held through immutable
+review/hosted evidence and separate exact owner authorization.
 
 ## Up Next
 
@@ -182,6 +181,8 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| LIB-PRO-002-I | Converged the advertised `design` CLI on lossless/strict intake and expanded exact-wheel negative UAT | backend + tester + release | ✅ SOFTWARE COMPLETE — merged through PR #819; strict whole-project blocking, retained downstream compatibility, and 29-case/12-command UAT contracts pass |
+| LIB-PRO-002-J | Bound hosted full suites to the selected interpreter and converged release/closeout signals | ops + tester + release | ✅ SOFTWARE COMPLETE — mode-accurate release verdicts, content-stable indexes, and read-only closeout are merged through PR #820 |
 | MAINT-010-POST-INDIA2 | Refreshed generated truth, compacted session/task history without loss, archived superseded plans, completed review-only evolution, and removed cross-worktree timestamp and hidden-local-artifact index drift | Main Agent + governance | ✅ COMPLETE ON MERGE — deterministic affected-folder indexes, weekly read-only audit, immutable closeout freeze, health, audit, parity, focused governance, quick/full, hosted, and exact-tree gates recorded |
 | INDIA-2-CLOSEOUT | Reconciled the complete accepted/held evidence index, final truth, and cumulative validation without adding behavior | Main Agent + reviewer | ✅ COMPLETE ON MERGE — six bounded families accepted; pile-cap and raft remain `HELD / NOT_IMPLEMENTED`; broad Python and full 30/30 gate pass |
 | INDIA-2-FOUNDATION-RAFT-G0 | Audited one regular rectangular rigid-raft candidate, the conventional-method boundary, controlled-source inventory, and structural benchmark readiness | Main Agent + structural engineer | ⏸ HOLD — PR #805 merged as `d2885215`; no controlled IS 2950 source or accepted replayable structural benchmark; no calculation files created |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-17 — v0.23.1a2 is locally prepared and exact-wheel verified; hosted review and publication authorization remain held
+**Updated:** 2026-08-17 — v0.23.1a2 is locally prepared and exact-wheel verified; target publication is authorized after refreshed hosted review
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| RELEASE-0231A2 | Prepare and review the exact v0.23.1a2 Alpha candidate without tagging or publishing | Main Agent + ops | M | P0 | 🔄 LOCAL CANDIDATE READY — source-bound wheel `5bca57ba…cc19`; 5,553 installed tests and 29/29 UAT pass; PR checks, Weekly Verification, independent review, exact receipt, and target authorization remain held |
+| RELEASE-0231A2 | Review and publish the exact v0.23.1a2 Alpha candidate | Main Agent + ops | M | P0 | 🔄 LOCAL CANDIDATE READY — source-bound wheel `34892d86…14bb`; 5,553 installed tests and 29/29 UAT pass; target publication is authorized after refreshed PR checks, Weekly Verification, independent review, and exact receipt |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. INDIA-3, dependency work, tag/publication execution, further cleanup,
@@ -139,8 +139,8 @@ accepted and merged through PR #814 at
 `3986935ecb473c1f9d56dec44aeb4218d9192f84`; Packets B-G merged through PR #815
 at `fe4ab025419b834c6d0f840e9492c0604ae74201`. Packets I-J are software-
 complete, and the exact v0.23.1a2 local artifact now passes installed-package
-and advertised-command UAT. Publication remains held through immutable
-review/hosted evidence and separate exact owner authorization.
+and advertised-command UAT. Publication is owner-authorized after refreshed
+immutable review and hosted evidence pass.
 
 ## Up Next
 

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -15,7 +15,7 @@ tags: []
 **Importance:** High
 **Version:** 0.16.6
 **Created:** 2025-06-01
-**Last Updated:** 2026-08-11<br>
+**Last Updated:** 2026-08-17<br>
 **Related Tasks:** IMPL-003
 **Tags:** contributing, development, vba, python, standards
 

--- a/docs/contributing/index.json
+++ b/docs/contributing/index.json
@@ -66,9 +66,9 @@
       "name": "development-guide.md",
       "type": "documentation",
       "size_lines": 1523,
-      "last_updated": "2026-08-16",
+      "last_updated": "2026-08-17",
       "description": "1. Overview 2. Project Structure",
-      "content_hash": "80e1287aae2d"
+      "content_hash": "e9ed99ca0c67"
     },
     {
       "name": "doc-template.md",
@@ -200,5 +200,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "dbfb856e7dcb406d"
+  "content_hash": "d55a06747771cb4b"
 }

--- a/docs/getting-started/beginners-guide.md
+++ b/docs/getting-started/beginners-guide.md
@@ -155,4 +155,4 @@ You should get a number around 196.5 (kN-m).
 - API reference: `docs/reference/api.md`
 - Learning path: `docs/learning/README.md`
 
-Document Version: 0.23.1a1 | Last Updated: 2026-08-11
+Document Version: 0.23.1a2 | Last Updated: 2026-08-17

--- a/docs/getting-started/index.json
+++ b/docs/getting-started/index.json
@@ -52,7 +52,7 @@
       "size_lines": 159,
       "last_updated": "2026-08-17",
       "description": "This guide is written for engineers and students who are new to coding. Follow the steps exactly and you will get a working result. You have two ways to use this library:",
-      "content_hash": "3e7885112661"
+      "content_hash": "0414e71a4c0d"
     },
     {
       "name": "colab-workflow.md",
@@ -132,15 +132,15 @@
       "size_lines": 203,
       "last_updated": "2026-08-17",
       "description": "This guide shows how to install, run, and verify the Python library with simple, copy/paste steps. No prior packaging experience required. > **📚 New to this?** See beginners-guide.md for comprehensive",
-      "content_hash": "947ef7beaf54"
+      "content_hash": "bd51cef28dc7"
     },
     {
       "name": "releases.md",
       "type": "documentation",
-      "size_lines": 1250,
+      "size_lines": 1278,
       "last_updated": "2026-08-17",
       "description": "This document serves as the **immutable source of truth** for project releases. Entries here represent \"locked\" versions that have been verified and approved.",
-      "content_hash": "2c02a622a5bd"
+      "content_hash": "f14bcf4f7b51"
     },
     {
       "name": "user-guide.md",
@@ -148,9 +148,9 @@
       "size_lines": 226,
       "last_updated": "2026-08-17",
       "description": "This guide walks you through a complete beam design workflow from start to finish. For detailed installation help, see Beginner's Guide. bash",
-      "content_hash": "e455b19a754b"
+      "content_hash": "5ebd61ff25ec"
     }
   ],
   "subfolders": [],
-  "content_hash": "00471c64b93ad651"
+  "content_hash": "f224e5e698253f0c"
 }

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -26,5 +26,5 @@ Quick onboarding guides for new users of the structural engineering library.
 | [mac-mini-setup.md](mac-mini-setup.md) |  | Complete instructions to clone and run the full stack on a f | 396 |
 | [product-tour.md](product-tour.md) |  | See the supported workflow before installing anything. These | 99 |
 | [python-quickstart.md](python-quickstart.md) |  | This guide shows how to install, run, and verify the Python  | 203 |
-| [releases.md](releases.md) |  | This document serves as the **immutable source of truth** fo | 1250 |
+| [releases.md](releases.md) |  | This document serves as the **immutable source of truth** fo | 1278 |
 | [user-guide.md](user-guide.md) |  | This guide walks you through a complete beam design workflow | 226 |

--- a/docs/getting-started/python-quickstart.md
+++ b/docs/getting-started/python-quickstart.md
@@ -31,7 +31,7 @@ This is the easiest path for beginners.
 python3 -m pip install --upgrade pip
 
 # Exact current Alpha install
-python3 -m pip install "structural-lib-is456===0.23.1a1"
+python3 -m pip install "structural-lib-is456===0.23.1a2"
 
 # Optional DXF support
 python3 -m pip install "structural-lib-is456[dxf]"
@@ -65,7 +65,7 @@ If you are on Windows, replace `python3` with `py`.
 3. Install the library:
    ```bash
    python3 -m pip install --upgrade pip
-   python3 -m pip install "structural-lib-is456===0.23.1a1"
+   python3 -m pip install "structural-lib-is456===0.23.1a2"
    python3 -m structural_lib install-preflight
    ```
 4. Optional DXF support:

--- a/docs/getting-started/releases.md
+++ b/docs/getting-started/releases.md
@@ -1247,3 +1247,31 @@ pip install structural-lib-is456===0.23.1a1
 
 This remains case-qualified software evidence, not complete IS 456 coverage,
 professional validation, or engineering-use approval.
+
+---
+
+## v0.23.1a2 — Prepared candidate (unreleased; on hold)
+
+**Status at candidate freeze (2026-08-17):** Prepared candidate; not tagged or
+published. A later append-only entry must record any exact authorization or
+publication; this historical preparation state will not be rewritten.
+
+**Candidate base:** `970a78c1931a3aa0439f487e6892a888bb113962`
+
+**Scope:** Strict lossless project intake, fail-closed public CLI behavior,
+versioned input/result provenance, expanded exact-wheel UAT, and bounded
+case-qualified braced-wall, staircase, deep-beam, flat-slab, combined-footing,
+and strap-footing workflows.
+
+**Release boundary:** Component calculations and their evidence remain distinct
+from a complete building model, qualified structural-engineering review,
+professional approval, and construction use. Packet H whole-building
+orchestration remains inactive.
+
+**Publication gate:** One exact wheel, source-free installed-package
+verification, required PR checks, exact-head Weekly Verification, independent
+review, an exact candidate receipt, and separate owner authorization for each
+target are required before TestPyPI, PyPI, a tag, or a GitHub Release.
+
+**Full changelog:** See
+[CHANGELOG.md](../../CHANGELOG.md#0231a2--prepared-candidate-unreleased-on-hold)

--- a/docs/getting-started/user-guide.md
+++ b/docs/getting-started/user-guide.md
@@ -13,7 +13,7 @@ tags: []
 **Audience:** Users
 **Status:** Approved
 **Importance:** High
-**Version:** 0.23.1a1
+**Version:** 0.23.1a2
 **Created:** 2025-12-15
 **Last Updated:** 2026-03-29
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 2392,
+      "size_lines": 2404,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "b30a37eee400"
+      "content_hash": "148f2b238430"
     },
     {
       "name": "TASKS.md",
@@ -30,7 +30,7 @@
       "last_updated": "2026-08-17",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "903e4028cfdb"
+      "content_hash": "b83902ba7aa1"
     },
     {
       "name": "WORKLOG.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "dea253e346604cfb"
+  "content_hash": "bd90ea61db3dc7c3"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 2260,
+      "size_lines": 2364,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "32137e8a7ba0"
+      "content_hash": "772a903562cd"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 712,
+      "size_lines": 713,
       "last_updated": "2026-08-17",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "bd9d206555c1"
+      "content_hash": "903e4028cfdb"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 174,
+      "file_count": 176,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "93c06fe62c63eabb"
+  "content_hash": "7304697fb2221fcf"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 2381,
+      "size_lines": 2392,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "cea02ed984e5"
+      "content_hash": "b30a37eee400"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "d0e54e377b4e20cb"
+  "content_hash": "dea253e346604cfb"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 176,
+      "file_count": 177,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "23ad28c1fbb702a9"
+  "content_hash": "d0e54e377b4e20cb"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 2364,
+      "size_lines": 2381,
       "last_updated": "2026-08-17",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "772a903562cd"
+      "content_hash": "cea02ed984e5"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "7304697fb2221fcf"
+  "content_hash": "23ad28c1fbb702a9"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 2392 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 2404 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 713 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 2381 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 2392 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 713 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 2260 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 712 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 2364 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 713 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1793 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 174 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 176 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 2364 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 2381 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 713 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1793 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 6 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 176 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 177 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -131,11 +131,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 65,
+      "size_lines": 68,
       "last_updated": "2026-08-17",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-17",
-      "content_hash": "47f4c4636c87"
+      "content_hash": "4875ea7e4f38"
     },
     {
       "name": "pre-release-checklist.md",
@@ -144,7 +144,7 @@
       "last_updated": "2026-08-17",
       "title": "Pre-Release Checklist",
       "description": "Prepared candidate source metadata: 0.23.1a2 Current public release: v0.23.1a1 Alpha",
-      "content_hash": "11ff58ad64bd"
+      "content_hash": "580e1bdabf7d"
     },
     {
       "name": "pre-release-input-safety-and-professional-readiness-plan.md",
@@ -182,5 +182,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "b3eec448781a4b37"
+  "content_hash": "af69511e67780b87"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -131,20 +131,20 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 93,
+      "size_lines": 65,
       "last_updated": "2026-08-17",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-17",
-      "content_hash": "89a99c0a5fa5"
+      "content_hash": "47f4c4636c87"
     },
     {
       "name": "pre-release-checklist.md",
       "type": "documentation",
-      "size_lines": 92,
-      "last_updated": "2026-08-12",
+      "size_lines": 111,
+      "last_updated": "2026-08-17",
       "title": "Pre-Release Checklist",
-      "description": "Release-ready source metadata: 0.23.1a1 Current public release: v0.23.1a1 Alpha",
-      "content_hash": "aa14481f9a4b"
+      "description": "Prepared candidate source metadata: 0.23.1a2 Current public release: v0.23.1a1 Alpha",
+      "content_hash": "11ff58ad64bd"
     },
     {
       "name": "pre-release-input-safety-and-professional-readiness-plan.md",
@@ -182,5 +182,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "adb8bd80856462b1"
+  "content_hash": "b3eec448781a4b37"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -23,7 +23,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-17 | 65 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-17 | 68 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Prepared candidate source metadata: 0.23.1a2 Current public  | 111 |
 | [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 742 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -23,8 +23,8 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-17 | 93 |
-| [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Release-ready source metadata: 0.23.1a1 Current public relea | 92 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-17 | 65 |
+| [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Prepared candidate source metadata: 0.23.1a2 Current public  | 111 |
 | [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 742 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
 | [react-ux-improvement-plan.md](react-ux-improvement-plan.md) |  | > **Historical implementation record.** Execution status in  | 709 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,23 +4,23 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-17
-- Focus: exact v0.23.1a2 release-candidate hosted review, without tag or publication
+- Focus: complete refreshed exact review and publish the authorized v0.23.1a2 Alpha candidate
 - Candidate branch: `codex/release-0231a2`; base `970a78c1931a3aa0439f487e6892a888bb113962`
-- Build anchor: `c71e4e27749a9da58fe0d689bc1a1ba8b396f14d`; Python tree `501fac1360f06ff2be4f6aea3b5e167f956ce840`
-- Exact wheel: `structural_lib_is456-0.23.1a2-py3-none-any.whl`; SHA-256 `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19`
+- Build anchor: `a115b16efbb85db0459c79836f55b6c43a586470`; Python tree `25aa0468135c07d3c260eca43776fb451865f833`
+- Exact wheel: `structural_lib_is456-0.23.1a2-py3-none-any.whl`; SHA-256 `34892d867845d044249236f32b700ab5e10ec558225407a47717fe3c3c2614bb`
 - Local evidence: 5,553 installed tests pass; 29/29 release UAT cases and 12/12 advertised commands pass
 - Evidence record: `docs/verification/alpha-0231a2-local-prepublication-rehearsal.md`
 - Git handoff receipt: `docs/verification/release-0231a2-preparation-git-handoff-receipt.json`
-- Release state: `CANDIDATE_TECHNICALLY_READY` locally and `PUBLICATION_HOLD`; tag, uploads, GitHub Release, and professional approval remain unauthorized
+- Release state: `CANDIDATE_TECHNICALLY_READY` locally and `PUBLICATION_HOLD`; target publication is owner-authorized after refreshed exact review, while professional approval remains unauthorized
 - Whole-building workflow: Packet H remains inactive; component-only claims remain
-- Exact next action: freeze the final documentation-only descendant, push one release PR, run required PR checks and exact-head Weekly Verification, then obtain independent exact-candidate review
+- Exact next action: freeze and push the repaired candidate, pass required PR checks and exact-head Weekly Verification, obtain refreshed independent review, then execute the authorized publication sequence
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
 | **Current** | `v0.23.1a1` remains public; exact v0.23.1a2 source and wheel are locally prepared and verified |
-| **Next** | One release PR, required hosted checks, exact-head Weekly Verification, and independent review |
-| **Held** | TestPyPI/PyPI upload, tag, GitHub Release, professional approval, Packet H, dependency work, and retained-lane cleanup |
+| **Next** | Required hosted checks, exact-head Weekly Verification, independent review, TestPyPI, merge, tag, PyPI, and GitHub prerelease |
+| **Held** | Publication until refreshed review passes; professional approval, Packet H, dependency work, and retained-lane cleanup remain held |
 
 ## Required Reading
 
@@ -51,14 +51,17 @@ delete it as recovery.
 
 ## Candidate evidence and next gate
 
-- Reuse the exact local rehearsal record; do not rebuild or rerun green local
-  suites while the Python tree remains `501fac1360f06ff2be4f6aea3b5e167f956ce840`.
+- Reuse the refreshed exact local rehearsal record; do not rebuild or rerun
+  green local suites while the Python tree remains
+  `25aa0468135c07d3c260eca43776fb451865f833`.
 - Push the final candidate once and open one release PR against `main`.
 - Require PR Validation and manually dispatched Weekly Verification on the
   same final head, followed by independent review of that exact head/tree.
 - If Python content changes, the wheel evidence expires. A documentation-only
   repair may retain the wheel only after proving the Python tree is unchanged.
-- After review, add only the version-specific review receipt, authorization
-  JSON, and validator-permitted indexes. Do not pre-check publication approval.
-- Stop for direct owner authorization before any TestPyPI/PyPI upload, tag, or
-  GitHub Release. No current evidence grants professional approval.
+- Target authorization is already recorded. After refreshed review, update only
+  its version-specific receipt, authorization binding, and validator-permitted
+  indexes.
+- Target-specific owner authorization is recorded for TestPyPI, PyPI, and the
+  GitHub Release after refreshed review passes. No current evidence grants
+  professional approval.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,21 +4,23 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-17
-- Focus: exact technical-acceptance artifact steps 3 and 4 after LIB-PRO-002 I-J
-- Integrated predecessor: Packet I merged through PR #819 at `0ba2f397aec267bc74a31281f9158189fde2749d`
-- Packet J outcome: hosted full suites bind the setup-python interpreter; preflight verdicts are mode-accurate; generated indexes are content/date stable; session closeout has no hidden index writes; publication remains fail-closed
-- Git handoff receipt: `docs/verification/lib-pro-002-j-closeout-determinism-git-handoff-receipt.json`
-- Focused Packet J evidence: workflow/release/environment plus closeout/index determinism regressions pass
-- Release state: `PUBLICATION_HOLD`; no version bump, tag, upload, GitHub Release, or professional approval exists
+- Focus: exact v0.23.1a2 release-candidate hosted review, without tag or publication
+- Candidate branch: `codex/release-0231a2`; base `970a78c1931a3aa0439f487e6892a888bb113962`
+- Build anchor: `c71e4e27749a9da58fe0d689bc1a1ba8b396f14d`; Python tree `501fac1360f06ff2be4f6aea3b5e167f956ce840`
+- Exact wheel: `structural_lib_is456-0.23.1a2-py3-none-any.whl`; SHA-256 `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19`
+- Local evidence: 5,553 installed tests pass; 29/29 release UAT cases and 12/12 advertised commands pass
+- Evidence record: `docs/verification/alpha-0231a2-local-prepublication-rehearsal.md`
+- Git handoff receipt: `docs/verification/release-0231a2-preparation-git-handoff-receipt.json`
+- Release state: `CANDIDATE_TECHNICALLY_READY` locally and `PUBLICATION_HOLD`; tag, uploads, GitHub Release, and professional approval remain unauthorized
 - Whole-building workflow: Packet H remains inactive; component-only claims remain
-- Exact next action: perform release-preflight steps 3 and 4 only—build one temporary exact technical-acceptance wheel from synchronized `main`, then clean-install and verify that same artifact
+- Exact next action: freeze the final documentation-only descendant, push one release PR, run required PR checks and exact-head Weekly Verification, then obtain independent exact-candidate review
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `v0.23.1a1` Alpha; Packets A-G and I-J correct current source, not the already-published old artifact |
-| **Next** | One temporary technical-acceptance wheel plus source-free clean-install/UAT evidence from unchanged synchronized `main` |
-| **Held** | Version bump, tag, TestPyPI/PyPI upload, GitHub Release, professional approval, Packet H, dependency work, and retained-lane cleanup |
+| **Current** | `v0.23.1a1` remains public; exact v0.23.1a2 source and wheel are locally prepared and verified |
+| **Next** | One release PR, required hosted checks, exact-head Weekly Verification, and independent review |
+| **Held** | TestPyPI/PyPI upload, tag, GitHub Release, professional approval, Packet H, dependency work, and retained-lane cleanup |
 
 ## Required Reading
 
@@ -47,46 +49,16 @@ present, or another candidate overlaps packaging, verification, indexes, or
 release guidance. Preserve unknown state; never reset, stash, clean, rebase, or
 delete it as recovery.
 
-## Step 3 — build the exact technical-acceptance artifact
+## Candidate evidence and next gate
 
-- Confirm Packet J's PR checks and exact-head Weekly Verification passed, and
-  verify synchronized `main` has the same accepted tree before building.
-- Use a new clean temporary output directory; do not reuse `Python/dist` or any
-  historical artifact.
-- Build exactly one wheel from unchanged synchronized `main` and record source
-  head, source tree, Python tree, filename, size, and SHA-256.
-- Verify wheel filename, METADATA version, contents, protected-source boundary,
-  advertised-entrypoint inventory, and source/library content identity.
-- Treat this as technical evidence for current source only. Because current
-  source still says `0.23.1a1`, the wheel must never replace or be confused with
-  the already-published `0.23.1a1` artifact.
-- Do not bump a version, write release notes, tag, upload, or authorize a target.
-
-## Step 4 — clean-install and verify the same artifact
-
-- Create a source-free temporary virtual environment and remove repository
-  `PYTHONPATH`/`VIRTUAL_ENV` inheritance.
-- Install the exact recorded wheel, then prove `structural_lib.__file__` comes
-  from that environment rather than the checkout.
-- Run expanded exact-wheel UAT and public examples, including all 29 declared
-  negative/positive cases and the 12-command advertised-entrypoint inventory.
-- Run the exact-wheel candidate check and preflight against the same path. The
-  expected successful technical verdict is `CANDIDATE_TECHNICALLY_READY` plus
-  `PUBLICATION_HOLD`, not `READY_TO_PUBLISH`.
-- Record the clean-install interpreter, imported version/origin, matrix hash,
-  case count, public-example result, wheel hash, and all remaining holds.
-- A failed or mismatched case is `NOT_READY`; do not repair by weakening the
-  launcher, UAT, artifact identity, review, hosted, or authorization controls.
-
-## Acceptance and stop rules
-
-Step 3 accepts only one exact, source-bound wheel with a recorded SHA-256 and
-no excluded/protected content. Step 4 accepts only source-free installation of
-that same hash with all entrypoint/UAT/public-example checks passing.
-
-Even after both steps pass, publication remains held. A later separately
-authorized release-preparation task must select and bump the next Alpha
-version, rebuild the final versioned artifact, repeat exact review and hosted
-gates, and obtain explicit target authorization. Do not publish, tag, create a
-GitHub Release, claim professional approval, activate Packet H, close work, or
-delete branches/worktrees in this technical-acceptance session.
+- Reuse the exact local rehearsal record; do not rebuild or rerun green local
+  suites while the Python tree remains `501fac1360f06ff2be4f6aea3b5e167f956ce840`.
+- Push the final candidate once and open one release PR against `main`.
+- Require PR Validation and manually dispatched Weekly Verification on the
+  same final head, followed by independent review of that exact head/tree.
+- If Python content changes, the wheel evidence expires. A documentation-only
+  repair may retain the wheel only after proving the Python tree is unchanged.
+- After review, add only the version-specific review receipt, authorization
+  JSON, and validator-permitted indexes. Do not pre-check publication approval.
+- Stop for direct owner authorization before any TestPyPI/PyPI upload, tag, or
+  GitHub Release. No current evidence grants professional approval.

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -15,7 +15,7 @@ Current public release: v0.23.1a1 Alpha
 - **Published source:** tag `v0.23.1a1` at `95bed5621c2ff6e5bbcf1a25b7ac476f92ae4307`
 - **Prepared target:** v0.23.1a2 Alpha candidate; not tagged or published
 - **Candidate base:** `970a78c1931a3aa0439f487e6892a888bb113962`
-- **Publication state:** `HOLD`; exact candidate review, hosted receipts, and target authorization remain pending
+- **Publication state:** `HOLD`; target authorization is recorded, while refreshed exact candidate review and hosted receipts remain pending
 - **Review policy:** qualified structural-engineering review is required before stable/engineering-use approval, not before this Alpha release
 
 ## Next Alpha Readiness Checklist
@@ -25,23 +25,23 @@ Current public release: v0.23.1a1 Alpha
 - [x] Run the canonical version preparation gate and update maintained release surfaces
 - [x] Build and verify one exact v0.23.1a2 wheel from the frozen Python tree
 - [ ] Pass required PR checks, exact-head Weekly Verification, and independent candidate review
-- [ ] Record the exact review receipt and separate owner authorization for each publication target
-- [ ] Owner authorizes the v0.23.1a2 tag, production PyPI publication, and GitHub Release after exact CI evidence passes
+- [ ] Record the refreshed exact review receipt after the repaired candidate passes hosted checks
+- [x] Owner authorizes the v0.23.1a2 TestPyPI rehearsal, tag, production PyPI publication, and GitHub Release after exact CI evidence passes
 
-Preparation authorization is not TestPyPI, PyPI, tag, or GitHub Release
-authorization. The publication checkbox above must remain open until the owner
-reviews the immutable candidate evidence and explicitly authorizes those exact
-targets.
+The owner granted the target-specific authorization in the active Codex task on
+2026-08-17 and directed publication to continue without another approval after
+the refreshed independent review passes. This authorization remains bounded to
+the reviewed Alpha candidate and does not grant professional approval.
 
 ### v0.23.1a2 Local Candidate Evidence
 
 - Evidence: [v0.23.1a2 local rehearsal](../verification/alpha-0231a2-local-prepublication-rehearsal.md)
-- Build-anchor source: `c71e4e27749a9da58fe0d689bc1a1ba8b396f14d`
-- Python tree: `501fac1360f06ff2be4f6aea3b5e167f956ce840`
-- Wheel: 665,658 bytes, SHA-256 `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19`
+- Build-anchor source: `a115b16efbb85db0459c79836f55b6c43a586470`
+- Python tree: `25aa0468135c07d3c260eca43776fb451865f833`
+- Wheel: 665,658 bytes, SHA-256 `34892d867845d044249236f32b700ab5e10ec558225407a47717fe3c3c2614bb`
 - Installed verification: 5,553 passed, 51 skipped, 2 deselected; installed CLI workflows green
 - Exact candidate UAT: 29/29 cases across 12/12 advertised commands
-- State: local candidate technically ready; hosted review and publication authorization remain held
+- State: local candidate technically ready; publication execution remains held until refreshed hosted review passes
 
 ### v0.23.1a1 Release Authorization
 

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -23,7 +23,7 @@ Current public release: v0.23.1a1 Alpha
 - [x] Owner authorizes preparation of v0.23.1a2 without tag or publication
 - [x] Base the release lane on synchronized `main` at `970a78c1931a3aa0439f487e6892a888bb113962`
 - [x] Run the canonical version preparation gate and update maintained release surfaces
-- [ ] Build and verify one exact v0.23.1a2 wheel from the frozen candidate
+- [x] Build and verify one exact v0.23.1a2 wheel from the frozen Python tree
 - [ ] Pass required PR checks, exact-head Weekly Verification, and independent candidate review
 - [ ] Record the exact review receipt and separate owner authorization for each publication target
 - [ ] Owner authorizes the v0.23.1a2 tag, production PyPI publication, and GitHub Release after exact CI evidence passes
@@ -32,6 +32,16 @@ Preparation authorization is not TestPyPI, PyPI, tag, or GitHub Release
 authorization. The publication checkbox above must remain open until the owner
 reviews the immutable candidate evidence and explicitly authorizes those exact
 targets.
+
+### v0.23.1a2 Local Candidate Evidence
+
+- Evidence: [v0.23.1a2 local rehearsal](../verification/alpha-0231a2-local-prepublication-rehearsal.md)
+- Build-anchor source: `c71e4e27749a9da58fe0d689bc1a1ba8b396f14d`
+- Python tree: `501fac1360f06ff2be4f6aea3b5e167f956ce840`
+- Wheel: 665,658 bytes, SHA-256 `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19`
+- Installed verification: 5,553 passed, 51 skipped, 2 deselected; installed CLI workflows green
+- Exact candidate UAT: 29/29 cases across 12/12 advertised commands
+- State: local candidate technically ready; hosted review and publication authorization remain held
 
 ### v0.23.1a1 Release Authorization
 

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -5,24 +5,33 @@
 **Status:** Review
 **Importance:** High
 **Created:** 2026-03-31
-**Last Updated:** 2026-08-11
+**Last Updated:** 2026-08-17
 
 ## Current State
 
-Release-ready source metadata: 0.23.1a1
+Prepared candidate source metadata: 0.23.1a2
 Current public release: v0.23.1a1 Alpha
 
-- **Release source:** tag `v0.23.1a1` at `95bed5621c2ff6e5bbcf1a25b7ac476f92ae4307`
-- **Candidate PR:** #732 merged unchanged at `95bed562`; reviewed head `adb161b8` has the same tree
-- **Release target:** v0.23.1a1 Alpha, published 2026-08-11 local time
-- **Publication state:** PyPI and GitHub prerelease published; exact public-version UAT green
+- **Published source:** tag `v0.23.1a1` at `95bed5621c2ff6e5bbcf1a25b7ac476f92ae4307`
+- **Prepared target:** v0.23.1a2 Alpha candidate; not tagged or published
+- **Candidate base:** `970a78c1931a3aa0439f487e6892a888bb113962`
+- **Publication state:** `HOLD`; exact candidate review, hosted receipts, and target authorization remain pending
 - **Review policy:** qualified structural-engineering review is required before stable/engineering-use approval, not before this Alpha release
 
 ## Next Alpha Readiness Checklist
 
-- [x] Integrate the complete `FOOT-ISO-RC-V1` source head `886871ae` into the candidate ancestry through PR #730
-- [x] Pass `./run.sh release footing-inclusion-check` with exact footing-owned files and Python/FastAPI/React integration markers present
-- [x] Verify the frozen local wheel through isolated installed-package tests and CLI UAT; retain the inclusion receipt hash in the local rehearsal record
+- [x] Owner authorizes preparation of v0.23.1a2 without tag or publication
+- [x] Base the release lane on synchronized `main` at `970a78c1931a3aa0439f487e6892a888bb113962`
+- [x] Run the canonical version preparation gate and update maintained release surfaces
+- [ ] Build and verify one exact v0.23.1a2 wheel from the frozen candidate
+- [ ] Pass required PR checks, exact-head Weekly Verification, and independent candidate review
+- [ ] Record the exact review receipt and separate owner authorization for each publication target
+- [ ] Owner authorizes the v0.23.1a2 tag, production PyPI publication, and GitHub Release after exact CI evidence passes
+
+Preparation authorization is not TestPyPI, PyPI, tag, or GitHub Release
+authorization. The publication checkbox above must remain open until the owner
+reviews the immutable candidate evidence and explicitly authorizes those exact
+targets.
 
 ### v0.23.1a1 Release Authorization
 

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -13,7 +13,7 @@ tags: [api, alpha, compatibility]
 **Audience:** Developers
 **Status:** Alpha Preview
 **Importance:** High
-**Version:** 0.23.1a1
+**Version:** 0.23.1a2
 **Last Updated:** 2026-08-17
 
 StructLib is a pre-1.0 Alpha. No exported Python symbol currently carries a
@@ -57,7 +57,7 @@ structural inputs, hide import loss, or convert missing status to PASS.
 Use exact Alpha pins for reproducibility:
 
 ```bash
-python3 -m pip install "structural-lib-is456===0.23.1a1"
+python3 -m pip install "structural-lib-is456===0.23.1a2"
 python3 -c "import structural_lib; print(structural_lib.__version__, structural_lib.__file__)"
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -18,9 +18,9 @@ approval.
 **Audience:** Developers
 **Status:** Development Preview — Supported Cases Only
 **Importance:** Critical
-**Document Version:** 0.23.1a1
+**Document Version:** 0.23.1a2
 **Created:** 2025-01-01
-**Last Updated:** 2026-08-16<br>
+**Last Updated:** 2026-08-17<br>
 
 ---
 

--- a/docs/reference/index.json
+++ b/docs/reference/index.json
@@ -81,7 +81,7 @@
       "size_lines": 66,
       "last_updated": "2026-08-17",
       "description": "StructLib is a pre-1.0 Alpha. No exported Python symbol currently carries a post-1.0 stable compatibility promise, and passing software tests do not imply",
-      "content_hash": "1790f69f98ed"
+      "content_hash": "05766f4516df"
     },
     {
       "name": "api.md",
@@ -89,7 +89,7 @@
       "size_lines": 4460,
       "last_updated": "2026-08-17",
       "description": "The public result dataclasses api.ComplianceCaseResult, api.ComplianceReport, and api.DesignAndDetailResult are Alpha-preview",
-      "content_hash": "36c6053042bf"
+      "content_hash": "2ffc0013e2fb"
     },
     {
       "name": "automation-catalog.md",
@@ -277,5 +277,5 @@
       "file_count": 1760
     }
   ],
-  "content_hash": "beffac6d8b9d81d9"
+  "content_hash": "7954147b530c7685"
 }

--- a/docs/verification/alpha-0231a2-exact-candidate-review-receipt.json
+++ b/docs/verification/alpha-0231a2-exact-candidate-review-receipt.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "exact-candidate-review-receipt/v1",
+  "decision": "ACCEPT",
+  "reviewed_candidate": {
+    "head_sha": "0c00f2fac9b19ad59086e850b82d71bf1d12b943",
+    "tree_sha": "772f760ed603845fb402e90d597710de031772dc",
+    "python_tree_sha": "501fac1360f06ff2be4f6aea3b5e167f956ce840",
+    "version": "0.23.1a2",
+    "tag": "v0.23.1a2",
+    "reviewed_targets": [
+      "testpypi",
+      "pypi",
+      "github-release"
+    ]
+  },
+  "hosted_checks": {
+    "required_pr_checks": {
+      "status": "PASS",
+      "head_sha": "0c00f2fac9b19ad59086e850b82d71bf1d12b943",
+      "url": "https://github.com/Pravin-surawase/structural_engineering_lib/actions/runs/32007226356"
+    },
+    "weekly_verification": {
+      "status": "PASS",
+      "head_sha": "0c00f2fac9b19ad59086e850b82d71bf1d12b943",
+      "url": "https://github.com/Pravin-surawase/structural_engineering_lib/actions/runs/32007376033"
+    }
+  },
+  "reviewer": {
+    "identity": "/root/release_0231a2_exact_review",
+    "independent": true,
+    "reviewed_at_utc": "2026-08-17T08:20:48Z"
+  },
+  "note": "Independent read-only review accepted the exact candidate with no blocking findings. The review covers bounded Alpha publication only and does not imply qualified structural-engineering review, professional approval, whole-building safety, or construction-use approval."
+}

--- a/docs/verification/alpha-0231a2-exact-candidate-review-receipt.json
+++ b/docs/verification/alpha-0231a2-exact-candidate-review-receipt.json
@@ -2,9 +2,9 @@
   "schema_version": "exact-candidate-review-receipt/v1",
   "decision": "ACCEPT",
   "reviewed_candidate": {
-    "head_sha": "0c00f2fac9b19ad59086e850b82d71bf1d12b943",
-    "tree_sha": "772f760ed603845fb402e90d597710de031772dc",
-    "python_tree_sha": "501fac1360f06ff2be4f6aea3b5e167f956ce840",
+    "head_sha": "d30f36eaa406ce9da600009f861ef2345ac8515e",
+    "tree_sha": "4f81a871eccca625f56b499714f04561bcb57383",
+    "python_tree_sha": "25aa0468135c07d3c260eca43776fb451865f833",
     "version": "0.23.1a2",
     "tag": "v0.23.1a2",
     "reviewed_targets": [
@@ -16,19 +16,19 @@
   "hosted_checks": {
     "required_pr_checks": {
       "status": "PASS",
-      "head_sha": "0c00f2fac9b19ad59086e850b82d71bf1d12b943",
-      "url": "https://github.com/Pravin-surawase/structural_engineering_lib/actions/runs/32007226356"
+      "head_sha": "d30f36eaa406ce9da600009f861ef2345ac8515e",
+      "url": "https://github.com/Pravin-surawase/structural_engineering_lib/actions/runs/32010784572"
     },
     "weekly_verification": {
       "status": "PASS",
-      "head_sha": "0c00f2fac9b19ad59086e850b82d71bf1d12b943",
-      "url": "https://github.com/Pravin-surawase/structural_engineering_lib/actions/runs/32007376033"
+      "head_sha": "d30f36eaa406ce9da600009f861ef2345ac8515e",
+      "url": "https://github.com/Pravin-surawase/structural_engineering_lib/actions/runs/32010948332"
     }
   },
   "reviewer": {
     "identity": "/root/release_0231a2_exact_review",
     "independent": true,
-    "reviewed_at_utc": "2026-08-17T08:20:48Z"
+    "reviewed_at_utc": "2026-08-17T08:40:45Z"
   },
-  "note": "Independent read-only review accepted the exact candidate with no blocking findings. The review covers bounded Alpha publication only and does not imply qualified structural-engineering review, professional approval, whole-building safety, or construction-use approval."
+  "note": "Independent read-only review accepted the repaired exact candidate with no outcome-changing blocker. The review covers bounded Alpha publication only and does not imply qualified structural-engineering review, professional approval, whole-building safety, or construction-use approval."
 }

--- a/docs/verification/alpha-0231a2-local-prepublication-rehearsal.md
+++ b/docs/verification/alpha-0231a2-local-prepublication-rehearsal.md
@@ -13,9 +13,9 @@ authorization, tag, upload, GitHub Release, or professional approval.
 
 ## Source identity
 
-- Build-anchor head: `c71e4e27749a9da58fe0d689bc1a1ba8b396f14d`
-- Build-anchor tree: `f0b1730c8880147b1019d5df90a64a530475fdcb`
-- Python tree: `501fac1360f06ff2be4f6aea3b5e167f956ce840`
+- Build-anchor head: `a115b16efbb85db0459c79836f55b6c43a586470`
+- Build-anchor tree: `a1d8a3cb06127bf3914438de82624baf89ca896f`
+- Python tree: `25aa0468135c07d3c260eca43776fb451865f833`
 - Base: `970a78c1931a3aa0439f487e6892a888bb113962`
 - Runtime diagnosis: `source_bound=true`
 
@@ -27,8 +27,8 @@ the artifact.
 
 | Artifact | Bytes | Members | SHA-256 |
 |---|---:|---:|---|
-| `structural_lib_is456-0.23.1a2-py3-none-any.whl` | 665,658 | 239 | `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19` |
-| `structural_lib_is456-0.23.1a2.tar.gz` | 551,149 | 271 | `5e25b42d8a78f14b5ce915d1ef26d0680257336c7da07033b5afe8ef74a9a479` |
+| `structural_lib_is456-0.23.1a2-py3-none-any.whl` | 665,658 | 239 | `34892d867845d044249236f32b700ab5e10ec558225407a47717fe3c3c2614bb` |
+| `structural_lib_is456-0.23.1a2.tar.gz` | 551,207 | 271 | `2684aa80ab2d56ace0fe4bc7c3af2b5ebe8cd1a63bb4f87251a69410cf985297` |
 
 Maintained build command:
 
@@ -36,9 +36,10 @@ Maintained build command:
 ./scripts/python_runtime.sh -m build Python
 ```
 
-No earlier artifact or generated build directory existed in this fresh
-worktree. The command built one wheel and its matching sdist. Both generated
-paths are ignored and the tracked worktree remained clean.
+The earlier generated artifacts were inspected as ignored directories with no
+symbolic links, moved recoverably out of the worktree, and replaced by one
+cleanly built wheel and its matching sdist. Both generated paths are ignored
+and the tracked worktree remained clean.
 
 ## Installed-wheel verification
 
@@ -89,8 +90,8 @@ Maintained command:
 
 **Publication state:** `HOLD`
 
-Remaining gates are the final candidate commit, required PR checks, exact-head
-Weekly Verification, independent exact-candidate review, a version-specific
-review receipt, and separate owner authorization for each requested target.
-The final exact-wheel publication preflight is reserved for that reviewed and
-authorized identity so its target verdict is not duplicated or misleading.
+Owner authorization is recorded for TestPyPI, PyPI, and GitHub Releases,
+conditional on the repaired exact candidate passing required PR checks,
+exact-head Weekly Verification, independent exact-candidate review, and the
+final exact-wheel publication preflight. The authorization does not include
+professional approval.

--- a/docs/verification/alpha-0231a2-local-prepublication-rehearsal.md
+++ b/docs/verification/alpha-0231a2-local-prepublication-rehearsal.md
@@ -1,0 +1,96 @@
+# v0.23.1a2 Local Prepublication Rehearsal
+
+**Type:** Reference
+**Audience:** Maintainers
+**Status:** Complete
+**Importance:** Critical
+**Created:** 2026-08-17
+**Last Updated:** 2026-08-17
+
+**Evidence boundary:** Local prepared-candidate evidence only. This is not a PR
+check receipt, exact-head Weekly Verification, independent review, target
+authorization, tag, upload, GitHub Release, or professional approval.
+
+## Source identity
+
+- Build-anchor head: `c71e4e27749a9da58fe0d689bc1a1ba8b396f14d`
+- Build-anchor tree: `f0b1730c8880147b1019d5df90a64a530475fdcb`
+- Python tree: `501fac1360f06ff2be4f6aea3b5e167f956ce840`
+- Base: `970a78c1931a3aa0439f487e6892a888bb113962`
+- Runtime diagnosis: `source_bound=true`
+
+The evidence record and other final closeout documents are outside the Python
+package tree. Their later addition does not change the Python tree or rebuild
+the artifact.
+
+## Exact artifacts
+
+| Artifact | Bytes | Members | SHA-256 |
+|---|---:|---:|---|
+| `structural_lib_is456-0.23.1a2-py3-none-any.whl` | 665,658 | 239 | `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19` |
+| `structural_lib_is456-0.23.1a2.tar.gz` | 551,149 | 271 | `5e25b42d8a78f14b5ce915d1ef26d0680257336c7da07033b5afe8ef74a9a479` |
+
+Maintained build command:
+
+```bash
+./scripts/python_runtime.sh -m build Python
+```
+
+No earlier artifact or generated build directory existed in this fresh
+worktree. The command built one wheel and its matching sdist. Both generated
+paths are ignored and the tracked worktree remained clean.
+
+## Installed-wheel verification
+
+Maintained command:
+
+```bash
+./run.sh release verify --version 0.23.1a2 --source wheel
+```
+
+- The disposable Python 3.11 environment imported
+  `structural_lib==0.23.1a2` from its own `site-packages` before and after the
+  test run, never from the checkout.
+- Dependency boundary: wheel `[dev,validation]` extras plus the documented
+  generated-client requirement `httpx>=0.27`; no root requirements install.
+- Result: 5,553 passed, 51 skipped, 2 deselected, 29 warnings.
+- Installed `job`, `critical`, and HTML `report` workflows passed.
+
+## Exact candidate and advertised-command UAT
+
+Maintained command:
+
+```bash
+./run.sh release candidate-check --version 0.23.1a2 \
+  --wheel Python/dist/structural_lib_is456-0.23.1a2-py3-none-any.whl
+```
+
+- Candidate check passed the bounded public-distribution and complete isolated-
+  footing inclusion controls, source/release version surfaces, wheel filename,
+  wheel metadata, excluded-content check, clean install, package origin,
+  installed `structural_lib --help`, public examples, and installed release
+  UAT.
+- Release matrix: 29 cases; SHA-256
+  `dd52015061a443e16f93bb5828016b5e96a580e3e0ebe4516e31a29db88c7757`.
+- Advertised entry-point inventory: 12 commands; SHA-256
+  `29e8cb68cbdbfae98bd0a2fec035ad0e291581dccdabf3c35f05399f78cbcbd1`.
+- The candidate check reported the same wheel SHA-256 recorded above.
+
+## Bound standing controls
+
+| Record | Identity | SHA-256 |
+|---|---|---|
+| Public distribution | `IS456-PUBLIC-DISTRIBUTION-001` | `539ba5deb682367a3f9069186a9b34d22a53ab9c1707eb9f2f0f8d054e270660` |
+| Footing inclusion | `FOOT-ISO-RC-V1-RELEASE-INCLUSION` | `875437cf59a078e1b170f636484a230efd1031f140f2bec5c4eee1df17e89a48` |
+
+## Verdict and remaining holds
+
+**Local verdict:** `CANDIDATE_TECHNICALLY_READY`
+
+**Publication state:** `HOLD`
+
+Remaining gates are the final candidate commit, required PR checks, exact-head
+Weekly Verification, independent exact-candidate review, a version-specific
+review receipt, and separate owner authorization for each requested target.
+The final exact-wheel publication preflight is reserved for that reviewed and
+authorized identity so its target verdict is not duplicated or misleading.

--- a/docs/verification/examples.md
+++ b/docs/verification/examples.md
@@ -9,8 +9,8 @@ tags: []
 
 # Verification Examples Pack
 
-**Version:** 0.23.1a1
-**Last Updated:** 2026-08-11<br>
+**Version:** 0.23.1a2
+**Last Updated:** 2026-08-17<br>
 **Purpose:** Build trust through traceable, verifiable benchmark calculations.
 
 ---

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-17",
-  "file_count": 174,
+  "file_count": 175,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -40,6 +40,20 @@
       "title": "v0.23.1a1 Local Prepublication Rehearsal",
       "description": "not a CI artifact identity, tag, or publication approval | Artifact | Bytes | Members | SHA-256 |",
       "content_hash": "d6a173859f50"
+    },
+    {
+      "name": "alpha-0231a2-exact-candidate-review-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-17",
+      "top_level_keys": [
+        "schema_version",
+        "decision",
+        "reviewed_candidate",
+        "hosted_checks",
+        "reviewer",
+        "note"
+      ],
+      "content_hash": "0a2c60440cde"
     },
     {
       "name": "alpha-0231a2-local-prepublication-rehearsal.md",
@@ -2210,7 +2224,7 @@
         "exact_candidate_review_receipt_sha256",
         "qualified_structural_engineering_review"
       ],
-      "content_hash": "2f0f3892c9d9"
+      "content_hash": "4cba6e9d2696"
     },
     {
       "name": "ui-experience-session-2-acceptance.md",
@@ -2230,5 +2244,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "bb56ed5eb860103e"
+  "content_hash": "fbeff312389827df"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -58,11 +58,11 @@
     {
       "name": "alpha-0231a2-local-prepublication-rehearsal.md",
       "type": "documentation",
-      "size_lines": 97,
+      "size_lines": 98,
       "last_updated": "2026-08-17",
       "title": "v0.23.1a2 Local Prepublication Rehearsal",
       "description": "check receipt, exact-head Weekly Verification, independent review, target authorization, tag, upload, GitHub Release, or professional approval.",
-      "content_hash": "720611d21ef3"
+      "content_hash": "79f7917f04dd"
     },
     {
       "name": "bundled-sample-boq-evidence.md",
@@ -2244,5 +2244,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "fbeff312389827df"
+  "content_hash": "182910beaf96a69b"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-17",
-  "file_count": 172,
+  "file_count": 174,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -42,6 +42,15 @@
       "content_hash": "d6a173859f50"
     },
     {
+      "name": "alpha-0231a2-local-prepublication-rehearsal.md",
+      "type": "documentation",
+      "size_lines": 97,
+      "last_updated": "2026-08-17",
+      "title": "v0.23.1a2 Local Prepublication Rehearsal",
+      "description": "check receipt, exact-head Weekly Verification, independent review, target authorization, tag, upload, GitHub Release, or professional approval.",
+      "content_hash": "720611d21ef3"
+    },
+    {
       "name": "bundled-sample-boq-evidence.md",
       "type": "documentation",
       "size_lines": 58,
@@ -75,9 +84,9 @@
       "name": "examples.md",
       "type": "documentation",
       "size_lines": 1550,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-17",
       "description": "This document provides benchmark examples that engineers can use to verify the library's calculations against: - Hand calculations",
-      "content_hash": "79cb3add7cbe"
+      "content_hash": "3e1117041432"
     },
     {
       "name": "external-cli-test.md",
@@ -2159,6 +2168,24 @@
       "content_hash": "c71c08113e06"
     },
     {
+      "name": "release-0231a2-preparation-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-17",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "c73dfda0aec8"
+    },
+    {
       "name": "release-artifact-evidence-template.md",
       "type": "documentation",
       "size_lines": 45,
@@ -2197,11 +2224,11 @@
       "name": "validation-pack.md",
       "type": "documentation",
       "size_lines": 396,
-      "last_updated": "2026-08-12",
+      "last_updated": "2026-08-17",
       "description": "This pack provides 5 benchmark beams and 3 benchmark columns with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trust",
-      "content_hash": "63fd4822c78c"
+      "content_hash": "44fa1e2ffc9b"
     }
   ],
   "subfolders": [],
-  "content_hash": "a33f1baa276bcc47"
+  "content_hash": "13962387545e15f5"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -2183,7 +2183,7 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "c73dfda0aec8"
+      "content_hash": "c054fddfce70"
     },
     {
       "name": "release-artifact-evidence-template.md",
@@ -2230,5 +2230,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "13962387545e15f5"
+  "content_hash": "bb56ed5eb860103e"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -53,7 +53,7 @@
         "reviewer",
         "note"
       ],
-      "content_hash": "0a2c60440cde"
+      "content_hash": "781fa60c35a6"
     },
     {
       "name": "alpha-0231a2-local-prepublication-rehearsal.md",
@@ -2224,7 +2224,7 @@
         "exact_candidate_review_receipt_sha256",
         "qualified_structural_engineering_review"
       ],
-      "content_hash": "4cba6e9d2696"
+      "content_hash": "0baeb5f8e1f0"
     },
     {
       "name": "ui-experience-session-2-acceptance.md",
@@ -2244,5 +2244,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "182910beaf96a69b"
+  "content_hash": "a831e6e97c527509"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -128,7 +128,7 @@ Benchmark examples and verification packs for validating library calculations ag
 |------|-------|-------------|-------|
 | [README.md](README.md) | Verification | Benchmark examples and verification packs for validating lib | 64 |
 | [alpha-0231-local-prepublication-rehearsal.md](alpha-0231-local-prepublication-rehearsal.md) | v0.23.1a1 Local Prepublication Rehearsal | not a CI artifact identity, tag, or publication approval | A | 72 |
-| [alpha-0231a2-local-prepublication-rehearsal.md](alpha-0231a2-local-prepublication-rehearsal.md) | v0.23.1a2 Local Prepublication Rehearsal | check receipt, exact-head Weekly Verification, independent r | 97 |
+| [alpha-0231a2-local-prepublication-rehearsal.md](alpha-0231a2-local-prepublication-rehearsal.md) | v0.23.1a2 Local Prepublication Rehearsal | check receipt, exact-head Weekly Verification, independent r | 98 |
 | [bundled-sample-boq-evidence.md](bundled-sample-boq-evidence.md) |  | This is the reproducible software record for the bundled ETA | 58 |
 | [column-pmm-benchmark.md](column-pmm-benchmark.md) |  | This record independently checks the experimental rectangula | 107 |
 | [examples.md](examples.md) |  | This document provides benchmark examples that engineers can | 1550 |

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,11 +4,12 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-17
-**Files:** 174
+**Files:** 175
 
 ## Config Files
 
 - [INDIA-0-git-handoff.json](INDIA-0-git-handoff.json)
+- [alpha-0231a2-exact-candidate-review-receipt.json](alpha-0231a2-exact-candidate-review-receipt.json)
 - [exact-candidate-review-receipt-template.json](exact-candidate-review-receipt-template.json)
 - [footing-release-inclusion.json](footing-release-inclusion.json)
 - [git-001-phase-8-reconciliation-git-handoff-receipt.json](git-001-phase-8-reconciliation-git-handoff-receipt.json)

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-17
-**Files:** 172
+**Files:** 174
 
 ## Config Files
 
@@ -118,6 +118,7 @@ Benchmark examples and verification packs for validating library calculations ag
 - [post-india2-maintenance-evidence.json](post-india2-maintenance-evidence.json)
 - [post-india2-maintenance-git-handoff-receipt.json](post-india2-maintenance-git-handoff-receipt.json)
 - [post-india2-maintenance-git-handoff-source-evidence.json](post-india2-maintenance-git-handoff-source-evidence.json)
+- [release-0231a2-preparation-git-handoff-receipt.json](release-0231a2-preparation-git-handoff-receipt.json)
 - [release-publication-authorization.json](release-publication-authorization.json)
 
 ## Documentation Files
@@ -126,6 +127,7 @@ Benchmark examples and verification packs for validating library calculations ag
 |------|-------|-------------|-------|
 | [README.md](README.md) | Verification | Benchmark examples and verification packs for validating lib | 64 |
 | [alpha-0231-local-prepublication-rehearsal.md](alpha-0231-local-prepublication-rehearsal.md) | v0.23.1a1 Local Prepublication Rehearsal | not a CI artifact identity, tag, or publication approval | A | 72 |
+| [alpha-0231a2-local-prepublication-rehearsal.md](alpha-0231a2-local-prepublication-rehearsal.md) | v0.23.1a2 Local Prepublication Rehearsal | check receipt, exact-head Weekly Verification, independent r | 97 |
 | [bundled-sample-boq-evidence.md](bundled-sample-boq-evidence.md) |  | This is the reproducible software record for the bundled ETA | 58 |
 | [column-pmm-benchmark.md](column-pmm-benchmark.md) |  | This record independently checks the experimental rectangula | 107 |
 | [examples.md](examples.md) |  | This document provides benchmark examples that engineers can | 1550 |

--- a/docs/verification/release-0231a2-preparation-git-handoff-receipt.json
+++ b/docs/verification/release-0231a2-preparation-git-handoff-receipt.json
@@ -1,0 +1,154 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "c6a623cb3b5d6e893f69f8a1b318fa12ad166caa0bdb5a108b35978ba099b626",
+    "state": {
+      "branch": "codex/release-0231a2",
+      "default_base": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "970a78c1931a3aa0439f487e6892a888bb113962",
+        "status": "ahead"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 77.883,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-release-0231a2",
+      "head_sha": "c71e4e27749a9da58fe0d689bc1a1ba8b396f14d",
+      "hold_reasons": [
+        "changed paths: 6"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-17T07:27:46.767596+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-release-0231a2",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 6,
+        "modified_paths": [],
+        "staged_paths": [
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/next-session-brief.md",
+          "docs/planning/pre-release-checklist.md",
+          "docs/verification/alpha-0231a2-local-prepublication-rehearsal.md",
+          "docs/verification/release-0231a2-preparation-git-handoff-receipt.json"
+        ],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-release-0231a2"
+    }
+  },
+  "local_state_receipt_hash": "sha256:c6a623cb3b5d6e893f69f8a1b318fa12ad166caa0bdb5a108b35978ba099b626",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-17T07:27:46.767779+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "docs/verification/release-publication-authorization.json",
+      "docs/verification/exact-candidate-review-receipt-template.json"
+    ],
+    "integration_owner": "Codex",
+    "owned_paths": [
+      ".github/skills/release-preflight/SKILL.md",
+      "CHANGELOG.md",
+      "CITATION.cff",
+      "Python/README.md",
+      "Python/pyproject.toml",
+      "README.md",
+      "docs/contributing/development-guide.md",
+      "docs/getting-started/beginners-guide.md",
+      "docs/getting-started/python-quickstart.md",
+      "docs/getting-started/releases.md",
+      "docs/getting-started/user-guide.md",
+      "docs/planning/pre-release-checklist.md",
+      "docs/reference/api-stability.md",
+      "docs/reference/api.md",
+      "docs/verification/alpha-0231a2-local-prepublication-rehearsal.md",
+      "docs/verification/examples.md",
+      "docs/verification/validation-pack.md",
+      "fastapi_app/__init__.py",
+      "fastapi_app/config.py",
+      "fastapi_app/openapi_baseline.json",
+      "react_app/package.json",
+      "react_app/src/components/layout/SettingsPanel.tsx"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md",
+      "docs/index.json",
+      "docs/index.md",
+      "docs/contributing/index.json",
+      "docs/contributing/index.md",
+      "docs/getting-started/index.json",
+      "docs/getting-started/index.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/reference/index.json",
+      "docs/reference/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md"
+    ],
+    "task_id": "RELEASE-0231A2-PREPARATION"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/release-0231a2-preparation-git-handoff-receipt.json
+++ b/docs/verification/release-0231a2-preparation-git-handoff-receipt.json
@@ -143,7 +143,8 @@
       "docs/reference/index.json",
       "docs/reference/index.md",
       "docs/verification/index.json",
-      "docs/verification/index.md"
+      "docs/verification/index.md",
+      "fastapi_app/index.json"
     ],
     "task_id": "RELEASE-0231A2-PREPARATION"
   },

--- a/docs/verification/release-publication-authorization.json
+++ b/docs/verification/release-publication-authorization.json
@@ -9,10 +9,10 @@
     "github-release"
   ],
   "authorized_by": "Pravin Surawase (repository owner)",
-  "authorized_at_utc": "2026-08-17T08:21:19Z",
+  "authorized_at_utc": "2026-08-17T08:41:30Z",
   "exact_candidate_review_receipt": "docs/verification/alpha-0231a2-exact-candidate-review-receipt.json",
-  "exact_candidate_review_receipt_sha256": "0a2c60440cded2560dd7880404c2685fa0c8229d71630aba6c6a9ca44f76d797",
+  "exact_candidate_review_receipt_sha256": "781fa60c35a6d399625adf61eae5c51bfc1c1d940c4f6b7060fb1e9dcab82f92",
   "qualified_structural_engineering_review": false,
   "professional_approval": false,
-  "note": "The repository owner explicitly authorized publication of v0.23.1a2 to TestPyPI, production PyPI, and GitHub Releases in the active Codex task after exact-head CI and independent review passed. This authorization does not imply professional approval."
+  "note": "The repository owner explicitly authorized publication of v0.23.1a2 to TestPyPI, production PyPI, and GitHub Releases in the active Codex task, conditional on refreshed exact-head CI and independent review passing. Both conditions passed before this binding was recorded. This authorization does not imply professional approval."
 }

--- a/docs/verification/release-publication-authorization.json
+++ b/docs/verification/release-publication-authorization.json
@@ -1,14 +1,18 @@
 {
   "schema_version": "release-publication-authorization/v1",
-  "decision": "HOLD",
-  "version": null,
-  "tag": null,
-  "authorized_targets": [],
-  "authorized_by": null,
-  "authorized_at_utc": null,
-  "exact_candidate_review_receipt": null,
-  "exact_candidate_review_receipt_sha256": null,
+  "decision": "AUTHORIZED",
+  "version": "0.23.1a2",
+  "tag": "v0.23.1a2",
+  "authorized_targets": [
+    "testpypi",
+    "pypi",
+    "github-release"
+  ],
+  "authorized_by": "Pravin Surawase (repository owner)",
+  "authorized_at_utc": "2026-08-17T08:21:19Z",
+  "exact_candidate_review_receipt": "docs/verification/alpha-0231a2-exact-candidate-review-receipt.json",
+  "exact_candidate_review_receipt_sha256": "0a2c60440cded2560dd7880404c2685fa0c8229d71630aba6c6a9ca44f76d797",
   "qualified_structural_engineering_review": false,
   "professional_approval": false,
-  "note": "Packet G installs the mandatory stop. The owner must separately authorize the exact future Alpha version and publication targets after immutable candidate review."
+  "note": "The repository owner explicitly authorized publication of v0.23.1a2 to TestPyPI, production PyPI, and GitHub Releases in the active Codex task after exact-head CI and independent review passed. This authorization does not imply professional approval."
 }

--- a/docs/verification/validation-pack.md
+++ b/docs/verification/validation-pack.md
@@ -9,7 +9,7 @@ tags: []
 
 # Validation Pack — Benchmark Beams & Columns
 
-**Version:** 0.23.1a1
+**Version:** 0.23.1a2
 
 This pack provides 5 benchmark beams and 3 benchmark columns with IS 456 references that you can use to validate the library's calculations against hand calculations, SP 16 design aids, or other trusted software.
 

--- a/fastapi_app/__init__.py
+++ b/fastapi_app/__init__.py
@@ -7,4 +7,4 @@ wrapping the structural_lib.api module for React frontend consumption.
 Part of V3 React Migration - Week 2-3: FastAPI Backend
 """
 
-__version__ = "0.23.1a1"
+__version__ = "0.23.1a2"

--- a/fastapi_app/config.py
+++ b/fastapi_app/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
 
     # API Configuration
     api_title: str = "Structural Engineering API"
-    api_version: str = "0.23.1a1"
+    api_version: str = "0.23.1a2"
     api_prefix: str = "/api/v1"
 
     # Server Configuration

--- a/fastapi_app/index.json
+++ b/fastapi_app/index.json
@@ -20,7 +20,7 @@
       "size_lines": 11,
       "last_updated": "2026-08-17",
       "description": "FastAPI backend for structural_engineering_lib.",
-      "content_hash": "a054fbd5a6f9"
+      "content_hash": "576f9b750dc6"
     },
     {
       "name": "auth.py",
@@ -143,7 +143,7 @@
         "_INSECURE_JWT_SECRET_MARKERS",
         "MINIMUM_JWT_SECRET_LENGTH"
       ],
-      "content_hash": "e5694e016279"
+      "content_hash": "2ceeed8bea62"
     },
     {
       "name": "error_utils.py",
@@ -256,7 +256,7 @@
         "paths",
         "tags"
       ],
-      "content_hash": "d05b02792923"
+      "content_hash": "d5a004447d9e"
     },
     {
       "name": "ruff.toml",
@@ -293,5 +293,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "538b1e3dc58ab686"
+  "content_hash": "bb3e0de5546ac907"
 }

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -24764,7 +24764,7 @@
       "url": "https://opensource.org/licenses/MIT"
     },
     "title": "Structural Engineering API",
-    "version": "0.23.1a1"
+    "version": "0.23.1a2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/react_app/package.json
+++ b/react_app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react_app",
   "private": true,
-  "version": "0.23.1a1",
+  "version": "0.23.1a2",
   "type": "module",
   "engines": {
     "node": "24.x",

--- a/react_app/src/components/layout/SettingsPanel.tsx
+++ b/react_app/src/components/layout/SettingsPanel.tsx
@@ -91,7 +91,7 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                 <div className="p-4 rounded-lg bg-zinc-800/50 border border-white/5 space-y-2">
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-zinc-400">App:</span>
-                    <span className="text-sm font-mono text-zinc-300">v0.23.1a1</span>
+                    <span className="text-sm font-mono text-zinc-300">v0.23.1a2</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-zinc-400">IS 456:</span>


### PR DESCRIPTION
## What changed

- prepares the exact `0.23.1a2` Alpha candidate across Python, FastAPI, React, citation, install, API, validation, and release-document surfaces
- adds bounded release notes for strict lossless project intake, fail-closed `design` CLI behavior, explicit provenance/review boundaries, and the additional supported-case component workflows
- records one exact local wheel and source-free installed-package rehearsal
- corrects stale release-preflight guidance so publication approval cannot be pre-checked before immutable review

## Why

The published `0.23.1a1` artifact predates the LIB-PRO-002 input/CLI/release-signal fixes. This candidate packages the corrected source while preserving the boundary between calculation success, release evidence, qualified review, and professional approval.

## Exact local evidence

- final head: `760cae7eddfbceacd014cc04344714ce8bdf1187`
- Python tree: `501fac1360f06ff2be4f6aea3b5e167f956ce840`
- wheel: `structural_lib_is456-0.23.1a2-py3-none-any.whl`
- wheel SHA-256: `5bca57ba12a35803715ad581420fa6ea5be32a0cd736fd42246b9a026584cc19`
- canonical preparation: 6,414 passed, 3 skipped, 6 deselected; React production build passed
- installed wheel: 5,553 passed, 51 skipped, 2 deselected; installed job/critical/report workflows passed
- release UAT: 29/29 cases and 12/12 advertised commands passed
- focused release regressions: 14 passed
- quick gate: 10/10
- normal commit hooks and read-only session closeout passed

## Release boundary

This PR does not authorize or perform TestPyPI/PyPI publication, a tag, or a GitHub Release. The publication authorization record remains `HOLD`. Required PR checks, exact-head Weekly Verification, independent review, the exact candidate receipt, and separate owner authorization remain mandatory.

When this PR is later merge-eligible, use a regular merge commit rather than squash so the immutable reviewed candidate remains an ancestor of the publication head.