### PR TITLE
feat(excel): add deterministic review bundle export

### DIFF
--- a/Python/structural_lib/core/excel_workbook.py
+++ b/Python/structural_lib/core/excel_workbook.py
@@ -19,6 +19,8 @@ __all__ = [
     "ExcelFreshnessRequestV1",
     "ExcelMappingFieldV1",
     "ExcelMappingPreviewV1",
+    "ExcelReviewBundleExportRequestV1",
+    "ExcelReviewBundleV1",
     "ExcelRetainedEvidenceV1",
     "ExcelReviewStateV1",
     "ExcelRowCountV1",
@@ -254,6 +256,25 @@ class ExcelFreshnessCheckV1(_FrozenModel):
     current_source_table_hash: str = Field(pattern=_SHA256_PATTERN)
     current_mapping_hash: str = Field(pattern=_SHA256_PATTERN)
     current_library_content_identity: str = Field(pattern=_SHA256_PATTERN)
+
+
+class ExcelReviewBundleExportRequestV1(_FrozenModel):
+    schema_version: Literal["excel-review-bundle-export-request/v1"] = (
+        "excel-review-bundle-export-request/v1"
+    )
+    current_request: ExcelWorkbookPreviewRequestV1
+    previous_evidence: ExcelRetainedEvidenceV1
+    confirmed_mapping_hash: str = Field(pattern=_SHA256_PATTERN)
+
+
+class ExcelReviewBundleV1(_FrozenModel):
+    schema_version: Literal["excel-review-bundle/v1"] = "excel-review-bundle/v1"
+    export_disposition: Literal["EVIDENCE_FOR_QUALIFIED_REVIEW"] = (
+        "EVIDENCE_FOR_QUALIFIED_REVIEW"
+    )
+    freshness_check: ExcelFreshnessCheckV1
+    result: ExcelWorkbookRunResultV1
+    review_bundle_hash: str = Field(pattern=_SHA256_PATTERN)
 
 
 class ExcelWorkbenchDefinitionV1(_FrozenModel):

--- a/Python/structural_lib/core/index.json
+++ b/Python/structural_lib/core/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/core",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-18",
+  "last_updated": "2026-08-22",
   "file_count": 24,
   "files": [
     {
@@ -525,8 +525,8 @@
     {
       "name": "excel_workbook.py",
       "type": "python",
-      "size_lines": 279,
-      "last_updated": "2026-08-18",
+      "size_lines": 300,
+      "last_updated": "2026-08-22",
       "description": "Versioned, calculation-free contracts for Excel Routine Workbench V1.",
       "classes": [
         {
@@ -582,7 +582,7 @@
         "_ID_PATTERN",
         "_SHA256_PATTERN"
       ],
-      "content_hash": "293f06fa91f5"
+      "content_hash": "f033578bb1ed"
     },
     {
       "name": "geometry.py",
@@ -1387,5 +1387,5 @@
     "GravityCombinationV1",
     "GravityFootingDestinationV1"
   ],
-  "content_hash": "b087b3639cd82bcf"
+  "content_hash": "afb02181eae5959e"
 }

--- a/Python/structural_lib/core/index.md
+++ b/Python/structural_lib/core/index.md
@@ -1,7 +1,7 @@
 # Core
 
 **Type:** Python Package
-**Last Updated:** 2026-08-18
+**Last Updated:** 2026-08-22
 **Files:** 24
 
 ## Public API
@@ -39,7 +39,7 @@
 | [deprecation.py](deprecation.py) | Module:       deprecation | 0 | 2 | 156 |
 | [error_messages.py](error_messages.py) | Module:       error_messages | 0 | 15 | 496 |
 | [errors.py](errors.py) | Module:       errors | 11 | 1 | 884 |
-| [excel_workbook.py](excel_workbook.py) | Versioned, calculation-free contracts for Excel Routine Work | 15 | 0 | 279 |
+| [excel_workbook.py](excel_workbook.py) | Versioned, calculation-free contracts for Excel Routine Work | 15 | 0 | 300 |
 | [geometry.py](geometry.py) | Code-agnostic geometry definitions. | 4 | 2 | 254 |
 | [gravity_workflow.py](gravity_workflow.py) | Versioned request, applicability, action, and result types f | 12 | 0 | 310 |
 | [inputs.py](inputs.py) | Module:       inputs | 6 | 3 | 635 |

--- a/Python/structural_lib/services/excel_workbench.py
+++ b/Python/structural_lib/services/excel_workbench.py
@@ -21,6 +21,8 @@ from structural_lib.core.excel_workbook import (
     ExcelMappingFieldV1,
     ExcelMappingPreviewV1,
     ExcelRetainedEvidenceV1,
+    ExcelReviewBundleExportRequestV1,
+    ExcelReviewBundleV1,
     ExcelReviewStateV1,
     ExcelRowCountV1,
     ExcelRowDispositionV1,
@@ -46,12 +48,15 @@ from structural_lib.services.project_beam import EffectiveDepthBasisV1
 from structural_lib.services.serialization import to_transport_value
 
 __all__ = [
+    "ExcelReviewBundleConflictError",
+    "build_excel_review_bundle_v1",
     "build_excel_mapping_preview_v1",
     "check_excel_workbook_freshness_v1",
     "get_excel_workbench_definition_v1",
     "retain_excel_workbook_evidence_v1",
     "render_excel_review_bundle_markdown_v1",
     "run_excel_workbook_v1",
+    "serialize_excel_review_bundle_v1",
 ]
 
 _REQUIRED_FIELDS = (
@@ -173,6 +178,24 @@ def _canonical_json_hash(value: Any) -> str:
         sort_keys=True,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    payload = to_transport_value(value)
+    return (
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+class ExcelReviewBundleConflictError(ValueError):
+    """The retained result identity conflicts with the current workbook state."""
 
 
 def _contract() -> ExcelWorkbookContractV1:
@@ -811,6 +834,66 @@ def retain_excel_workbook_evidence_v1(
         mapping_hash=result.mapping.mapping_hash,
         library_content_identity=result.library_content_identity,
     )
+
+
+def build_excel_review_bundle_v1(
+    request: ExcelReviewBundleExportRequestV1,
+) -> ExcelReviewBundleV1:
+    preview = build_excel_mapping_preview_v1(request.current_request)
+    if preview.is_blocked:
+        raise ValueError(
+            "Excel mapping preview is blocked; review bundle was not exported."
+        )
+    if request.confirmed_mapping_hash != preview.mapping_hash:
+        raise ValueError(
+            "confirmed_mapping_hash does not match the current mapping preview"
+        )
+    if request.previous_evidence.mapping_hash != request.confirmed_mapping_hash:
+        raise ExcelReviewBundleConflictError(
+            "Retained mapping identity does not match the confirmed mapping."
+        )
+
+    freshness = check_excel_workbook_freshness_v1(
+        ExcelFreshnessRequestV1(
+            previous_evidence=request.previous_evidence,
+            current_request=request.current_request,
+        )
+    )
+    if freshness.freshness_status != "CURRENT":
+        raise ExcelReviewBundleConflictError(
+            "Retained Excel result is stale: " + ", ".join(freshness.reasons)
+        )
+
+    result = run_excel_workbook_v1(
+        ExcelWorkbookRunRequestV1(
+            selection=request.current_request.selection,
+            headers=request.current_request.headers,
+            rows=request.current_request.rows,
+            confirmed_mapping_hash=request.confirmed_mapping_hash,
+        )
+    )
+    if result.bundle_hash != request.previous_evidence.bundle_hash:
+        raise ExcelReviewBundleConflictError(
+            "Regenerated result identity does not match the retained result."
+        )
+
+    payload = {
+        "schema_version": "excel-review-bundle/v1",
+        "export_disposition": "EVIDENCE_FOR_QUALIFIED_REVIEW",
+        "freshness_check": freshness.model_dump(mode="json"),
+        "result": result.model_dump(mode="json"),
+    }
+    return ExcelReviewBundleV1(
+        freshness_check=freshness,
+        result=result,
+        review_bundle_hash=_canonical_json_hash(payload),
+    )
+
+
+def serialize_excel_review_bundle_v1(bundle: ExcelReviewBundleV1) -> bytes:
+    """Return deterministic complete review evidence as UTF-8 JSON plus one LF."""
+
+    return _canonical_json_bytes(bundle.model_dump(mode="json"))
 
 
 def render_excel_review_bundle_markdown_v1(

--- a/Python/structural_lib/services/index.json
+++ b/Python/structural_lib/services/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/services",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-18",
+  "last_updated": "2026-08-22",
   "file_count": 54,
   "files": [
     {
@@ -1894,9 +1894,15 @@
     {
       "name": "excel_workbench.py",
       "type": "python",
-      "size_lines": 868,
-      "last_updated": "2026-08-18",
+      "size_lines": 951,
+      "last_updated": "2026-08-22",
       "description": "Strict selected-table orchestration for Excel Routine Workbench V1.",
+      "classes": [
+        {
+          "name": "ExcelReviewBundleConflictError",
+          "description": "The retained result identity conflicts with the current workbook state."
+        }
+      ],
       "functions": [
         {
           "name": "get_excel_workbench_definition_v1"
@@ -1926,6 +1932,19 @@
           ]
         },
         {
+          "name": "build_excel_review_bundle_v1",
+          "params": [
+            "request"
+          ]
+        },
+        {
+          "name": "serialize_excel_review_bundle_v1",
+          "description": "Return deterministic complete review evidence as UTF-8 JSON plus one LF.",
+          "params": [
+            "bundle"
+          ]
+        },
+        {
           "name": "render_excel_review_bundle_markdown_v1",
           "params": [
             "result"
@@ -1941,7 +1960,7 @@
         "_WORKBOOK_ARTIFACT_NAME",
         "_WORKBOOK_RESOURCE_DIR"
       ],
-      "content_hash": "c63bcf13878c"
+      "content_hash": "090d514bfa97"
     },
     {
       "name": "flat_slab_api.py",
@@ -3400,5 +3419,5 @@
     "PropertyLineStrapFootingDesignStatus",
     "design_property_line_strap_footing_is456"
   ],
-  "content_hash": "f38c58c33a85ccf1"
+  "content_hash": "96688dfaf6b7e525"
 }

--- a/Python/structural_lib/services/index.md
+++ b/Python/structural_lib/services/index.md
@@ -1,7 +1,7 @@
 # Services
 
 **Type:** Python Package
-**Last Updated:** 2026-08-18
+**Last Updated:** 2026-08-22
 **Files:** 54
 
 ## Public API
@@ -55,7 +55,7 @@
 | [evidence.py](evidence.py) | Canonical evidence identity for the supported IS 456 beam de | 0 | 4 | 386 |
 | [excel_bridge.py](excel_bridge.py) | Excel UDF Bridge - Exposes structural_lib functions to Excel | 0 | 7 | 305 |
 | [excel_integration.py](excel_integration.py) | Excel Integration Module — Bridge between Excel data and Det | 2 | 9 | 489 |
-| [excel_workbench.py](excel_workbench.py) | Strict selected-table orchestration for Excel Routine Workbe | 0 | 6 | 868 |
+| [excel_workbench.py](excel_workbench.py) | Strict selected-table orchestration for Excel Routine Workbe | 1 | 8 | 951 |
 | [flat_slab_api.py](flat_slab_api.py) | Stable orchestration for the bounded regular interior flat-s | 4 | 2 | 339 |
 | [footing_api.py](footing_api.py) | Bounded orchestration for concentric isolated footings (IS 4 | 5 | 1 | 915 |
 | [gravity_calculation_book.py](gravity_calculation_book.py) | Deterministic review dossier for Building Gravity Workflow V | 3 | 4 | 254 |

--- a/Python/tests/unit/test_excel_workbench_v1.py
+++ b/Python/tests/unit/test_excel_workbench_v1.py
@@ -4,21 +4,27 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from structural_lib.__main__ import main
 from structural_lib.core.excel_workbook import (
     ExcelFreshnessRequestV1,
+    ExcelReviewBundleExportRequestV1,
     ExcelWorkbookPreviewRequestV1,
     ExcelWorkbookRunRequestV1,
     ExcelWorkbookSelectionV1,
 )
 from structural_lib.services.beam_api import design_beam_is456
 from structural_lib.services.excel_workbench import (
+    ExcelReviewBundleConflictError,
     build_excel_mapping_preview_v1,
+    build_excel_review_bundle_v1,
     check_excel_workbook_freshness_v1,
     get_excel_workbench_definition_v1,
     render_excel_review_bundle_markdown_v1,
     retain_excel_workbook_evidence_v1,
     run_excel_workbook_v1,
+    serialize_excel_review_bundle_v1,
 )
 from structural_lib.services.project_beam import EffectiveDepthBasisV1
 from structural_lib.services.serialization import to_transport_value
@@ -118,6 +124,19 @@ def _run_request(
         selection=preview_request.selection,
         headers=headers,
         rows=rows,
+        confirmed_mapping_hash=preview.mapping_hash,
+    )
+
+
+def _export_request(
+    rows: tuple[tuple[object, ...], ...],
+) -> ExcelReviewBundleExportRequestV1:
+    current = _preview_request(rows)
+    preview = build_excel_mapping_preview_v1(current)
+    result = run_excel_workbook_v1(_run_request(rows))
+    return ExcelReviewBundleExportRequestV1(
+        current_request=current,
+        previous_evidence=retain_excel_workbook_evidence_v1(result),
         confirmed_mapping_hash=preview.mapping_hash,
     )
 
@@ -308,6 +327,75 @@ def test_run_and_review_bundle_are_deterministic() -> None:
     assert first.bundle_hash == second.bundle_hash
     assert first.row_ledger[0].passport == second.row_ledger[0].passport
     assert first.bundle_hash in render_excel_review_bundle_markdown_v1(first)
+
+
+def test_complete_review_bundle_and_file_bytes_are_deterministic() -> None:
+    request = _export_request((_derived_row(), _explicit_row()))
+
+    first = build_excel_review_bundle_v1(request)
+    second = build_excel_review_bundle_v1(request)
+    first_bytes = serialize_excel_review_bundle_v1(first)
+    second_bytes = serialize_excel_review_bundle_v1(second)
+    decoded = json.loads(first_bytes)
+
+    assert first == second
+    assert first_bytes == second_bytes
+    assert first_bytes.endswith(b"\n")
+    assert len(first.review_bundle_hash) == 64
+    assert first.freshness_check.freshness_status == "CURRENT"
+    assert first.result.bundle_hash == request.previous_evidence.bundle_hash
+    assert decoded["export_disposition"] == "EVIDENCE_FOR_QUALIFIED_REVIEW"
+    assert decoded["result"]["mapping"]["mapped_fields"]
+    assert len(decoded["result"]["row_ledger"]) == 2
+    assert decoded["result"]["row_ledger"][0]["result"] is not None
+    assert decoded["result"]["row_ledger"][0]["passport"] is not None
+    assert decoded["result"]["qualified_review_required"] is True
+    assert decoded["result"]["review_state"] == "NOT_REVIEWED"
+
+
+def test_review_bundle_fails_closed_for_stale_source_and_result_identity() -> None:
+    request = _export_request((_derived_row(),))
+    edited = list(_derived_row())
+    edited[3] = 151.0
+    stale_request = request.model_copy(
+        update={"current_request": _preview_request((tuple(edited),))}
+    )
+    mismatched_result = request.model_copy(
+        update={
+            "previous_evidence": request.previous_evidence.model_copy(
+                update={"bundle_hash": "f" * 64}
+            )
+        }
+    )
+
+    with pytest.raises(ExcelReviewBundleConflictError, match="SOURCE_TABLE_CHANGED"):
+        build_excel_review_bundle_v1(stale_request)
+    with pytest.raises(ExcelReviewBundleConflictError, match="Regenerated result"):
+        build_excel_review_bundle_v1(mismatched_result)
+
+
+def test_review_bundle_rejects_unconfirmed_blocked_and_engine_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _export_request((_derived_row(),))
+    unconfirmed = request.model_copy(update={"confirmed_mapping_hash": "0" * 64})
+    blocked_current = _preview_request(
+        (_derived_row(),),
+        tuple(item for item in HEADERS if item != "Beam ID"),
+    )
+    blocked = request.model_copy(update={"current_request": blocked_current})
+
+    with pytest.raises(ValueError, match="confirmed_mapping_hash"):
+        build_excel_review_bundle_v1(unconfirmed)
+    with pytest.raises(ValueError, match="mapping preview is blocked"):
+        build_excel_review_bundle_v1(blocked)
+
+    monkeypatch.setattr(
+        "structural_lib.services.excel_workbench.get_library_content_identity",
+        lambda: "f" * 64,
+    )
+    with pytest.raises(ExcelReviewBundleConflictError, match="ENGINE_CHANGED"):
+        build_excel_review_bundle_v1(request)
 
 
 def test_definition_does_not_claim_real_windows_excel_evidence() -> None:

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,75 @@
 
 ---
 
+## 2026-08-22 — Session: E1 complete review-bundle export
+
+**Agent:** Codex (`reviewer`, sole writer)
+
+**Branch:** `codex/e1-review-bundle-export`, stacked on exact Windows-validated
+predecessor `514155b266af6dff3e30bf39ee28671c17345454`.
+
+**Git handoff receipt:** `docs/verification/e1-review-bundle-export-git-handoff-receipt.json`
+
+**Focus:** Close the G3 export-surface gap with one complete, deterministic,
+fail-closed Python/REST/Office.js successor; preserve workbook bytes,
+calculations, manifest, ETABS/VBA, release, merge, cleanup, and professional
+approval boundaries.
+
+### Summary
+
+- Added a versioned complete review-bundle request/result contract and
+  deterministic JSON serialization.
+- Added a same-origin REST attachment whose file, logical bundle, and canonical
+  result identities are explicit.
+- Added an installed-pane Export control that is eligible only after a current
+  run or explicit freshness check and verifies response bytes before download.
+- Extended focused Python, REST, Office.js, source-free wheel, plan, evidence,
+  and Windows acceptance surfaces.
+
+### Issues encountered
+
+- The frozen G3 journey required pane-accessible deterministic review-bundle
+  export, but the installed pane and REST router exposed no export operation.
+- The existing deterministic Markdown renderer was a compact status summary;
+  it omitted the complete mapping, structured results, passports, raw ledger
+  detail, and issues required for qualified review.
+- The first OpenAPI assertion found the new route documented no response
+  content even though its runtime JSON attachment passed.
+- The first affected-file Ruff run stopped before mypy because two new service
+  contract imports were not in canonical order.
+
+### Root causes and resolutions
+
+- Confirmed root cause: local renderer determinism had been accepted as proof
+  of a complete installed Excel export journey even though no source-to-pane
+  route existed. Resolution: add one typed export request, service regeneration
+  boundary, raw JSON attachment route, pane action, and exact identity checks.
+- Confirmed root cause: the old renderer was designed as a human-readable
+  summary and its tests asserted repeatability plus hash presence, not complete
+  artifact content. Resolution: make `ExcelReviewBundleV1` contain the full
+  canonical run result, preserve the renderer as a summary-only compatibility
+  surface, and add nested-content plus deterministic-byte tests.
+- Confirmed root cause: setting generic `Response` as the decorator response
+  class suppressed FastAPI's schema content even with a response model.
+  Resolution: keep `ExcelReviewBundleV1` as the documented response model and
+  return a raw `Response` instance only at runtime. Proof: the failed OpenAPI
+  assertion and refreshed 89-endpoint/434-schema baseline check pass.
+- Confirmed root cause: the new retained/export contract imports were added in
+  semantic rather than Ruff alphabetical order. Resolution: reorder only those
+  imports; affected Black/Ruff and the previously skipped configured mypy pass.
+
+### Validation through content freeze
+
+- Focused Python/REST/Open XML: 22 cases pass using one impact-mapped repair
+  rerun; Office.js: 21/21; four JavaScript modules and the manifest parse.
+- Black, Ruff, configured mypy, 217-file architecture, 685-file/4,732-import
+  validation, and the 89-endpoint/434-schema OpenAPI baseline pass.
+- A source-free wheel proves unchanged workbook SHA-256 `497dd44d…ac85`, new
+  library content identity `87ae4fbe…d57a5`, and complete deterministic 8,987-
+  byte review evidence with both structured result and passport.
+- Documentation, maintained indexes, quick gate, hooks, immutable commit/audit,
+  hosted checks, and Windows G3 remain in the closeout sequence.
+
 ## 2026-08-22 — Session: E1 blank-workbook guard repair
 
 **Agent:** Codex (`backend`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-21 — E1 Windows W0 setup is complete except for the user-approved Excel catalog share; G3 remains unstarted
+**Updated:** 2026-08-22 — E1 Windows W0 is ready; G3 preflight exposed the missing complete export surface, now in one authorized successor
 
 ---
 
@@ -128,7 +128,7 @@
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
 | RELEASE-0231A2 | Review and publish the exact v0.23.1a2 Alpha candidate | Main Agent + ops | M | P0 | 🔄 LOCAL CANDIDATE READY — source-bound wheel `34892d86…14bb`; 5,553 installed tests and 29/29 UAT pass; target publication is authorized after refreshed PR checks, Weekly Verification, independent review, and exact receipt |
-| E1-EXCEL-ROUTINE-WORKBENCH | Complete the real Windows Excel gate for the frozen selected-table workbench | Main Agent | M | P1 | 🔄 W0 repair locally validated — [host/catalog/add-in discovery pass](verification/e1-windows-w0-setup-evidence.md); the [blank-workbook guard](verification/e1-blank-workbook-guard-evidence.md) needs exact-head Windows revalidation before G3 |
+| E1-EXCEL-ROUTINE-WORKBENCH | Complete the real Windows Excel gate for the frozen selected-table workbench | Main Agent | M | P1 | 🔄 W0 `READY_FOR_G3`; first G3 preflight correctly stopped on the missing complete review-bundle export, now owned by the [single authorized successor](verification/e1-review-bundle-export-evidence.md) |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. INDIA-3, dependency work, tag/publication execution, further cleanup,
@@ -147,8 +147,11 @@ The separately accepted integrated component/gravity program has completed A1,
 A2, B1, and B2 through PRs #822-#825. Building Gravity Workflow V1 is merged at
 `c127e4b2`. E1 software remains in draft PR #826 at `ef5ee05c`; Windows W0
 proved the host, catalog, and add-in discovery, then exposed an eager missing-
-sheet startup defect. Its stacked blank-workbook guard passes local focused
-checks and awaits exact-head Windows revalidation. G3 has not started.
+sheet startup defect. Its stacked blank-workbook guard passed exact-head
+Windows revalidation at `514155b2`. The first G3 preflight stopped before
+workbook creation because the pane/API had no complete export surface. The
+authorized `codex/e1-review-bundle-export` successor closes that gap before one
+G3 rerun.
 ETABS file/live work and all write-back/nightly work remain outside E1.
 
 ## Up Next

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 3454,
+      "size_lines": 3523,
       "last_updated": "2026-08-22",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "abb7a2b7757f"
+      "content_hash": "e94797c26e5f"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 725,
+      "size_lines": 728,
       "last_updated": "2026-08-22",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "8bfa8126c49c"
+      "content_hash": "f9adc9c563c8"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 196,
+      "file_count": 199,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "9355860976fab88e"
+  "content_hash": "6da31efa75407d92"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 3454 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 725 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 3523 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 728 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1793 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 8 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 196 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 199 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/e1-excel-routine-workbench-v1-plan.md
+++ b/docs/planning/e1-excel-routine-workbench-v1-plan.md
@@ -4,7 +4,7 @@ title: Excel Routine Workbench V1 Execution Plan
 status: active
 owner: Main Agent
 created: 2026-08-17
-last_updated: 2026-08-18
+last_updated: 2026-08-22
 doc_type: spec
 ---
 
@@ -21,6 +21,13 @@ is installed package data and retains SHA-256
 This is a software candidate, not a G3 pass. The mandatory installed Windows
 11 x64 plus Microsoft 365 Excel x64 journey remains `TO_VERIFY_WINDOWS`; T1/T2
 ETABS and all write-back/nightly work remain held.
+
+Windows W0 later reached `READY_FOR_G3` on blank-workbook guard head
+`514155b266af6dff3e30bf39ee28671c17345454`. The first G3 preflight then
+stopped before opening a disposable workbook because the installed pane had no
+supported complete review-bundle export. The authorized successor
+`codex/e1-review-bundle-export` adds that missing end-user surface without
+changing workbook bytes, structural calculations, or the Office manifest.
 
 ## 1. Outcome and start boundary
 
@@ -59,6 +66,13 @@ release publication, or professional-approval claims.
    identity changes the current hash and marks the retained result `STALE`.
 8. Review/export produces a deterministic bundle containing the mapping,
    reconciled row ledger, structured results, passports, issues, and hashes.
+
+Export is eligible only after the current mapping has been confirmed and the
+retained result is `CURRENT`. The service regenerates the canonical result from
+the exact current source snapshot, requires its result hash to equal the
+retained hash, and returns canonical JSON plus file and logical identity
+headers. An edit, mapping change, engine change, or result mismatch blocks the
+download.
 
 ## 3. Frozen `ExcelWorkbookContractV1`
 
@@ -193,7 +207,8 @@ boundaries. It does not merely change the visible status formula.
 3. Implement strict row mapping and reconciliation before workbook I/O.
 4. Bind accepted rows to `design_beam_is456` and its canonical result envelope;
    add parity vectors against Python, CLI, and REST.
-5. Add deterministic passports, stale detection, and review-bundle export.
+5. Add deterministic passports and stale detection, then expose complete
+   review-bundle export through the service, REST route, and installed pane.
 6. Generate the macro-free workbook and golden reopen/recalculate fixtures.
 7. Add the selected-table task pane and explicit installation/capability view.
 8. Complete code, tests, docs, fixtures, packaging, and evidence before the one
@@ -234,8 +249,9 @@ identity.
 
 Required journey: install exact wheel and task pane, open exact workbook, select
 the named table, preview mapping, run frozen vectors, edit one input, observe
-`STALE`, recalculate, export the review bundle, close/reopen, and prove identities
-and statuses persist.
+`STALE`, prove export is disabled, recalculate, export the complete bundle
+twice with identical bytes, close/reopen, pass freshness, export again, and
+prove identities and statuses persist.
 
 macOS, Linux, Open XML, jsdom, and hosted CI checks do not prove installed Excel.
 If the Windows cell is unavailable, record `TO_VERIFY_WINDOWS`; the software

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -41,10 +41,10 @@
     {
       "name": "e1-excel-routine-workbench-v1-plan.md",
       "type": "documentation",
-      "size_lines": 260,
-      "last_updated": "2026-08-18",
+      "size_lines": 276,
+      "last_updated": "2026-08-22",
       "description": "The planned E1 software is implemented on the isolated branch. The frozen Python, REST, Office.js, Open XML, architecture, import, OpenAPI, type, style,",
-      "content_hash": "51cb5752fa2e"
+      "content_hash": "c186cd5106f0"
     },
     {
       "name": "etabs-killer-masterplan.md",
@@ -131,11 +131,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 101,
+      "size_lines": 66,
       "last_updated": "2026-08-22",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-22",
-      "content_hash": "8944521575e2"
+      "content_hash": "777013afbc4d"
     },
     {
       "name": "pre-release-checklist.md",
@@ -174,5 +174,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "9f1b4a0ceb8b1ffa"
+  "content_hash": "60a583b3674cb340"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -12,7 +12,7 @@
 | [compact-modernization-plan.md](compact-modernization-plan.md) |  | Modernize the repository's CI, maintenance controls, and age | 794 |
 | [democratization-vision.md](democratization-vision.md) |  | > **"What was not possible few years back, or only possible  | 273 |
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
-| [e1-excel-routine-workbench-v1-plan.md](e1-excel-routine-workbench-v1-plan.md) |  | The planned E1 software is implemented on the isolated branc | 260 |
+| [e1-excel-routine-workbench-v1-plan.md](e1-excel-routine-workbench-v1-plan.md) |  | The planned E1 software is implemented on the isolated branc | 276 |
 | [etabs-killer-masterplan.md](etabs-killer-masterplan.md) | Project BHEEM: Open-Source Structural De | > **BHEEM** — **B**uilding **H**olistic **E**ngineering **E* | 2855 |
 | [gpt-5-3-codex-spark-work-program.md](gpt-5-3-codex-spark-work-program.md) |  | Use GPT-5.3-Codex-Spark as a high-throughput implementation  | 614 |
 | [india-2-next-session-publication-and-closeout-plan.md](india-2-next-session-publication-and-closeout-plan.md) |  | Combined-footing and strap-footing G0/A-D plus focused famil | 529 |
@@ -23,7 +23,7 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 101 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 66 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Prepared candidate source metadata: 0.23.1a2 Current public  | 111 |
 | [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 742 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,95 +4,60 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-22
-- Focus: freeze the blank-workbook guard repair, then rerun only the final W0 blank-workbook check on Windows
-- Original E1 candidate: `codex/e1-excel-routine-workbench` at `ef5ee05c785904e1a01c2d09cc65649edc8745ab`
-- Ordered predecessor: `codex/e1-w0-maintenance-plan` at `654e40b1370d098fca4d001146a030b9937536a8`
-- Repair lane: `codex/e1-blank-workbook-guard`, stacked on the predecessor
-- Evidence: `docs/verification/e1-blank-workbook-guard-evidence.md`
-- Git handoff receipt: `docs/verification/e1-blank-workbook-guard-repair-git-handoff-receipt.json` (`HOLD`; file SHA-256 `9845a1b1b8f810f66796eddf027c13fcfad87fd084f1272eae9bf93b5f1901aa`)
-- Current verdict: `LOCAL_REPAIR_VALIDATION_PASS / W0_REVALIDATION_PENDING`; G3 has not started
-- Held: product-workbook G3 until W0 passes; all ETABS file/live work, write-back, optimization, nightly work, publication, release, and professional approval
+- Focus: complete one deterministic review-bundle export successor, then rerun the frozen Windows G3 journey once
+- Validated predecessor: `codex/e1-blank-workbook-guard` at `514155b266af6dff3e30bf39ee28671c17345454`, tree `57e563909f84736a0d3b1a161d2e4d02ee4a4fe3`
+- Successor lane: `codex/e1-review-bundle-export`, stacked directly on the validated predecessor
+- Evidence: `docs/verification/e1-review-bundle-export-evidence.md`
+- Git handoff receipt: `docs/verification/e1-review-bundle-export-git-handoff-receipt.json` (`HOLD`; file SHA-256 `b5a8e9624c6d11503bdc197e31a2a11ab851ce42bac4a11847d64f4046d270fe`)
+- Current verdict: `FOCUSED LOCAL PASS / CLOSEOUT PENDING / G3 HELD`
+- Held: Windows G3 until one immutable successor passes local/hosted evidence; all ETABS/VBA, write-back, optimization, nightly work, publication, release, merge, cleanup, and professional approval
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | Windows entitlement, candidate identity, wheel, restricted catalog, trusted HTTPS, loopback API, and add-in discovery pass; the original E1 pane exposed an eager missing-sheet lookup before its API call |
-| **Next** | Commit and independently inspect the local repair, then send its exact immutable head to a fresh Windows task for the single blank-workbook revalidation |
-| **After W0** | Run the frozen product-workbook G3 journey only if the unchanged repair head returns `READY_FOR_G3` |
+| **Current** | Windows W0 is `READY_FOR_G3`; first G3 preflight stopped before workbook creation because the installed pane/API could not export the complete deterministic evidence required by the frozen plan |
+| **Next** | Freeze and verify the single export successor: full Python bundle, fail-closed REST attachment, pane byte/hash verification, source-free wheel, quick gate, hooks, and immutable audit |
+| **After local closeout** | Push one stacked draft PR, run hosted checks, then send the exact head/tree/wheel/pane identities to a fresh Windows task for one impact-mapped blank-workbook check and the full G3 journey |
 | **Held** | ETABS/VBA execution, real model access, analysis control, write-back, optimization, publication, release, and professional approval remain outside this packet |
 
-## Confirmed failure and repair
+## Confirmed G3 blocker and repair
 
-The original pane loaded from Excel's trusted `SHARED FOLDER` catalog but then
-reported `WORKBOOK CONTRACT ERROR — The requested resource doesn't exist`.
-Read-only source tracing proved that `registerInputChange()` eagerly called
-`worksheets.getItem("Beam_Workbench")` in a blank workbook containing only
-`Sheet1`. The next `context.sync()` therefore failed with the documented Office
-`ItemNotFound` message before the definition API request. Missing document
-settings were not the cause.
+The blank-workbook guard and its static-module route pass on Windows at the
+exact predecessor head. The fresh G3 task then proved two separate gaps:
 
-The repair:
+- the installed pane has no export control and the router has no export route;
+- the existing Markdown renderer is a status summary, not the complete
+  mapping/result/passport/issue evidence required by the plan.
 
-- probes the exact sheet and table with `getItemOrNullObject()`;
-- contacts the local definition endpoint but leaves a blank/wrong workbook
-  read-only with `E1 WORKBOOK NOT OPEN`;
-- disables every calculation control until the complete workbook surface,
-  settings initialization, and event registration succeed;
-- preserves genuine settings, permission, and Office sync errors with useful
-  code/debug details;
-- serves every locally imported task-pane module over the trusted HTTPS origin;
-- leaves Python calculations, REST contracts, workbook bytes, manifest, and
-  structural-engineering behavior unchanged.
+The successor accepts the current selected-table snapshot plus retained hashes,
+regenerates the result in Python, requires source/mapping/engine/result identity
+agreement, and returns the complete result as deterministic JSON. The pane
+verifies the exact bytes before initiating one download. Edits or unverified
+reopen state disable export.
 
-The first Windows attempt against head `a52233a2` proved the new helper returned
-HTTP 404 because `serve.mjs` lacked its route. The pane stayed at `INITIALIZING`
-and made no definition request. The consolidated repair adds the route and a
-module-map regression test. Local focused evidence passes 16 Office.js tests,
-JavaScript/manifest parsing,
-and all 217 architecture files with zero violations.
+## Frozen Windows G3 journey after successor closeout
 
-## Frozen Windows W0 revalidation
-
-Use a fresh Windows task and the exact immutable repair head. Reuse all passing
-host, entitlement, share/catalog, certificate, wheel, workbook, and service
-evidence; do not repeat setup.
-
-1. Update only the catalog task-pane files to the exact repair head and verify
-   their Git blob/content identities.
-2. Start FastAPI and the trusted HTTPS pane on loopback only; require HTTP 200
-   for `taskpane.mjs`, `taskpane-core.mjs`, and `taskpane-office.mjs`.
-3. Open one unsaved blank workbook and load `Excel Routine Workbench V1` from
-   `SHARED FOLDER`.
-4. Require the connected library/workbook identity and the precise
-   `E1 WORKBOOK NOT OPEN` hold.
-5. Require Preview, Review, Run, and freshness controls to remain disabled.
-6. Close and discard the unsaved blank workbook; record any save prompt but do
-   not use it as evidence of settings mutation. Require no orphan Excel process
-   and no listeners on ports 3000 or 8000.
-7. Stop with exactly `READY_FOR_G3` or `SETUP_BLOCKED` and one compact receipt.
-
-Do not open the packaged product workbook during W0 and do not start G3 in the
-repair-validation task.
-
-## Frozen G3 journey after `READY_FOR_G3`
-
-1. Open the exact packaged workbook.
-2. Select `tbl_Beam_Workbench_V1` and preview the visible mapping.
-3. Run the frozen PASS, FAIL, HOLD, and blocked vectors.
-4. Reconcile every source row with the ledger and canonical result/passport.
-5. Edit one calculation-bearing input and observe `STALE`.
-6. Recalculate to `CURRENT` and export the deterministic review bundle.
-7. Close and reopen Excel; prove identities, results, and freshness persist.
-8. Capture the receipt and stop. Do not start ETABS in the G3 task.
+1. Reuse the proven entitlement, certificate, restricted catalog, and loopback
+   setup; install only the exact new wheel and pane files.
+2. Run one blank-workbook guard check because `taskpane.mjs` changed.
+3. Open the unchanged packaged workbook and run the frozen PASS, FAIL, HOLD,
+   blocked, and blank-row vectors with full reconciliation.
+4. Export twice from one current snapshot and require identical bytes and
+   complete mapping/results/passports/issues.
+5. Edit one calculation-bearing input; require `STALE` and disabled export.
+6. Recalculate, export twice, close/reopen, pass freshness, and export again;
+   same-snapshot bytes and identities must match.
+7. Capture G3 receipt and stop. Do not start ETABS.
 
 ## Required Reading
 
-1. [Blank-workbook guard evidence](../verification/e1-blank-workbook-guard-evidence.md)
-2. [Windows W0 evidence](../verification/e1-windows-w0-setup-evidence.md)
-3. [E1 evidence](../verification/e1-excel-routine-workbench-v1-evidence.md)
-4. [E1 execution plan](e1-excel-routine-workbench-v1-plan.md)
-5. [Current task board](../TASKS.md)
-6. [Git workflow single source](../git-automation/git-workflow-single-source.md)
+1. [Review-bundle export evidence](../verification/e1-review-bundle-export-evidence.md)
+2. [Blank-workbook guard evidence](../verification/e1-blank-workbook-guard-evidence.md)
+3. [Windows W0 evidence](../verification/e1-windows-w0-setup-evidence.md)
+4. [E1 evidence](../verification/e1-excel-routine-workbench-v1-evidence.md)
+5. [E1 execution plan](e1-excel-routine-workbench-v1-plan.md)
+6. [Current task board](../TASKS.md)
+7. [Git workflow single source](../git-automation/git-workflow-single-source.md)
 
 Historical VBA/API reference files remain preserved at
 `C:\CodexWork\reference\etabs-vba-handoff`. They are not part of this repair.

--- a/docs/verification/e1-blank-workbook-guard-evidence.md
+++ b/docs/verification/e1-blank-workbook-guard-evidence.md
@@ -104,20 +104,18 @@ evidence of document-settings mutation. The workbook was discarded, Excel and
 ETABS closed, services stopped, ports freed, and both Git worktrees remained
 clean.
 
-## Remaining Windows revalidation
+## Windows revalidation result
 
-Against the exact immutable repair head:
+The fresh W2 task revalidated exact final head
+`514155b266af6dff3e30bf39ee28671c17345454` and tree
+`57e563909f84736a0d3b1a161d2e4d02ee4a4fe3` on the supported Windows host.
+All three local modules returned HTTP 200 with exact content, the definition
+API returned 200, and a blank workbook displayed connected identity plus
+`E1 WORKBOOK NOT OPEN` with Preview, Review, Run, and freshness disabled. Excel
+and ETABS closed cleanly and ports 3000/8000 were free. W2 returned
+`READY_FOR_G3`.
 
-1. Reuse the installed entitlement, restricted SMB catalog, certificate, wheel,
-   workbook, and local API identities already proven by W0.
-2. Update only the trusted catalog and served add-in files to the exact repair
-   head; require HTTP 200 for every local module before opening Excel.
-3. Start the two loopback services and load the add-in in one unsaved blank
-   workbook.
-4. Require connected identity plus `E1 WORKBOOK NOT OPEN`, disabled controls,
-   no generic contract error, and a completed definition API request.
-5. Close and discard the unsaved blank workbook; record any prompt without
-   treating it as settings evidence. Stop services and verify clean Git and no
-   orphan processes.
-
-G3 remains held until this narrow W0 revalidation returns `READY_FOR_G3`.
+The subsequent G3 preflight found a separate missing review-bundle export
+surface before opening the product workbook. That gap does not invalidate the
+blank-workbook guard result; it is owned by the separately authorized
+`codex/e1-review-bundle-export` successor.

--- a/docs/verification/e1-excel-routine-workbench-v1-evidence.md
+++ b/docs/verification/e1-excel-routine-workbench-v1-evidence.md
@@ -18,7 +18,7 @@ doc_type: log
 - template: `structural-lib-rectangular-beam-workbench` version `1.0`;
 - canonical function/result: `design_beam_is456` / `canonical-beam-result/v1`;
 - workbook trust: `MACRO_FREE_OFFICE_JS`;
-- installed Windows Excel evidence: `W0_REPAIR_REQUIRED / G3_NOT_RUN`.
+- installed Windows Excel evidence: `READY_FOR_G3 / G3_BLOCKED_EXPORT_SURFACE`.
 
 ETABS file/live access, write-back, optimization, nightly execution, release publication, and professional approval are outside this candidate.
 
@@ -53,7 +53,9 @@ Broad Python and full repository validation are reserved for cumulative M4 close
 4. Four-hash retained evidence avoids storing a potentially large result bundle in Office settings while keeping reopen-time freshness verifiable.
 5. The single workbook artifact is installed package data. Its manifest and definition endpoint fail on byte/hash/size mismatch.
 6. The task pane clears approval on worksheet edits, requires exact preview snapshot plus mapping hash, and writes separate ledger/result/passport tables.
-7. OpenAPI baseline now contains 88 endpoints and 432 schemas after adding the four E1 endpoints.
+7. The original OpenAPI baseline contains 88 endpoints and 432 schemas after
+   adding the first four E1 endpoints. The authorized export successor adds a
+   fifth typed E1 endpoint and records its new baseline separately.
 
 ## Consolidated focused results
 
@@ -87,7 +89,7 @@ Python/REST/OpenAPI/wheel evidence were repeated; all pass.
 | Structural formulas | none |
 | VBA/macros | none |
 | Visual review | PASS on all six rendered sheets, 2026-08-18 |
-| Installed Windows Excel | `W0_REPAIR_REQUIRED / G3_NOT_RUN`; see [Windows W0 evidence](e1-windows-w0-setup-evidence.md) |
+| Installed Windows Excel | `READY_FOR_G3 / G3_BLOCKED_EXPORT_SURFACE`; see [Windows W0 evidence](e1-windows-w0-setup-evidence.md) and [export successor evidence](e1-review-bundle-export-evidence.md) |
 
 ## Focused implementation diagnostics already completed
 
@@ -101,14 +103,21 @@ These diagnostics are recorded separately from the passing consolidated batch.
 
 ## Current verdict
 
-`SOFTWARE CANDIDATE / G3 HELD`.
+`SOFTWARE CANDIDATE / G3 BLOCKED ON EXPORT SURFACE`.
 
 The focused batch, source-free wheel proof, immutable candidate closeout, and
 hosted PR #826 checks pass. Windows W0 subsequently proved the active Microsoft
 365 entitlement, exact clean candidate, isolated installed wheel identity,
 restricted trusted catalog, localhost HTTPS, and loopback service readiness.
 The exact add-in loaded in a blank workbook but exposed a pre-API
-`ItemNotFound` defect in eager `Beam_Workbench` event registration. A stacked
-[blank-workbook guard repair](e1-blank-workbook-guard-evidence.md) now has local
-focused evidence; narrow W0 revalidation remains required before G3. G3 was not
-run.
+`ItemNotFound` defect in eager `Beam_Workbench` event registration. The stacked
+[blank-workbook guard repair](e1-blank-workbook-guard-evidence.md) was then
+repaired for its missing static-module route and returned `READY_FOR_G3` on
+Windows at exact head `514155b2`.
+
+The first G3 preflight stopped before workbook creation because the installed
+pane and REST API had no complete review-bundle export. Source inspection also
+proved that the existing Markdown renderer is a compact status summary, not
+the mapping/result/passport/issue artifact required by the frozen plan. The
+authorized [export successor](e1-review-bundle-export-evidence.md) closes both
+gaps before the single G3 rerun.

--- a/docs/verification/e1-review-bundle-export-evidence.md
+++ b/docs/verification/e1-review-bundle-export-evidence.md
@@ -1,0 +1,125 @@
+---
+task: E1-REVIEW-BUNDLE-EXPORT
+title: E1 Complete Review Bundle Export Evidence
+status: active
+owner: Main Agent
+created: 2026-08-22
+last_updated: 2026-08-22
+doc_type: log
+---
+
+# E1 Complete Review Bundle Export Evidence
+
+## Candidate boundary
+
+- branch: `codex/e1-review-bundle-export`;
+- exact stacked base: `codex/e1-blank-workbook-guard` at
+  `514155b266af6dff3e30bf39ee28671c17345454`, tree
+  `57e563909f84736a0d3b1a161d2e4d02ee4a4fe3`;
+- predecessor PR: draft PR #828;
+- Git handoff receipt:
+  `docs/verification/e1-review-bundle-export-git-handoff-receipt.json`;
+- scope: complete deterministic review-bundle service, REST, and installed-pane
+  export only.
+
+Workbook bytes, Office manifest, beam formulas, canonical calculation results,
+ETABS/VBA, professional approval, release, merge, and cleanup remain unchanged
+or held.
+
+## G3 blocker and confirmed root cause
+
+Windows W0 returned `READY_FOR_G3` on the exact predecessor. The frozen G3
+preflight then stopped before creating or opening a disposable workbook because
+the installed pane exposed only Preview, Review, Run, and Freshness, while the
+REST router exposed only definition, mapping-preview, run, and freshness.
+
+The existing deterministic Markdown renderer is service/CLI-only and contains
+hashes, counts, and a status table. It omits the complete mapping, structured
+results, calculation passports, raw ledger details, and issues required by the
+frozen G3 contract. The root cause was treating renderer determinism as proof
+of a complete pane-accessible export journey.
+
+## Repair contract
+
+1. Add `excel-review-bundle-export-request/v1` containing the exact current
+   selected-table snapshot, four-hash retained evidence, and confirmed mapping
+   hash.
+2. Recompute mapping and freshness, regenerate the canonical result from the
+   current snapshot, and require its result bundle hash to match retained
+   evidence.
+3. Return `excel-review-bundle/v1` containing `CURRENT` freshness plus the full
+   `ExcelWorkbookRunResultV1`. Preserve `NOT_REVIEWED`,
+   `qualified_review_required=true`, and every limitation.
+4. Serialize sorted compact ASCII-safe JSON plus one LF. Expose exact file,
+   logical review-bundle, and result-bundle SHA-256 identities and a
+   deterministic filename.
+5. Enable the pane Export control only after a current run or an explicit
+   `CURRENT` reopen-time freshness check. Any edit, busy state, unavailable
+   workbook, missing evidence, stale result, mapping mismatch, engine mismatch,
+   result mismatch, response mismatch, or byte-hash mismatch blocks download.
+6. Use same-origin POST/fetch, WebCrypto verification, and one temporary Blob
+   download. Do not use the Office File API, which represents the workbook
+   document rather than this separate evidence artifact.
+
+## Frozen verification selection
+
+| Evidence | Exact command |
+|---|---|
+| Python contract/service | `./scripts/python_runtime.sh -m pytest Python/tests/unit/test_excel_workbench_v1.py -q` |
+| REST endpoint/OpenAPI semantics | `./scripts/python_runtime.sh -m pytest fastapi_app/tests/test_excel_workbench.py -q` |
+| Office.js export and predecessor guards | `npm test --prefix excel_addin` |
+| JavaScript/XML parse | `node --check excel_addin/taskpane-core.mjs && node --check excel_addin/taskpane-office.mjs && node --check excel_addin/taskpane.mjs && node --check excel_addin/serve.mjs && xmllint --noout excel_addin/manifest.xml` |
+| Python format/lint/types | Affected-file Black, Ruff, and configured core/service mypy |
+| Architecture/import/OpenAPI | Maintained architecture and import scripts, then the updated OpenAPI snapshot check |
+| Source-free wheel | Build one exact wheel in a temporary directory, then run `scripts/verify_excel_workbench_artifact.py` on it |
+| Documentation | Strict docs and link checks |
+| Repository gate | `./run.sh check --quick` once after content freeze |
+| Closeout | Normal hooks once, immutable commit, then read-only `session end` once |
+
+Only failed or impact-mapped evidence may be repeated after an
+outcome-changing repair. Broad Python/full repository gates remain reserved for
+cumulative M4 closeout.
+
+## Windows acceptance after local closeout
+
+1. Install the exact new wheel and serve the exact new pane files; record
+   head/tree/wheel/file identities.
+2. Run one impact-mapped blank-workbook guard check because `taskpane.mjs`
+   changed; do not repeat W0 entitlement/catalog setup.
+3. Open the unchanged packaged workbook, preview/review mapping, and run the
+   frozen PASS, FAIL, HOLD, blocked, and blank-row vectors.
+4. Export twice from one current snapshot and require identical bytes, logical
+   hashes, complete mapping/results/passports/issues, and the qualified-review
+   boundary.
+5. Edit a calculation-bearing cell and require visible `STALE` plus disabled
+   export. Recalculate and require deterministic new-snapshot exports.
+6. Close/reopen, require explicit `CURRENT` freshness, export again, and match
+   the last same-snapshot bytes. Capture G3 receipt and stop; do not start
+   ETABS.
+
+## Current verdict
+
+`FOCUSED LOCAL PASS / CLOSEOUT PENDING / G3 HELD`.
+
+## Focused results through implementation freeze
+
+| Evidence | Result |
+|---|---|
+| Python/REST/Open XML | PASS — 22 total focused cases; 21 passed in the first batch and the single repaired OpenAPI assertion passed impact-mapped |
+| Office.js | PASS — 21 tests, including export eligibility, request identity, byte/hash rejection, single-download behavior, installed-pane wiring, and all blank-workbook guards |
+| JavaScript/XML | PASS — four modules parse and `manifest.xml` validates |
+| Style/types | PASS — affected Black and Ruff; configured mypy reports no issues in the core/service modules |
+| Architecture/import | PASS — 217 files with zero boundary violations; 685 files and 4,732 imports with zero broken imports |
+| OpenAPI | PASS — 89 endpoints and 434 schemas match the refreshed baseline; the fifth E1 route has typed `ExcelReviewBundleV1` JSON content |
+| Source-free wheel | PASS — wheel SHA-256 `1cda121103d6e07653fdf0b97875cc9835493d7c31fb9c16f3075c7b5ac702b3`; installed library content `87ae4fbe362143186703fd1873a8882b92e0217523638db3f05f0af2ff3d57a5` |
+| Installed bundle probe | PASS — 8,987 bytes; file SHA-256 `73ce28e6730bb403ce1564bf6e917db621d6fbdccd7fe2dbfe377846c90dac06`; logical hash `2f80a1cc7a2b7c7f47a22386b71b33ee2fecfec3e4dca1912dff6f466116a900`; structured result/passport present |
+| Workbook package data | UNCHANGED — SHA-256 `497dd44d8dbe30ca8a6f3154b17d1d3598c517d96ffe0923e3ca44778450ac85`, 15,204 bytes |
+
+The first focused batch found two integration issues. Declaring generic
+`Response` as the route's decorator response class allowed exact runtime bytes
+but suppressed typed OpenAPI response content. The route now retains its
+`ExcelReviewBundleV1` response model for documentation while returning a raw
+`Response` instance at runtime. A new import pair was also out of Ruff order,
+which stopped the chained type check. Only the OpenAPI assertion/baseline and
+affected style/type checks were repeated; Office.js, architecture, imports,
+and unchanged behavior tests were not rerun.

--- a/docs/verification/e1-review-bundle-export-git-handoff-receipt.json
+++ b/docs/verification/e1-review-bundle-export-git-handoff-receipt.json
@@ -1,0 +1,212 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-21T20:05:48Z",
+      "query_status": "OK",
+      "reference": "task:E1-REVIEW-BUNDLE-EXPORT:user-said-proceed-with-E1-export",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_DRAFT_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-21T20:05:48Z",
+    "prohibited_actions": [
+      "AMEND_PREDECESSOR_PR",
+      "MERGE_PULL_REQUEST",
+      "START_G3_BEFORE_EXACT_CANDIDATE_CLOSEOUT",
+      "START_ETABS_FILE_SNAPSHOT",
+      "START_LIVE_ETABS",
+      "RUN_ETABS_ANALYSIS",
+      "START_ETABS_WRITE_BACK",
+      "START_NIGHTLY_OPTIMIZATION",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "DISCARD_USER_CHANGE",
+      "CLOSE_PULL_REQUEST",
+      "PUBLISH_RELEASE",
+      "CLAIM_PROFESSIONAL_APPROVAL"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_DRAFT_PR"
+      ],
+      "branch": "codex/e1-review-bundle-export",
+      "head_sha": "514155b266af6dff3e30bf39ee28671c17345454",
+      "task_id": "E1-REVIEW-BUNDLE-EXPORT"
+    }
+  },
+  "holds": [
+    "E1_PRS_826_TO_828_NOT_INTEGRATED",
+    "EXPORT_SUCCESSOR_NOT_REVIEWED",
+    "G3_NOT_RUN",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "STACKED_BEHIND_E1_PR_SEQUENCE_AND_G3_NOT_RUN",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "5d0b6dfa9b5615dd8c04590cc3d8591577614974742cc92c7b149897a59f9187",
+    "state": {
+      "branch": "codex/e1-review-bundle-export",
+      "default_base": {
+        "ahead": 7,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "c127e4b2325fceb9adebf3d29d59e549f7ae4aa6",
+        "status": "ahead"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 92.024,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-e1-review-bundle-export",
+      "head_sha": "514155b266af6dff3e30bf39ee28671c17345454",
+      "hold_reasons": [
+        "changed paths: 22"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-21T20:06:22.532323+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-review-bundle-export",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 22,
+        "modified_paths": [
+          "Python/structural_lib/core/excel_workbook.py",
+          "Python/structural_lib/services/excel_workbench.py",
+          "Python/tests/unit/test_excel_workbench_v1.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/e1-excel-routine-workbench-v1-plan.md",
+          "docs/planning/next-session-brief.md",
+          "docs/verification/e1-blank-workbook-guard-evidence.md",
+          "docs/verification/e1-excel-routine-workbench-v1-evidence.md",
+          "excel_addin/README.md",
+          "excel_addin/taskpane-core.mjs",
+          "excel_addin/taskpane.css",
+          "excel_addin/taskpane.html",
+          "excel_addin/taskpane.mjs",
+          "excel_addin/tests/serve-static-files.test.mjs",
+          "excel_addin/tests/taskpane-core.test.mjs",
+          "fastapi_app/openapi_baseline.json",
+          "fastapi_app/routers/excel_workbench.py",
+          "fastapi_app/tests/test_excel_workbench.py",
+          "scripts/verify_excel_workbench_artifact.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/e1-review-bundle-export-evidence.md",
+          "docs/verification/e1-review-bundle-export-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-review-bundle-export"
+    }
+  },
+  "local_state_receipt_hash": "sha256:5d0b6dfa9b5615dd8c04590cc3d8591577614974742cc92c7b149897a59f9187",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-21T20:06:22.532480+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [
+      "E1_PRS_826_TO_828_NOT_INTEGRATED",
+      "EXPORT_SUCCESSOR_NOT_REVIEWED",
+      "G3_NOT_RUN"
+    ],
+    "observed_at_utc": "2026-08-21T20:05:48Z",
+    "owner": "Main Agent under the user-authorized E1 export successor",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/services/beam_api.py",
+      "Python/structural_lib/codes/is456",
+      "Python/structural_lib/data/excel/outputs/e1-excel-routine-workbench/structural-lib-rectangular-beam-workbench-v1.xlsx",
+      "excel_addin/manifest.xml",
+      "Etabs_CSV"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "Python/structural_lib/core/excel_workbook.py",
+      "Python/structural_lib/services/excel_workbench.py",
+      "Python/tests/unit/test_excel_workbench_v1.py",
+      "fastapi_app/routers/excel_workbench.py",
+      "fastapi_app/tests/test_excel_workbench.py",
+      "excel_addin/README.md",
+      "excel_addin/taskpane-core.mjs",
+      "excel_addin/taskpane.css",
+      "excel_addin/taskpane.html",
+      "excel_addin/taskpane.mjs",
+      "excel_addin/tests/serve-static-files.test.mjs",
+      "excel_addin/tests/taskpane-core.test.mjs",
+      "scripts/verify_excel_workbench_artifact.py",
+      "docs/verification/e1-review-bundle-export-evidence.md",
+      "docs/verification/e1-review-bundle-export-git-handoff-source-evidence.json",
+      "docs/verification/e1-review-bundle-export-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "fastapi_app/openapi_baseline.json",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/e1-excel-routine-workbench-v1-plan.md",
+      "docs/planning/next-session-brief.md",
+      "docs/verification/e1-blank-workbook-guard-evidence.md",
+      "docs/verification/e1-excel-routine-workbench-v1-evidence.md",
+      "docs/index.json",
+      "docs/index.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md"
+    ],
+    "task_id": "E1-REVIEW-BUNDLE-EXPORT"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/e1-review-bundle-export-git-handoff-source-evidence.json
+++ b/docs/verification/e1-review-bundle-export-git-handoff-source-evidence.json
@@ -1,0 +1,67 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-21T20:05:48Z",
+      "query_status": "OK",
+      "reference": "task:E1-REVIEW-BUNDLE-EXPORT:user-said-proceed-with-E1-export",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_DRAFT_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-21T20:05:48Z",
+    "prohibited_actions": [
+      "AMEND_PREDECESSOR_PR",
+      "MERGE_PULL_REQUEST",
+      "START_G3_BEFORE_EXACT_CANDIDATE_CLOSEOUT",
+      "START_ETABS_FILE_SNAPSHOT",
+      "START_LIVE_ETABS",
+      "RUN_ETABS_ANALYSIS",
+      "START_ETABS_WRITE_BACK",
+      "START_NIGHTLY_OPTIMIZATION",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF",
+      "DISCARD_USER_CHANGE",
+      "CLOSE_PULL_REQUEST",
+      "PUBLISH_RELEASE",
+      "CLAIM_PROFESSIONAL_APPROVAL"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_DRAFT_PR"
+      ],
+      "branch": "codex/e1-review-bundle-export",
+      "head_sha": "514155b266af6dff3e30bf39ee28671c17345454",
+      "task_id": "E1-REVIEW-BUNDLE-EXPORT"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "STACKED_BEHIND_E1_PR_SEQUENCE_AND_G3_NOT_RUN",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [
+      "E1_PRS_826_TO_828_NOT_INTEGRATED",
+      "EXPORT_SUCCESSOR_NOT_REVIEWED",
+      "G3_NOT_RUN"
+    ],
+    "observed_at_utc": "2026-08-21T20:05:48Z",
+    "owner": "Main Agent under the user-authorized E1 export successor",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-22",
-  "file_count": 194,
+  "file_count": 197,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -175,10 +175,10 @@
     {
       "name": "e1-blank-workbook-guard-evidence.md",
       "type": "documentation",
-      "size_lines": 124,
+      "size_lines": 122,
       "last_updated": "2026-08-22",
       "description": "- repair branch: codex/e1-blank-workbook-guard; - stacked base: codex/e1-w0-maintenance-plan at",
-      "content_hash": "236effa4592d"
+      "content_hash": "11c0568d099c"
     },
     {
       "name": "e1-blank-workbook-guard-git-handoff-receipt.json",
@@ -273,10 +273,48 @@
     {
       "name": "e1-excel-routine-workbench-v1-evidence.md",
       "type": "documentation",
-      "size_lines": 115,
+      "size_lines": 124,
       "last_updated": "2026-08-22",
       "description": "- branch: codex/e1-excel-routine-workbench; - merged base: c127e4b2325fceb9adebf3d29d59e549f7ae4aa6;",
-      "content_hash": "9d67c0330ff5"
+      "content_hash": "518566f75056"
+    },
+    {
+      "name": "e1-review-bundle-export-evidence.md",
+      "type": "documentation",
+      "size_lines": 126,
+      "last_updated": "2026-08-22",
+      "description": "- branch: codex/e1-review-bundle-export; - exact stacked base: codex/e1-blank-workbook-guard at",
+      "content_hash": "dc183c1f743d"
+    },
+    {
+      "name": "e1-review-bundle-export-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "b5a8e9624c6d"
+    },
+    {
+      "name": "e1-review-bundle-export-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "b511d3739207"
     },
     {
       "name": "e1-w0-maintenance-git-handoff-receipt.json",
@@ -2479,5 +2517,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "8bded3424c0c77f5"
+  "content_hash": "681e884a260ca9ff"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-22
-**Files:** 194
+**Files:** 197
 
 ## Config Files
 
@@ -20,6 +20,8 @@ Benchmark examples and verification packs for validating library calculations ag
 - [e1-blank-workbook-guard-repair-git-handoff-source-evidence.json](e1-blank-workbook-guard-repair-git-handoff-source-evidence.json)
 - [e1-excel-routine-workbench-git-handoff-receipt.json](e1-excel-routine-workbench-git-handoff-receipt.json)
 - [e1-excel-routine-workbench-git-handoff-source-evidence.json](e1-excel-routine-workbench-git-handoff-source-evidence.json)
+- [e1-review-bundle-export-git-handoff-receipt.json](e1-review-bundle-export-git-handoff-receipt.json)
+- [e1-review-bundle-export-git-handoff-source-evidence.json](e1-review-bundle-export-git-handoff-source-evidence.json)
 - [e1-w0-maintenance-git-handoff-receipt.json](e1-w0-maintenance-git-handoff-receipt.json)
 - [e1-w0-maintenance-git-handoff-source-evidence.json](e1-w0-maintenance-git-handoff-source-evidence.json)
 - [exact-candidate-review-receipt-template.json](exact-candidate-review-receipt-template.json)
@@ -147,8 +149,9 @@ Benchmark examples and verification packs for validating library calculations ag
 | [b2-gravity-workflow-v1-evidence.md](b2-gravity-workflow-v1-evidence.md) |  | This record covers the bounded B2 orchestration candidate bu | 113 |
 | [bundled-sample-boq-evidence.md](bundled-sample-boq-evidence.md) |  | This is the reproducible software record for the bundled ETA | 58 |
 | [column-pmm-benchmark.md](column-pmm-benchmark.md) |  | This record independently checks the experimental rectangula | 107 |
-| [e1-blank-workbook-guard-evidence.md](e1-blank-workbook-guard-evidence.md) |  | - repair branch: codex/e1-blank-workbook-guard; - stacked ba | 124 |
-| [e1-excel-routine-workbench-v1-evidence.md](e1-excel-routine-workbench-v1-evidence.md) |  | - branch: codex/e1-excel-routine-workbench; - merged base: c | 115 |
+| [e1-blank-workbook-guard-evidence.md](e1-blank-workbook-guard-evidence.md) |  | - repair branch: codex/e1-blank-workbook-guard; - stacked ba | 122 |
+| [e1-excel-routine-workbench-v1-evidence.md](e1-excel-routine-workbench-v1-evidence.md) |  | - branch: codex/e1-excel-routine-workbench; - merged base: c | 124 |
+| [e1-review-bundle-export-evidence.md](e1-review-bundle-export-evidence.md) |  | - branch: codex/e1-review-bundle-export; - exact stacked bas | 126 |
 | [e1-windows-w0-setup-evidence.md](e1-windows-w0-setup-evidence.md) |  | SETUP_BLOCKED — the Windows host/catalog setup now passes, b | 143 |
 | [examples.md](examples.md) |  | This document provides benchmark examples that engineers can | 1550 |
 | [external-cli-test.md](external-cli-test.md) |  | Purpose: capture a repeatable, human-run CLI test from a fre | 98 |

--- a/excel_addin/README.md
+++ b/excel_addin/README.md
@@ -1,6 +1,6 @@
 # Excel Routine Workbench V1 task pane
 
-This macro-free Office.js task pane reads only `Beam_Workbench / tbl_Beam_Workbench_V1`, previews the strict mapping, and sends a confirmed snapshot through the local FastAPI Excel Workbench V1 endpoints. It writes the returned row ledger, canonical result projections, and calculation passports to their named workbook tables.
+This macro-free Office.js task pane reads only `Beam_Workbench / tbl_Beam_Workbench_V1`, previews the strict mapping, and sends a confirmed snapshot through the local FastAPI Excel Workbench V1 endpoints. It writes the returned row ledger, canonical result projections, and calculation passports to their named workbook tables. After a current run or an explicit `CURRENT` freshness check, it can download a complete deterministic JSON review bundle whose bytes and result identities are verified before save.
 
 ## Local development transport
 
@@ -20,6 +20,8 @@ The HTTPS server exposes `https://localhost:3000/taskpane.html` and proxies same
 - If the exact E1 worksheet/table is not open, the pane may prove the local API identity but remains read-only: it does not create document settings, register events, or enable calculation controls.
 - A Run is rejected unless the current selected-table snapshot equals the previewed snapshot and the 64-character mapping hash is confirmed.
 - The Office document settings retain the workbook instance ID, four-hash freshness evidence, and stale flag across task-pane sessions; complete ledgers, results, and passports remain in their workbook tables.
+- Export sends the current source snapshot and retained identities back to Python. The service regenerates the canonical result, requires exact source/mapping/library/result agreement, and returns complete JSON evidence; Excel never packages a client-supplied old result.
+- Any edit disables export immediately. A reopened workbook must pass an explicit freshness check before export is re-enabled.
 - Excel does not execute structural-design formulas. VBA/macros, torsion, serviceability, ETABS access, write-back, release claims, and professional approval are outside E1.
 
 Installed Windows Excel evidence is a separate gate and remains `TO_VERIFY_WINDOWS` until executed on the supported environment.

--- a/excel_addin/taskpane-core.mjs
+++ b/excel_addin/taskpane-core.mjs
@@ -4,6 +4,7 @@ const TEMPLATE = Object.freeze({
   worksheet_name: "Beam_Workbench",
   table_name: "tbl_Beam_Workbench_V1",
 });
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 
 export const SETTINGS_KEYS = Object.freeze({
   workbookId: "excel_workbench_v1.workbook_instance_id",
@@ -59,7 +60,7 @@ export function buildPreviewRequest({
 }
 
 export function buildRunRequest(previewRequest, confirmedMappingHash) {
-  if (!/^[0-9a-f]{64}$/.test(String(confirmedMappingHash ?? ""))) {
+  if (!SHA256_PATTERN.test(String(confirmedMappingHash ?? ""))) {
     throw new Error("A reviewed 64-character mapping hash is required.");
   }
   return {
@@ -69,9 +70,56 @@ export function buildRunRequest(previewRequest, confirmedMappingHash) {
   };
 }
 
+export function buildReviewBundleExportRequest(
+  currentRequest,
+  previousEvidence,
+  confirmedMappingHash,
+) {
+  if (!currentRequest || currentRequest.schema_version !== "excel-workbook-preview-request/v1") {
+    throw new Error("A current selected-table snapshot is required for export.");
+  }
+  if (
+    !previousEvidence ||
+    previousEvidence.schema_version !== "excel-retained-evidence/v1" ||
+    ![
+      previousEvidence.bundle_hash,
+      previousEvidence.source_table_hash,
+      previousEvidence.mapping_hash,
+      previousEvidence.library_content_identity,
+    ].every((value) => SHA256_PATTERN.test(String(value ?? "")))
+  ) {
+    throw new Error("Complete retained result evidence is required for export.");
+  }
+  if (!SHA256_PATTERN.test(String(confirmedMappingHash ?? ""))) {
+    throw new Error("A confirmed current mapping hash is required for export.");
+  }
+  return {
+    schema_version: "excel-review-bundle-export-request/v1",
+    current_request: currentRequest,
+    previous_evidence: previousEvidence,
+    confirmed_mapping_hash: confirmedMappingHash,
+  };
+}
+
 export function sameSourceSnapshot(left, right) {
   if (!left || !right) return false;
   return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function reviewBundleExportEligible({
+  workbookSurfaceAvailable,
+  busy,
+  previousEvidence,
+  stale,
+  freshnessVerified,
+}) {
+  return Boolean(
+    workbookSurfaceAvailable &&
+      !busy &&
+      previousEvidence &&
+      !stale &&
+      freshnessVerified,
+  );
 }
 
 export function unwrapApiResponse(body) {
@@ -129,6 +177,130 @@ export async function getWorkbenchApi(
     throw new Error(body?.error?.message || `The local API returned HTTP ${response.status}.`);
   }
   return unwrapApiResponse(body);
+}
+
+function responseHeader(response, name) {
+  return response.headers?.get?.(name) ?? null;
+}
+
+export function reviewBundleFilename(contentDisposition, resultBundleHash) {
+  if (!SHA256_PATTERN.test(String(resultBundleHash ?? ""))) {
+    throw new Error("The review-bundle response has an invalid result identity.");
+  }
+  const expected = `e1-review-bundle-${resultBundleHash}.json`;
+  const match = /^attachment;\s*filename="([A-Za-z0-9._-]+)"$/i.exec(
+    String(contentDisposition ?? ""),
+  );
+  if (!match || match[1] !== expected) {
+    throw new Error("The review-bundle response has an invalid attachment filename.");
+  }
+  return expected;
+}
+
+export async function sha256Hex(bytes, { cryptoImpl = globalThis.crypto } = {}) {
+  if (!cryptoImpl?.subtle) throw new Error("WebCrypto SHA-256 is unavailable.");
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const digest = await cryptoImpl.subtle.digest("SHA-256", view);
+  return Array.from(new Uint8Array(digest), (value) =>
+    value.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+export async function postReviewBundleApi(
+  baseUrl,
+  path,
+  payload,
+  { token = "", fetchImpl = globalThis.fetch, cryptoImpl = globalThis.crypto } = {},
+) {
+  const root = String(baseUrl || "").replace(/\/$/, "");
+  if (!root) throw new Error("The local API base URL is required.");
+  const headers = { "Content-Type": "application/json", Accept: "application/json" };
+  if (token.trim()) headers.Authorization = `Bearer ${token.trim()}`;
+  const response = await fetchImpl(`${root}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    let body;
+    try {
+      body = await response.json();
+    } catch {
+      throw new Error(`The local API returned non-JSON HTTP ${response.status}.`);
+    }
+    throw new Error(body?.error?.message || `The local API returned HTTP ${response.status}.`);
+  }
+
+  if (!String(responseHeader(response, "Content-Type") ?? "").includes("application/json")) {
+    throw new Error("The review-bundle response is not JSON.");
+  }
+  const fileHash = responseHeader(response, "X-E1-File-SHA256");
+  const reviewBundleHash = responseHeader(response, "X-E1-Review-Bundle-Hash");
+  const resultBundleHash = responseHeader(response, "X-E1-Result-Bundle-Hash");
+  if (![fileHash, reviewBundleHash, resultBundleHash].every((value) => SHA256_PATTERN.test(String(value ?? "")))) {
+    throw new Error("The review-bundle response is missing a valid identity header.");
+  }
+  if (resultBundleHash !== payload.previous_evidence?.bundle_hash) {
+    throw new Error("The exported result identity does not match retained evidence.");
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const actualFileHash = await sha256Hex(bytes, { cryptoImpl });
+  if (actualFileHash !== fileHash) {
+    throw new Error("The downloaded review-bundle bytes failed SHA-256 verification.");
+  }
+  let bundle;
+  try {
+    bundle = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new Error("The downloaded review bundle is not valid JSON.");
+  }
+  if (
+    bundle?.schema_version !== "excel-review-bundle/v1" ||
+    bundle?.export_disposition !== "EVIDENCE_FOR_QUALIFIED_REVIEW" ||
+    bundle?.freshness_check?.freshness_status !== "CURRENT" ||
+    bundle?.result?.qualified_review_required !== true ||
+    bundle?.review_bundle_hash !== reviewBundleHash ||
+    bundle?.result?.bundle_hash !== resultBundleHash
+  ) {
+    throw new Error("The downloaded review-bundle content failed identity validation.");
+  }
+  return {
+    bytes,
+    fileHash,
+    reviewBundleHash,
+    resultBundleHash,
+    filename: reviewBundleFilename(
+      responseHeader(response, "Content-Disposition"),
+      resultBundleHash,
+    ),
+  };
+}
+
+export function downloadReviewBundle(
+  download,
+  {
+    documentImpl = globalThis.document,
+    urlImpl = globalThis.URL,
+    BlobImpl = globalThis.Blob,
+  } = {},
+) {
+  if (!download?.bytes || !download?.filename) {
+    throw new Error("Verified review-bundle bytes are required for download.");
+  }
+  const blob = new BlobImpl([download.bytes], { type: "application/json" });
+  const href = urlImpl.createObjectURL(blob);
+  const anchor = documentImpl.createElement("a");
+  anchor.href = href;
+  anchor.download = download.filename;
+  anchor.hidden = true;
+  documentImpl.body.append(anchor);
+  try {
+    anchor.click();
+  } finally {
+    anchor.remove();
+    urlImpl.revokeObjectURL(href);
+  }
 }
 
 export function projectMappingRows(preview) {

--- a/excel_addin/taskpane.css
+++ b/excel_addin/taskpane.css
@@ -26,6 +26,7 @@ main { display: grid; gap: 12px; padding: 14px; }
 button { width: 100%; margin-top: 10px; padding: 10px 12px; border: 0; border-radius: 5px; color: white; background: #087e8b; font-weight: 700; cursor: pointer; }
 button.secondary { color: #16324f; border: 1px solid #9fb0bc; background: white; }
 button:disabled { cursor: not-allowed; opacity: .45; }
+button:focus-visible, input:focus-visible, summary:focus-visible { outline: 3px solid #f0a202; outline-offset: 2px; }
 .check { display: flex; gap: 8px; align-items: flex-start; margin-top: 10px; }
 .check input { margin-top: 2px; }
 code { font-size: 11px; }

--- a/excel_addin/taskpane.html
+++ b/excel_addin/taskpane.html
@@ -17,7 +17,7 @@
     </header>
 
     <main>
-      <section id="status" class="status hold" aria-live="polite">
+      <section id="status" class="status hold" aria-live="polite" aria-atomic="true" aria-busy="true" tabindex="-1">
         <strong id="status-title">INITIALIZING</strong>
         <span id="status-detail">Checking the workbook contract.</span>
       </section>
@@ -38,6 +38,13 @@
         </label>
         <button id="run" type="button" disabled>Run canonical design</button>
         <button id="freshness" class="secondary" type="button" disabled>Check retained-result freshness</button>
+      </section>
+
+      <section class="card">
+        <h2>3. Export review evidence</h2>
+        <p>Regenerates the current result through the local library and verifies its hashes before saving complete JSON evidence.</p>
+        <button id="export" type="button" aria-describedby="export-detail" disabled>Export current review bundle</button>
+        <p id="export-detail" class="detail" aria-live="polite" aria-atomic="true">Export becomes available after a current reviewed run.</p>
       </section>
 
       <details class="card">

--- a/excel_addin/taskpane.mjs
+++ b/excel_addin/taskpane.mjs
@@ -1,14 +1,18 @@
 import {
   SETTINGS_KEYS,
   buildPreviewRequest,
+  buildReviewBundleExportRequest,
   buildRunRequest,
+  downloadReviewBundle,
   getWorkbenchApi,
   postWorkbenchApi,
+  postReviewBundleApi,
   projectLedgerRows,
   projectMappingRows,
   projectPassportRows,
   projectResultRows,
   reconciliationSummary,
+  reviewBundleExportEligible,
   retainEvidence,
   sameSourceSnapshot,
 } from "./taskpane-core.mjs";
@@ -31,6 +35,9 @@ const state = {
   previousEvidence: null,
   definition: null,
   stale: true,
+  freshnessVerified: false,
+  confirmedMappingHash: null,
+  inputRevision: 0,
   eventRegistered: false,
   workbookSurfaceAvailable: false,
 };
@@ -49,6 +56,14 @@ function setBusy(busy) {
   ui.freshness.disabled = busy || unavailable || !state.previousEvidence;
   ui.review.disabled = busy || unavailable || !state.mapping || state.mapping.is_blocked;
   ui.run.disabled = busy || unavailable || !ui.review.checked || state.stale;
+  ui.export.disabled = !reviewBundleExportEligible({
+    workbookSurfaceAvailable: !unavailable,
+    busy,
+    previousEvidence: state.previousEvidence,
+    stale: state.stale,
+    freshnessVerified: state.freshnessVerified,
+  });
+  ui.status.setAttribute("aria-busy", busy ? "true" : "false");
 }
 
 async function persistEvidence(evidence, stale) {
@@ -150,11 +165,15 @@ async function writeRunResult(result) {
 
 let staleTimer;
 function markStale() {
+  state.inputRevision += 1;
   state.stale = true;
+  state.freshnessVerified = false;
+  state.confirmedMappingHash = null;
   state.previewRequest = null;
   state.mapping = null;
   ui.review.checked = false;
   ui.mapping.textContent = "Mapping review required after the latest input edit.";
+  ui.exportDetail.textContent = "Export is disabled until the edited table is recalculated.";
   setStatus("hold", "STALE", "Preview and review the mapping before running again.");
   setBusy(false);
   clearTimeout(staleTimer);
@@ -187,7 +206,10 @@ async function previewMapping() {
     state.previewRequest = request;
     state.mapping = preview;
     state.stale = true;
+    state.freshnessVerified = false;
+    state.confirmedMappingHash = null;
     ui.review.checked = false;
+    ui.exportDetail.textContent = "Run a reviewed current mapping before export.";
     ui.mapping.textContent = preview.is_blocked
       ? `${preview.issues.length} mapping issue(s); Run remains blocked.`
       : `${preview.mapped_fields.length} fields mapped. Hash ${preview.mapping_hash}`;
@@ -238,7 +260,10 @@ async function runCalculation() {
     await writeRunResult(result);
     state.previousEvidence = retainEvidence(result);
     state.stale = false;
+    state.freshnessVerified = true;
+    state.confirmedMappingHash = result.mapping.mapping_hash;
     await persistEvidence(state.previousEvidence, false);
+    ui.exportDetail.textContent = "The current result is eligible for deterministic evidence export.";
     setStatus("ready", "RESULT CURRENT", `${summary}. Qualified review remains required.`);
   } catch (error) {
     setStatus("blocked", "RUN FAILED", error.message);
@@ -259,18 +284,68 @@ async function checkFreshness() {
       { token: ui.token.value },
     );
     state.stale = check.freshness_status === "STALE";
+    state.freshnessVerified = !state.stale;
+    state.confirmedMappingHash = state.stale ? null : check.current_mapping_hash;
     if (state.stale) {
       state.previewRequest = null;
       state.mapping = null;
       ui.review.checked = false;
     }
+    ui.exportDetail.textContent = state.stale
+      ? "Export is blocked because retained evidence is stale."
+      : "Retained evidence is current and eligible for export.";
     setStatus(
       state.stale ? "hold" : "ready",
       check.freshness_status,
       state.stale ? check.reasons.join(", ") : "Source, mapping, and library identity match.",
     );
   } catch (error) {
+    state.freshnessVerified = false;
+    state.confirmedMappingHash = null;
+    ui.exportDetail.textContent = "Freshness could not be verified; export remains disabled.";
     setStatus("blocked", "FRESHNESS CHECK FAILED", error.message);
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function exportReviewBundle() {
+  setBusy(true);
+  setStatus(
+    "working",
+    "EXPORTING",
+    "Regenerating and verifying the current review evidence.",
+  );
+  const revision = state.inputRevision;
+  try {
+    const current = await captureInput();
+    const request = buildReviewBundleExportRequest(
+      current,
+      state.previousEvidence,
+      state.confirmedMappingHash,
+    );
+    const download = await postReviewBundleApi(
+      API_ROOT,
+      "/excel-workbench/v1/review-bundle",
+      request,
+      { token: ui.token.value },
+    );
+    if (state.inputRevision !== revision || state.stale) {
+      throw new Error("The selected table changed during export; no file was saved.");
+    }
+    downloadReviewBundle(download);
+    ui.exportDetail.textContent = `${download.filename} · SHA-256 ${download.fileHash}`;
+    setStatus(
+      "ready",
+      "REVIEW BUNDLE SAVED",
+      "The complete current JSON evidence was verified before download. Qualified review remains required.",
+    );
+  } catch (error) {
+    state.freshnessVerified = false;
+    state.confirmedMappingHash = null;
+    ui.exportDetail.textContent = "Check freshness or recalculate before trying export again.";
+    setStatus("blocked", "EXPORT BLOCKED", error.message);
+    ui.status.focus();
   } finally {
     setBusy(false);
   }
@@ -284,6 +359,8 @@ async function initialize() {
   ui.review = document.getElementById("review");
   ui.run = document.getElementById("run");
   ui.freshness = document.getElementById("freshness");
+  ui.export = document.getElementById("export");
+  ui.exportDetail = document.getElementById("export-detail");
   ui.mapping = document.getElementById("mapping");
   ui.context = document.getElementById("context");
   ui.token = document.getElementById("token");
@@ -291,6 +368,7 @@ async function initialize() {
   ui.review.addEventListener("change", mappingReviewChanged);
   ui.run.addEventListener("click", runCalculation);
   ui.freshness.addEventListener("click", checkFreshness);
+  ui.export.addEventListener("click", exportReviewBundle);
   setBusy(true);
 
   let surface;
@@ -331,6 +409,8 @@ async function initialize() {
     );
     state.stale =
       Office.context.document.settings.get(SETTINGS_KEYS.stale) !== false;
+    state.freshnessVerified = false;
+    state.confirmedMappingHash = null;
     await registerInputChange();
     state.workbookSurfaceAvailable = true;
     setStatus(
@@ -340,6 +420,9 @@ async function initialize() {
         ? "Use Check freshness before relying on retained evidence."
         : "Start by previewing the exact selected-table mapping.",
     );
+    ui.exportDetail.textContent = state.previousEvidence && !state.stale
+      ? "Check retained-result freshness before export."
+      : "Export becomes available after a current reviewed run.";
   } catch (error) {
     setStatus("blocked", "WORKBOOK INITIALIZATION FAILED", officeErrorDetail(error));
   }

--- a/excel_addin/tests/serve-static-files.test.mjs
+++ b/excel_addin/tests/serve-static-files.test.mjs
@@ -10,6 +10,10 @@ const serverSource = fs.readFileSync(
   new URL("../serve.mjs", import.meta.url),
   "utf8",
 );
+const taskpaneHtml = fs.readFileSync(
+  new URL("../taskpane.html", import.meta.url),
+  "utf8",
+);
 
 test("HTTPS server exposes every local task-pane module dependency", () => {
   const modulePaths = Array.from(
@@ -27,4 +31,12 @@ test("HTTPS server exposes every local task-pane module dependency", () => {
       `${modulePath} must be served over the trusted HTTPS origin`,
     );
   }
+});
+
+test("installed pane exposes and wires fail-closed review-bundle export", () => {
+  assert.match(taskpaneHtml, /id="export"[^>]*aria-describedby="export-detail"[^>]*disabled/);
+  assert.match(taskpaneHtml, /id="export-detail"[^>]*aria-live="polite"/);
+  assert.match(taskpaneSource, /\/excel-workbench\/v1\/review-bundle/);
+  assert.match(taskpaneSource, /ui\.export\.addEventListener\("click", exportReviewBundle\)/);
+  assert.match(taskpaneSource, /state\.freshnessVerified = false/);
 });

--- a/excel_addin/tests/taskpane-core.test.mjs
+++ b/excel_addin/tests/taskpane-core.test.mjs
@@ -1,19 +1,29 @@
 import assert from "node:assert/strict";
+import { createHash, webcrypto } from "node:crypto";
 import test from "node:test";
 
 import {
   buildPreviewRequest,
+  buildReviewBundleExportRequest,
   buildRunRequest,
+  downloadReviewBundle,
   getWorkbenchApi,
   normalizeCalculationMode,
   postWorkbenchApi,
+  postReviewBundleApi,
   projectLedgerRows,
   projectPassportRows,
   projectResultRows,
   reconciliationSummary,
+  reviewBundleExportEligible,
   retainEvidence,
   sameSourceSnapshot,
 } from "../taskpane-core.mjs";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+const HASH_C = "c".repeat(64);
+const HASH_D = "d".repeat(64);
 
 const snapshot = {
   workbookInstanceId: "EXCEL-WORKBOOK-1",
@@ -49,6 +59,49 @@ test("run request requires a reviewed mapping hash", () => {
   const run = buildRunRequest(preview, "a".repeat(64));
   assert.equal(run.confirmed_mapping_hash, "a".repeat(64));
   assert.equal(run.schema_version, "excel-workbook-run-request/v1");
+});
+
+test("review-bundle request requires complete retained and mapping identities", () => {
+  const current = buildPreviewRequest(snapshot);
+  const evidence = {
+    schema_version: "excel-retained-evidence/v1",
+    bundle_hash: HASH_A,
+    source_table_hash: HASH_B,
+    mapping_hash: HASH_C,
+    library_content_identity: HASH_D,
+  };
+  assert.throws(
+    () => buildReviewBundleExportRequest(current, null, HASH_C),
+    /retained result evidence/,
+  );
+  assert.throws(
+    () => buildReviewBundleExportRequest(current, evidence, "bad"),
+    /mapping hash/,
+  );
+  assert.deepEqual(buildReviewBundleExportRequest(current, evidence, HASH_C), {
+    schema_version: "excel-review-bundle-export-request/v1",
+    current_request: current,
+    previous_evidence: evidence,
+    confirmed_mapping_hash: HASH_C,
+  });
+});
+
+test("review-bundle eligibility is fail-closed for busy, stale, and reopened state", () => {
+  const ready = {
+    workbookSurfaceAvailable: true,
+    busy: false,
+    previousEvidence: { bundle_hash: HASH_A },
+    stale: false,
+    freshnessVerified: true,
+  };
+  assert.equal(reviewBundleExportEligible(ready), true);
+  assert.equal(reviewBundleExportEligible({ ...ready, busy: true }), false);
+  assert.equal(reviewBundleExportEligible({ ...ready, stale: true }), false);
+  assert.equal(reviewBundleExportEligible({ ...ready, previousEvidence: null }), false);
+  assert.equal(
+    reviewBundleExportEligible({ ...ready, freshnessVerified: false }),
+    false,
+  );
 });
 
 test("source snapshot detects any row or selection change", () => {
@@ -130,4 +183,95 @@ test("non-reconciling API output is rejected", () => {
     () => reconciliationSummary({ counts: { source_rows: 2, accepted_rows: 1, blocked_rows: 0, excluded_rows: 0 } }),
     /non-reconciling/,
   );
+});
+
+function headerBag(values) {
+  const normalized = new Map(
+    Object.entries(values).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  return { get: (name) => normalized.get(name.toLowerCase()) ?? null };
+}
+
+function reviewBundleResponse({ fileHashOverride } = {}) {
+  const bundle = {
+    schema_version: "excel-review-bundle/v1",
+    export_disposition: "EVIDENCE_FOR_QUALIFIED_REVIEW",
+    freshness_check: { freshness_status: "CURRENT" },
+    result: { qualified_review_required: true, bundle_hash: HASH_A },
+    review_bundle_hash: HASH_B,
+  };
+  const bytes = new TextEncoder().encode(`${JSON.stringify(bundle)}\n`);
+  const fileHash = createHash("sha256").update(bytes).digest("hex");
+  return {
+    ok: true,
+    status: 200,
+    headers: headerBag({
+      "Content-Type": "application/json",
+      "Content-Disposition": `attachment; filename="e1-review-bundle-${HASH_A}.json"`,
+      "X-E1-File-SHA256": fileHashOverride ?? fileHash,
+      "X-E1-Review-Bundle-Hash": HASH_B,
+      "X-E1-Result-Bundle-Hash": HASH_A,
+    }),
+    arrayBuffer: async () => bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ),
+  };
+}
+
+test("review-bundle download verifies exact bytes and logical identities", async () => {
+  const payload = { previous_evidence: { bundle_hash: HASH_A } };
+  const download = await postReviewBundleApi(
+    "/api/v1",
+    "/review-bundle",
+    payload,
+    { fetchImpl: async () => reviewBundleResponse(), cryptoImpl: webcrypto },
+  );
+
+  assert.equal(download.resultBundleHash, HASH_A);
+  assert.equal(download.reviewBundleHash, HASH_B);
+  assert.equal(download.filename, `e1-review-bundle-${HASH_A}.json`);
+  assert.equal(download.fileHash.length, 64);
+  await assert.rejects(
+    postReviewBundleApi("/api/v1", "/review-bundle", payload, {
+      fetchImpl: async () => reviewBundleResponse({ fileHashOverride: HASH_D }),
+      cryptoImpl: webcrypto,
+    }),
+    /failed SHA-256/,
+  );
+});
+
+test("verified review bundle triggers exactly one temporary download", () => {
+  let clicks = 0;
+  let removals = 0;
+  let appends = 0;
+  let revocations = 0;
+  const anchor = {
+    click() { clicks += 1; },
+    remove() { removals += 1; },
+  };
+  const documentImpl = {
+    createElement: () => anchor,
+    body: { append: () => { appends += 1; } },
+  };
+  const urlImpl = {
+    createObjectURL: () => "blob:e1",
+    revokeObjectURL: () => { revocations += 1; },
+  };
+  class FakeBlob {
+    constructor(parts, options) {
+      this.parts = parts;
+      this.options = options;
+    }
+  }
+
+  downloadReviewBundle(
+    { bytes: new Uint8Array([1, 2, 3]), filename: `e1-review-bundle-${HASH_A}.json` },
+    { documentImpl, urlImpl, BlobImpl: FakeBlob },
+  );
+
+  assert.equal(appends, 1);
+  assert.equal(clicks, 1);
+  assert.equal(removals, 1);
+  assert.equal(revocations, 1);
 });

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -14416,6 +14416,70 @@
         "title": "ExcelRetainedEvidenceV1",
         "type": "object"
       },
+      "ExcelReviewBundleExportRequestV1": {
+        "additionalProperties": false,
+        "properties": {
+          "confirmed_mapping_hash": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Confirmed Mapping Hash",
+            "type": "string"
+          },
+          "current_request": {
+            "$ref": "#/components/schemas/ExcelWorkbookPreviewRequestV1"
+          },
+          "previous_evidence": {
+            "$ref": "#/components/schemas/ExcelRetainedEvidenceV1"
+          },
+          "schema_version": {
+            "const": "excel-review-bundle-export-request/v1",
+            "default": "excel-review-bundle-export-request/v1",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_request",
+          "previous_evidence",
+          "confirmed_mapping_hash"
+        ],
+        "title": "ExcelReviewBundleExportRequestV1",
+        "type": "object"
+      },
+      "ExcelReviewBundleV1": {
+        "additionalProperties": false,
+        "properties": {
+          "export_disposition": {
+            "const": "EVIDENCE_FOR_QUALIFIED_REVIEW",
+            "default": "EVIDENCE_FOR_QUALIFIED_REVIEW",
+            "title": "Export Disposition",
+            "type": "string"
+          },
+          "freshness_check": {
+            "$ref": "#/components/schemas/ExcelFreshnessCheckV1"
+          },
+          "result": {
+            "$ref": "#/components/schemas/ExcelWorkbookRunResultV1"
+          },
+          "review_bundle_hash": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Review Bundle Hash",
+            "type": "string"
+          },
+          "schema_version": {
+            "const": "excel-review-bundle/v1",
+            "default": "excel-review-bundle/v1",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "freshness_check",
+          "result",
+          "review_bundle_hash"
+        ],
+        "title": "ExcelReviewBundleV1",
+        "type": "object"
+      },
       "ExcelReviewStateV1": {
         "enum": [
           "NOT_REVIEWED",
@@ -34668,6 +34732,127 @@
           }
         },
         "summary": "Preview and hash the selected Excel table mapping",
+        "tags": [
+          "excel-workbench"
+        ]
+      }
+    },
+    "/api/v1/excel-workbench/v1/review-bundle": {
+      "post": {
+        "operationId": "export_excel_review_bundle_api_v1_excel_workbench_v1_review_bundle_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExcelReviewBundleExportRequestV1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExcelReviewBundleV1"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "State conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Request validation failed"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Concurrency or rate limit"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Internal application error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Capability unavailable"
+          }
+        },
+        "summary": "Export complete current Excel evidence for qualified review",
         "tags": [
           "excel-workbench"
         ]

--- a/fastapi_app/routers/excel_workbench.py
+++ b/fastapi_app/routers/excel_workbench.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
+import hashlib
 
 from fastapi import APIRouter, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from starlette.concurrency import run_in_threadpool
 
 from fastapi_app.error_utils import sanitize_error
@@ -14,14 +15,19 @@ from structural_lib.services.excel_workbench import (
     ExcelFreshnessCheckV1,
     ExcelFreshnessRequestV1,
     ExcelMappingPreviewV1,
+    ExcelReviewBundleConflictError,
+    ExcelReviewBundleExportRequestV1,
+    ExcelReviewBundleV1,
     ExcelWorkbookPreviewRequestV1,
     ExcelWorkbookRunRequestV1,
     ExcelWorkbookRunResultV1,
     ExcelWorkbenchDefinitionV1,
     build_excel_mapping_preview_v1,
+    build_excel_review_bundle_v1,
     check_excel_workbook_freshness_v1,
     get_excel_workbench_definition_v1,
     run_excel_workbook_v1,
+    serialize_excel_review_bundle_v1,
 )
 
 logger = logging.getLogger(__name__)
@@ -76,3 +82,45 @@ async def run_excel_workbook(request: ExcelWorkbookRunRequestV1):
 )
 async def check_excel_workbook_freshness(request: ExcelFreshnessRequestV1):
     return success_response(check_excel_workbook_freshness_v1(request))
+
+
+@router.post(
+    "/review-bundle",
+    response_model=ExcelReviewBundleV1,
+    summary="Export complete current Excel evidence for qualified review",
+)
+async def export_excel_review_bundle(request: ExcelReviewBundleExportRequestV1):
+    try:
+        bundle = await run_in_threadpool(build_excel_review_bundle_v1, request)
+        payload = serialize_excel_review_bundle_v1(bundle)
+        file_sha256 = hashlib.sha256(payload).hexdigest()
+        result_hash = bundle.result.bundle_hash
+        return Response(
+            content=payload,
+            media_type="application/json",
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Disposition": (
+                    f'attachment; filename="e1-review-bundle-{result_hash}.json"'
+                ),
+                "X-E1-File-SHA256": file_sha256,
+                "X-E1-Review-Bundle-Hash": bundle.review_bundle_hash,
+                "X-E1-Result-Bundle-Hash": result_hash,
+            },
+        )
+    except ExcelReviewBundleConflictError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=error_response(sanitize_error(exc, "Excel Workbench V1 export")),
+        )
+    except (TypeError, ValueError) as exc:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=error_response(sanitize_error(exc, "Excel Workbench V1 export")),
+        )
+    except Exception as exc:  # pragma: no cover - defensive transport boundary
+        logger.exception("Excel Workbench V1 export failed")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content=error_response(sanitize_error(exc, "Excel Workbench V1 export")),
+        )

--- a/fastapi_app/routers/index.json
+++ b/fastapi_app/routers/index.json
@@ -2,7 +2,7 @@
   "folder": "fastapi_app/routers",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-18",
+  "last_updated": "2026-08-22",
   "file_count": 27,
   "files": [
     {
@@ -346,8 +346,8 @@
     {
       "name": "excel_workbench.py",
       "type": "python",
-      "size_lines": 79,
-      "last_updated": "2026-08-18",
+      "size_lines": 127,
+      "last_updated": "2026-08-22",
       "description": "Versioned REST transport for Excel Routine Workbench V1.",
       "functions": [
         {
@@ -370,9 +370,15 @@
           "params": [
             "request"
           ]
+        },
+        {
+          "name": "export_excel_review_bundle",
+          "params": [
+            "request"
+          ]
         }
       ],
-      "content_hash": "265f8d22c4b8"
+      "content_hash": "c32475c8b162"
     },
     {
       "name": "export.py",
@@ -1119,5 +1125,5 @@
     "strap_footing",
     "streaming"
   ],
-  "content_hash": "bef1b0f9d9de102a"
+  "content_hash": "a6b9b18f33d5c08a"
 }

--- a/fastapi_app/routers/index.md
+++ b/fastapi_app/routers/index.md
@@ -1,7 +1,7 @@
 # Routers
 
 **Type:** Python Package
-**Last Updated:** 2026-08-18
+**Last Updated:** 2026-08-22
 **Files:** 27
 
 ## Public API
@@ -41,7 +41,7 @@
 | [deep_beam.py](deep_beam.py) | FastAPI transport for the bounded simply supported deep-beam | 0 | 1 | 133 |
 | [design.py](design.py) | Beam Design Router. | 0 | 10 | 1083 |
 | [detailing.py](detailing.py) | Beam Detailing Router. | 0 | 4 | 412 |
-| [excel_workbench.py](excel_workbench.py) | Versioned REST transport for Excel Routine Workbench V1. | 0 | 4 | 79 |
+| [excel_workbench.py](excel_workbench.py) | Versioned REST transport for Excel Routine Workbench V1. | 0 | 5 | 127 |
 | [export.py](export.py) | Export Router — BBS, DXF, and Report exports. | 4 | 5 | 805 |
 | [flat_slab.py](flat_slab.py) | FastAPI transport for the bounded regular interior flat-slab | 0 | 1 | 154 |
 | [footing.py](footing.py) | FastAPI transport for the bounded concentric isolated-footin | 0 | 1 | 69 |

--- a/fastapi_app/tests/index.json
+++ b/fastapi_app/tests/index.json
@@ -2,7 +2,7 @@
   "folder": "fastapi_app/tests",
   "type": "python-package",
   "description": "Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming.",
-  "last_updated": "2026-08-18",
+  "last_updated": "2026-08-22",
   "file_count": 45,
   "files": [
     {
@@ -981,8 +981,8 @@
     {
       "name": "test_excel_workbench.py",
       "type": "python",
-      "size_lines": 128,
-      "last_updated": "2026-08-18",
+      "size_lines": 242,
+      "last_updated": "2026-08-22",
       "description": "REST semantic vectors for Excel Routine Workbench V1.",
       "functions": [
         {
@@ -1002,12 +1002,30 @@
           "params": [
             "client"
           ]
+        },
+        {
+          "name": "test_review_bundle_exports_complete_deterministic_json_attachment",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_review_bundle_returns_409_for_stale_or_mismatched_retained_result",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_review_bundle_openapi_exposes_fifth_typed_endpoint",
+          "params": [
+            "client"
+          ]
         }
       ],
       "constants": [
         "HEADERS"
       ],
-      "content_hash": "dc4202f091bd"
+      "content_hash": "d9b8dba4c993"
     },
     {
       "name": "test_export_bbs_dxf.py",
@@ -2084,5 +2102,5 @@
   ],
   "subfolders": [],
   "has_init": true,
-  "content_hash": "e94f86d04ab48714"
+  "content_hash": "d07d4203d3885a66"
 }

--- a/fastapi_app/tests/index.md
+++ b/fastapi_app/tests/index.md
@@ -3,7 +3,7 @@
 Tests for the FastAPI backend endpoints, authentication, WebSocket, and streaming.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-18
+**Last Updated:** 2026-08-22
 **Files:** 45
 
 ## Documentation Files
@@ -38,7 +38,7 @@ Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin
 | [test_detailing_anchorage.py](test_detailing_anchorage.py) | Tests for detailing router anchorage endpoint. | 1 | 1 | 98 |
 | [test_endpoints.py](test_endpoints.py) | Integration Tests for FastAPI Endpoints. | 11 | 0 | 1242 |
 | [test_error_sanitization.py](test_error_sanitization.py) | Tests for error sanitization utilities (TASK-796). | 2 | 0 | 118 |
-| [test_excel_workbench.py](test_excel_workbench.py) | REST semantic vectors for Excel Routine Workbench V1. | 0 | 3 | 128 |
+| [test_excel_workbench.py](test_excel_workbench.py) | REST semantic vectors for Excel Routine Workbench V1. | 0 | 6 | 242 |
 | [test_export_bbs_dxf.py](test_export_bbs_dxf.py) | Tests for export router endpoints. | 3 | 2 | 202 |
 | [test_flat_slab.py](test_flat_slab.py) | Contract tests for the bounded regular interior flat-slab Fa | 0 | 6 | 199 |
 | [test_footing.py](test_footing.py) | Contract tests for the isolated concentric-footing FastAPI s | 0 | 7 | 239 |

--- a/fastapi_app/tests/test_excel_workbench.py
+++ b/fastapi_app/tests/test_excel_workbench.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+
 from fastapi_app.tests.conftest import unwrap
 
 HEADERS = [
@@ -125,3 +127,115 @@ def test_run_rejects_unreviewed_or_changed_mapping(client):
     assert body["success"] is False
     assert body["data"] is None
     assert "mapping" in body["error"]["message"].lower()
+
+
+def test_review_bundle_exports_complete_deterministic_json_attachment(client):
+    payload = _preview_payload()
+    preview = unwrap(
+        client.post("/api/v1/excel-workbench/v1/mapping-preview", json=payload)
+    )
+    run_payload = {
+        **payload,
+        "schema_version": "excel-workbook-run-request/v1",
+        "confirmed_mapping_hash": preview["mapping_hash"],
+    }
+    result = unwrap(client.post("/api/v1/excel-workbench/v1/run", json=run_payload))
+    export_payload = {
+        "schema_version": "excel-review-bundle-export-request/v1",
+        "current_request": payload,
+        "previous_evidence": {
+            "bundle_hash": result["bundle_hash"],
+            "source_table_hash": result["source_table_hash"],
+            "mapping_hash": result["mapping"]["mapping_hash"],
+            "library_content_identity": result["library_content_identity"],
+        },
+        "confirmed_mapping_hash": preview["mapping_hash"],
+    }
+
+    first = client.post("/api/v1/excel-workbench/v1/review-bundle", json=export_payload)
+    second = client.post(
+        "/api/v1/excel-workbench/v1/review-bundle", json=export_payload
+    )
+
+    assert first.status_code == 200
+    assert first.content == second.content
+    assert first.content.endswith(b"\n")
+    assert first.headers["cache-control"] == "no-store"
+    assert (
+        first.headers["x-e1-file-sha256"] == hashlib.sha256(first.content).hexdigest()
+    )
+    assert first.headers["x-e1-result-bundle-hash"] == result["bundle_hash"]
+    assert first.headers["content-disposition"] == (
+        f'attachment; filename="e1-review-bundle-{result["bundle_hash"]}.json"'
+    )
+    bundle = first.json()
+    assert bundle["review_bundle_hash"] == first.headers["x-e1-review-bundle-hash"]
+    assert bundle["freshness_check"]["freshness_status"] == "CURRENT"
+    assert bundle["result"]["mapping"]["mapped_fields"]
+    assert bundle["result"]["row_ledger"][0]["result"] is not None
+    assert bundle["result"]["row_ledger"][0]["passport"] is not None
+    assert bundle["result"]["qualified_review_required"] is True
+
+
+def test_review_bundle_returns_409_for_stale_or_mismatched_retained_result(client):
+    payload = _preview_payload()
+    preview = unwrap(
+        client.post("/api/v1/excel-workbench/v1/mapping-preview", json=payload)
+    )
+    run_payload = {
+        **payload,
+        "schema_version": "excel-workbook-run-request/v1",
+        "confirmed_mapping_hash": preview["mapping_hash"],
+    }
+    result = unwrap(client.post("/api/v1/excel-workbench/v1/run", json=run_payload))
+    evidence = {
+        "bundle_hash": result["bundle_hash"],
+        "source_table_hash": result["source_table_hash"],
+        "mapping_hash": result["mapping"]["mapping_hash"],
+        "library_content_identity": result["library_content_identity"],
+    }
+    edited = _preview_payload()
+    edited["rows"][0][3] = 151.0
+    stale = client.post(
+        "/api/v1/excel-workbench/v1/review-bundle",
+        json={
+            "current_request": edited,
+            "previous_evidence": evidence,
+            "confirmed_mapping_hash": preview["mapping_hash"],
+        },
+    )
+    mismatch = client.post(
+        "/api/v1/excel-workbench/v1/review-bundle",
+        json={
+            "current_request": payload,
+            "previous_evidence": {**evidence, "bundle_hash": "f" * 64},
+            "confirmed_mapping_hash": preview["mapping_hash"],
+        },
+    )
+
+    unconfirmed = client.post(
+        "/api/v1/excel-workbench/v1/review-bundle",
+        json={
+            "current_request": payload,
+            "previous_evidence": evidence,
+            "confirmed_mapping_hash": "0" * 64,
+        },
+    )
+
+    assert stale.status_code == 409
+    assert "stale" in stale.json()["error"]["message"].lower()
+    assert mismatch.status_code == 409
+    assert "retained" in mismatch.json()["error"]["message"].lower()
+    assert unconfirmed.status_code == 422
+    assert "mapping" in unconfirmed.json()["error"]["message"].lower()
+
+
+def test_review_bundle_openapi_exposes_fifth_typed_endpoint(client):
+    operation = client.app.openapi()["paths"][
+        "/api/v1/excel-workbench/v1/review-bundle"
+    ]["post"]
+    response_schema = operation["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+
+    assert response_schema["$ref"].endswith("/ExcelReviewBundleV1")

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -2,7 +2,7 @@
   "folder": "scripts",
   "type": "python-package",
   "description": "> Development, validation, discovery, release-preparation, and maintenance tools.",
-  "last_updated": "2026-08-18",
+  "last_updated": "2026-08-22",
   "file_count": 114,
   "files": [
     {
@@ -5574,8 +5574,8 @@
     {
       "name": "verify_excel_workbench_artifact.py",
       "type": "python",
-      "size_lines": 217,
-      "last_updated": "2026-08-18",
+      "size_lines": 244,
+      "last_updated": "2026-08-22",
       "description": "Verify E1 workbook identity and behavior from one source-free wheel.",
       "functions": [
         {
@@ -5594,7 +5594,7 @@
         "_MANIFEST_MEMBER",
         "_INSTALLED_PROBE"
       ],
-      "content_hash": "e73687b2a972"
+      "content_hash": "6dba9bcda7cf"
     },
     {
       "name": "watch_tests.sh",
@@ -5613,5 +5613,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "4a6202dfd46f3204"
+  "content_hash": "53a1db3a947d3dfd"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -3,7 +3,7 @@
 > Development, validation, discovery, release-preparation, and maintenance tools.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-18
+**Last Updated:** 2026-08-22
 **Files:** 114
 
 ## Config Files
@@ -114,7 +114,7 @@
 | [validate_schema_snapshots.py](validate_schema_snapshots.py) | Schema Snapshot Validator. | 0 | 6 | 257 |
 | [validate_script_refs.py](validate_script_refs.py) | Validate that active control paths reference existing script | 0 | 6 | 235 |
 | [verify_canonical_transport_artifact.py](verify_canonical_transport_artifact.py) | Verify A1's source-free wheel and exact-head application imp | 0 | 2 | 280 |
-| [verify_excel_workbench_artifact.py](verify_excel_workbench_artifact.py) | Verify E1 workbook identity and behavior from one source-fre | 0 | 2 | 217 |
+| [verify_excel_workbench_artifact.py](verify_excel_workbench_artifact.py) | Verify E1 workbook identity and behavior from one source-fre | 0 | 2 | 244 |
 
 ## Shell Script Files
 

--- a/scripts/verify_excel_workbench_artifact.py
+++ b/scripts/verify_excel_workbench_artifact.py
@@ -19,6 +19,7 @@ _WORKBOOK_MEMBER = f"{_RESOURCE_DIR}/structural-lib-rectangular-beam-workbench-v
 _MANIFEST_MEMBER = f"{_RESOURCE_DIR}/workbook-manifest.json"
 
 _INSTALLED_PROBE = r"""
+import hashlib
 import json
 import os
 from importlib import resources
@@ -26,14 +27,18 @@ from pathlib import Path
 
 import structural_lib
 from structural_lib.core.excel_workbook import (
+    ExcelReviewBundleExportRequestV1,
     ExcelWorkbookPreviewRequestV1,
     ExcelWorkbookRunRequestV1,
     ExcelWorkbookSelectionV1,
 )
 from structural_lib.services.excel_workbench import (
     build_excel_mapping_preview_v1,
+    build_excel_review_bundle_v1,
     get_excel_workbench_definition_v1,
+    retain_excel_workbook_evidence_v1,
     run_excel_workbook_v1,
+    serialize_excel_review_bundle_v1,
 )
 
 installed_root = Path(os.environ["E1_INSTALLED_ROOT"]).resolve()
@@ -78,6 +83,25 @@ result = run_excel_workbook_v1(ExcelWorkbookRunRequestV1(
 ))
 if result.row_ledger[0].result_envelope["overall_status"] != "PASS":
     raise AssertionError(result.row_ledger[0])
+export_request = ExcelReviewBundleExportRequestV1(
+    current_request=preview_request,
+    previous_evidence=retain_excel_workbook_evidence_v1(result),
+    confirmed_mapping_hash=preview.mapping_hash,
+)
+review_bundle = build_excel_review_bundle_v1(export_request)
+review_bytes = serialize_excel_review_bundle_v1(review_bundle)
+repeat_bytes = serialize_excel_review_bundle_v1(
+    build_excel_review_bundle_v1(export_request)
+)
+if review_bytes != repeat_bytes:
+    raise AssertionError("Installed review-bundle bytes are not deterministic.")
+decoded_bundle = json.loads(review_bytes)
+if decoded_bundle["result"]["bundle_hash"] != result.bundle_hash:
+    raise AssertionError("Installed review bundle changed the result identity.")
+if not decoded_bundle["result"]["row_ledger"][0]["result"]:
+    raise AssertionError("Installed review bundle omitted the structured result.")
+if not decoded_bundle["result"]["row_ledger"][0]["passport"]:
+    raise AssertionError("Installed review bundle omitted the calculation passport.")
 
 resource = resources.files("structural_lib").joinpath(
     "data/excel/outputs/e1-excel-routine-workbench/structural-lib-rectangular-beam-workbench-v1.xlsx"
@@ -93,6 +117,9 @@ print(json.dumps({
     "installed_windows_excel_evidence": definition.installed_windows_excel_evidence,
     "row_counts": result.counts.model_dump(mode="json"),
     "overall_status": result.row_ledger[0].result_envelope["overall_status"],
+    "review_bundle_hash": review_bundle.review_bundle_hash,
+    "review_bundle_file_sha256": hashlib.sha256(review_bytes).hexdigest(),
+    "review_bundle_size_bytes": len(review_bytes),
 }))
 """
 


### PR DESCRIPTION
## Summary
- add complete versioned Excel review-bundle contract and deterministic JSON bytes
- add fail-closed FastAPI attachment with file, logical bundle, and result identities
- add installed-pane Export control with freshness gating and WebCrypto verification
- preserve workbook bytes, Office manifest, canonical calculations, and qualified-review boundary

## Root cause
G3 preflight proved the frozen export requirement exceeded the implemented installed pane. The existing Markdown renderer was deterministic but only a status summary and was not pane-accessible.

## Evidence
- focused Python, REST, and Open XML: 22 cases pass
- Office.js: 21 tests pass; four modules and manifest parse
- architecture: 217 files, zero violations
- imports: 685 files and 4732 imports, zero broken
- OpenAPI: 89 endpoints and 434 schemas
- quick gate: 10 of 10
- normal hooks and read-only session audit pass
- source-free wheel proves unchanged workbook SHA and complete deterministic review JSON

## Stack and boundary
Draft successor to PR #828. Do not merge ahead of PRs #826 to #828. G3, ETABS, release, merge, cleanup, and professional approval remain held.