### PR TITLE
fix(safety): close public numeric boundaries

### DIFF
--- a/Python/structural_lib/codes/is456/beam/flexure.py
+++ b/Python/structural_lib/codes/is456/beam/flexure.py
@@ -43,7 +43,11 @@ from structural_lib.core.errors import (
     E_INPUT_003a,
     MaterialError,
 )
-from structural_lib.core.validation import validate_dimensions, validate_materials
+from structural_lib.core.validation import (
+    validate_dimensions,
+    validate_finite_real,
+    validate_materials,
+)
 
 __all__ = [
     "calculate_mu_lim",
@@ -373,6 +377,7 @@ def design_singly_reinforced(
     """
     # Input validation with structured errors using validation utilities
     input_errors = validate_dimensions(b, d, d_total)
+    input_errors.extend(validate_finite_real(mu_knm, "mu_knm"))
 
     if input_errors:
         # Build specific error message based on which fields failed

--- a/Python/structural_lib/codes/is456/beam/shear.py
+++ b/Python/structural_lib/codes/is456/beam/shear.py
@@ -20,6 +20,7 @@ from structural_lib.core.errors import (
     E_SHEAR_005,
     DimensionError,
 )
+from structural_lib.core.validation import validate_finite_reals
 
 from .. import tables
 from ..traceability import clause
@@ -347,8 +348,31 @@ def design_shear(
         - Assumes uniform beam cross-section; haunched beams or
           variable-depth members are not handled.
     """
-    # Input validation with structured errors
-    input_errors = []
+    # Input validation with structured errors.  Relational checks alone are
+    # insufficient because every comparison with NaN is false.
+    finite_inputs: dict[str, object] = {
+        "vu_kn": vu_kn,
+        "b": b,
+        "d": d,
+        "fck": fck,
+        "fy": fy,
+        "asv": asv,
+        "pt": pt,
+    }
+    if av_mm is not None:
+        finite_inputs["av_mm"] = av_mm
+    input_errors = validate_finite_reals(**finite_inputs)
+    if input_errors:
+        return ShearResult(
+            tau_v=0.0,
+            tau_c=0.0,
+            tau_c_max=0.0,
+            Vus=0.0,
+            spacing=0.0,
+            is_safe=False,
+            errors=tuple(input_errors),
+        )
+
     if b <= 0:
         input_errors.append(E_INPUT_001)
     if d <= 0:

--- a/Python/structural_lib/codes/is456/column/index.json
+++ b/Python/structural_lib/codes/is456/column/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/codes/is456/column",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-12",
+  "last_updated": "2026-08-22",
   "file_count": 10,
   "files": [
     {
@@ -278,8 +278,8 @@
     {
       "name": "uniaxial.py",
       "type": "python",
-      "size_lines": 880,
-      "last_updated": "2026-08-12",
+      "size_lines": 918,
+      "last_updated": "2026-08-22",
       "description": "Module:       uniaxial",
       "functions": [
         {
@@ -310,7 +310,7 @@
           ]
         }
       ],
-      "content_hash": "9e2c590e0ba0"
+      "content_hash": "9b4f730d75ce"
     }
   ],
   "subfolders": [],
@@ -331,5 +331,5 @@
     "slenderness",
     "uniaxial"
   ],
-  "content_hash": "7b266170c127d4c7"
+  "content_hash": "2023f2a965c3a4a0"
 }

--- a/Python/structural_lib/codes/is456/column/index.md
+++ b/Python/structural_lib/codes/is456/column/index.md
@@ -1,7 +1,7 @@
 # Column
 
 **Type:** Python Package
-**Last Updated:** 2026-08-12
+**Last Updated:** 2026-08-22
 **Files:** 10
 
 ## Public API
@@ -34,4 +34,4 @@
 | [long_column.py](long_column.py) | Module:       long_column | 0 | 1 | 416 |
 | [pmm.py](pmm.py) | Experimental strain-compatibility analysis for rectangular c | 0 | 3 | 514 |
 | [slenderness.py](slenderness.py) | Module:       slenderness | 0 | 1 | 225 |
-| [uniaxial.py](uniaxial.py) | Module:       uniaxial | 0 | 2 | 880 |
+| [uniaxial.py](uniaxial.py) | Module:       uniaxial | 0 | 2 | 918 |

--- a/Python/structural_lib/codes/is456/column/uniaxial.py
+++ b/Python/structural_lib/codes/is456/column/uniaxial.py
@@ -48,11 +48,29 @@ from structural_lib.core.errors import (
     MaterialError,
 )
 from structural_lib.core.numerics import safe_divide
+from structural_lib.core.validation import validate_finite_real
 
 __all__ = [
     "design_short_column_uniaxial",
     "pm_interaction_curve",
 ]
+
+
+def _require_finite_column_value(
+    name: str,
+    value: object,
+    error_type: type[DimensionError] | type[MaterialError],
+    clause_ref: str,
+) -> None:
+    """Apply the shared finite-real invariant using column exception types."""
+    errors = validate_finite_real(value, name)
+    if errors:
+        raise error_type(
+            errors[0].message,
+            details={name: value},
+            clause_ref=clause_ref,
+        )
+
 
 # ---------------------------------------------------------------------------
 # SP:16 Table I -- Stress-block coefficients for xu > D
@@ -338,6 +356,26 @@ def design_short_column_uniaxial(
     # ===========================================================
     warnings: list[str] = []
 
+    for name, value, clause_ref in (
+        ("b_mm", b_mm, "Cl. 39.5"),
+        ("D_mm", D_mm, "Cl. 39.5"),
+        ("le_mm", le_mm, "Cl. 25.1.2"),
+        ("d_prime_mm", d_prime_mm, "Cl. 26.4"),
+        ("Pu_kN", Pu_kN, "Cl. 39.5"),
+        ("Mu_kNm", Mu_kNm, "Cl. 39.5"),
+        ("Asc_mm2", Asc_mm2, "Cl. 26.5.3.1"),
+    ):
+        _require_finite_column_value(name, value, DimensionError, clause_ref)
+    if l_unsupported_mm is not None:
+        _require_finite_column_value(
+            "l_unsupported_mm",
+            l_unsupported_mm,
+            DimensionError,
+            "Cl. 25.4",
+        )
+    for name, value in (("fck", fck), ("fy", fy)):
+        _require_finite_column_value(name, value, MaterialError, "Cl. 39.5")
+
     # --- Dimensions ---
     if b_mm <= 0:
         raise DimensionError(
@@ -615,7 +653,7 @@ def design_short_column_uniaxial(
         )
 
     utilization_ratio = round(utilization, 4)
-    is_safe = utilization_ratio <= 1.0
+    is_safe = utilization <= 1.0
 
     # Determine governing check description
     if not is_safe:

--- a/Python/structural_lib/codes/is456/compliance.py
+++ b/Python/structural_lib/codes/is456/compliance.py
@@ -17,6 +17,7 @@ Design constraints:
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Sequence
 from dataclasses import asdict
 from enum import Enum
@@ -38,6 +39,7 @@ from structural_lib.core.data_types import (
     TorsionResult,
 )
 from structural_lib.core.errors import Severity
+from structural_lib.core.validation import validate_finite_reals
 
 from .beam import flexure, serviceability, shear, torsion
 
@@ -50,11 +52,20 @@ __all__ = [
 ]
 
 
+def _require_finite_inputs(**kwargs: object) -> None:
+    """Reject non-finite calculation inputs before any design arithmetic."""
+    errors = validate_finite_reals(**kwargs)
+    if errors:
+        raise ValueError("; ".join(error.message for error in errors))
+
+
 def _utilization_safe(numer: float, denom: float) -> float:
     """Compute utilization ratio with safe division.
 
     Returns inf if denominator ≤ 0 and numerator > 0, else 0 for zero/zero.
     """
+    if not math.isfinite(numer) or not math.isfinite(denom):
+        return float("inf")
     if denom <= 0:
         return float("inf") if numer > 0 else 0.0
     return numer / denom
@@ -215,6 +226,30 @@ def check_compliance_case(
       else falls back to using flexure-required Ast (recorded as an assumption).
     """
 
+    finite_inputs: dict[str, object] = {
+        "mu_knm": mu_knm,
+        "vu_kn": vu_kn,
+        "b_mm": b_mm,
+        "D_mm": D_mm,
+        "d_mm": d_mm,
+        "fck_nmm2": fck_nmm2,
+        "fy_nmm2": fy_nmm2,
+        "d_dash_mm": d_dash_mm,
+        "asv_mm2": asv_mm2,
+        "tu_knm": tu_knm,
+        "stirrup_dia_mm": stirrup_dia_mm,
+    }
+    for name, value in (
+        ("pt_percent", pt_percent),
+        ("ast_mm2_for_shear", ast_mm2_for_shear),
+        ("cover_mm", cover_mm),
+        ("bf_mm", bf_mm),
+        ("Df_mm", Df_mm),
+    ):
+        if value is not None:
+            finite_inputs[name] = value
+    _require_finite_inputs(**finite_inputs)
+
     failed_checks: list[str] = []
     assumptions: list[str] = []
     torsion_result: TorsionResult | None = None
@@ -368,6 +403,11 @@ def check_compliance_case(
         utilizations["crack_width"] = _compute_crack_utilization(crack)
 
     governing_util = max(utilizations.values()) if utilizations else 0.0
+    for check_name, utilization in utilizations.items():
+        if not math.isfinite(utilization) and not any(
+            check_name in failed_check for failed_check in failed_checks
+        ):
+            failed_checks.append(f"{check_name} (non-finite utilization)")
     is_ok = len(failed_checks) == 0
 
     remarks = "OK" if is_ok else ("FAIL: " + ", ".join(failed_checks))
@@ -449,6 +489,9 @@ def check_compliance_report(
     """
 
     results: list[ComplianceCaseResult] = []
+
+    if not cases:
+        raise ValueError("cases must contain at least one compliance case.")
 
     if deflection_defaults is not None and not isinstance(deflection_defaults, dict):
         raise ValueError("deflection_defaults must be a dict when provided.")

--- a/Python/structural_lib/codes/is456/index.json
+++ b/Python/structural_lib/codes/is456/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib/codes/is456",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-17",
+  "last_updated": "2026-08-22",
   "file_count": 14,
   "files": [
     {
@@ -45,8 +45,8 @@
     {
       "name": "compliance.py",
       "type": "python",
-      "size_lines": 583,
-      "last_updated": "2026-08-16",
+      "size_lines": 626,
+      "last_updated": "2026-08-22",
       "description": "Module: compliance",
       "functions": [
         {
@@ -65,7 +65,7 @@
           ]
         }
       ],
-      "content_hash": "084d68bf329d"
+      "content_hash": "54dcc958301e"
     },
     {
       "name": "detailing.py",
@@ -468,5 +468,5 @@
     "list_clauses_by_category",
     "search_clauses"
   ],
-  "content_hash": "b636637e363d3371"
+  "content_hash": "d19571f00012cc9a"
 }

--- a/Python/structural_lib/codes/is456/index.md
+++ b/Python/structural_lib/codes/is456/index.md
@@ -1,7 +1,7 @@
 # Is456
 
 **Type:** Python Package
-**Last Updated:** 2026-08-17
+**Last Updated:** 2026-08-22
 **Files:** 14
 
 ## Public API
@@ -35,7 +35,7 @@
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | IS 456:2000 - Indian Standard for Plain and Reinforced Concr | 1 | 0 | 148 |
-| [compliance.py](compliance.py) | Module: compliance | 0 | 3 | 583 |
+| [compliance.py](compliance.py) | Module: compliance | 0 | 3 | 626 |
 | [detailing.py](detailing.py) | Backward compatibility shim — detailing module moved to beam | 0 | 0 | 28 |
 | [ductile.py](ductile.py) | Backward compatibility shim — ductile module moved to codes/ | 0 | 0 | 30 |
 | [flexure.py](flexure.py) | Backward compatibility shim — flexure module moved to beam/  | 0 | 0 | 28 |

--- a/Python/structural_lib/core/index.json
+++ b/Python/structural_lib/core/index.json
@@ -1203,10 +1203,22 @@
     {
       "name": "validation.py",
       "type": "python",
-      "size_lines": 643,
-      "last_updated": "2026-08-17",
+      "size_lines": 684,
+      "last_updated": "2026-08-22",
       "description": "Module:       validation",
       "functions": [
+        {
+          "name": "validate_finite_real",
+          "description": "Validate that a numeric input is a finite real value.",
+          "params": [
+            "value",
+            "field_name"
+          ]
+        },
+        {
+          "name": "validate_finite_reals",
+          "description": "Validate multiple named numeric inputs with stable field attribution."
+        },
         {
           "name": "validate_dimensions",
           "description": "Validate beam dimensions (b, d, D).",
@@ -1323,7 +1335,7 @@
           ]
         }
       ],
-      "content_hash": "114bd96ff3ea"
+      "content_hash": "b908ade80916"
     },
     {
       "name": "version.py",
@@ -1387,5 +1399,5 @@
     "GravityCombinationV1",
     "GravityFootingDestinationV1"
   ],
-  "content_hash": "afb02181eae5959e"
+  "content_hash": "eec7be7d95778c07"
 }

--- a/Python/structural_lib/core/index.md
+++ b/Python/structural_lib/core/index.md
@@ -53,5 +53,5 @@
 | [source_identity.py](source_identity.py) | Layer-neutral identities for the exact controlled IS 456 sou | 0 | 0 | 13 |
 | [types.py](types.py) | Compatibility shim for the renamed data_types module. | 0 | 0 | 51 |
 | [utilities.py](utilities.py) | Module:       utilities | 0 | 4 | 70 |
-| [validation.py](validation.py) | Module:       validation | 0 | 13 | 643 |
+| [validation.py](validation.py) | Module:       validation | 0 | 15 | 684 |
 | [version.py](version.py) | Runtime package-version identity without source/installation | 1 | 2 | 123 |

--- a/Python/structural_lib/core/validation.py
+++ b/Python/structural_lib/core/validation.py
@@ -12,7 +12,9 @@ See docs/research/cs-best-practices-audit.md for design rationale.
 
 from __future__ import annotations
 
+import math
 import warnings
+from numbers import Real
 
 from .errors import (
     E_INPUT_001,
@@ -27,6 +29,39 @@ from .errors import (
     E_INPUT_003a,
     Severity,
 )
+
+
+def validate_finite_real(value: object, field_name: str) -> list[DesignError]:
+    """Validate that a numeric input is a finite real value.
+
+    ``bool`` is rejected deliberately even though it is a numeric subtype in
+    Python.  A stable structured error lets result-returning calculation
+    functions fail closed without serializing NaN or infinity.
+    """
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(value)
+    ):
+        return [
+            DesignError(
+                code="E_INPUT_017",
+                severity=Severity.ERROR,
+                message=f"{field_name} must be a finite real number",
+                field=field_name,
+                hint="Replace NaN, infinity, booleans, or non-numeric values.",
+                recovery=f"Provide a finite real value for {field_name}.",
+            )
+        ]
+    return []
+
+
+def validate_finite_reals(**kwargs: object) -> list[DesignError]:
+    """Validate multiple named numeric inputs with stable field attribution."""
+    errors: list[DesignError] = []
+    for field_name, value in kwargs.items():
+        errors.extend(validate_finite_real(value, field_name))
+    return errors
 
 
 def validate_dimensions(
@@ -52,7 +87,9 @@ def validate_dimensions(
         >>> if errors:
         ...     return FlexureResult(..., errors=errors)
     """
-    errors: list[DesignError] = []
+    errors = validate_finite_reals(b=b, d=d, d_total=D)
+    if errors:
+        return errors
 
     if b <= 0:
         errors.append(E_INPUT_001)
@@ -85,7 +122,9 @@ def validate_materials(fck: float, fy: float) -> list[DesignError]:
         >>> if errors:
         ...     return FlexureResult(..., errors=errors)
     """
-    errors: list[DesignError] = []
+    errors = validate_finite_reals(fck=fck, fy=fy)
+    if errors:
+        return errors
 
     if fck <= 0:
         errors.append(E_INPUT_004)
@@ -626,6 +665,8 @@ def validate_beam_inputs(
 
 
 __all__ = [
+    "validate_finite_real",
+    "validate_finite_reals",
     "validate_dimensions",
     "validate_materials",
     "validate_positive",

--- a/Python/structural_lib/index.json
+++ b/Python/structural_lib/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/structural_lib",
   "type": "python-package",
   "description": "> **Purpose:** IS 456:2000 RC beam design calculations",
-  "last_updated": "2026-08-21",
+  "last_updated": "2026-08-22",
   "file_count": 52,
   "files": [
     {
@@ -526,10 +526,10 @@
     {
       "name": "validation.py",
       "type": "python",
-      "size_lines": 24,
-      "last_updated": "2026-08-17",
+      "size_lines": 26,
+      "last_updated": "2026-08-22",
       "description": "Backward compatibility stub.",
-      "content_hash": "f86adfaa535d"
+      "content_hash": "5aa4120aa18a"
     }
   ],
   "subfolders": [
@@ -610,5 +610,5 @@
     "serviceability",
     "shear"
   ],
-  "content_hash": "9754fb00c4dba902"
+  "content_hash": "5086d117e5f622a3"
 }

--- a/Python/structural_lib/index.md
+++ b/Python/structural_lib/index.md
@@ -3,7 +3,7 @@
 > **Purpose:** IS 456:2000 RC beam design calculations
 
 **Type:** Python Package
-**Last Updated:** 2026-08-21
+**Last Updated:** 2026-08-22
 **Files:** 52
 
 ## Public API
@@ -88,7 +88,7 @@
 | [traceability.py](traceability.py) | Backward compatibility stub. | 0 | 0 | 15 |
 | [types.py](types.py) | Backward compatibility stub. | 0 | 0 | 28 |
 | [utilities.py](utilities.py) | Backward compatibility stub. | 0 | 0 | 17 |
-| [validation.py](validation.py) | Backward compatibility stub. | 0 | 0 | 24 |
+| [validation.py](validation.py) | Backward compatibility stub. | 0 | 0 | 26 |
 
 ## Subfolders
 

--- a/Python/structural_lib/services/column_api.py
+++ b/Python/structural_lib/services/column_api.py
@@ -42,6 +42,7 @@ from structural_lib.core.result_contract import (
     IntakeStatus,
     StructuralResultEnvelopeV1,
 )
+from structural_lib.core.validation import validate_finite_reals
 
 # ============================================================================
 # Deprecated-parameter resolution helper
@@ -73,6 +74,13 @@ def _resolve_deprecated_param(
     if new_val is not None:
         return new_val
     raise TypeError(f"{func_name}() requires '{new_name}'")
+
+
+def _require_finite_column_inputs(**kwargs: object) -> None:
+    """Reject non-finite public column inputs before routing or amplification."""
+    errors = validate_finite_reals(**kwargs)
+    if errors:
+        raise ValueError("; ".join(error.message for error in errors))
 
 
 # ============================================================================
@@ -385,12 +393,6 @@ def design_short_column_uniaxial_is456(
         - codes.is456.column.uniaxial.design_short_column_uniaxial: Core implementation
     """
 
-    # Plausibility guards (aligned with existing api.py patterns)
-    if Pu_kN < 0:
-        raise ValueError(f"Axial load Pu_kN must be >= 0, got {Pu_kN}")
-    if Mu_kNm < 0:
-        raise ValueError(f"Moment Mu_kNm must be >= 0, got {Mu_kNm}")
-
     # Resolve deprecated parameter aliases
     fck_nmm2 = _resolve_deprecated_param(
         fck_nmm2, fck, "fck_nmm2", "fck", "design_short_column_uniaxial_is456"
@@ -398,6 +400,27 @@ def design_short_column_uniaxial_is456(
     fy_nmm2 = _resolve_deprecated_param(
         fy_nmm2, fy, "fy_nmm2", "fy", "design_short_column_uniaxial_is456"
     )
+
+    finite_inputs: dict[str, object] = {
+        "Pu_kN": Pu_kN,
+        "Mu_kNm": Mu_kNm,
+        "b_mm": b_mm,
+        "D_mm": D_mm,
+        "le_mm": le_mm,
+        "fck_nmm2": fck_nmm2,
+        "fy_nmm2": fy_nmm2,
+        "Asc_mm2": Asc_mm2,
+        "d_prime_mm": d_prime_mm,
+    }
+    if l_unsupported_mm is not None:
+        finite_inputs["l_unsupported_mm"] = l_unsupported_mm
+    _require_finite_column_inputs(**finite_inputs)
+
+    # Plausibility guards (aligned with existing api.py patterns)
+    if Pu_kN < 0:
+        raise ValueError(f"Axial load Pu_kN must be >= 0, got {Pu_kN}")
+    if Mu_kNm < 0:
+        raise ValueError(f"Moment Mu_kNm must be >= 0, got {Mu_kNm}")
 
     # Dimension checks
     if not (100 <= b_mm <= 2000):
@@ -1177,7 +1200,29 @@ def design_column_is456(
         - biaxial_bending_check_is456: Short column biaxial check
         - design_long_column_is456: Slender column design with Ma
     """
-    # Validate required inputs
+    # Validate required inputs.  Check finite values before ``max`` or range
+    # comparisons can turn infinity into an apparently valid design action.
+    finite_inputs = {
+        "Pu_kN": Pu_kN,
+        "Mux_kNm": Mux_kNm,
+        "Muy_kNm": Muy_kNm,
+        "b_mm": b_mm,
+        "D_mm": D_mm,
+        "l_mm": l_mm,
+        "Asc_mm2": Asc_mm2,
+        "d_prime_mm": d_prime_mm,
+    }
+    for name, value in (
+        ("l_unsupported_mm", l_unsupported_mm),
+        ("M1x_kNm", M1x_kNm),
+        ("M2x_kNm", M2x_kNm),
+        ("M1y_kNm", M1y_kNm),
+        ("M2y_kNm", M2y_kNm),
+    ):
+        if value is not None:
+            finite_inputs[name] = value
+    _require_finite_column_inputs(**finite_inputs)
+
     if b_mm <= 0 or D_mm <= 0:
         raise ValueError(f"Column dimensions must be > 0 (got b={b_mm}, D={D_mm})")
     if l_mm <= 0:
@@ -1192,6 +1237,7 @@ def design_column_is456(
     fy_nmm2 = _resolve_deprecated_param(
         fy_nmm2, fy, "fy_nmm2", "fy", "design_column_is456"
     )
+    _require_finite_column_inputs(fck_nmm2=fck_nmm2, fy_nmm2=fy_nmm2)
 
     # Step 1: Calculate effective lengths in both directions
     le_result = calculate_effective_length_is456(l_mm, end_condition)

--- a/Python/structural_lib/services/index.json
+++ b/Python/structural_lib/services/index.json
@@ -927,8 +927,8 @@
     {
       "name": "column_api.py",
       "type": "python",
-      "size_lines": 1546,
-      "last_updated": "2026-08-17",
+      "size_lines": 1592,
+      "last_updated": "2026-08-22",
       "description": "Module:       column_api",
       "functions": [
         {
@@ -1074,7 +1074,7 @@
       "constants": [
         "_T"
       ],
-      "content_hash": "23dc5143b8a0"
+      "content_hash": "64068f55a652"
     },
     {
       "name": "combined_footing_api.py",
@@ -1894,7 +1894,7 @@
     {
       "name": "excel_workbench.py",
       "type": "python",
-      "size_lines": 951,
+      "size_lines": 952,
       "last_updated": "2026-08-22",
       "description": "Strict selected-table orchestration for Excel Routine Workbench V1.",
       "classes": [
@@ -1960,7 +1960,7 @@
         "_WORKBOOK_ARTIFACT_NAME",
         "_WORKBOOK_RESOURCE_DIR"
       ],
-      "content_hash": "090d514bfa97"
+      "content_hash": "3e5405b70986"
     },
     {
       "name": "flat_slab_api.py",
@@ -3419,5 +3419,5 @@
     "PropertyLineStrapFootingDesignStatus",
     "design_property_line_strap_footing_is456"
   ],
-  "content_hash": "96688dfaf6b7e525"
+  "content_hash": "fff25116f32d6d15"
 }

--- a/Python/structural_lib/services/index.md
+++ b/Python/structural_lib/services/index.md
@@ -44,7 +44,7 @@
 | [calculation_report.py](calculation_report.py) | Module:       calculation_report | 4 | 1 | 722 |
 | [capabilities.py](capabilities.py) | Discoverable supported-case registry for the IS 456 public l | 7 | 3 | 2057 |
 | [cli_design.py](cli_design.py) | Strict, lossless intake and compatibility output for the adv | 4 | 2 | 628 |
-| [column_api.py](column_api.py) | Module:       column_api | 0 | 13 | 1546 |
+| [column_api.py](column_api.py) | Module:       column_api | 0 | 13 | 1592 |
 | [combined_footing_api.py](combined_footing_api.py) | Stable orchestration for the bounded symmetric combined-foot | 4 | 2 | 252 |
 | [common_api.py](common_api.py) | Module:       common_api | 0 | 5 | 709 |
 | [costing.py](costing.py) | Cost calculation utilities for structural elements. | 2 | 8 | 376 |
@@ -55,7 +55,7 @@
 | [evidence.py](evidence.py) | Canonical evidence identity for the supported IS 456 beam de | 0 | 4 | 386 |
 | [excel_bridge.py](excel_bridge.py) | Excel UDF Bridge - Exposes structural_lib functions to Excel | 0 | 7 | 305 |
 | [excel_integration.py](excel_integration.py) | Excel Integration Module — Bridge between Excel data and Det | 2 | 9 | 489 |
-| [excel_workbench.py](excel_workbench.py) | Strict selected-table orchestration for Excel Routine Workbe | 1 | 8 | 951 |
+| [excel_workbench.py](excel_workbench.py) | Strict selected-table orchestration for Excel Routine Workbe | 1 | 8 | 952 |
 | [flat_slab_api.py](flat_slab_api.py) | Stable orchestration for the bounded regular interior flat-s | 4 | 2 | 339 |
 | [footing_api.py](footing_api.py) | Bounded orchestration for concentric isolated footings (IS 4 | 5 | 1 | 915 |
 | [gravity_calculation_book.py](gravity_calculation_book.py) | Deterministic review dossier for Building Gravity Workflow V | 3 | 4 | 254 |

--- a/Python/structural_lib/validation.py
+++ b/Python/structural_lib/validation.py
@@ -11,6 +11,8 @@ from structural_lib.core.validation import (  # noqa: F401, E402
     validate_beam_inputs,
     validate_cover,
     validate_dimensions,
+    validate_finite_real,
+    validate_finite_reals,
     validate_geometry_relationship,
     validate_loads,
     validate_material_grades,

--- a/Python/tests/codes/is456/column/test_uniaxial.py
+++ b/Python/tests/codes/is456/column/test_uniaxial.py
@@ -301,6 +301,51 @@ class TestUniaxialErrors:
                 **STD,
             )
 
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "Pu_kN",
+            "Mu_kNm",
+            "b_mm",
+            "D_mm",
+            "le_mm",
+            "fck",
+            "fy",
+            "Asc_mm2",
+            "d_prime_mm",
+            "l_unsupported_mm",
+        ],
+    )
+    @pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_inputs_raise_before_envelope_calculation(self, field, invalid):
+        kwargs = {
+            "Pu_kN": 500.0,
+            "Mu_kNm": 100.0,
+            **STD,
+            "l_unsupported_mm": 3000.0,
+        }
+        kwargs[field] = invalid
+
+        with pytest.raises((DimensionError, MaterialError), match=field):
+            design_short_column_uniaxial(**kwargs)
+
+    def test_unrounded_utilization_controls_safety_at_display_boundary(self):
+        result = design_short_column_uniaxial(
+            Pu_kN=500.0,
+            Mu_kNm=240.49446624425235,
+            b_mm=400.0,
+            D_mm=400.0,
+            le_mm=1950.0,
+            fck=25.0,
+            fy=415.0,
+            Asc_mm2=3200.0,
+            d_prime_mm=50.0,
+        )
+
+        assert result.utilization_ratio == 1.0
+        assert result.is_safe is False
+        assert "exceeded" in result.governing_check
+
     def test_b_mm_zero_raises(self):
         """b_mm = 0 -> DimensionError."""
         with pytest.raises(DimensionError, match="b_mm"):

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/tests",
   "type": "python-package",
   "description": "This document describes the test taxonomy and structure for the structural_engineering_lib test suite.",
-  "last_updated": "2026-08-21",
+  "last_updated": "2026-08-22",
   "file_count": 75,
   "files": [
     {
@@ -1360,8 +1360,8 @@
     {
       "name": "test_column_return_types.py",
       "type": "python",
-      "size_lines": 281,
-      "last_updated": "2026-08-17",
+      "size_lines": 312,
+      "last_updated": "2026-08-22",
       "description": "Tests for UX-02: Column API return type unification.",
       "classes": [
         {
@@ -1443,9 +1443,15 @@
         {
           "name": "uniaxial_result",
           "description": "Standard uniaxial result for a 300x450 column."
+        },
+        {
+          "name": "test_unified_column_rejects_infinite_moment_before_minimum_amplification"
+        },
+        {
+          "name": "test_public_uniaxial_column_rejects_non_finite_action"
         }
       ],
-      "content_hash": "376e193ec460"
+      "content_hash": "6863ccf8df17"
     },
     {
       "name": "test_core.py",
@@ -4974,5 +4980,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "764196b61d0427a8"
+  "content_hash": "c8b3b9e466ca453b"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -3,7 +3,7 @@
 This document describes the test taxonomy and structure for the structural_engineering_lib test suite.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-21
+**Last Updated:** 2026-08-22
 **Files:** 75
 
 ## Documentation Files
@@ -37,7 +37,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_column_biaxial.py](test_column_biaxial.py) | Tests for IS 456 Cl 39.6 biaxial bending check — TASK-635. | 8 | 0 | 958 |
 | [test_column_helical.py](test_column_helical.py) | Tests for IS 456 Cl 39.4 helical reinforcement check. | 7 | 0 | 356 |
 | [test_column_long.py](test_column_long.py) | Tests for IS 456 Cl 39.7 long (slender) column design. | 15 | 0 | 662 |
-| [test_column_return_types.py](test_column_return_types.py) | Tests for UX-02: Column API return type unification. | 7 | 2 | 281 |
+| [test_column_return_types.py](test_column_return_types.py) | Tests for UX-02: Column API return type unification. | 7 | 4 | 312 |
 | [test_core.py](test_core.py) | Tests for structural_lib.core module. | 6 | 0 | 176 |
 | [test_core_types.py](test_core_types.py) | Tests for core types and error dataclasses. | 11 | 0 | 391 |
 | [test_dashboard.py](test_dashboard.py) | Tests for the dashboard analytics module. | 4 | 0 | 259 |

--- a/Python/tests/test_column_return_types.py
+++ b/Python/tests/test_column_return_types.py
@@ -19,6 +19,7 @@ import pytest
 
 from structural_lib import (
     design_column_axial_is456,
+    design_column_is456,
     design_short_column_uniaxial_is456,
 )
 from structural_lib.core.data_types import (
@@ -278,3 +279,33 @@ class TestFrozenDataclass:
         """ColumnUniaxialResult cannot be mutated."""
         with pytest.raises(dataclasses.FrozenInstanceError):
             uniaxial_result.is_safe = False  # type: ignore[misc]
+
+
+def test_unified_column_rejects_infinite_moment_before_minimum_amplification():
+    with pytest.raises(ValueError, match="Mux_kNm must be a finite real number"):
+        design_column_is456(
+            Pu_kN=100.0,
+            Mux_kNm=float("-inf"),
+            b_mm=300.0,
+            D_mm=450.0,
+            l_mm=3000.0,
+            fck_nmm2=25.0,
+            fy_nmm2=415.0,
+            Asc_mm2=2700.0,
+            d_prime_mm=50.0,
+        )
+
+
+def test_public_uniaxial_column_rejects_non_finite_action():
+    with pytest.raises(ValueError, match="Mu_kNm must be a finite real number"):
+        design_short_column_uniaxial_is456(
+            Pu_kN=1200.0,
+            Mu_kNm=float("nan"),
+            b_mm=300.0,
+            D_mm=450.0,
+            le_mm=3000.0,
+            fck_nmm2=25.0,
+            fy_nmm2=415.0,
+            Asc_mm2=2700.0,
+            d_prime_mm=50.0,
+        )

--- a/Python/tests/unit/test_compliance_validation.py
+++ b/Python/tests/unit/test_compliance_validation.py
@@ -1,6 +1,53 @@
 import pytest
 
-from structural_lib.compliance import check_compliance_report
+from structural_lib import check_compliance_report as check_public_compliance_report
+from structural_lib.compliance import check_compliance_case, check_compliance_report
+
+COMMON = {
+    "b_mm": 230.0,
+    "D_mm": 500.0,
+    "d_mm": 450.0,
+    "fck_nmm2": 25.0,
+    "fy_nmm2": 500.0,
+    "asv_mm2": 100.0,
+}
+
+
+def test_public_compliance_report_rejects_empty_cases():
+    with pytest.raises(ValueError, match="at least one compliance case"):
+        check_public_compliance_report(cases=[], **COMMON)
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf"), True])
+def test_compliance_case_rejects_non_finite_actions_before_calculation(invalid):
+    with pytest.raises(ValueError, match="mu_knm must be a finite real number"):
+        check_compliance_case(
+            case_id="NONFINITE",
+            mu_knm=invalid,
+            vu_kn=20.0,
+            **COMMON,
+        )
+
+
+@pytest.mark.parametrize("field", ["pt_percent", "ast_mm2_for_shear"])
+def test_compliance_case_rejects_non_finite_optional_shear_inputs(field):
+    kwargs = {
+        "case_id": "NONFINITE_OPTIONAL",
+        "mu_knm": 20.0,
+        "vu_kn": 20.0,
+        **COMMON,
+        field: float("nan"),
+    }
+    with pytest.raises(ValueError, match=field):
+        check_compliance_case(**kwargs)
+
+
+def test_public_compliance_report_rejects_numeric_text_nan():
+    with pytest.raises(ValueError, match="mu_knm must be a finite real number"):
+        check_public_compliance_report(
+            cases=[{"case_id": "TEXT_NAN", "mu_knm": "nan", "vu_kn": 20.0}],
+            **COMMON,
+        )
 
 
 def test_compliance_report_handles_bad_deflection_defaults_without_crashing():

--- a/Python/tests/unit/test_input_validation.py
+++ b/Python/tests/unit/test_input_validation.py
@@ -84,6 +84,27 @@ def test_flexure_design_singly_reinforced_rejects_invalid_inputs(
     ) or _has_error_with_message(res.errors, expected_substring)
 
 
+@pytest.mark.parametrize("field", ["b", "d", "d_total", "mu_knm", "fck", "fy"])
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_flexure_design_singly_reinforced_rejects_non_finite_inputs(field, invalid):
+    kwargs = {
+        "b": 230.0,
+        "d": 450.0,
+        "d_total": 500.0,
+        "mu_knm": 100.0,
+        "fck": 25.0,
+        "fy": 415.0,
+    }
+    kwargs[field] = invalid
+
+    result = flexure.design_singly_reinforced(**kwargs)
+
+    assert result.is_safe is False
+    assert any(
+        error.code == "E_INPUT_017" and error.field == field for error in result.errors
+    )
+
+
 def test_flexure_design_doubly_reinforced_rejects_nonpositive_d_dash():
     b, d, d_total = 230.0, 450.0, 500.0
     res = flexure.design_doubly_reinforced(
@@ -188,4 +209,29 @@ def test_shear_design_rejects_invalid_inputs(kwargs, expected_field):
     # Check that error for the expected field is in the errors list
     assert _has_error_with_field(res.errors, expected_field) or _has_error_with_message(
         res.errors, expected_field
+    )
+
+
+@pytest.mark.parametrize(
+    "field", ["vu_kn", "b", "d", "fck", "fy", "asv", "pt", "av_mm"]
+)
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_shear_design_rejects_non_finite_inputs(field, invalid):
+    kwargs = {
+        "vu_kn": 100.0,
+        "b": 230.0,
+        "d": 450.0,
+        "fck": 25.0,
+        "fy": 415.0,
+        "asv": 100.0,
+        "pt": 1.0,
+        "av_mm": 900.0,
+    }
+    kwargs[field] = invalid
+
+    result = shear.design_shear(**kwargs)
+
+    assert result.is_safe is False
+    assert any(
+        error.code == "E_INPUT_017" and error.field == field for error in result.errors
     )

--- a/Python/tests/unit/test_validation.py
+++ b/Python/tests/unit/test_validation.py
@@ -2,6 +2,8 @@
 Tests for validation utilities module.
 """
 
+import pytest
+
 from structural_lib import validation
 from structural_lib.core.errors import (
     E_INPUT_001,
@@ -14,6 +16,21 @@ from structural_lib.core.errors import (
     E_INPUT_015,
     E_INPUT_003a,
 )
+
+
+@pytest.mark.parametrize(
+    "value", [float("nan"), float("inf"), float("-inf"), True, "25"]
+)
+def test_validate_finite_real_rejects_non_real_or_non_finite_values(value):
+    errors = validation.validate_finite_real(value, "load")
+
+    assert len(errors) == 1
+    assert errors[0].code == "E_INPUT_017"
+    assert errors[0].field == "load"
+
+
+def test_validate_finite_real_accepts_a_finite_boundary():
+    assert validation.validate_finite_real(0.0, "load") == []
 
 
 class TestValidateDimensions:

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,82 @@
 
 ---
 
+## 2026-08-22 — Session: LIB-PRO-003-A public numeric boundaries
+
+**Agent:** Codex (`backend`, sole writer)
+
+**Branch:** `codex/public-route-numeric-boundaries`, from hosted `main` at
+`e40c0b564acae82f6696e204e8b382342fbf4321`.
+
+**Git handoff receipt:**
+`docs/verification/lib-pro-003-a-git-handoff-receipt.json`
+
+**Focus:** Close reproduced non-finite public calculation outcomes, empty
+compliance success, and the rounded uniaxial-column safety decision without
+changing engineering formulas or supported domains.
+
+### Summary
+
+- Introduced one shared finite-real structured validation boundary and applied
+  it before arithmetic in lower-level beam flexure, beam shear, compliance,
+  direct uniaxial-column, and unified column routes.
+- Changed an empty compliance report from vacuous success to explicit input
+  rejection.
+- Changed uniaxial-column safety to compare exact utilization while retaining
+  the rounded public display field.
+- Added direct regressions for all affected numeric arguments, the exact
+  `-infinity` column and `1.0000` display-boundary reproductions, empty public
+  compliance, numeric-text NaN, booleans, and compatibility exports.
+- Froze the remaining public-route safety work as `LIB-PRO-003` Packets B-D;
+  INDIA-3 and the next package remain held behind that sequence.
+- Verification: 260 unique implementation-focused tests and 138 independent
+  verification/API tests pass; focused Ruff and `git diff --check` pass; the
+  consolidated quick gate passes 10/10.
+
+### Issues encountered
+
+- The first focused run had six failures because the new canonical validation
+  helper was not exposed through the backward-compatible
+  `structural_lib.validation` module.
+- A focused Ruff check found one extra blank line in the compliance-validation
+  test import block.
+- ⚠️ TERMINAL ISSUE: unquoted forbidden-path globs expanded during the first
+  handoff-receipt command and were rejected as extra arguments; quoting the
+  literal patterns produced the receipt successfully and no failed-command
+  write occurred.
+- The first normal commit-hook pass stopped after Black reformatted the changed
+  uniaxial module and two focused test files.
+
+### Root causes and resolutions
+
+- Symptom: `AttributeError` occurred only through the compatibility facade.
+  Root cause: that facade uses an explicit import list, so adding the helper to
+  canonical `core.validation.__all__` did not update the old module. Resolution:
+  add both finite-real helpers to the explicit facade import list. Evidence:
+  the complete 86-test validation file passes.
+- Symptom: focused Ruff reported `I001`. Root cause: the patched import block
+  contained one surplus blank line. Resolution: remove that line. Evidence:
+  focused Ruff and `git diff --check` pass.
+- Symptom: the first receipt command rejected many expanded file arguments.
+  Root cause: zsh expanded unquoted `**` patterns before the script received
+  them. Resolution: quote each forbidden pattern. Evidence: receipt creation
+  and session handoff both completed successfully.
+- Symptom: the candidate commit was not created on the first hook pass. Root
+  cause: three changed Python files were Ruff-clean but not Black-normalized.
+  Resolution: retain Black's mechanical output, refresh only its affected
+  maintained indexes, and restage the candidate. Evidence: Black identified
+  and reformatted exactly those three files; all other normal hooks passed on
+  that pass, including repository-wide mypy over 243 source files.
+
+### Remaining holds
+
+- `LIB-PRO-003-B` through D remain open.
+- No package publication, version bump, stable/professional-use claim,
+  qualified-engineer approval, INDIA-3 work, ETABS, or desktop Excel work is
+  authorized by this packet.
+
+---
+
 ## 2026-08-22 — Session: E1 G3 integration and roadmap closeout
 
 **Agent:** Codex (`orchestrator`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -127,12 +127,13 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| — | No implementation packet active | — | — | — | Awaiting owner activation of the next bounded program |
+| LIB-PRO-003-A | Close non-finite public calculation inputs, empty compliance success, and rounded column safety decisions | backend + tester | M | P0 | 🚧 ACTIVE — exact-tree audit accepted; implementation and focused regression evidence in progress |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
-boundary. INDIA-3, dependency work, the next package version, further cleanup,
-and professional approval remain separately held until their own packet is
-activated.
+boundary. The reproduced public-route safety defects take priority over new
+capability work. INDIA-3, dependency work, the next package version, further
+cleanup, and professional approval remain separately held until `LIB-PRO-003`
+closes and their own packet is activated.
 
 `LIB-PRO-002-G0` was independently accepted and merged through PR #812 at
 `55104e11257937b0a42fb06f931a70b8484cef39`. Packet A was independently
@@ -157,7 +158,10 @@ write-back/nightly work remain outside E1.
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | ⏸ READY FOR OWNER ACTIVATION — truth/benchmark/contract audit first; no new formulas or support claims |
+| LIB-PRO-003-B | Enforce beam/column material and reinforcement domains, repair the stale column key, and close footing provenance | backend + tester | M | P0 | ⏸ NEXT AFTER A — bounded outcome-changing safety repair |
+| LIB-PRO-003-C | Convert slab capacity, malformed legacy CSV, and negative BOQ inputs to structured fail-closed outcomes | backend + API developer + tester | M | P0 | ⏸ AFTER B |
+| LIB-PRO-003-D | Make Excel CI and input audits decisive and synchronize release/route-count truth | ops + governance | S | P0 | ⏸ AFTER C |
+| INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | ⏸ AFTER LIB-PRO-003 — truth/benchmark/contract audit only; no new formulas or support claims |
 | SPARK-001-G0 | Reassess the stale Spark work-program proposal before any implementation | repository owner | review gate | P2 | ⏸ OWNER REVIEW — the 2026-08-11 model/preview assumptions and bulk wave require refresh or rejection |
 
 ## Backlog
@@ -180,7 +184,8 @@ with exact beam stress-block arithmetic and controlled Clause 38.1/Annex G
 provenance. Exact post-INDIA-2 cleanup is complete for frozen candidate set
 `POST-INDIA2-2499DF4ADE0DF704`: 58 worktrees, 64 local branches, and 71 remote
 branches were removed; every non-candidate lane remains retained or held.
-The v0.23.1a1 Alpha is published.
+The v0.23.1a2 Alpha is published; Gravity and E1 are later `main` work and are
+not part of that immutable artifact.
 UIX-001 P0-P15 is accepted: the revision-safe workbench, authoritative
 3D inspection, versioned capability catalogue, curated renderer, bounded
 development workflow, generated beam manifest, canonical routes, and integrated

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 3688,
+      "size_lines": 3764,
       "last_updated": "2026-08-22",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "b6858330d4c7"
+      "content_hash": "e3e8c05e23ec"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 730,
+      "size_lines": 735,
       "last_updated": "2026-08-22",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "ab243290ae6e"
+      "content_hash": "31fb4ea07117"
     },
     {
       "name": "WORKLOG.md",
@@ -181,7 +181,7 @@
     {
       "name": "planning",
       "path": "planning/",
-      "file_count": 22
+      "file_count": 23
     },
     {
       "name": "publications",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 204,
+      "file_count": 207,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "1ea030066c62144e"
+  "content_hash": "9883ce3f9aa53c79"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 3688 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 730 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 3764 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 735 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -43,9 +43,9 @@ Guides, references, evidence, and contributor material for the
 | [learning-foundations/](learning-foundations/) | 13 | These are NOT specific to this repo. They are universal concepts every developer |
 | [legal/](legal/) | 6 | Engineering certification templates and usage guidelines. |
 | [migration/](migration/) | 45 |  |
-| [planning/](planning/) | 22 |  |
+| [planning/](planning/) | 23 |  |
 | [publications/](publications/) | 10 | This directory contains blog posts, technical articles, and academic papers docu |
 | [reference/](reference/) | 1793 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 8 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 204 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 207 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -20,6 +20,7 @@ Internal planning documents and research notes.
 | [Next Session Brief](next-session-brief.md) | What to work on next |
 | [TASKS.md](../TASKS.md) | Canonical task backlog |
 | [Pre-Release Input Safety and Professional Readiness Plan](pre-release-input-safety-and-professional-readiness-plan.md) | Active contract-first remediation and release holds from the one-storey usability pilot |
+| [Public Route Safety Closure Plan](public-route-safety-closure-plan.md) | Current exact-tree remediation sequence for reproduced lower-level public-route safety defects |
 | [IS 456 Solid Slabs Master Plan](is456-solid-slabs-master-plan.md) | Source-gated, implementation-ready program for simply supported/continuous one-way and common two-way solid slabs; flat slabs held separately |
 | [MAINT-008 Compact Modernization Plan](compact-modernization-plan.md) | Dependency-ordered implementation packets for CI and maintenance modernization |
 | [IS 456 Library-First Master Plan](is456-library-first-master-plan.md) | Worker-ready plan for completing the supported Python library, evidence, packaging, and PyPI flow before broad API/UI work |
@@ -33,6 +34,7 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
+| `public-route-safety-closure-plan.md` | 2026-08-22 | 🚧 LIB-PRO-003-A active; new release and professional/stable claims held through A-D |
 | `next-session-brief.md` | 2026-08-17 | 📋 LIB-PRO-002-I CLI closure then J release-signal convergence are the exact next sequence |
 | `pre-release-input-safety-and-professional-readiness-plan.md` | 2026-08-17 | 🚧 A-G merged; CLI, hosted-interpreter, preflight-verdict, and authorization holds remain through I-J |
 | `is456-solid-slabs-master-plan.md` | 2026-08-10 | 📋 Master plan ready; implementation has not started |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -3,16 +3,16 @@
   "type": "documentation",
   "description": "",
   "last_updated": "2026-08-22",
-  "file_count": 20,
+  "file_count": 21,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
-      "size_lines": 156,
-      "last_updated": "2026-08-17",
+      "size_lines": 158,
+      "last_updated": "2026-08-22",
       "title": "Planning",
       "description": "Internal planning documents and research notes. | Document | Purpose |",
-      "content_hash": "d73132ea428c"
+      "content_hash": "915446794030"
     },
     {
       "name": "compact-modernization-plan.md",
@@ -131,11 +131,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 82,
+      "size_lines": 83,
       "last_updated": "2026-08-22",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-22",
-      "content_hash": "3abab3f4828f"
+      "content_hash": "e5f565f6589d"
     },
     {
       "name": "pre-release-checklist.md",
@@ -165,6 +165,14 @@
       "content_hash": "31095ffcf998"
     },
     {
+      "name": "public-route-safety-closure-plan.md",
+      "type": "documentation",
+      "size_lines": 90,
+      "last_updated": "2026-08-22",
+      "description": "engineering-use approval until the bounded packets below close. The 2026-08-22 exact-tree replay confirmed that the bounded Gravity Workflow",
+      "content_hash": "d5ddf133d209"
+    },
+    {
       "name": "ui-experience-foundation-master-plan.md",
       "type": "documentation",
       "size_lines": 2408,
@@ -174,5 +182,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "5bd71db89b2e07e1"
+  "content_hash": "f4242bde2e948174"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -2,13 +2,13 @@
 
 **Type:** Documentation
 **Last Updated:** 2026-08-22
-**Files:** 20
+**Files:** 21
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [README.md](README.md) | Planning | Internal planning documents and research notes. | Document | | 156 |
+| [README.md](README.md) | Planning | Internal planning documents and research notes. | Document | | 158 |
 | [compact-modernization-plan.md](compact-modernization-plan.md) |  | Modernize the repository's CI, maintenance controls, and age | 794 |
 | [democratization-vision.md](democratization-vision.md) |  | > **"What was not possible few years back, or only possible  | 273 |
 | [dependency-security-baseline.md](dependency-security-baseline.md) |  | This record makes MAINT-003 reproducible. It separates confi | 69 |
@@ -23,8 +23,9 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 82 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 83 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Current source metadata: 0.23.1a2 Current public Alpha: v0.2 | 114 |
 | [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 742 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
+| [public-route-safety-closure-plan.md](public-route-safety-closure-plan.md) |  | engineering-use approval until the bounded packets below clo | 90 |
 | [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2408 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,19 +4,19 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-22
-- Focus: Close accepted E1, reconcile release/task truth, and select the next bounded library decision packet without ETABS or new engineering implementation.
-- Git receipt: docs/verification/e1-g3-closeout-git-handoff-receipt.json | sha256:7237912b87c081142c2bda364d639fb96f4c9a1eca48a4c520586f048a34ef85 | HOLD
-- Git identity: codex/e1-g3-closeout@b720119ea6a22a2b1963be0a0b9b300fca333d4a | upstream=origin/main@b720119ea6a22a2b1963be0a0b9b300fca333d4a | base=origin/main@b720119ea6a22a2b1963be0a0b9b300fca333d4a | tree=dirty | operation=none
+- Focus: Close reproduced non-finite public calculation outcomes, empty
+- Git receipt: docs/verification/lib-pro-003-a-git-handoff-receipt.json | sha256:5f9f0b31deb4a96d04f826319cd8594a7f23e7a30d7e9820e9b80a7a43cbb57d | HOLD
+- Git identity: codex/public-route-numeric-boundaries@e40c0b564acae82f6696e204e8b382342fbf4321 | upstream=origin/main@e40c0b564acae82f6696e204e8b382342fbf4321 | base=origin/main@e40c0b564acae82f6696e204e8b382342fbf4321 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: COMMIT_INTENDED_PATHS
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | E1 passed the real installed Windows Excel journey and is integrated into `main` |
-| **Next** | Owner may activate `INDIA-3-G0`: audit existing IS 13920 beam/column/joint truth and freeze one bounded acceptance sequence |
-| **Why** | INDIA-0, INDIA-1, and bounded INDIA-2 are complete; INDIA-4 depends on a frozen INDIA-3 scope |
-| **Held** | No new formulas, support claims, IS 875/IS 1893 work, ETABS work, package publication, or professional approval in G0 |
+| **Current** | `LIB-PRO-003-A` is active against exact hosted `main`: close non-finite calculation inputs, empty compliance success, and rounded column safety decisions |
+| **Next** | Complete the dependency-ordered `LIB-PRO-003` A-D public-route safety closure before capability expansion |
+| **Why** | Direct replay reproduced 13 outcome-changing behaviours still exposed outside the newer bounded Gravity/E1 workflows |
+| **Held** | INDIA-3, new formulas/support claims, ETABS, package publication, stable/professional claims, and qualified approval remain separate and held |
 
 ## E1 final acceptance
 
@@ -42,27 +42,29 @@ authority. Results remain `NOT_REVIEWED` with
 
 ## Correct next library packet
 
-`INDIA-3-G0` is a decision and truth-audit packet, not implementation.
+`LIB-PRO-003-A` is the active bounded implementation packet.
 
-1. Inventory the currently implemented and advertised IS 13920 beam, column,
-   and joint checks.
-2. Bind every claimed case to exact source provenance, units, applicability,
-   result/status contracts, and independent benchmarks.
-3. Identify false registration, missing cross-layer exposure, or unsupported
-   claims that change user outcomes.
-4. Freeze one small acceptance sequence and explicit exclusions before any new
-   calculation, API, or UI work.
-5. Return `ACCEPT`, `REVISE`, or `HOLD` plus the exact first implementation
-   packet.
+1. Reject booleans, NaN, and infinity before lower-level beam flexure, beam
+   shear, compliance, or column arithmetic can produce a safety result.
+2. Reject an empty compliance report instead of accepting `all([])`.
+3. Reject non-finite unified-column moments before minimum-moment
+   amplification can replace them with finite values.
+4. Compare exact uniaxial utilization to `1.0`; round only the returned display
+   field.
+5. Preserve valid arithmetic, public result shapes, and all formula/source
+   boundaries.
 
-Do not start IS 13920 wall/foundation expansion, IS 875, IS 1893, response
-spectrum, FEM, or ETABS during G0.
+Packets B-D then close material/reinforcement/provenance domains, structured
+slab/CSV/BOQ failures, and decisive CI/audit/documentation truth. Do not start
+new engineering formulas, IS 13920 expansion, IS 875, IS 1893, FEM, or ETABS.
 
 ## Other live work
 
 - `v0.23.1a2` is already public. Gravity and E1 were merged afterward, so any
   next package must use a new version and fresh exact-artifact evidence; never
   republish `0.23.1a2`.
+- `INDIA-3-G0` remains the next capability-truth packet, but it is deferred
+  until the reproduced public-route safety closure is complete.
 - `SPARK-001-G0` remains an owner-review proposal. Its model/preview assumptions
   date from 2026-08-11 and must be refreshed or rejected before a wave starts.
 - Dependabot PRs are separate maintenance work and do not outrank the
@@ -74,8 +76,7 @@ spectrum, FEM, or ETABS during G0.
 
 ## Required Reading
 
-1. [Indian-code completion plan](indian-code-completion-plan.md)
-2. [IS 456 library-first master plan](is456-library-first-master-plan.md)
-3. [E1 workbook-open repair evidence](../verification/e1-workbook-open-repair-evidence.md)
-4. [Current task board](../TASKS.md)
-5. [Git workflow single source](../git-automation/git-workflow-single-source.md)
+1. [Public route safety closure plan](public-route-safety-closure-plan.md)
+2. [Current task board](../TASKS.md)
+3. [Pre-release input safety plan](pre-release-input-safety-and-professional-readiness-plan.md)
+4. [Git workflow single source](../git-automation/git-workflow-single-source.md)

--- a/docs/planning/public-route-safety-closure-plan.md
+++ b/docs/planning/public-route-safety-closure-plan.md
@@ -1,0 +1,89 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-22
+doc_type: plan
+complexity: advanced
+tags: [safety, validation, public-api, release-hold]
+---
+
+# Public Route Safety Closure Plan
+
+**Task:** `LIB-PRO-003`
+**Source base:** hosted `main` at `e40c0b564acae82f6696e204e8b382342fbf4321`
+**Decision:** `HOLD` for a new package, stable/professional claims, and
+engineering-use approval until the bounded packets below close.
+
+## Audit decision
+
+The 2026-08-22 exact-tree replay confirmed that the bounded Gravity Workflow
+V1 and E1 contracts remain valid, while 13 outcome-changing behaviours remain
+available through older or lower-level public routes. Mechanical green checks
+do not supersede those direct public outcomes.
+
+The confirmed families are:
+
+1. non-finite flexure, shear, compliance, and column actions can report safe;
+2. an empty compliance aggregate can report success;
+3. beam shear inputs, steel percentages, and unsupported material grades can
+   be substituted, clamped, or accepted as top-level success;
+4. column reinforcement limits, an unrounded capacity boundary, and one stale
+   result key can produce false PASS or a crash;
+5. footing provenance can accept an unknown origin;
+6. slab over-capacity, malformed legacy CSV, and negative BOQ rates do not use
+   truthful structured failure contracts; and
+7. Excel add-in CI, audit-tool exit policy, release wording, and route-count
+   wording are not decisive or synchronized.
+
+This is a new evidence-driven program. It does not reopen or rewrite the
+historical `LIB-PRO-001` or `LIB-PRO-002` ledgers.
+
+## Frozen sequence
+
+### Packet A — Numeric and aggregate fail-closed boundaries
+
+**Status:** active.
+
+**Owned behaviour:**
+
+- add one stable finite-real validation issue and apply it before arithmetic in
+  public lower-level beam flexure, beam shear, compliance, and column routes;
+- reject empty compliance reports instead of relying on vacuous `all([])`;
+- reject non-finite unified-column actions before minimum-moment amplification;
+- decide uniaxial-column safety from exact utilization and round only the
+  returned display value.
+
+**Acceptance:** the reproduced NaN, infinity, empty-report, `-infinity`
+column, and `1.0000` rounded-utilization cases fail closed; all affected valid
+tests and independent column benchmarks remain unchanged.
+
+### Packet B — Beam, column, and provenance domains
+
+Reject supplied non-positive shear steel instead of substituting it; reject
+out-of-domain steel percentages and unsupported material grades; enforce
+column reinforcement limits; repair the stale uniaxial result key; and require
+a declared footing provenance origin.
+
+### Packet C — Structured failure and intake truth
+
+Return a structured slab capacity `FAIL`, make the legacy CSV route block
+malformed numeric cells without zero coercion or row loss, and reject negative
+BOQ rates at the request boundary.
+
+### Packet D — Decisive gates and repository truth
+
+Run the Excel add-in tests for `excel_addin/**` changes, make the input audit
+surface and exit result decisive, and reconcile release and endpoint-count
+wording with clearly named metrics.
+
+After A-D pass focused, quick, broad, and hosted acceptance, the owner may
+resume `INDIA-3-G0`. A future package remains a separate versioned artifact and
+owner-authorized release operation.
+
+## Non-goals
+
+- no IS 456, IS 13920, IS 875, or IS 1893 formula expansion;
+- no ETABS or desktop Excel activity;
+- no package version bump, tag, upload, or GitHub Release;
+- no claim of formula certification, professional approval, or project fitness;
+- no cleanup, deletion, or reinterpretation of preserved branches/worktrees.

--- a/docs/reference/error-schema.md
+++ b/docs/reference/error-schema.md
@@ -156,6 +156,7 @@ engineering disposition because calculation may not have occurred.
 | `E_INPUT_014` | `Df` | `Df must be > 0` | Check flange thickness input. |
 | `E_INPUT_015` | `bf` | `bf must be >= bw` | Ensure flange width is not smaller than web width. |
 | `E_INPUT_016` | `Df` | `Df must be < d` | Ensure flange thickness is less than effective depth. |
+| `E_INPUT_017` | dynamic | `<field> must be a finite real number` | Replace NaN, infinity, booleans, or non-numeric values. |
 
 #### Flexure (`E_FLEXURE_`)
 

--- a/docs/reference/index.json
+++ b/docs/reference/index.json
@@ -2,7 +2,7 @@
   "folder": "docs/reference",
   "type": "mixed",
   "description": "",
-  "last_updated": "2026-08-17",
+  "last_updated": "2026-08-22",
   "file_count": 31,
   "files": [
     {
@@ -194,10 +194,10 @@
     {
       "name": "error-schema.md",
       "type": "documentation",
-      "size_lines": 317,
-      "last_updated": "2026-08-17",
+      "size_lines": 318,
+      "last_updated": "2026-08-22",
       "description": "*Structured error format for machine-readable and human-friendly errors* This document defines the standard error schema for all structural_lib errors. The goal is:",
-      "content_hash": "7c8c14e70ebf"
+      "content_hash": "337c94f04699"
     },
     {
       "name": "fastapi-rest-api.md",
@@ -279,5 +279,5 @@
       "file_count": 1760
     }
   ],
-  "content_hash": "ce6face1a63d9004"
+  "content_hash": "e1a93ead62b556c1"
 }

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,7 @@
 # Reference
 
 **Type:** Mixed
-**Last Updated:** 2026-08-17
+**Last Updated:** 2026-08-22
 **Files:** 31
 
 ## Config Files
@@ -31,7 +31,7 @@
 | [deprecation-policy.md](deprecation-policy.md) |  | This document defines the deprecation policy for the structu | 368 |
 | [dxf-layer-standards.md](dxf-layer-standards.md) |  | This document defines CAD layer standards used in DXF drawin | 469 |
 | [error-codes.md](error-codes.md) |  | > Auto-generated from Python/structural_lib/core/errors.py.  | 87 |
-| [error-schema.md](error-schema.md) |  | *Structured error format for machine-readable and human-frie | 317 |
+| [error-schema.md](error-schema.md) |  | *Structured error format for machine-readable and human-frie | 318 |
 | [fastapi-rest-api.md](fastapi-rest-api.md) |  | The FastAPI application exposes the maintained Python calcul | 307 |
 | [insights-api.md](insights-api.md) |  | > **Status:** Preview (v0.13.0+) > **Stability:** Experiment | 994 |
 | [is456-formulas.md](is456-formulas.md) |  | $$d = D - c_{clear} - \phi_{stirrup} - \frac{\phi_{main}}{2} | 245 |

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-22",
-  "file_count": 202,
+  "file_count": 205,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -2267,6 +2267,44 @@
       "content_hash": "2ae22416068d"
     },
     {
+      "name": "lib-pro-003-a-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "ae682506d54c"
+    },
+    {
+      "name": "lib-pro-003-a-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "6cc77e879c31"
+    },
+    {
+      "name": "lib-pro-003-a-numeric-boundaries-evidence.md",
+      "type": "documentation",
+      "size_lines": 68,
+      "last_updated": "2026-08-22",
+      "description": "- Source base: hosted main at e40c0b564acae82f6696e204e8b382342fbf4321.",
+      "content_hash": "770c3d6c52a5"
+    },
+    {
       "name": "next-session-git-issues-plan-git-handoff-receipt.json",
       "type": "config",
       "last_updated": "2026-08-16",
@@ -2585,5 +2623,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "9201082f19508939"
+  "content_hash": "1cff27079d48d61b"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-22
-**Files:** 202
+**Files:** 205
 
 ## Config Files
 
@@ -122,6 +122,8 @@ Benchmark examples and verification packs for validating library calculations ag
 - [lib-pro-002-j-git-handoff-receipt.json](lib-pro-002-j-git-handoff-receipt.json)
 - [lib-pro-002-j-hosted-repair-git-handoff-receipt.json](lib-pro-002-j-hosted-repair-git-handoff-receipt.json)
 - [lib-pro-002-post-fix-recheck-git-handoff-receipt.json](lib-pro-002-post-fix-recheck-git-handoff-receipt.json)
+- [lib-pro-003-a-git-handoff-receipt.json](lib-pro-003-a-git-handoff-receipt.json)
+- [lib-pro-003-a-git-handoff-source-evidence.json](lib-pro-003-a-git-handoff-source-evidence.json)
 - [next-session-git-issues-plan-git-handoff-receipt.json](next-session-git-issues-plan-git-handoff-receipt.json)
 - [next-session-git-issues-plan-git-handoff-source-evidence.json](next-session-git-issues-plan-git-handoff-source-evidence.json)
 - [post-india2-cleanup-disposition-evidence.json](post-india2-cleanup-disposition-evidence.json)
@@ -210,6 +212,7 @@ Benchmark examples and verification packs for validating library calculations ag
 | [is456-library-first-evidence.md](is456-library-first-evidence.md) | IS 456 Library-First Evidence and Claim  | | Source | SHA-256 | Pages | Use | |---|---|---:|---| | 169 |
 | [is456-slab-evidence.md](is456-slab-evidence.md) | IS 456 Solid Slab Source and Benchmark L | | ID | Identity | Permitted implementation use | State | |-- | 125 |
 | [lib-pro-002-e-evidence-identity.md](lib-pro-002-e-evidence-identity.md) |  | The bounded design_beam_is456 strength route is bound to the | 37 |
+| [lib-pro-003-a-numeric-boundaries-evidence.md](lib-pro-003-a-numeric-boundaries-evidence.md) |  | - Source base: hosted main at e40c0b564acae82f6696e204e8b382 | 68 |
 | [pack.md](pack.md) |  | This repo’s unit tests validate correctness and edge cases,  | 56 |
 | [post-india2-cleanup-authorization-proposal.md](post-india2-cleanup-authorization-proposal.md) |  | Exact candidate set POST-INDIA2-2499DF4ADE0DF704 contains ** | 162 |
 | [release-artifact-evidence-template.md](release-artifact-evidence-template.md) | Release Artifact Evidence Template | Complete this record from the CI run that built the exact ca | 45 |

--- a/docs/verification/lib-pro-003-a-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-003-a-git-handoff-receipt.json
@@ -1,0 +1,210 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-22T09:52:21Z",
+      "query_status": "OK",
+      "reference": "task:LIB-PRO-003-A:user-request-continue-this-work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-22T09:52:21Z",
+    "prohibited_actions": [
+      "PUBLISH_RELEASE",
+      "CLAIM_PROFESSIONAL_APPROVAL",
+      "START_INDIA_3",
+      "START_ETABS_OR_DESKTOP_EXCEL",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR"
+      ],
+      "branch": "codex/public-route-numeric-boundaries",
+      "head_sha": "e40c0b564acae82f6696e204e8b382342fbf4321",
+      "task_id": "LIB-PRO-003-A"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "5f9f0b31deb4a96d04f826319cd8594a7f23e7a30d7e9820e9b80a7a43cbb57d",
+    "state": {
+      "branch": "codex/public-route-numeric-boundaries",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "e40c0b564acae82f6696e204e8b382342fbf4321",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 83.635,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-public-route-numeric-boundaries",
+      "head_sha": "e40c0b564acae82f6696e204e8b382342fbf4321",
+      "hold_reasons": [
+        "changed paths: 21"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-22T09:54:24.799478+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-numeric-boundaries",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 21,
+        "modified_paths": [
+          "Python/structural_lib/codes/is456/beam/flexure.py",
+          "Python/structural_lib/codes/is456/beam/shear.py",
+          "Python/structural_lib/codes/is456/column/uniaxial.py",
+          "Python/structural_lib/codes/is456/compliance.py",
+          "Python/structural_lib/core/validation.py",
+          "Python/structural_lib/services/column_api.py",
+          "Python/structural_lib/validation.py",
+          "Python/tests/codes/is456/column/test_uniaxial.py",
+          "Python/tests/test_column_return_types.py",
+          "Python/tests/unit/test_compliance_validation.py",
+          "Python/tests/unit/test_input_validation.py",
+          "Python/tests/unit/test_validation.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/README.md",
+          "docs/planning/next-session-brief.md",
+          "docs/reference/error-schema.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/planning/public-route-safety-closure-plan.md",
+          "docs/verification/lib-pro-003-a-git-handoff-receipt.json",
+          "docs/verification/lib-pro-003-a-git-handoff-source-evidence.json",
+          "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "e40c0b564acae82f6696e204e8b382342fbf4321",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-numeric-boundaries"
+    }
+  },
+  "local_state_receipt_hash": "sha256:5f9f0b31deb4a96d04f826319cd8594a7f23e7a30d7e9820e9b80a7a43cbb57d",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-22T09:54:24.799626+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-22T09:52:21Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/services/adapters.py",
+      "Python/structural_lib/services/footing_api.py",
+      "Python/structural_lib/codes/is456/slab/**",
+      "fastapi_app/**",
+      "react_app/**",
+      "excel_addin/**",
+      ".github/workflows/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "Python/structural_lib/core/validation.py",
+      "Python/structural_lib/validation.py",
+      "Python/structural_lib/codes/is456/beam/flexure.py",
+      "Python/structural_lib/codes/is456/beam/shear.py",
+      "Python/structural_lib/codes/is456/compliance.py",
+      "Python/structural_lib/codes/is456/column/uniaxial.py",
+      "Python/structural_lib/services/column_api.py",
+      "Python/tests/unit/test_validation.py",
+      "Python/tests/unit/test_input_validation.py",
+      "Python/tests/unit/test_compliance_validation.py",
+      "Python/tests/codes/is456/column/test_uniaxial.py",
+      "Python/tests/test_column_return_types.py",
+      "docs/reference/error-schema.md",
+      "docs/planning/public-route-safety-closure-plan.md",
+      "docs/planning/next-session-brief.md",
+      "docs/planning/README.md",
+      "docs/TASKS.md",
+      "docs/SESSION_LOG.md",
+      "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md",
+      "docs/verification/lib-pro-003-a-git-handoff-source-evidence.json",
+      "docs/verification/lib-pro-003-a-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "Python/structural_lib/index.json",
+      "Python/structural_lib/index.md",
+      "Python/structural_lib/core/index.json",
+      "Python/structural_lib/core/index.md",
+      "Python/structural_lib/codes/is456/index.json",
+      "Python/structural_lib/codes/is456/index.md",
+      "Python/structural_lib/codes/is456/column/index.json",
+      "Python/structural_lib/codes/is456/column/index.md",
+      "Python/structural_lib/services/index.json",
+      "Python/structural_lib/services/index.md",
+      "Python/tests/index.json",
+      "Python/tests/index.md",
+      "docs/index.json",
+      "docs/index.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/reference/index.json",
+      "docs/reference/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md"
+    ],
+    "task_id": "LIB-PRO-003-A"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-003-a-git-handoff-source-evidence.json
+++ b/docs/verification/lib-pro-003-a-git-handoff-source-evidence.json
@@ -1,0 +1,55 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-22T09:52:21Z",
+      "query_status": "OK",
+      "reference": "task:LIB-PRO-003-A:user-request-continue-this-work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-22T09:52:21Z",
+    "prohibited_actions": [
+      "PUBLISH_RELEASE",
+      "CLAIM_PROFESSIONAL_APPROVAL",
+      "START_INDIA_3",
+      "START_ETABS_OR_DESKTOP_EXCEL",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR"
+      ],
+      "branch": "codex/public-route-numeric-boundaries",
+      "head_sha": "e40c0b564acae82f6696e204e8b382342fbf4321",
+      "task_id": "LIB-PRO-003-A"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-22T09:52:21Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md
+++ b/docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md
@@ -1,0 +1,67 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-22
+doc_type: verification
+complexity: advanced
+tags: [safety, validation, public-api, regression]
+---
+
+# LIB-PRO-003-A Numeric Boundary Evidence
+
+## Identity and scope
+
+- Source base: hosted `main` at
+  `e40c0b564acae82f6696e204e8b382342fbf4321`.
+- Branch: `codex/public-route-numeric-boundaries`.
+- Runtime diagnosis: `source_bound=true`; initial Git state `READY_LOCAL`.
+- Scope: finite-real public calculation boundaries, empty compliance
+  aggregation, and exact uniaxial-column safety comparison only.
+- No engineering formulas, supported grades, release artifacts, ETABS, or
+  desktop Excel operations changed.
+
+## Confirmed root causes and corrected outcomes
+
+| Reproduction | Root cause | Corrected outcome |
+|---|---|---|
+| NaN flexure and shear returned safe results | Positive/range comparisons do not reject NaN | Shared `E_INPUT_017` finite-real validation returns an unsafe structured result before arithmetic |
+| NaN compliance returned `is_ok=True` | Calculation inputs and derived utilization were not required to be finite | Direct and service compliance routes reject the input before component design |
+| `check_compliance_report(cases=[])` returned success | `all([])` is vacuously true | Empty reports raise a stable `ValueError` and cannot produce a compliance disposition |
+| Unified column accepted `Mux=-inf` | Minimum-moment `max()` replaced the invalid action with a finite value | Every numeric routing input is finite-validated before classification or amplification |
+| Exact utilization slightly above one displayed `1.0000` and passed | Safety used the rounded display value | Safety uses exact utilization; the returned display ratio remains rounded and reports unsafe |
+
+The shared helper also rejects booleans and non-real values. Every directly
+consumed numeric argument in the affected flexure, shear, compliance, and
+uniaxial-column routes is covered before arithmetic.
+
+## Compatibility and contracts
+
+- Result-returning beam functions preserve their existing result types and use
+  the stable structured issue `E_INPUT_017`.
+- Exception-based compliance and column service routes preserve their existing
+  `ValueError`/structural-validation contracts.
+- The compatibility `structural_lib.validation` facade exports the new helper.
+- The public error registry records `E_INPUT_017`.
+- Valid SP:16 column, beam verification-pack, and public API-stability vectors
+  remain unchanged.
+
+## Focused verification
+
+- 260 unique implementation-focused tests are green across core validation,
+  flexure/shear input validation, compliance validation, uniaxial columns, and
+  public column return contracts. The first diagnostic run exposed six missing
+  compatibility exports; after that root repair, the 86-test validation file
+  passed and the other 174 tests remained green.
+- 138 independent verification/API tests passed: 20 column golden vectors,
+  seven beam/shear/compliance verification-pack tests, and 111 public API
+  stability tests.
+- Focused Ruff and `git diff --check` passed.
+- The consolidated quick gate passed 10/10, including documentation, import,
+  Git-state, CLI-smoke, hygiene, and unfinished-operation checks.
+
+## Remaining release blockers
+
+This packet closes only `LIB-PRO-003-A`. Packets B-D remain required for
+beam/column domain contracts and footing provenance; structured slab, legacy
+CSV, and BOQ failure; and decisive Excel CI/audit/documentation gates. A new
+package and all stable/professional-use claims remain `HOLD`.


### PR DESCRIPTION
## Summary

- reject booleans, NaN, and infinity before lower-level beam, compliance, and column calculations can report safety
- reject empty compliance reports and decide uniaxial-column safety from exact rather than rounded utilization
- freeze the remaining public-route remediation as LIB-PRO-003 B-D while keeping release and professional-use claims held

## Root causes corrected

Relational comparisons allowed NaN through, minimum-moment amplification replaced an invalid infinite action, empty aggregation relied on vacuous `all([])`, and column safety used a rounded display ratio.

## Verification

- 260 unique implementation-focused tests pass
- 138 independent verification, golden-vector, and public API stability tests pass
- focused Ruff, diff checks, and targeted mypy pass
- quick gate: 10/10
- normal hooks pass, including Black, Ruff, repository-wide mypy, Bandit, docs, task, session, and link checks
- final clean-commit session validation passes

## Boundaries

No engineering formulas, supported grades, FastAPI/React/Excel surfaces, package version, release, ETABS activity, or professional-approval claim changed. LIB-PRO-003 B-D remain required before INDIA-3 or a future package.
