### PR TITLE
fix(safety): structure public failure contracts

### DIFF
--- a/Python/structural_lib/codes/is456/slab/__init__.py
+++ b/Python/structural_lib/codes/is456/slab/__init__.py
@@ -37,11 +37,13 @@ from structural_lib.codes.is456.slab.external_coefficients import (
     record_external_two_way_slab_coefficients,
 )
 from structural_lib.codes.is456.slab.models import (
+    SlabCapacityFailureResult,
     SlabClassification,
     SlabClassificationResult,
     SlabContractError,
     SlabScopeStatus,
     SolidRectangularSlabGeometry,
+    slab_capacity_failure,
 )
 from structural_lib.codes.is456.slab.one_way import (
     OneWaySlabFlexureInput,
@@ -98,9 +100,11 @@ from structural_lib.codes.is456.slab.two_way_complete import (
 __all__ = [
     "SlabClassification",
     "SlabClassificationResult",
+    "SlabCapacityFailureResult",
     "SlabContractError",
     "SlabScopeStatus",
     "SolidRectangularSlabGeometry",
+    "slab_capacity_failure",
     "classify_solid_rectangular_slab",
     "built_in_coefficients",
     "coefficients",

--- a/Python/structural_lib/codes/is456/slab/models.py
+++ b/Python/structural_lib/codes/is456/slab/models.py
@@ -14,17 +14,90 @@ from dataclasses import dataclass
 from enum import StrEnum
 from numbers import Real
 
+from structural_lib.core.result_contract import (
+    CalculationStatus,
+    EngineeringStatus,
+    IntakeStatus,
+    StructuralIssueV1,
+    StructuralResultEnvelopeV1,
+)
+
 __all__ = [
     "SlabClassification",
     "SlabClassificationResult",
+    "SlabCapacityFailureResult",
     "SlabContractError",
     "SlabScopeStatus",
     "SolidRectangularSlabGeometry",
+    "slab_capacity_failure",
 ]
 
 
 class SlabContractError(ValueError):
     """Raised when input is outside the P6 solid rectangular slab contract."""
+
+
+@dataclass(frozen=True)
+class SlabCapacityFailureResult:
+    """Structured engineering failure for supported slab flexural demand."""
+
+    component: str
+    governing_region: str
+    factored_moment_knm: float
+    limiting_moment_knm: float
+    utilization_ratio: float
+    clause_refs: tuple[str, ...]
+    source_refs: tuple[str, ...]
+    status: EngineeringStatus
+    qualified_review_required: bool
+    result_envelope: StructuralResultEnvelopeV1
+
+    @property
+    def is_safe(self) -> bool:
+        """Capacity exceedance is always an engineering failure."""
+
+        return False
+
+
+def slab_capacity_failure(
+    *,
+    component: str,
+    governing_region: str,
+    factored_moment_knm: float,
+    limiting_moment_knm: float,
+    clause_refs: tuple[str, ...],
+    source_refs: tuple[str, ...],
+) -> SlabCapacityFailureResult:
+    """Build the canonical VALID/COMPLETED/FAIL slab-capacity result."""
+
+    utilization_ratio = factored_moment_knm / limiting_moment_knm
+    issue = StructuralIssueV1(
+        code="SLAB_FLEXURE_CAPACITY_EXCEEDED",
+        path="$.factored_area_load_kn_per_m2",
+        message=(
+            f"{governing_region} factored moment {factored_moment_knm:.6g} kN m "
+            f"exceeds limiting singly reinforced capacity "
+            f"{limiting_moment_knm:.6g} kN m."
+        ),
+    )
+    result_envelope = StructuralResultEnvelopeV1(
+        intake_status=IntakeStatus.VALID,
+        calculation_status=CalculationStatus.COMPLETED,
+        engineering_status=EngineeringStatus.FAIL,
+        issues=(issue,),
+    )
+    return SlabCapacityFailureResult(
+        component=component,
+        governing_region=governing_region,
+        factored_moment_knm=factored_moment_knm,
+        limiting_moment_knm=limiting_moment_knm,
+        utilization_ratio=utilization_ratio,
+        clause_refs=clause_refs,
+        source_refs=source_refs,
+        status=EngineeringStatus.FAIL,
+        qualified_review_required=True,
+        result_envelope=result_envelope,
+    )
 
 
 class SlabClassification(StrEnum):

--- a/Python/structural_lib/codes/is456/slab/one_way.py
+++ b/Python/structural_lib/codes/is456/slab/one_way.py
@@ -23,9 +23,11 @@ from structural_lib.codes.is456.slab.classification import (
     classify_solid_rectangular_slab,
 )
 from structural_lib.codes.is456.slab.models import (
+    SlabCapacityFailureResult,
     SlabClassification,
     SlabContractError,
     SolidRectangularSlabGeometry,
+    slab_capacity_failure,
 )
 from structural_lib.codes.is456.traceability import clause
 
@@ -169,7 +171,7 @@ class OneWaySlabFlexureResult:
 @clause("24.1", "38.1")
 def design_simply_supported_one_way_slab_flexure(
     design_input: OneWaySlabFlexureInput,
-) -> OneWaySlabFlexureResult:
+) -> OneWaySlabFlexureResult | SlabCapacityFailureResult:
     """Calculate P7 flexure for one simply supported solid one-way slab strip.
 
     The caller supplies factored uniform area load and effective spans.  The
@@ -208,8 +210,13 @@ def design_simply_supported_one_way_slab_flexure(
         / 1_000_000.0
     )
     if factored_moment_knm > limiting_moment_knm:
-        raise SlabContractError(
-            "factored moment exceeds the P7 singly reinforced rectangular capacity"
+        return slab_capacity_failure(
+            component="one_way_slab_flexure",
+            governing_region="simply_supported_midspan",
+            factored_moment_knm=factored_moment_knm,
+            limiting_moment_knm=limiting_moment_knm,
+            clause_refs=("IS 456:2000 Cl. 24.1", "IS 456:2000 Cl. 38.1"),
+            source_refs=_SOURCE_REFS,
         )
 
     ast_required_mm2, neutral_axis_depth_mm = (
@@ -222,8 +229,13 @@ def design_simply_supported_one_way_slab_flexure(
         )
     )
     if neutral_axis_depth_mm > xu_max_over_d * design_input.d_mm:
-        raise SlabContractError(
-            "P7 stress-block root exceeds the supported limiting neutral-axis depth"
+        return slab_capacity_failure(
+            component="one_way_slab_flexure",
+            governing_region="simply_supported_midspan",
+            factored_moment_knm=factored_moment_knm,
+            limiting_moment_knm=limiting_moment_knm,
+            clause_refs=("IS 456:2000 Cl. 24.1", "IS 456:2000 Cl. 38.1"),
+            source_refs=_SOURCE_REFS,
         )
 
     return OneWaySlabFlexureResult(

--- a/Python/structural_lib/codes/is456/slab/two_way.py
+++ b/Python/structural_lib/codes/is456/slab/two_way.py
@@ -25,7 +25,12 @@ from structural_lib.codes.is456.slab.external_coefficients import (
     ExternalCoefficientReviewStatus,
     ExternalTwoWaySlabCoefficientRecord,
 )
-from structural_lib.codes.is456.slab.models import SlabClassification, SlabContractError
+from structural_lib.codes.is456.slab.models import (
+    SlabCapacityFailureResult,
+    SlabClassification,
+    SlabContractError,
+    slab_capacity_failure,
+)
 from structural_lib.codes.is456.traceability import clause
 
 __all__ = [
@@ -313,8 +318,9 @@ def _direction_result(
     fck_n_per_mm2: float,
     fy_n_per_mm2: float,
     xu_max_over_d: float,
-) -> TwoWaySlabFlexuralDirectionResult:
-    """Calculate one direction and reject a demand beyond its limiting capacity."""
+    source_refs: tuple[str, ...],
+) -> TwoWaySlabFlexuralDirectionResult | SlabCapacityFailureResult:
+    """Calculate one direction and structure a limiting-capacity failure."""
     factored_moment_knm = coefficient * line_load_kn_per_m * effective_short_span_m**2
     limiting_moment_knm = (
         0.36
@@ -326,8 +332,13 @@ def _direction_result(
         / 1_000_000.0
     )
     if factored_moment_knm > limiting_moment_knm:
-        raise SlabContractError(
-            f"P10 {direction}-direction factored moment exceeds the singly reinforced rectangular capacity"
+        return slab_capacity_failure(
+            component="two_way_slab_flexure",
+            governing_region=f"{direction}_direction",
+            factored_moment_knm=factored_moment_knm,
+            limiting_moment_knm=limiting_moment_knm,
+            clause_refs=("IS 456:2000 Cl. 24.4", "IS 456:2000 Cl. 38.1"),
+            source_refs=source_refs,
         )
     ast_required_mm2, neutral_axis_depth_mm = (
         calculate_ast_from_rectangular_stress_block(
@@ -340,8 +351,13 @@ def _direction_result(
     )
     limiting_neutral_axis_depth_mm = xu_max_over_d * d_mm
     if neutral_axis_depth_mm > limiting_neutral_axis_depth_mm:
-        raise SlabContractError(
-            f"P10 {direction}-direction stress-block root exceeds the limiting neutral-axis depth"
+        return slab_capacity_failure(
+            component="two_way_slab_flexure",
+            governing_region=f"{direction}_direction",
+            factored_moment_knm=factored_moment_knm,
+            limiting_moment_knm=limiting_moment_knm,
+            clause_refs=("IS 456:2000 Cl. 24.4", "IS 456:2000 Cl. 38.1"),
+            source_refs=source_refs,
         )
     return TwoWaySlabFlexuralDirectionResult(
         direction=direction,
@@ -357,7 +373,7 @@ def _direction_result(
 @clause("24.1", "24.4", "38.1")
 def design_supported_interior_two_way_slab_flexure(
     design_input: TwoWaySlabFlexureInput,
-) -> TwoWaySlabFlexureResult:
+) -> TwoWaySlabFlexureResult | SlabCapacityFailureResult:
     """Calculate P10 moments and raw steel for one declared interior panel.
 
     The area load is converted to a line load over the default 1 m or explicit
@@ -378,6 +394,7 @@ def design_supported_interior_two_way_slab_flexure(
     effective_short_span_mm = geometry.short_effective_span_mm
     effective_short_span_m = effective_short_span_mm / 1000.0
     xu_max_over_d = materials.get_xu_max_d(design_input.fy_n_per_mm2)
+    source_refs = _SOURCE_REFS + record.source_ids
     x_direction = _direction_result(
         direction="x",
         coefficient=record.alpha_x,
@@ -388,7 +405,10 @@ def design_supported_interior_two_way_slab_flexure(
         fck_n_per_mm2=design_input.fck_n_per_mm2,
         fy_n_per_mm2=design_input.fy_n_per_mm2,
         xu_max_over_d=xu_max_over_d,
+        source_refs=source_refs,
     )
+    if isinstance(x_direction, SlabCapacityFailureResult):
+        return x_direction
     y_direction = _direction_result(
         direction="y",
         coefficient=record.alpha_y,
@@ -399,7 +419,10 @@ def design_supported_interior_two_way_slab_flexure(
         fck_n_per_mm2=design_input.fck_n_per_mm2,
         fy_n_per_mm2=design_input.fy_n_per_mm2,
         xu_max_over_d=xu_max_over_d,
+        source_refs=source_refs,
     )
+    if isinstance(y_direction, SlabCapacityFailureResult):
+        return y_direction
     return TwoWaySlabFlexureResult(
         input=design_input,
         effective_short_span_mm=effective_short_span_mm,
@@ -424,7 +447,7 @@ def design_supported_interior_two_way_slab_flexure(
         status=(
             TwoWaySlabFlexureStatus.EXTERNALLY_ACCEPTED_COEFFICIENT_FLEXURE_ONLY_SUPPORTED_CASE
         ),
-        source_refs=_SOURCE_REFS + record.source_ids,
+        source_refs=source_refs,
         assumptions=(
             "The caller declares a solid rectangular interior panel with all four edges continuous.",
             "P9 retains review_required; qualified acceptance is caller-supplied provenance, not coefficient verification by P10.",

--- a/Python/structural_lib/codes/is456/slab/two_way_complete.py
+++ b/Python/structural_lib/codes/is456/slab/two_way_complete.py
@@ -17,7 +17,11 @@ from structural_lib.codes.is456.slab.detailing import (
     SlabReinforcementRegionResult,
     check_slab_reinforcement_region,
 )
-from structural_lib.codes.is456.slab.models import SlabContractError
+from structural_lib.codes.is456.slab.models import (
+    SlabCapacityFailureResult,
+    SlabContractError,
+    slab_capacity_failure,
+)
 from structural_lib.codes.is456.slab.shear import (
     SlabShearInput,
     SlabShearResult,
@@ -184,7 +188,8 @@ def _moment_region(
     fy: float,
     thickness: float,
     bars: ProvidedSlabBars,
-) -> TwoWayMomentRegionResult:
+    source_refs: tuple[str, ...],
+) -> TwoWayMomentRegionResult | SlabCapacityFailureResult:
     moment = coefficient * load * short_span_m**2
     xu_max_over_d = materials.get_xu_max_d(fy)
     limiting = (
@@ -197,7 +202,14 @@ def _moment_region(
         / 1_000_000.0
     )
     if moment > limiting:
-        raise SlabContractError(f"{region_id} exceeds singly reinforced capacity")
+        return slab_capacity_failure(
+            component="two_way_slab_panel_flexure",
+            governing_region=region_id,
+            factored_moment_knm=moment,
+            limiting_moment_knm=limiting,
+            clause_refs=("IS 456:2000 Cl. 24.4", "IS 456:2000 Cl. 38.1"),
+            source_refs=source_refs,
+        )
     if moment == 0.0:
         ast, xu = 0.0, 0.0
     else:
@@ -229,46 +241,78 @@ def _moment_region(
 @clause("24.4", "40.2")
 def design_two_way_slab_panel(
     design_input: TwoWayPanelDesignInput,
-) -> TwoWayPanelDesignResult:
+) -> TwoWayPanelDesignResult | SlabCapacityFailureResult:
     """Design common physical topologies without bundling coefficient tables."""
     if not isinstance(design_input, TwoWayPanelDesignInput):
         raise SlabContractError("design_input must be TwoWayPanelDesignInput")
     coefficients = design_input.coefficients
-    common = {
-        "load": design_input.factored_area_load_kn_per_m2,
-        "short_span_m": design_input.geometry.x_effective_span_mm / 1000.0,
-        "fck": design_input.fck_n_per_mm2,
-        "fy": design_input.fy_n_per_mm2,
-        "thickness": design_input.geometry.thickness_mm,
-    }
+    load = design_input.factored_area_load_kn_per_m2
+    short_span_m = design_input.geometry.x_effective_span_mm / 1000.0
+    fck = design_input.fck_n_per_mm2
+    fy = design_input.fy_n_per_mm2
+    thickness = design_input.geometry.thickness_mm
+    source_refs = (
+        "IS 456:2000 Cl. 24.4",
+        "IS 456:2000 Cl. 38.1",
+        design_input.coefficients.source_reference,
+        design_input.coefficients.qualified_acceptance_reference,
+    )
     x_negative = _moment_region(
         region_id="x_negative_continuous_edge",
         coefficient=coefficients.alpha_x_negative,
         d_mm=design_input.d_x_mm,
         bars=design_input.x_negative_bars,
-        **common,
+        load=load,
+        short_span_m=short_span_m,
+        fck=fck,
+        fy=fy,
+        thickness=thickness,
+        source_refs=source_refs,
     )
+    if isinstance(x_negative, SlabCapacityFailureResult):
+        return x_negative
     x_positive = _moment_region(
         region_id="x_positive_middle_strip",
         coefficient=coefficients.alpha_x_positive,
         d_mm=design_input.d_x_mm,
         bars=design_input.x_positive_bars,
-        **common,
+        load=load,
+        short_span_m=short_span_m,
+        fck=fck,
+        fy=fy,
+        thickness=thickness,
+        source_refs=source_refs,
     )
+    if isinstance(x_positive, SlabCapacityFailureResult):
+        return x_positive
     y_negative = _moment_region(
         region_id="y_negative_continuous_edge",
         coefficient=coefficients.alpha_y_negative,
         d_mm=design_input.d_y_mm,
         bars=design_input.y_negative_bars,
-        **common,
+        load=load,
+        short_span_m=short_span_m,
+        fck=fck,
+        fy=fy,
+        thickness=thickness,
+        source_refs=source_refs,
     )
+    if isinstance(y_negative, SlabCapacityFailureResult):
+        return y_negative
     y_positive = _moment_region(
         region_id="y_positive_middle_strip",
         coefficient=coefficients.alpha_y_positive,
         d_mm=design_input.d_y_mm,
         bars=design_input.y_positive_bars,
-        **common,
+        load=load,
+        short_span_m=short_span_m,
+        fck=fck,
+        fy=fy,
+        thickness=thickness,
+        source_refs=source_refs,
     )
+    if isinstance(y_positive, SlabCapacityFailureResult):
+        return y_positive
     edge_strip = check_slab_reinforcement_region(
         region_id="edge_strips_minimum_reinforcement",
         required_for_moment_mm2_per_m=0.0,

--- a/Python/structural_lib/services/adapters.py
+++ b/Python/structural_lib/services/adapters.py
@@ -1813,6 +1813,31 @@ class GenericCSVAdapter(InputAdapter):
 
         return column_map
 
+    @staticmethod
+    def _parse_force_value(
+        raw_value: object,
+        *,
+        field_name: str,
+        row_number: int,
+    ) -> float:
+        """Parse one optional force cell without coercing malformed text to zero."""
+
+        text = "" if raw_value is None else str(raw_value).strip()
+        if not text:
+            return 0.0
+        try:
+            value = float(text)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid {field_name} value at CSV row {row_number}: {text!r}"
+            ) from exc
+        if not math.isfinite(value):
+            raise ValueError(
+                f"Invalid {field_name} value at CSV row {row_number}: "
+                f"{text!r} is not finite"
+            )
+        return abs(value)
+
     def load_geometry(
         self,
         source: Path | str,
@@ -2008,7 +2033,7 @@ class GenericCSVAdapter(InputAdapter):
                     f"Available: {headers}"
                 )
 
-            for row in reader:
+            for row_number, row in enumerate(reader, start=2):
                 try:
                     beam_id = row[column_map["beam_id"]].strip()
                     if not beam_id:
@@ -2036,28 +2061,25 @@ class GenericCSVAdapter(InputAdapter):
                     pu = 0.0
 
                     if mu_col:
-                        mu_val = row.get(mu_col, "0")
-                        if mu_val and str(mu_val).strip():
-                            try:
-                                mu = abs(float(mu_val))
-                            except ValueError:
-                                pass
+                        mu = self._parse_force_value(
+                            row.get(mu_col, "0"),
+                            field_name="mu_knm",
+                            row_number=row_number,
+                        )
 
                     if vu_col:
-                        vu_val = row.get(vu_col, "0")
-                        if vu_val and str(vu_val).strip():
-                            try:
-                                vu = abs(float(vu_val))
-                            except ValueError:
-                                pass
+                        vu = self._parse_force_value(
+                            row.get(vu_col, "0"),
+                            field_name="vu_kn",
+                            row_number=row_number,
+                        )
 
                     if pu_col:
-                        pu_val = row.get(pu_col, "0")
-                        if pu_val and str(pu_val).strip():
-                            try:
-                                pu = abs(float(pu_val))
-                            except ValueError:
-                                pass
+                        pu = self._parse_force_value(
+                            row.get(pu_col, "0"),
+                            field_name="pu_kn",
+                            row_number=row_number,
+                        )
 
                     # Build unique ID
                     full_id = f"{beam_id}_{story}" if story else beam_id
@@ -2072,8 +2094,10 @@ class GenericCSVAdapter(InputAdapter):
                     )
                     forces.append(force)
 
-                except (KeyError, ValueError):
-                    continue
+                except KeyError as exc:
+                    raise ValueError(
+                        f"Malformed CSV row {row_number}: missing {exc.args[0]!r}"
+                    ) from exc
 
         return forces
 

--- a/Python/structural_lib/services/boq.py
+++ b/Python/structural_lib/services/boq.py
@@ -15,8 +15,10 @@ Units:
 
 from __future__ import annotations
 
+import math
 from collections import defaultdict
 from dataclasses import dataclass, field
+from numbers import Real
 from typing import Any
 
 from structural_lib.services.bbs import BBSDocument
@@ -75,6 +77,17 @@ class ProjectBOQ:
     grand_total_cost_inr: float
 
 
+def _require_positive_rate(value: object, field_name: str) -> float:
+    """Return a finite positive rate or reject the costing input."""
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{field_name} must be a real monetary rate")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0.0:
+        raise ValueError(f"{field_name} must be finite and greater than zero")
+    return normalized
+
+
 def aggregate_project_boq(
     bbs_documents: list[BBSDocument],
     beam_metadata: list[dict[str, Any]],
@@ -98,9 +111,25 @@ def aggregate_project_boq(
 
     Units:
         Steel: kg, Concrete: m³, Cost: ₹ (INR), Dimensions: mm (inputs).
+
+    Raises:
+        ValueError: If a steel or concrete rate, or a concrete-grade key, is
+            outside its finite positive domain.
     """
+    steel_cost_per_kg = _require_positive_rate(steel_cost_per_kg, "steel_cost_per_kg")
     if concrete_costs is None:
         concrete_costs = dict(DEFAULT_CONCRETE_COSTS)
+    else:
+        validated_concrete_costs: dict[int, float] = {}
+        for fck, rate in concrete_costs.items():
+            if isinstance(fck, bool) or not isinstance(fck, int) or fck <= 0:
+                raise ValueError(
+                    "concrete_costs keys must be positive integer fck grades"
+                )
+            validated_concrete_costs[fck] = _require_positive_rate(
+                rate, f"concrete_costs[{fck}]"
+            )
+        concrete_costs = validated_concrete_costs
 
     # Accumulators keyed by grade/story
     steel_acc: dict[str, dict[str, Any]] = defaultdict(

--- a/Python/structural_lib/services/evidence.py
+++ b/Python/structural_lib/services/evidence.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from functools import lru_cache
@@ -35,7 +36,7 @@ from structural_lib.services.source_identity import (
 )
 
 BEAM_EVIDENCE_ARTIFACT_SCHEMA = "structural_lib.beam-evidence"
-BEAM_EVIDENCE_SCHEMA_VERSION = "3.0"
+BEAM_EVIDENCE_SCHEMA_VERSION = "3.1"
 BEAM_CAPABILITY_ID = "design_beam_is456"
 BEAM_RESULT_CONTRACT_VERSION = "canonical-beam-result/v1"
 QUALIFIED_REVIEW_REQUIREMENT = (
@@ -315,12 +316,27 @@ def build_beam_evidence_envelope(
     source_basis_hash = _sha256_json(source_basis_payload)
     source_resolved = source_basis.is_resolved
     supported = supported and source_resolved
-    exact_utilization = (
-        None
-        if not supported or governing_utilization is None
-        else float(governing_utilization)
+    raw_utilization = (
+        None if governing_utilization is None else float(governing_utilization)
     )
-    status = "HOLD" if not supported else ("PASS" if is_ok else "FAIL")
+    if not supported or raw_utilization is None:
+        exact_utilization = None
+        utilization_disposition = "NOT_EVALUATED"
+    elif math.isfinite(raw_utilization):
+        exact_utilization = raw_utilization
+        utilization_disposition = "FINITE"
+    else:
+        exact_utilization = None
+        utilization_disposition = "UNBOUNDED_FAILURE"
+    status = (
+        "HOLD"
+        if not supported
+        else (
+            "PASS"
+            if is_ok and utilization_disposition != "UNBOUNDED_FAILURE"
+            else "FAIL"
+        )
+    )
     governing_check = _governing_check(utilizations or {})
     calculation_identity = _sha256_json(
         {
@@ -335,6 +351,7 @@ def build_beam_evidence_envelope(
             "support_status": "SUPPORTED" if supported else "HELD",
             "governing_check": governing_check,
             "exact_utilization": exact_utilization,
+            "utilization_disposition": utilization_disposition,
             "status": status,
         }
     )
@@ -377,6 +394,7 @@ def build_beam_evidence_envelope(
         "replay_receipt_hash": replay_receipt_hash,
         "governing_check": governing_check,
         "exact_utilization": exact_utilization,
+        "utilization_disposition": utilization_disposition,
         "margin": None if exact_utilization is None else 1.0 - exact_utilization,
         "status": status,
         "generated_at": generated_at or datetime.now(UTC).isoformat(),

--- a/Python/structural_lib/services/gravity_workflow.py
+++ b/Python/structural_lib/services/gravity_workflow.py
@@ -663,7 +663,9 @@ def run_gravity_workflow_v1(
             )
             passed = (
                 slab_result.reinforcement.is_detailing_adequate
+                and slab_result.shear is not None
                 and slab_result.shear.is_safe_without_shear_reinforcement
+                and slab_result.serviceability is not None
                 and slab_result.serviceability.is_satisfied
             )
             components.append(

--- a/Python/structural_lib/services/index.json
+++ b/Python/structural_lib/services/index.json
@@ -16,8 +16,8 @@
     {
       "name": "adapters.py",
       "type": "python",
-      "size_lines": 2100,
-      "last_updated": "2026-08-17",
+      "size_lines": 2124,
+      "last_updated": "2026-08-22",
       "description": "Adapters for converting various input formats to canonical models.",
       "classes": [
         {
@@ -78,7 +78,7 @@
           ]
         }
       ],
-      "content_hash": "605681463531"
+      "content_hash": "6875040171f2"
     },
     {
       "name": "api.py",
@@ -726,8 +726,8 @@
     {
       "name": "boq.py",
       "type": "python",
-      "size_lines": 209,
-      "last_updated": "2026-08-17",
+      "size_lines": 238,
+      "last_updated": "2026-08-22",
       "description": "Project Bill of Quantities (BOQ) — Aggregation Module",
       "classes": [
         {
@@ -760,7 +760,7 @@
           ]
         }
       ],
-      "content_hash": "58d94c335273"
+      "content_hash": "678c3e359d5a"
     },
     {
       "name": "calculation_report.py",
@@ -2162,8 +2162,8 @@
     {
       "name": "gravity_workflow.py",
       "type": "python",
-      "size_lines": 914,
-      "last_updated": "2026-08-18",
+      "size_lines": 916,
+      "last_updated": "2026-08-22",
       "description": "Fail-closed component orchestration for Building Gravity Workflow V1.",
       "functions": [
         {
@@ -2200,7 +2200,7 @@
         "_FOOTING_GENERATED",
         "_FOOTING_SUPPLIED"
       ],
-      "content_hash": "0e7951623e39"
+      "content_hash": "c4e16ce0f866"
     },
     {
       "name": "import_ledger.py",
@@ -2604,8 +2604,8 @@
     {
       "name": "release_uat.py",
       "type": "python",
-      "size_lines": 591,
-      "last_updated": "2026-08-17",
+      "size_lines": 592,
+      "last_updated": "2026-08-22",
       "description": "Source-free exact-wheel UAT for the pre-release input-safety contract.",
       "functions": [
         {
@@ -2624,7 +2624,7 @@
         "_CLI_HEADER",
         "_CLI_VALID_ROW"
       ],
-      "content_hash": "edd91f23d9b8"
+      "content_hash": "e4eb98fa0b40"
     },
     {
       "name": "report.py",
@@ -2892,8 +2892,8 @@
     {
       "name": "slab_api.py",
       "type": "python",
-      "size_lines": 851,
-      "last_updated": "2026-08-17",
+      "size_lines": 871,
+      "last_updated": "2026-08-22",
       "description": "Stable orchestration entry points for the bounded IS 456 slab workflows.",
       "classes": [
         {
@@ -2951,7 +2951,7 @@
         "_COMPLETE_ONE_WAY_DETAILING_LIMITATIONS",
         "_SINGLE_ACTION_LOAD_BOUNDARY"
       ],
-      "content_hash": "245ec7df5734"
+      "content_hash": "6443e3fbadd8"
     },
     {
       "name": "source_identity.py",
@@ -3420,5 +3420,5 @@
     "PropertyLineStrapFootingDesignStatus",
     "design_property_line_strap_footing_is456"
   ],
-  "content_hash": "7fb28e9f04f9288d"
+  "content_hash": "737f10dce7c477eb"
 }

--- a/Python/structural_lib/services/index.json
+++ b/Python/structural_lib/services/index.json
@@ -1692,8 +1692,8 @@
     {
       "name": "evidence.py",
       "type": "python",
-      "size_lines": 386,
-      "last_updated": "2026-08-17",
+      "size_lines": 404,
+      "last_updated": "2026-08-22",
       "description": "Canonical evidence identity for the supported IS 456 beam design route.",
       "functions": [
         {
@@ -1725,7 +1725,7 @@
         "_REQUIRED_CONSUMED_INPUTS",
         "_SUPPORT_ALIASES"
       ],
-      "content_hash": "3d703fe4959e"
+      "content_hash": "44e3c3ba064b"
     },
     {
       "name": "excel_bridge.py",
@@ -3420,5 +3420,5 @@
     "PropertyLineStrapFootingDesignStatus",
     "design_property_line_strap_footing_is456"
   ],
-  "content_hash": "737f10dce7c477eb"
+  "content_hash": "4f7274c8ab0e9a23"
 }

--- a/Python/structural_lib/services/index.md
+++ b/Python/structural_lib/services/index.md
@@ -52,7 +52,7 @@
 | [deep_beam_api.py](deep_beam_api.py) | Stable orchestration for the bounded IS 456 simply supported | 3 | 1 | 247 |
 | [dxf_export.py](dxf_export.py) | DXF Export Module — Beam Detail Drawing Generation | 0 | 18 | 1833 |
 | [etabs_import.py](etabs_import.py) | ETABS CSV Import Module. | 3 | 12 | 1089 |
-| [evidence.py](evidence.py) | Canonical evidence identity for the supported IS 456 beam de | 0 | 4 | 386 |
+| [evidence.py](evidence.py) | Canonical evidence identity for the supported IS 456 beam de | 0 | 4 | 404 |
 | [excel_bridge.py](excel_bridge.py) | Excel UDF Bridge - Exposes structural_lib functions to Excel | 0 | 7 | 305 |
 | [excel_integration.py](excel_integration.py) | Excel Integration Module — Bridge between Excel data and Det | 2 | 9 | 489 |
 | [excel_workbench.py](excel_workbench.py) | Strict selected-table orchestration for Excel Routine Workbe | 1 | 8 | 952 |

--- a/Python/structural_lib/services/index.md
+++ b/Python/structural_lib/services/index.md
@@ -31,7 +31,7 @@
 | File | Description | Classes | Functions | Lines |
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | Application-layer public workflow exports. | 0 | 0 | 50 |
-| [adapters.py](adapters.py) | Adapters for converting various input formats to canonical m | 6 | 0 | 2100 |
+| [adapters.py](adapters.py) | Adapters for converting various input formats to canonical m | 6 | 0 | 2124 |
 | [api.py](api.py) | Module:       api | 0 | 0 | 454 |
 | [api_hub.py](api_hub.py) | Module:       api | 0 | 0 | 238 |
 | [api_results.py](api_results.py) | Module:       api_results | 8 | 0 | 507 |
@@ -40,7 +40,7 @@
 | [bbs.py](bbs.py) | Bar Bending Schedule (BBS) Module — IS 2502:1999 / SP 34:198 | 3 | 19 | 1134 |
 | [beam_api.py](beam_api.py) | Module:       beam_api | 0 | 20 | 2384 |
 | [beam_pipeline.py](beam_pipeline.py) | beam_pipeline — Unified application-layer pipeline for beam  | 10 | 3 | 660 |
-| [boq.py](boq.py) | Project Bill of Quantities (BOQ) — Aggregation Module | 4 | 1 | 209 |
+| [boq.py](boq.py) | Project Bill of Quantities (BOQ) — Aggregation Module | 4 | 1 | 238 |
 | [calculation_report.py](calculation_report.py) | Module:       calculation_report | 4 | 1 | 722 |
 | [capabilities.py](capabilities.py) | Discoverable supported-case registry for the IS 456 public l | 7 | 3 | 2057 |
 | [cli_design.py](cli_design.py) | Strict, lossless intake and compatibility output for the adv | 4 | 2 | 628 |
@@ -60,7 +60,7 @@
 | [footing_api.py](footing_api.py) | Bounded orchestration for concentric isolated footings (IS 4 | 5 | 1 | 927 |
 | [gravity_calculation_book.py](gravity_calculation_book.py) | Deterministic review dossier for Building Gravity Workflow V | 3 | 4 | 254 |
 | [gravity_loads.py](gravity_loads.py) | Deterministic dead/live source, transfer, combination, and b | 8 | 1 | 631 |
-| [gravity_workflow.py](gravity_workflow.py) | Fail-closed component orchestration for Building Gravity Wor | 0 | 3 | 914 |
+| [gravity_workflow.py](gravity_workflow.py) | Fail-closed component orchestration for Building Gravity Wor | 0 | 3 | 916 |
 | [import_ledger.py](import_ledger.py) | Versioned, lossless import evidence models. | 11 | 0 | 187 |
 | [imports.py](imports.py) | Fail-closed multi-format CSV import boundary. | 2 | 6 | 1104 |
 | [intelligence.py](intelligence.py) | Compatibility shim for legacy imports. | 0 | 0 | 36 |
@@ -71,11 +71,11 @@
 | [project_beam.py](project_beam.py) | Versioned, fail-closed project beam input and result contrac | 8 | 2 | 716 |
 | [rebar.py](rebar.py) | Rebar configuration validation and application helpers. | 0 | 2 | 251 |
 | [rebar_optimizer.py](rebar_optimizer.py) | Rebar arrangement optimizer (deterministic). | 1 | 1 | 322 |
-| [release_uat.py](release_uat.py) | Source-free exact-wheel UAT for the pre-release input-safety | 0 | 2 | 591 |
+| [release_uat.py](release_uat.py) | Source-free exact-wheel UAT for the pre-release input-safety | 0 | 2 | 592 |
 | [report.py](report.py) | Report generation module for beam design results. | 5 | 14 | 1772 |
 | [report_svg.py](report_svg.py) | SVG helpers for report visuals (stdlib only). | 0 | 2 | 279 |
 | [serialization.py](serialization.py) | JSON serialization utilities for canonical data models. | 0 | 13 | 476 |
-| [slab_api.py](slab_api.py) | Stable orchestration entry points for the bounded IS 456 sla | 4 | 7 | 851 |
+| [slab_api.py](slab_api.py) | Stable orchestration entry points for the bounded IS 456 sla | 4 | 7 | 871 |
 | [source_identity.py](source_identity.py) | Controlled IS 456 source and route-specific amendment identi | 2 | 0 | 67 |
 | [staircase_api.py](staircase_api.py) | Stable orchestration for the bounded IS 456 straight-flight  | 3 | 1 | 209 |
 | [strap_footing_api.py](strap_footing_api.py) | Stable orchestration for the bounded property-line strap-foo | 4 | 2 | 280 |

--- a/Python/structural_lib/services/release_uat.py
+++ b/Python/structural_lib/services/release_uat.py
@@ -444,6 +444,7 @@ def _case_safe_result_review_boundary() -> dict[str, Any]:
         distribution_bar_diameter_mm=8,
         distribution_bar_spacing_mm=250,
     )
+    assert slab.detailing is not None
     assert slab.detailing.qualified_review_required is True
     serialized = repr(slab.detailing).lower()
     assert "no_qualified_review_required" not in serialized

--- a/Python/structural_lib/services/slab_api.py
+++ b/Python/structural_lib/services/slab_api.py
@@ -22,7 +22,10 @@ from structural_lib.codes.is456.slab.detailing import (
 from structural_lib.codes.is456.slab.external_coefficients import (
     record_external_two_way_slab_coefficients,
 )
-from structural_lib.codes.is456.slab.models import SolidRectangularSlabGeometry
+from structural_lib.codes.is456.slab.models import (
+    SlabCapacityFailureResult,
+    SolidRectangularSlabGeometry,
+)
 from structural_lib.codes.is456.slab.one_way import (
     OneWaySlabFlexureInput,
     OneWaySlabFlexureResult,
@@ -105,14 +108,14 @@ _SINGLE_ACTION_LOAD_BOUNDARY = (
 class OneWaySlabDesignResult:
     """Flexure and provided-bar checks for the supported one-way slab strip."""
 
-    flexure: OneWaySlabFlexureResult
-    detailing: OneWaySlabDetailingResult
+    flexure: OneWaySlabFlexureResult | SlabCapacityFailureResult
+    detailing: OneWaySlabDetailingResult | None
     load_envelope_status: str = _SINGLE_ACTION_LOAD_BOUNDARY
 
     @property
     def is_detailing_adequate(self) -> bool:
         """Return the bounded provided-bar detailing outcome."""
-        return self.detailing.is_detailing_adequate
+        return self.detailing is not None and self.detailing.is_detailing_adequate
 
 
 @dataclass(frozen=True)
@@ -120,8 +123,8 @@ class CompleteOneWaySlabDesignResult:
     """Compatibility one-way design plus explicit shear and serviceability."""
 
     reinforcement: OneWaySlabDesignResult
-    shear: SlabShearResult
-    serviceability: SlabServiceabilityResult
+    shear: SlabShearResult | None
+    serviceability: SlabServiceabilityResult | None
     punching_shear_disposition: str
     complete_engineering_design_approved: bool = False
     load_envelope_status: str = _SINGLE_ACTION_LOAD_BOUNDARY
@@ -146,8 +149,8 @@ class ContinuousOneWaySlabDesignResult:
 class TwoWaySlabPanelWorkflowResult:
     """Bounded common two-way panel design with explicit serviceability carrier."""
 
-    panel: TwoWayPanelDesignResult
-    serviceability: SlabServiceabilityResult
+    panel: TwoWayPanelDesignResult | SlabCapacityFailureResult
+    serviceability: SlabServiceabilityResult | None
     complete_engineering_design_approved: bool = False
     load_envelope_status: str = _SINGLE_ACTION_LOAD_BOUNDARY
 
@@ -188,6 +191,8 @@ def design_one_way_slab_is456(
             fy_n_per_mm2=fy_n_per_mm2,
         )
     )
+    if isinstance(flexure, SlabCapacityFailureResult):
+        return OneWaySlabDesignResult(flexure=flexure, detailing=None)
     detailing = check_simply_supported_one_way_slab_detailing(
         OneWaySlabDetailingInput(
             flexure_result=flexure,
@@ -236,6 +241,17 @@ def design_complete_one_way_slab_is456(
         distribution_bar_spacing_mm=distribution_bar_spacing_mm,
         strip_width_mm=strip_width_mm,
     )
+    if isinstance(reinforcement.flexure, SlabCapacityFailureResult):
+        return CompleteOneWaySlabDesignResult(
+            reinforcement=reinforcement,
+            shear=None,
+            serviceability=None,
+            punching_shear_disposition=(
+                "not_evaluated_due_to_flexural_capacity_failure"
+            ),
+        )
+    if reinforcement.detailing is None:  # pragma: no cover - guarded invariant
+        raise RuntimeError("accepted slab flexure must include detailing")
     factored_shear_kn = (
         reinforcement.flexure.line_load_kn_per_m
         * (reinforcement.flexure.effective_short_span_mm / 1000.0)
@@ -648,6 +664,8 @@ def design_two_way_slab_panel_is456(
             ),
         )
     )
+    if isinstance(panel, SlabCapacityFailureResult):
+        return TwoWaySlabPanelWorkflowResult(panel=panel, serviceability=None)
     serviceability = check_slab_span_depth_serviceability(
         SlabServiceabilityInput(
             effective_span_mm=x_effective_span_mm,
@@ -775,6 +793,8 @@ def design_two_way_slab_panel_builtin_is456(
             qualified_serviceability_acceptance_acknowledged
         ),
     )
+    if isinstance(result.panel, SlabCapacityFailureResult):
+        return result
     built_in_input = replace(result.panel.input, coefficients=coefficients)
     built_in_panel = replace(
         result.panel,
@@ -803,7 +823,7 @@ def design_two_way_slab_is456(
     fck_n_per_mm2: float,
     fy_n_per_mm2: float,
     strip_width_mm: float = 1000.0,
-) -> TwoWaySlabFlexureResult:
+) -> TwoWaySlabFlexureResult | SlabCapacityFailureResult:
     """Compute flexure for the sole externally accepted-coefficient case.
 
     Coefficients are caller supplied and must carry explicit source approval

--- a/Python/tests/codes/is456/index.json
+++ b/Python/tests/codes/is456/index.json
@@ -2,7 +2,7 @@
   "folder": "Python/tests/codes/is456",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-16",
+  "last_updated": "2026-08-22",
   "file_count": 1,
   "files": [
     {
@@ -50,6 +50,12 @@
       "is_package": true
     },
     {
+      "name": "strap_footing",
+      "path": "strap_footing/",
+      "file_count": 5,
+      "is_package": true
+    },
+    {
       "name": "wall",
       "path": "wall/",
       "file_count": 5,
@@ -57,5 +63,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "6d00940ee8221505"
+  "content_hash": "30fbf199a535ecf7"
 }

--- a/Python/tests/codes/is456/index.md
+++ b/Python/tests/codes/is456/index.md
@@ -1,7 +1,7 @@
 # Is456
 
 **Type:** Python Package
-**Last Updated:** 2026-08-16
+**Last Updated:** 2026-08-22
 **Files:** 1
 
 ## Python Files
@@ -20,4 +20,5 @@
 | [flat_slab/](flat_slab/) 📦 | 7 |  |
 | [slab/](slab/) | 7 |  |
 | [staircase/](staircase/) 📦 | 5 |  |
+| [strap_footing/](strap_footing/) 📦 | 5 |  |
 | [wall/](wall/) 📦 | 5 |  |

--- a/Python/tests/codes/is456/slab/test_extended_workflows.py
+++ b/Python/tests/codes/is456/slab/test_extended_workflows.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 import pytest
 
-from structural_lib.codes.is456.slab.models import SlabContractError
+from structural_lib.codes.is456.slab.models import (
+    SlabCapacityFailureResult,
+    SlabContractError,
+)
 from structural_lib.codes.is456.slab.one_way import OneWaySlabFlexureStatus
 from structural_lib.codes.is456.slab.serviceability import (
     SlabServiceabilityInput,
@@ -21,6 +24,7 @@ from structural_lib.codes.is456.slab.topology import (
     SlabSupportTopology,
     SlabSupportTopologyKind,
 )
+from structural_lib.core.result_contract import EngineeringStatus
 from structural_lib.services.slab_api import (
     design_complete_one_way_slab_is456,
     design_continuous_one_way_slab_is456,
@@ -277,3 +281,46 @@ def test_complete_simply_supported_route_adds_shear_and_strict_serviceability() 
     assert result.shear.is_safe_without_shear_reinforcement is True
     assert result.serviceability.is_satisfied is True
     assert result.complete_engineering_design_approved is False
+
+
+def test_complete_one_way_capacity_miss_returns_structured_fail() -> None:
+    result = design_complete_one_way_slab_is456(
+        short_effective_span_mm=3000,
+        long_effective_span_mm=7000,
+        thickness_mm=150,
+        d_mm=100,
+        factored_area_load_kn_per_m2=50,
+        fck_n_per_mm2=20,
+        fy_n_per_mm2=415,
+        main_bar_diameter_mm=10,
+        main_bar_spacing_mm=200,
+        distribution_bar_diameter_mm=8,
+        distribution_bar_spacing_mm=250,
+        reviewed_base_span_depth_limit=20,
+        reviewed_aggregate_modification_factor=1.0,
+        serviceability_limit_source_reference="reviewed:packet-c",
+        serviceability_limit_source_is_approved=True,
+        qualified_serviceability_acceptance_reference="review:packet-c",
+        qualified_serviceability_acceptance_acknowledged=True,
+    )
+
+    failure = result.reinforcement.flexure
+    assert isinstance(failure, SlabCapacityFailureResult)
+    assert failure.factored_moment_knm == pytest.approx(56.25)
+    assert failure.limiting_moment_knm == pytest.approx(27.5925, abs=0.001)
+    assert failure.result_envelope.engineering_status is EngineeringStatus.FAIL
+    assert result.reinforcement.detailing is None
+    assert result.shear is None
+    assert result.serviceability is None
+    assert result.punching_shear_disposition == (
+        "not_evaluated_due_to_flexural_capacity_failure"
+    )
+
+
+def test_complete_two_way_capacity_miss_returns_structured_fail() -> None:
+    result = _two_way_b04(factored_area_load_kn_per_m2=100)
+
+    assert isinstance(result.panel, SlabCapacityFailureResult)
+    assert result.panel.governing_region == "x_negative_continuous_edge"
+    assert result.panel.result_envelope.engineering_status is EngineeringStatus.FAIL
+    assert result.serviceability is None

--- a/Python/tests/codes/is456/slab/test_one_way_flexure.py
+++ b/Python/tests/codes/is456/slab/test_one_way_flexure.py
@@ -9,6 +9,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 from structural_lib.codes.is456.slab.models import (
+    SlabCapacityFailureResult,
     SlabContractError,
     SolidRectangularSlabGeometry,
 )
@@ -18,6 +19,11 @@ from structural_lib.codes.is456.slab.one_way import (
     design_simply_supported_one_way_slab_flexure,
 )
 from structural_lib.codes.is456.traceability import get_clause_refs
+from structural_lib.core.result_contract import (
+    CalculationStatus,
+    EngineeringStatus,
+    IntakeStatus,
+)
 
 
 def _benchmark_input() -> OneWaySlabFlexureInput:
@@ -146,8 +152,17 @@ def test_over_capacity_demand_fails_closed() -> None:
         fy_n_per_mm2=415,
     )
 
-    with pytest.raises(SlabContractError, match="singly reinforced"):
-        design_simply_supported_one_way_slab_flexure(design_input)
+    result = design_simply_supported_one_way_slab_flexure(design_input)
+
+    assert isinstance(result, SlabCapacityFailureResult)
+    assert result.factored_moment_knm == pytest.approx(45.0)
+    assert result.limiting_moment_knm == pytest.approx(43.113, abs=0.001)
+    assert result.utilization_ratio > 1.0
+    assert result.status is EngineeringStatus.FAIL
+    assert result.result_envelope.intake_status is IntakeStatus.VALID
+    assert result.result_envelope.calculation_status is CalculationStatus.COMPLETED
+    assert result.result_envelope.engineering_status is EngineeringStatus.FAIL
+    assert result.result_envelope.issues[0].code == ("SLAB_FLEXURE_CAPACITY_EXCEEDED")
 
 
 def test_input_and_result_are_frozen() -> None:

--- a/Python/tests/codes/is456/slab/test_two_way_flexure.py
+++ b/Python/tests/codes/is456/slab/test_two_way_flexure.py
@@ -12,6 +12,7 @@ from structural_lib.codes.is456.slab.external_coefficients import (
     record_external_two_way_slab_coefficients,
 )
 from structural_lib.codes.is456.slab.models import (
+    SlabCapacityFailureResult,
     SlabContractError,
     SolidRectangularSlabGeometry,
 )
@@ -21,6 +22,11 @@ from structural_lib.codes.is456.slab.two_way import (
     TwoWaySlabFlexureInput,
     TwoWaySlabFlexureStatus,
     design_supported_interior_two_way_slab_flexure,
+)
+from structural_lib.core.result_contract import (
+    CalculationStatus,
+    EngineeringStatus,
+    IntakeStatus,
 )
 
 
@@ -178,10 +184,17 @@ def test_one_way_record_is_rejected_before_p10_input_can_be_built() -> None:
 
 
 def test_over_capacity_demand_fails_closed() -> None:
-    with pytest.raises(SlabContractError, match="singly reinforced"):
-        design_supported_interior_two_way_slab_flexure(
-            _input(factored_area_load_kn_per_m2=100)
-        )
+    result = design_supported_interior_two_way_slab_flexure(
+        _input(factored_area_load_kn_per_m2=100)
+    )
+
+    assert isinstance(result, SlabCapacityFailureResult)
+    assert result.governing_region == "x_direction"
+    assert result.factored_moment_knm == pytest.approx(128.0)
+    assert result.utilization_ratio > 1.0
+    assert result.result_envelope.intake_status is IntakeStatus.VALID
+    assert result.result_envelope.calculation_status is CalculationStatus.COMPLETED
+    assert result.result_envelope.engineering_status is EngineeringStatus.FAIL
 
 
 def test_explicit_strip_width_scales_the_per_strip_moments() -> None:

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -1889,8 +1889,8 @@
     {
       "name": "test_evidence.py",
       "type": "python",
-      "size_lines": 237,
-      "last_updated": "2026-08-17",
+      "size_lines": 254,
+      "last_updated": "2026-08-22",
       "description": "Focused tests for the supported IS 456 beam evidence envelope.",
       "functions": [
         {
@@ -1921,10 +1921,13 @@
           "name": "test_held_beam_evidence_does_not_present_a_pass_or_fail"
         },
         {
+          "name": "test_unbounded_derived_utilization_is_a_structured_supported_failure"
+        },
+        {
           "name": "test_beam_report_exports_evidence_without_approval_claim"
         }
       ],
-      "content_hash": "c01bec0fd3de"
+      "content_hash": "0fa922fe89c8"
     },
     {
       "name": "test_exception_hierarchy.py",
@@ -4995,5 +4998,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "a594000243f6c3cc"
+  "content_hash": "d4f3f1edbd1d6345"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -534,8 +534,8 @@
     {
       "name": "test_boq.py",
       "type": "python",
-      "size_lines": 190,
-      "last_updated": "2026-08-17",
+      "size_lines": 213,
+      "last_updated": "2026-08-22",
       "description": "Tests for the BOQ (Bill of Quantities) aggregation module.",
       "classes": [
         {
@@ -549,13 +549,13 @@
             "test_story_grouping",
             "test_empty_input_returns_empty_schedule",
             "test_custom_concrete_costs",
+            "test_rejects_invalid_cost_domains",
             "test_multiple_steel_grades",
-            "test_default_concrete_costs_used",
-            "test_project_name_default"
+            "test_default_concrete_costs_used"
           ]
         }
       ],
-      "content_hash": "5b94d7b3d0bd"
+      "content_hash": "b0c041f2f234"
     },
     {
       "name": "test_branch_disposition.py",
@@ -4995,5 +4995,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "e32abdf31e8e6c0e"
+  "content_hash": "a594000243f6c3cc"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -27,7 +27,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_assertion_helpers.py](test_assertion_helpers.py) | Tests for the IS 456 test assertion helpers. | 3 | 0 | 82 |
 | [test_audit.py](test_audit.py) | Tests for audit module (TASK-278). | 6 | 0 | 471 |
 | [test_audit_readiness_truth.py](test_audit_readiness_truth.py) | Readiness must aggregate semantic truth instead of reporting | 0 | 3 | 83 |
-| [test_boq.py](test_boq.py) | Tests for the BOQ (Bill of Quantities) aggregation module. | 1 | 0 | 190 |
+| [test_boq.py](test_boq.py) | Tests for the BOQ (Bill of Quantities) aggregation module. | 1 | 0 | 213 |
 | [test_branch_disposition.py](test_branch_disposition.py) | Outcome tests for the inspection-only branch disposition cla | 0 | 12 | 437 |
 | [test_bump_version_semantics.py](test_bump_version_semantics.py) | Regression coverage for candidate-version documentation sema | 0 | 1 | 66 |
 | [test_calculation_report.py](test_calculation_report.py) | Tests for the calculation_report module (TASK-277). | 9 | 4 | 745 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -45,7 +45,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_docs_index_generator.py](test_docs_index_generator.py) | Regression tests for deterministic docs-index file output. | 0 | 1 | 32 |
 | [test_error_messages.py](test_error_messages.py) | Tests for error message templates. | 7 | 0 | 294 |
 | [test_etabs_import_integration.py](test_etabs_import_integration.py) | Integration tests for etabs_import Pydantic conversion funct | 4 | 4 | 330 |
-| [test_evidence.py](test_evidence.py) | Focused tests for the supported IS 456 beam evidence envelop | 0 | 9 | 237 |
+| [test_evidence.py](test_evidence.py) | Focused tests for the supported IS 456 beam evidence envelop | 0 | 10 | 254 |
 | [test_exception_hierarchy.py](test_exception_hierarchy.py) | Tests for exception hierarchy in errors module. | 4 | 0 | 278 |
 | [test_footing.py](test_footing.py) | Tests for IS 456 footing design — TASK-650/651/652. | 11 | 1 | 1801 |
 | [test_footing_api.py](test_footing_api.py) | Focused contract tests for Phase B1 isolated-footing orchest | 0 | 15 | 401 |

--- a/Python/tests/test_boq.py
+++ b/Python/tests/test_boq.py
@@ -162,6 +162,29 @@ class TestAggregateProjectBOQ:
         expected_vol = 300.0 * 500.0 * 5000.0 / 1e9
         assert concrete_m30.cost_inr == pytest.approx(expected_vol * 10000.0, abs=0.01)
 
+    @pytest.mark.parametrize(
+        ("steel_rate", "concrete_costs", "message"),
+        [
+            (-1.0, {25: 6000.0}, "steel_cost_per_kg"),
+            (60.0, {25: -1.0}, r"concrete_costs\[25\]"),
+            (60.0, {25: float("inf")}, r"concrete_costs\[25\]"),
+            (60.0, {-5: 6000.0}, "positive integer fck grades"),
+        ],
+    )
+    def test_rejects_invalid_cost_domains(
+        self,
+        steel_rate: float,
+        concrete_costs: dict[int, float],
+        message: str,
+    ):
+        with pytest.raises(ValueError, match=message):
+            aggregate_project_boq(
+                [_make_bbs_doc()],
+                [_make_meta()],
+                steel_cost_per_kg=steel_rate,
+                concrete_costs=concrete_costs,
+            )
+
     def test_multiple_steel_grades(self):
         """Beams with different steel grades produce separate SteelSummary entries."""
         bbs_docs = [

--- a/Python/tests/test_evidence.py
+++ b/Python/tests/test_evidence.py
@@ -109,7 +109,7 @@ def test_beam_evidence_v2_binds_torsion_and_enabled_serviceability() -> None:
     service_evidence = _evidence(service)
 
     assert base_evidence["artifact_schema_version"] == BEAM_EVIDENCE_SCHEMA_VERSION
-    assert BEAM_EVIDENCE_SCHEMA_VERSION == "3.0"
+    assert BEAM_EVIDENCE_SCHEMA_VERSION == "3.1"
     assert (
         torsion_evidence["normalized_input_hash"]
         != base_evidence["normalized_input_hash"]
@@ -211,6 +211,23 @@ def test_held_beam_evidence_does_not_present_a_pass_or_fail() -> None:
     assert evidence["support_status"] == "HELD"
     assert evidence["status"] == "HOLD"
     assert evidence["exact_utilization"] is None
+    assert evidence["margin"] is None
+
+
+def test_unbounded_derived_utilization_is_a_structured_supported_failure() -> None:
+    evidence = build_beam_evidence_envelope(
+        inputs=_beam_inputs(),
+        is_ok=True,
+        governing_utilization=float("inf"),
+        utilizations={"flexure": float("inf")},
+        generated_at="2026-08-10T00:00:00+00:00",
+    )
+
+    assert evidence["support_status"] == "SUPPORTED"
+    assert evidence["status"] == "FAIL"
+    assert evidence["governing_check"] == "flexure"
+    assert evidence["exact_utilization"] is None
+    assert evidence["utilization_disposition"] == "UNBOUNDED_FAILURE"
     assert evidence["margin"] is None
 
 

--- a/Python/tests/unit/test_generic_csv_adapter.py
+++ b/Python/tests/unit/test_generic_csv_adapter.py
@@ -162,6 +162,22 @@ class TestGenericCSVAdapterLoadForces:
         assert b3.mu_knm == pytest.approx(250.0)
         assert b3.vu_kn == pytest.approx(150.0)
 
+    @pytest.mark.parametrize("bad_value", ["not-a-number", "NaN", "inf", "-inf"])
+    def test_rejects_malformed_force_instead_of_coercing_zero(
+        self,
+        adapter: GenericCSVAdapter,
+        tmp_path: Path,
+        bad_value: str,
+    ):
+        csv_path = tmp_path / "malformed_force.csv"
+        with open(csv_path, "w", newline="") as file_obj:
+            writer = csv.writer(file_obj)
+            writer.writerow(["beam_id", "Mu", "Vu"])
+            writer.writerow(["B1", bad_value, "10"])
+
+        with pytest.raises(ValueError, match=r"mu_knm.*CSV row 2"):
+            adapter.load_forces(csv_path)
+
     def test_load_forces_with_load_case(
         self, adapter: GenericCSVAdapter, tmp_path: Path
     ):
@@ -428,10 +444,10 @@ class TestGenericCSVAdapterColumnMapping:
 class TestGenericCSVAdapterEdgeCases:
     """Test edge cases and error handling."""
 
-    def test_handles_non_numeric_forces(
+    def test_rejects_non_numeric_forces(
         self, adapter: GenericCSVAdapter, tmp_path: Path
     ):
-        """Handle non-numeric force values gracefully."""
+        """Reject a malformed row instead of preserving it with zero forces."""
         csv_path = tmp_path / "bad_forces.csv"
         with open(csv_path, "w", newline="") as f:
             writer = csv.writer(f)
@@ -439,13 +455,8 @@ class TestGenericCSVAdapterEdgeCases:
             writer.writerow(["B1", "150.0", "100.0"])
             writer.writerow(["B2", "N/A", "---"])  # Invalid values
 
-        forces = adapter.load_forces(csv_path)
-
-        assert len(forces) == 2
-        # B2 should have 0 for invalid forces
-        b2 = next(f for f in forces if f.id == "B2")
-        assert b2.mu_knm == pytest.approx(0.0)
-        assert b2.vu_kn == pytest.approx(0.0)
+        with pytest.raises(ValueError, match=r"mu_knm.*CSV row 3"):
+            adapter.load_forces(csv_path)
 
     def test_handles_bom_encoding(self, adapter: GenericCSVAdapter, tmp_path: Path):
         """Handle UTF-8 BOM encoding from Excel exports."""

--- a/Python/tests/unit/test_gravity_workflow_v1.py
+++ b/Python/tests/unit/test_gravity_workflow_v1.py
@@ -34,9 +34,15 @@ def _request(
     *,
     with_supported_component_bases: bool = False,
     beam_effective_depth_mm: float = 450,
+    superimposed_dead_load_kn_m2: float = 1.5,
+    live_load_kn_m2: float = 3.0,
 ) -> GravityWorkflowRequestV1:
     building = building or _building()
-    loads = _loads(building)
+    loads = _loads(
+        building,
+        superimposed_dead_load_kn_m2=superimposed_dead_load_kn_m2,
+        live_load_kn_m2=live_load_kn_m2,
+    )
     slab_bases: tuple[GravitySlabDesignBasisV1, ...] = ()
     beam_bases: tuple[GravityBeamDesignBasisV1, ...] = ()
     column_bases: tuple[GravityColumnDesignBasisV1, ...] = ()
@@ -259,6 +265,26 @@ def test_component_failure_remains_fail_while_other_missing_basis_holds_aggregat
     assert by_id["B2"].result_envelope["overall_status"] == "FAIL"
     assert by_id["F1"].result_envelope["overall_status"] == "HOLD"
     assert result.result_envelope["overall_status"] == "HOLD"
+
+
+def test_slab_capacity_failure_remains_structured_component_fail() -> None:
+    request = _request(
+        _building_with_x_span(10_000),
+        with_supported_component_bases=True,
+        superimposed_dead_load_kn_m2=50,
+        live_load_kn_m2=50,
+    )
+
+    result = run_gravity_workflow_v1(request)
+    slab = next(item for item in result.components if item.component_id == "P1")
+
+    assert slab.result_envelope["intake_status"] == "VALID"
+    assert slab.result_envelope["calculation_status"] == "COMPLETED"
+    assert slab.result_envelope["engineering_status"] == "FAIL"
+    assert slab.result is not None
+    assert slab.result["reinforcement"]["flexure"]["status"] == "FAIL"
+    assert slab.result["shear"] is None
+    assert slab.result["serviceability"] is None
 
 
 def test_footing_cannot_relabel_superstructure_handoff_as_complete_external_action() -> (

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -54,6 +54,9 @@ contracts, without changing supported engineering formulas.
 - The first normal commit-hook run blocked on three repository-wide mypy
   errors: Gravity Workflow read optional slab shear/serviceability results and
   release UAT read optional detailing without narrowing the new failure union.
+- Hosted FastAPI validation on PR #834 left 471 tests green but failed two
+  unsafe-beam routes with HTTP 422 because strict evidence hashing received an
+  infinite derived utilization; `PR Gate` correctly failed with it.
 - ⚠️ TERMINAL ISSUE: the first slab lookup guessed a nonexistent
   `one_way_flexure.py`; `rg --files` identified the maintained `one_way.py`.
 - ⚠️ TERMINAL ISSUE: a direct complete-workflow replay omitted six required
@@ -123,6 +126,15 @@ contracts, without changing supported engineering formulas.
   Evidence: 13 affected Gravity/UAT tests pass, the overloaded workflow result
   is `VALID/COMPLETED/FAIL`, and targeted mypy passes all three affected source
   modules.
+- Symptom: valid but grossly unsafe beam designs could not return their
+  expected HTTP 200 engineering `FAIL`. Root cause: a zero/invalid calculated
+  capacity intentionally produced mathematical infinity, but beam evidence
+  schema 3.0 inserted that value into strict JSON identity. Resolution: schema
+  3.1 records `UNBOUNDED_FAILURE`, leaves `exact_utilization` and margin null,
+  and forces `SUPPORTED/FAIL` even if a contradictory caller supplies
+  `is_ok=True`. Evidence: the two hosted reproductions plus the evidence
+  fail-closed regression pass; 14 affected tests and 20 API-contract tests are
+  green with no OpenAPI breaking drift.
 
 ### Verification through content freeze
 
@@ -131,6 +143,9 @@ contracts, without changing supported engineering formulas.
   independent API surface/manifest tests pass.
 - 13 affected downstream Gravity Workflow and release-UAT tests pass after the
   full-source typing repair.
+- The first hosted run passed Python, documentation, and repository validation
+  but failed FastAPI 2/473 and therefore failed `PR Gate`; the exact two failed
+  nodes, evidence regressions, and 20 API-contract tests pass after repair.
 - The schema snapshot authority reports five models and two enums unchanged;
   the canonical OpenAPI baseline contains the reviewed response-model update.
 - Targeted mypy reports no issues in seven changed source modules; focused

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,148 @@
 
 ---
 
+## 2026-08-22 — Session: LIB-PRO-003-C public failure contracts
+
+**Agent:** Codex (`backend` + `api-developer`, sole writer)
+
+**Branch:** `codex/public-route-failure-contracts`, from hosted `main` at
+`e19b757ccb9922061369a236501f037ec20503ab` after exact-tree merge of
+`LIB-PRO-003-B` PR #833.
+
+**Git handoff receipt:**
+`docs/verification/lib-pro-003-c-git-handoff-receipt.json`
+
+**Focus:** Replace slab over-capacity exceptions, malformed legacy CSV zero
+coercion, and invalid BOQ pricing arithmetic with truthful public failure
+contracts, without changing supported engineering formulas.
+
+### Summary
+
+- Added one shared slab capacity-failure carrier with demand, capacity,
+  utilization, clause/source provenance, a stable issue, qualified-review
+  requirement, and the common `VALID/COMPLETED/FAIL` envelope.
+- Returned that carrier through one-way, two-way, complete-workflow, service,
+  FastAPI, and OpenAPI serialization paths while retaining exceptions for
+  invalid or unsupported intake.
+- Made `GenericCSVAdapter.load_forces` reject malformed and non-finite numeric
+  cells with field and source-row context; blank optional cells retain the
+  documented zero default.
+- Rejected bool, non-real, non-finite, and non-positive BOQ rates and
+  non-positive concrete grades at the Python and request-model boundaries.
+- Regenerated the canonical OpenAPI baseline after the response-model change.
+  Packet D, cumulative broad acceptance, release authority, INDIA-3, ETABS,
+  and professional approval remain held.
+
+### Issues encountered
+
+- The first 122-test focused run left five adapter-test failures: four new
+  parameter cases inherited assertions from the prior valid-fixture test, and
+  one historical test still expected malformed text to become zero.
+- A broad-context patch initially matched repeated force-row loops in the
+  2,100-line adapter module and changed two unrelated adapter classes.
+- Targeted mypy found that an untyped shared two-way argument dictionary widened
+  required floats and source references to `object`; Ruff found two import
+  blocks; Black identified three formatting-only files.
+- The read-only documentation audit found an inherited 401-file count against
+  its 400-file hard cap and three invalid front-matter values already present
+  at the exact source base; a new Markdown packet record would raise the count
+  to 402.
+- The first normal commit-hook run blocked on three repository-wide mypy
+  errors: Gravity Workflow read optional slab shear/serviceability results and
+  release UAT read optional detailing without narrowing the new failure union.
+- ⚠️ TERMINAL ISSUE: the first slab lookup guessed a nonexistent
+  `one_way_flexure.py`; `rg --files` identified the maintained `one_way.py`.
+- ⚠️ TERMINAL ISSUE: a direct complete-workflow replay omitted six required
+  reviewed serviceability inputs; the already-covered one-way public endpoint
+  replay was used for the exact capacity evidence instead.
+- ⚠️ TERMINAL ISSUE: unquoted `index.*` probes triggered zsh `no matches
+  found`; a literal `find` expression then identified the maintained parent
+  indexes without changing files.
+- ⚠️ TERMINAL ISSUE: the first explicit staging parser called `trim()` on
+  porcelain output, removed the first line's leading status marker, and formed
+  the nonexistent path `ython/...`; Git rejected the command and staged no
+  files.
+
+### Root causes and resolutions
+
+- Symptom: supported slab overload raised `SlabContractError` and prevented a
+  disposition. Root cause: the flexure functions treated a completed capacity
+  miss as invalid intake. Resolution: introduce a shared typed failure carrier
+  and propagate it before detailing/serviceability access. Evidence: both slab
+  systems serialize demand, capacity, provenance, issue, and
+  `VALID/COMPLETED/FAIL`; supported valid workflows remain green.
+- Symptom: malformed CSV forces became zero or disappeared. Root cause: each
+  force conversion caught `ValueError`, kept its initialized zero, and the
+  outer row handler also swallowed `ValueError`. Resolution: one finite parser
+  now raises with field/row context and only a missing mapped key is wrapped as
+  malformed-row intake. Evidence: malformed/non-finite cells reject while
+  valid, blank, SAFE, STAAD, and end-to-end adapter tests pass.
+- Symptom: negative BOQ rates produced negative totals. Root cause: neither
+  Pydantic request models nor the reusable Python aggregator constrained rates
+  or concrete-grade keys. Resolution: finite positive request fields plus a
+  direct public aggregator guard. Evidence: API cases return 422 and direct
+  calls raise `ValueError`; all valid costing tests remain unchanged.
+- Symptom: unrelated adapter loops appeared in the patch. Root cause: repeated
+  method and loop text made a broad context patch non-unique. Resolution:
+  inspect the diff immediately and reverse only the unintended SAFE/STAAD
+  edits. Evidence: the final adapter diff contains only `GenericCSVAdapter`.
+- Symptom: the first focused suite had five test failures. Root cause: the new
+  parametrized test split the preceding fixture assertions, and one expected
+  contract was intentionally obsolete. Resolution: restore valid-fixture
+  assertions to their original test and change malformed-text expectations to
+  explicit rejection. Evidence: all affected nodes and the complete 122-test
+  selection pass.
+- Symptom: static checks failed after runtime tests were green. Root cause:
+  dictionary unpacking erased precise types and patched imports/lines were not
+  normalized. Resolution: pass the six two-way shared values explicitly and
+  apply deterministic Ruff/Black ordering. Evidence: targeted mypy, Ruff,
+  Black, and `git diff --check` pass.
+- Symptom: the standalone Markdown evidence worsened a pre-existing hard doc
+  budget failure. Root cause: the exact base already contained 401 counted
+  Markdown files and three older invalid `doc_type` values. Resolution: retain
+  the full narrative in this required session record and store standalone
+  machine evidence as JSON. Evidence: Packet C adds zero counted Markdown
+  files; the inherited 401-file/front-matter debt remains visible for Packet D
+  gate truth instead of being misreported as green.
+- Symptom: explicit staging failed on one malformed path. Root cause: trimming
+  the whole porcelain output altered only the first record before its fixed
+  three-character status prefix was removed. Resolution: preserve the raw
+  first-line whitespace and split before slicing each status prefix. Evidence:
+  the failed command left the index and worktree unchanged; the corrected
+  parser stages the complete 43-path candidate.
+- Symptom: normal hooks rejected otherwise-green Packet C source. Root cause:
+  two downstream public consumers encoded the old assumption that every valid
+  slab intake reaches detailing, shear, and serviceability, which is no longer
+  true for a completed flexural capacity failure. Resolution: Gravity Workflow
+  treats absent downstream checks as component `FAIL`, and release UAT asserts
+  its known-safe fixture reached detailing before checking review status.
+  Evidence: 13 affected Gravity/UAT tests pass, the overloaded workflow result
+  is `VALID/COMPLETED/FAIL`, and targeted mypy passes all three affected source
+  modules.
+
+### Verification through content freeze
+
+- 122 implementation-focused tests pass across slab, CSV, BOQ, and FastAPI.
+- 214 independent neighboring slab, adapter, and costing tests pass; 20
+  independent API surface/manifest tests pass.
+- 13 affected downstream Gravity Workflow and release-UAT tests pass after the
+  full-source typing repair.
+- The schema snapshot authority reports five models and two enums unchanged;
+  the canonical OpenAPI baseline contains the reviewed response-model update.
+- Targeted mypy reports no issues in seven changed source modules; focused
+  Ruff, Black, and `git diff --check` pass. The consolidated quick gate passes
+  10/10; commit hooks, immutable commit, hosted checks, and exact-tree merge
+  remain in the candidate sequence.
+
+### Remaining holds
+
+- `LIB-PRO-003-D` and cumulative broad acceptance remain open.
+- No package publication, version bump, stable/professional-use claim,
+  qualified-engineer approval, INDIA-3 work, ETABS, or desktop Excel work is
+  authorized by this packet.
+
+---
+
 ## 2026-08-22 — Session: LIB-PRO-003-B domains and footing provenance
 
 **Agent:** Codex (`backend`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-22 — LIB-PRO-003-A merged; Packet B domain and provenance closure active
+**Updated:** 2026-08-22 — LIB-PRO-003-B merged; Packet C failure-contract closure active
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-003-B | Enforce beam/column material and reinforcement domains, repair the stale column key, and close footing provenance | backend + tester | M | P0 | 🚧 ACTIVE — adversarial replay and focused implementation evidence green; final candidate gates pending |
+| LIB-PRO-003-C | Convert slab capacity, malformed legacy CSV, and negative BOQ inputs to structured fail-closed outcomes | backend + API developer + tester | M | P0 | 🚧 ACTIVE — 122 focused, 214 independent, and 20 API-contract tests pass; candidate gates pending |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. The reproduced public-route safety defects take priority over new
@@ -136,7 +136,9 @@ cleanup, and professional approval remain separately held until `LIB-PRO-003`
 closes and their own packet is activated.
 
 `LIB-PRO-003-A` was accepted and exact-tree merged through PR #832 at
-`e7698a63b86d2db6db2f3970871122af1ce562f6`. `LIB-PRO-002-G0` was
+`e7698a63b86d2db6db2f3970871122af1ce562f6`; Packet B was accepted and
+exact-tree merged through PR #833 at
+`e19b757ccb9922061369a236501f037ec20503ab`. `LIB-PRO-002-G0` was
 independently accepted and merged through PR #812 at
 `55104e11257937b0a42fb06f931a70b8484cef39`. Packet A was independently
 accepted and merged through PR #814 at
@@ -160,7 +162,6 @@ write-back/nightly work remain outside E1.
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-003-C | Convert slab capacity, malformed legacy CSV, and negative BOQ inputs to structured fail-closed outcomes | backend + API developer + tester | M | P0 | ⏸ AFTER B |
 | LIB-PRO-003-D | Make Excel CI and input audits decisive and synchronize release/route-count truth | ops + governance | S | P0 | ⏸ AFTER C |
 | INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | ⏸ AFTER LIB-PRO-003 — truth/benchmark/contract audit only; no new formulas or support claims |
 | SPARK-001-G0 | Reassess the stale Spark work-program proposal before any implementation | repository owner | review gate | P2 | ⏸ OWNER REVIEW — the 2026-08-11 model/preview assumptions and bulk wave require refresh or rejection |

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4003,
+      "size_lines": 4018,
       "last_updated": "2026-08-22",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "7dca332f024c"
+      "content_hash": "0e04304abeae"
     },
     {
       "name": "TASKS.md",
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "c8d8e262a51dd92a"
+  "content_hash": "e856922f3497aceb"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 3861,
+      "size_lines": 4003,
       "last_updated": "2026-08-22",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "35dc475544c2"
+      "content_hash": "7dca332f024c"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 736,
+      "size_lines": 737,
       "last_updated": "2026-08-22",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "f6baea6ae710"
+      "content_hash": "b0beb2e8e4ed"
     },
     {
       "name": "WORKLOG.md",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 210,
+      "file_count": 213,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "39c33b9fcd0a950f"
+  "content_hash": "c8d8e262a51dd92a"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4003 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4018 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 737 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 3861 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 736 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4003 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 737 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1793 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 8 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 210 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 213 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -34,8 +34,8 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
-| `public-route-safety-closure-plan.md` | 2026-08-22 | 🚧 LIB-PRO-003-B active after A merged; new release and professional/stable claims held through B-D |
-| `next-session-brief.md` | 2026-08-17 | 📋 LIB-PRO-002-I CLI closure then J release-signal convergence are the exact next sequence |
+| `public-route-safety-closure-plan.md` | 2026-08-22 | 🚧 LIB-PRO-003-C active after A-B merged; new release and professional/stable claims held through C-D |
+| `next-session-brief.md` | 2026-08-22 | 🚧 LIB-PRO-003-C failure contracts active; D and one cumulative gate follow |
 | `pre-release-input-safety-and-professional-readiness-plan.md` | 2026-08-17 | 🚧 A-G merged; CLI, hosted-interpreter, preflight-verdict, and authorization holds remain through I-J |
 | `is456-solid-slabs-master-plan.md` | 2026-08-10 | 📋 Master plan ready; implementation has not started |
 | `ui-experience-foundation-master-plan.md` | 2026-08-10 | ✅ Two-session P0-P15 workbench/capability program accepted |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -12,7 +12,7 @@
       "last_updated": "2026-08-22",
       "title": "Planning",
       "description": "Internal planning documents and research notes. | Document | Purpose |",
-      "content_hash": "cb821a16fac8"
+      "content_hash": "101b542a6e4f"
     },
     {
       "name": "compact-modernization-plan.md",
@@ -131,11 +131,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 80,
+      "size_lines": 81,
       "last_updated": "2026-08-22",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-22",
-      "content_hash": "44cf861d88f6"
+      "content_hash": "cef29437c349"
     },
     {
       "name": "pre-release-checklist.md",
@@ -167,10 +167,10 @@
     {
       "name": "public-route-safety-closure-plan.md",
       "type": "documentation",
-      "size_lines": 94,
+      "size_lines": 98,
       "last_updated": "2026-08-22",
       "description": "engineering-use approval until the bounded packets below close. The 2026-08-22 exact-tree replay confirmed that the bounded Gravity Workflow",
-      "content_hash": "9e3d6d47e0bc"
+      "content_hash": "7aa87d8149c5"
     },
     {
       "name": "ui-experience-foundation-master-plan.md",
@@ -182,5 +182,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "849f408688ababe2"
+  "content_hash": "263e398e3904f03d"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -23,9 +23,9 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 80 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 81 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Current source metadata: 0.23.1a2 Current public Alpha: v0.2 | 114 |
 | [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 742 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
-| [public-route-safety-closure-plan.md](public-route-safety-closure-plan.md) |  | engineering-use approval until the bounded packets below clo | 94 |
+| [public-route-safety-closure-plan.md](public-route-safety-closure-plan.md) |  | engineering-use approval until the bounded packets below clo | 98 |
 | [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2408 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -13,8 +13,8 @@
 
 | State | Boundary |
 |---|---|
-| **Current** | `LIB-PRO-003-B` is active from exact hosted `main` at `e7698a63`: close beam/column domains, stale column result access, and footing provenance |
-| **Next** | Complete Packets C-D for structured slab/CSV/BOQ failure and decisive CI/audit/documentation truth |
+| **Current** | `LIB-PRO-003-C` is active from exact hosted `main` at `e19b757c`: close slab-capacity, malformed CSV, and BOQ-rate failure contracts |
+| **Next** | Complete Packet D for decisive CI/audit/documentation truth, then run one cumulative broad acceptance sequence |
 | **Why** | Direct replay reproduced 13 outcome-changing behaviours still exposed outside the newer bounded Gravity/E1 workflows |
 | **Held** | INDIA-3, new formulas/support claims, ETABS, package publication, stable/professional claims, and qualified approval remain separate and held |
 
@@ -42,17 +42,18 @@ authority. Results remain `NOT_REVIEWED` with
 
 ## Correct next library packet
 
-`LIB-PRO-003-B` is the active bounded implementation packet. Packet A was
-exact-tree merged through PR #832 at `e7698a63`.
+`LIB-PRO-003-C` is the active bounded implementation packet. Packets A-B were
+exact-tree merged through PRs #832-#833 at `e7698a63` and `e19b757c`.
 
-1. Reject unsupported beam material and Table 19 percentage domains.
-2. Reject supplied non-positive shear steel instead of replacing it.
-3. Enforce 0.8-4.0% column longitudinal steel before a safety result.
-4. Read the current typed uniaxial safety field in unified column routing.
-5. Reject unknown footing provenance origins before replay identity is built.
+1. Return a typed `VALID/COMPLETED/FAIL` result when a supported one-way or
+   two-way slab demand exceeds capacity.
+2. Reject malformed or non-finite legacy CSV force cells instead of replacing
+   them with zero or dropping their rows.
+3. Reject non-positive concrete grades and non-finite/non-positive BOQ rates at
+   both the public Python and FastAPI boundaries.
 
-Packets C-D then close structured slab/CSV/BOQ failures and decisive
-CI/audit/documentation truth. Do not start
+Packet D then closes decisive CI/audit/documentation truth before one
+cumulative broad acceptance run. Do not start
 new engineering formulas, IS 13920 expansion, IS 875, IS 1893, FEM, or ETABS.
 
 ## Other live work

--- a/docs/planning/public-route-safety-closure-plan.md
+++ b/docs/planning/public-route-safety-closure-plan.md
@@ -60,8 +60,8 @@ tests and independent column benchmarks remain unchanged.
 
 ### Packet B — Beam, column, and provenance domains
 
-**Status:** active on `codex/public-route-domain-provenance` from
-`e7698a63`.
+**Status:** integrated through PR #833 at `e19b757c` with reviewed and merged
+trees equal.
 
 Reject supplied non-positive shear steel instead of substituting it; reject
 out-of-domain steel percentages and unsupported material grades; enforce
@@ -70,6 +70,9 @@ a declared footing provenance origin.
 
 ### Packet C — Structured failure and intake truth
 
+**Status:** active on `codex/public-route-failure-contracts` from
+`e19b757c`; adversarial, focused, independent, and API-contract checks pass.
+
 Return a structured slab capacity `FAIL`, make the legacy CSV route block
 malformed numeric cells without zero coercion or row loss, and reject negative
 BOQ rates at the request boundary.
@@ -77,8 +80,9 @@ BOQ rates at the request boundary.
 ### Packet D — Decisive gates and repository truth
 
 Run the Excel add-in tests for `excel_addin/**` changes, make the input audit
-surface and exit result decisive, and reconcile release and endpoint-count
-wording with clearly named metrics.
+surface and exit result decisive, reconcile release and endpoint-count wording
+with clearly named metrics, and make the inherited documentation audit state
+truthful without weakening its gate.
 
 After A-D pass focused, quick, broad, and hosted acceptance, the owner may
 resume `INDIA-3-G0`. A future package remains a separate versioned artifact and

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-22",
-  "file_count": 208,
+  "file_count": 211,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -2343,6 +2343,50 @@
       "content_hash": "00533ed8679b"
     },
     {
+      "name": "lib-pro-003-c-failure-contracts-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "identity",
+        "outcomes",
+        "scope_exclusions",
+        "status",
+        "verification",
+        "holds"
+      ],
+      "content_hash": "3c5c07100ee1"
+    },
+    {
+      "name": "lib-pro-003-c-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "d9748fdaae40"
+    },
+    {
+      "name": "lib-pro-003-c-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "dc0eb616043d"
+    },
+    {
       "name": "next-session-git-issues-plan-git-handoff-receipt.json",
       "type": "config",
       "last_updated": "2026-08-16",
@@ -2661,5 +2705,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "0f0f43b5ac5d2357"
+  "content_hash": "bac87fb74cfcb859"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -2351,10 +2351,11 @@
         "outcomes",
         "scope_exclusions",
         "status",
+        "hosted_repair",
         "verification",
         "holds"
       ],
-      "content_hash": "3c5c07100ee1"
+      "content_hash": "f32a1f07ffa3"
     },
     {
       "name": "lib-pro-003-c-git-handoff-receipt.json",
@@ -2372,7 +2373,7 @@
         "receipt_grants_authority",
         "receipt_kind"
       ],
-      "content_hash": "d9748fdaae40"
+      "content_hash": "3f2fc4b49c6f"
     },
     {
       "name": "lib-pro-003-c-git-handoff-source-evidence.json",
@@ -2384,7 +2385,7 @@
         "retention",
         "task_archive"
       ],
-      "content_hash": "dc0eb616043d"
+      "content_hash": "1c53deea3c97"
     },
     {
       "name": "next-session-git-issues-plan-git-handoff-receipt.json",
@@ -2705,5 +2706,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "bac87fb74cfcb859"
+  "content_hash": "93ad80366ea2d8c1"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-22
-**Files:** 208
+**Files:** 211
 
 ## Config Files
 
@@ -126,6 +126,9 @@ Benchmark examples and verification packs for validating library calculations ag
 - [lib-pro-003-a-git-handoff-source-evidence.json](lib-pro-003-a-git-handoff-source-evidence.json)
 - [lib-pro-003-b-git-handoff-receipt.json](lib-pro-003-b-git-handoff-receipt.json)
 - [lib-pro-003-b-git-handoff-source-evidence.json](lib-pro-003-b-git-handoff-source-evidence.json)
+- [lib-pro-003-c-failure-contracts-evidence.json](lib-pro-003-c-failure-contracts-evidence.json)
+- [lib-pro-003-c-git-handoff-receipt.json](lib-pro-003-c-git-handoff-receipt.json)
+- [lib-pro-003-c-git-handoff-source-evidence.json](lib-pro-003-c-git-handoff-source-evidence.json)
 - [next-session-git-issues-plan-git-handoff-receipt.json](next-session-git-issues-plan-git-handoff-receipt.json)
 - [next-session-git-issues-plan-git-handoff-source-evidence.json](next-session-git-issues-plan-git-handoff-source-evidence.json)
 - [post-india2-cleanup-disposition-evidence.json](post-india2-cleanup-disposition-evidence.json)

--- a/docs/verification/lib-pro-003-c-failure-contracts-evidence.json
+++ b/docs/verification/lib-pro-003-c-failure-contracts-evidence.json
@@ -34,7 +34,18 @@
     "package version or publication",
     "ETABS or desktop Excel"
   ],
-  "status": "READY_FOR_CANDIDATE",
+  "status": "READY_FOR_REPAIR_CANDIDATE",
+  "hosted_repair": {
+    "affected_tests_passed": 14,
+    "api_contract_tests_passed": 20,
+    "corrected_outcome": "Valid but unsafe beams with unbounded derived utilization return SUPPORTED/FAIL without non-finite JSON.",
+    "first_hosted_fastapi_result": "471 passed, 2 failed",
+    "first_pr_gate": "FAIL",
+    "openapi_breaking_drift": false,
+    "root_cause": "Beam evidence schema 3.0 attempted to hash mathematical infinity as strict JSON.",
+    "schema_version": "3.1",
+    "utilization_disposition": "UNBOUNDED_FAILURE"
+  },
   "verification": {
     "api_contract_tests_passed": 20,
     "api_surface": {

--- a/docs/verification/lib-pro-003-c-failure-contracts-evidence.json
+++ b/docs/verification/lib-pro-003-c-failure-contracts-evidence.json
@@ -1,0 +1,66 @@
+{
+  "identity": {
+    "branch": "codex/public-route-failure-contracts",
+    "source_base": "e19b757ccb9922061369a236501f037ec20503ab",
+    "source_pr": 833,
+    "task_id": "LIB-PRO-003-C"
+  },
+  "outcomes": [
+    {
+      "corrected_outcome": "Public service and HTTP routes return a typed slab failure with demand, capacity, utilization, provenance, issue, qualified-review flag, and VALID/COMPLETED/FAIL envelope.",
+      "reproduction": "One-way 3.0 m span, 50 kN/m2 factored load, d=100 mm raised at 56.25 kNm demand versus 27.5925 kNm capacity.",
+      "root_cause": "A completed capacity miss was classified as invalid intake."
+    },
+    {
+      "corrected_outcome": "The first governing failed region returns the same structured engineering failure through direct, panel, service, and HTTP serialization.",
+      "reproduction": "A supported two-way panel overload raised SlabContractError.",
+      "root_cause": "Each moment-region helper used an exception-only capacity boundary."
+    },
+    {
+      "corrected_outcome": "Malformed and non-finite force cells reject with field and one-based source-row context; blank optional cells remain zero by contract.",
+      "reproduction": "Generic CSV not-a-number, NaN, or infinity became zero or lost its row.",
+      "root_cause": "Inner parsing and the outer row handler swallowed ValueError."
+    },
+    {
+      "corrected_outcome": "FastAPI returns 422 and direct aggregation rejects invalid grades/rates before arithmetic.",
+      "reproduction": "Negative concrete or steel rates produced negative totals.",
+      "root_cause": "Request schemas and the reusable aggregator accepted unconstrained rates and concrete-grade keys."
+    }
+  ],
+  "scope_exclusions": [
+    "engineering formulas",
+    "supported slab topologies",
+    "coefficient sources",
+    "package version or publication",
+    "ETABS or desktop Excel"
+  ],
+  "status": "READY_FOR_CANDIDATE",
+  "verification": {
+    "api_contract_tests_passed": 20,
+    "api_surface": {
+      "endpoints": 89,
+      "schemas": 435
+    },
+    "focused_tests_passed": 122,
+    "downstream_gravity_and_release_uat_tests_passed": 13,
+    "independent_tests_passed": 214,
+    "openapi_drift": false,
+    "quick_gate": "10/10 PASS",
+    "schema_snapshot": "5 models and 2 enums match",
+    "static_checks": [
+      "targeted mypy: PASS",
+      "focused Ruff: PASS",
+      "focused Black: PASS",
+      "git diff --check: PASS"
+    ]
+  },
+  "holds": [
+    "LIB-PRO-003-D",
+    "cumulative broad acceptance",
+    "new package release",
+    "stable or professional-use claims",
+    "qualified-engineer approval",
+    "INDIA-3",
+    "ETABS"
+  ]
+}

--- a/docs/verification/lib-pro-003-c-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-003-c-git-handoff-receipt.json
@@ -2,7 +2,7 @@
   "authorization": {
     "authority_source": {
       "kind": "USER_DELEGATION",
-      "observed_at_utc": "2026-08-22T10:43:10Z",
+      "observed_at_utc": "2026-08-22T10:57:58Z",
       "query_status": "OK",
       "reference": "task:LIB-PRO-003:user-request-continue-this-work",
       "status": "OBSERVED"
@@ -13,7 +13,7 @@
       "CREATE_OR_UPDATE_PR"
     ],
     "next_action": "COMMIT_INTENDED_PATHS",
-    "observed_at_utc": "2026-08-22T10:43:10Z",
+    "observed_at_utc": "2026-08-22T10:57:58Z",
     "prohibited_actions": [
       "PUBLISH_RELEASE",
       "CLAIM_PROFESSIONAL_APPROVAL",
@@ -32,7 +32,7 @@
         "CREATE_OR_UPDATE_PR"
       ],
       "branch": "codex/public-route-failure-contracts",
-      "head_sha": "e19b757ccb9922061369a236501f037ec20503ab",
+      "head_sha": "60ceb7b9af7ec91fd09a637816bd68166ac4a05d",
       "task_id": "LIB-PRO-003-C"
     }
   },
@@ -49,27 +49,27 @@
   },
   "local": {
     "authority": "scripts/git_state.py",
-    "receipt_sha256": "44eb1aba1259963c7bb54ee8b9f2d35ca87ad78e2cb35c8fecf752b106dcc281",
+    "receipt_sha256": "f375155d18c79ba75c2ed9e89fbac24441c4d8da77e9c24275b273ac60c1c615",
     "state": {
       "branch": "codex/public-route-failure-contracts",
       "default_base": {
-        "ahead": 0,
+        "ahead": 1,
         "behind": 0,
         "ref": "origin/main",
         "sha": "e19b757ccb9922061369a236501f037ec20503ab",
-        "status": "equal"
+        "status": "ahead"
       },
       "derived_action": "HOLD_DIRTY",
-      "duration_ms": 105.348,
+      "duration_ms": 106.287,
       "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
       "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-public-route-failure-contracts",
-      "head_sha": "e19b757ccb9922061369a236501f037ec20503ab",
+      "head_sha": "60ceb7b9af7ec91fd09a637816bd68166ac4a05d",
       "hold_reasons": [
-        "changed paths: 46"
+        "changed paths: 9"
       ],
       "linked_worktree": true,
       "locks": [],
-      "observed_at_utc": "2026-08-22T10:51:11.209156+00:00",
+      "observed_at_utc": "2026-08-22T10:58:49.193413+00:00",
       "operation": "none",
       "operation_markers": [],
       "query_failures": [],
@@ -80,74 +80,34 @@
       "tree": {
         "clean": false,
         "conflicted_paths": [],
-        "dirty_count": 46,
+        "dirty_count": 9,
         "modified_paths": [
-          "Python/structural_lib/services/gravity_workflow.py",
-          "Python/structural_lib/services/release_uat.py",
-          "Python/tests/unit/test_gravity_workflow_v1.py",
+          "Python/structural_lib/services/evidence.py",
+          "Python/tests/test_evidence.py",
           "docs/SESSION_LOG.md",
-          "docs/verification/lib-pro-003-c-failure-contracts-evidence.json"
-        ],
-        "staged_paths": [
-          "Python/structural_lib/codes/is456/slab/__init__.py",
-          "Python/structural_lib/codes/is456/slab/models.py",
-          "Python/structural_lib/codes/is456/slab/one_way.py",
-          "Python/structural_lib/codes/is456/slab/two_way.py",
-          "Python/structural_lib/codes/is456/slab/two_way_complete.py",
-          "Python/structural_lib/services/adapters.py",
-          "Python/structural_lib/services/boq.py",
-          "Python/structural_lib/services/index.json",
-          "Python/structural_lib/services/index.md",
-          "Python/structural_lib/services/slab_api.py",
-          "Python/tests/codes/is456/index.json",
-          "Python/tests/codes/is456/index.md",
-          "Python/tests/codes/is456/slab/test_extended_workflows.py",
-          "Python/tests/codes/is456/slab/test_one_way_flexure.py",
-          "Python/tests/codes/is456/slab/test_two_way_flexure.py",
-          "Python/tests/index.json",
-          "Python/tests/index.md",
-          "Python/tests/test_boq.py",
-          "Python/tests/unit/test_generic_csv_adapter.py",
-          "docs/SESSION_LOG.md",
-          "docs/TASKS.md",
-          "docs/index.json",
-          "docs/index.md",
-          "docs/planning/README.md",
-          "docs/planning/index.json",
-          "docs/planning/index.md",
-          "docs/planning/next-session-brief.md",
-          "docs/planning/public-route-safety-closure-plan.md",
-          "docs/verification/index.json",
-          "docs/verification/index.md",
           "docs/verification/lib-pro-003-c-failure-contracts-evidence.json",
-          "docs/verification/lib-pro-003-c-git-handoff-receipt.json",
           "docs/verification/lib-pro-003-c-git-handoff-source-evidence.json",
-          "fastapi_app/index.json",
-          "fastapi_app/models/boq.py",
-          "fastapi_app/models/index.json",
-          "fastapi_app/models/index.md",
-          "fastapi_app/models/library_core.py",
+          "fastapi_app/models/beam.py",
           "fastapi_app/openapi_baseline.json",
-          "fastapi_app/tests/index.json",
-          "fastapi_app/tests/index.md",
-          "fastapi_app/tests/test_insights_dashboard.py",
-          "fastapi_app/tests/test_library_core.py"
+          "fastapi_app/tests/test_beam_primary_route.py",
+          "fastapi_app/tests/test_endpoints.py"
         ],
+        "staged_paths": [],
         "untracked_paths": []
       },
       "upstream": {
         "ahead": 0,
         "behind": 0,
-        "ref": "origin/main",
-        "sha": "e19b757ccb9922061369a236501f037ec20503ab",
+        "ref": "origin/codex/public-route-failure-contracts",
+        "sha": "60ceb7b9af7ec91fd09a637816bd68166ac4a05d",
         "status": "equal"
       },
       "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-failure-contracts"
     }
   },
-  "local_state_receipt_hash": "sha256:44eb1aba1259963c7bb54ee8b9f2d35ca87ad78e2cb35c8fecf752b106dcc281",
+  "local_state_receipt_hash": "sha256:f375155d18c79ba75c2ed9e89fbac24441c4d8da77e9c24275b273ac60c1c615",
   "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
-  "observed_at_utc": "2026-08-22T10:51:11.209348+00:00",
+  "observed_at_utc": "2026-08-22T10:58:49.193598+00:00",
   "pull_request": {
     "query_status": "UNKNOWN",
     "status": "NOT_CHECKED"
@@ -162,7 +122,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-22T10:43:10Z",
+    "observed_at_utc": "2026-08-22T10:57:58Z",
     "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
     "query_status": "OK",
     "status": "OBSERVED"
@@ -192,6 +152,7 @@
       "Python/structural_lib/codes/is456/slab/two_way_complete.py",
       "Python/structural_lib/services/adapters.py",
       "Python/structural_lib/services/boq.py",
+      "Python/structural_lib/services/evidence.py",
       "Python/structural_lib/services/gravity_workflow.py",
       "Python/structural_lib/services/release_uat.py",
       "Python/structural_lib/services/slab_api.py",
@@ -199,10 +160,14 @@
       "Python/tests/codes/is456/slab/test_one_way_flexure.py",
       "Python/tests/codes/is456/slab/test_two_way_flexure.py",
       "Python/tests/test_boq.py",
+      "Python/tests/test_evidence.py",
       "Python/tests/unit/test_generic_csv_adapter.py",
       "Python/tests/unit/test_gravity_workflow_v1.py",
+      "fastapi_app/models/beam.py",
       "fastapi_app/models/boq.py",
       "fastapi_app/models/library_core.py",
+      "fastapi_app/tests/test_beam_primary_route.py",
+      "fastapi_app/tests/test_endpoints.py",
       "fastapi_app/tests/test_insights_dashboard.py",
       "fastapi_app/tests/test_library_core.py",
       "docs/verification/lib-pro-003-c-failure-contracts-evidence.json",

--- a/docs/verification/lib-pro-003-c-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-003-c-git-handoff-receipt.json
@@ -1,0 +1,243 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-22T10:43:10Z",
+      "query_status": "OK",
+      "reference": "task:LIB-PRO-003:user-request-continue-this-work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-22T10:43:10Z",
+    "prohibited_actions": [
+      "PUBLISH_RELEASE",
+      "CLAIM_PROFESSIONAL_APPROVAL",
+      "START_INDIA_3",
+      "START_ETABS_OR_DESKTOP_EXCEL",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR"
+      ],
+      "branch": "codex/public-route-failure-contracts",
+      "head_sha": "e19b757ccb9922061369a236501f037ec20503ab",
+      "task_id": "LIB-PRO-003-C"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "44eb1aba1259963c7bb54ee8b9f2d35ca87ad78e2cb35c8fecf752b106dcc281",
+    "state": {
+      "branch": "codex/public-route-failure-contracts",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "e19b757ccb9922061369a236501f037ec20503ab",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 105.348,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-public-route-failure-contracts",
+      "head_sha": "e19b757ccb9922061369a236501f037ec20503ab",
+      "hold_reasons": [
+        "changed paths: 46"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-22T10:51:11.209156+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-failure-contracts",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 46,
+        "modified_paths": [
+          "Python/structural_lib/services/gravity_workflow.py",
+          "Python/structural_lib/services/release_uat.py",
+          "Python/tests/unit/test_gravity_workflow_v1.py",
+          "docs/SESSION_LOG.md",
+          "docs/verification/lib-pro-003-c-failure-contracts-evidence.json"
+        ],
+        "staged_paths": [
+          "Python/structural_lib/codes/is456/slab/__init__.py",
+          "Python/structural_lib/codes/is456/slab/models.py",
+          "Python/structural_lib/codes/is456/slab/one_way.py",
+          "Python/structural_lib/codes/is456/slab/two_way.py",
+          "Python/structural_lib/codes/is456/slab/two_way_complete.py",
+          "Python/structural_lib/services/adapters.py",
+          "Python/structural_lib/services/boq.py",
+          "Python/structural_lib/services/index.json",
+          "Python/structural_lib/services/index.md",
+          "Python/structural_lib/services/slab_api.py",
+          "Python/tests/codes/is456/index.json",
+          "Python/tests/codes/is456/index.md",
+          "Python/tests/codes/is456/slab/test_extended_workflows.py",
+          "Python/tests/codes/is456/slab/test_one_way_flexure.py",
+          "Python/tests/codes/is456/slab/test_two_way_flexure.py",
+          "Python/tests/index.json",
+          "Python/tests/index.md",
+          "Python/tests/test_boq.py",
+          "Python/tests/unit/test_generic_csv_adapter.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/README.md",
+          "docs/planning/index.json",
+          "docs/planning/index.md",
+          "docs/planning/next-session-brief.md",
+          "docs/planning/public-route-safety-closure-plan.md",
+          "docs/verification/index.json",
+          "docs/verification/index.md",
+          "docs/verification/lib-pro-003-c-failure-contracts-evidence.json",
+          "docs/verification/lib-pro-003-c-git-handoff-receipt.json",
+          "docs/verification/lib-pro-003-c-git-handoff-source-evidence.json",
+          "fastapi_app/index.json",
+          "fastapi_app/models/boq.py",
+          "fastapi_app/models/index.json",
+          "fastapi_app/models/index.md",
+          "fastapi_app/models/library_core.py",
+          "fastapi_app/openapi_baseline.json",
+          "fastapi_app/tests/index.json",
+          "fastapi_app/tests/index.md",
+          "fastapi_app/tests/test_insights_dashboard.py",
+          "fastapi_app/tests/test_library_core.py"
+        ],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "e19b757ccb9922061369a236501f037ec20503ab",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-failure-contracts"
+    }
+  },
+  "local_state_receipt_hash": "sha256:44eb1aba1259963c7bb54ee8b9f2d35ca87ad78e2cb35c8fecf752b106dcc281",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-22T10:51:11.209348+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-22T10:43:10Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/codes/is456/beam/**",
+      "Python/structural_lib/codes/is456/column/**",
+      "Python/structural_lib/services/beam_api.py",
+      "Python/structural_lib/services/column_api.py",
+      "Python/structural_lib/services/footing_api.py",
+      "react_app/**",
+      "excel_addin/**",
+      ".github/workflows/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "Python/structural_lib/codes/is456/slab/__init__.py",
+      "Python/structural_lib/codes/is456/slab/models.py",
+      "Python/structural_lib/codes/is456/slab/one_way.py",
+      "Python/structural_lib/codes/is456/slab/two_way.py",
+      "Python/structural_lib/codes/is456/slab/two_way_complete.py",
+      "Python/structural_lib/services/adapters.py",
+      "Python/structural_lib/services/boq.py",
+      "Python/structural_lib/services/gravity_workflow.py",
+      "Python/structural_lib/services/release_uat.py",
+      "Python/structural_lib/services/slab_api.py",
+      "Python/tests/codes/is456/slab/test_extended_workflows.py",
+      "Python/tests/codes/is456/slab/test_one_way_flexure.py",
+      "Python/tests/codes/is456/slab/test_two_way_flexure.py",
+      "Python/tests/test_boq.py",
+      "Python/tests/unit/test_generic_csv_adapter.py",
+      "Python/tests/unit/test_gravity_workflow_v1.py",
+      "fastapi_app/models/boq.py",
+      "fastapi_app/models/library_core.py",
+      "fastapi_app/tests/test_insights_dashboard.py",
+      "fastapi_app/tests/test_library_core.py",
+      "docs/verification/lib-pro-003-c-failure-contracts-evidence.json",
+      "docs/verification/lib-pro-003-c-git-handoff-source-evidence.json",
+      "docs/verification/lib-pro-003-c-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "fastapi_app/openapi_baseline.json",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/README.md",
+      "docs/planning/next-session-brief.md",
+      "docs/planning/public-route-safety-closure-plan.md",
+      "Python/structural_lib/services/index.json",
+      "Python/structural_lib/services/index.md",
+      "Python/tests/index.json",
+      "Python/tests/index.md",
+      "Python/tests/codes/is456/index.json",
+      "Python/tests/codes/is456/index.md",
+      "docs/index.json",
+      "docs/index.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md",
+      "fastapi_app/index.json",
+      "fastapi_app/models/index.json",
+      "fastapi_app/models/index.md",
+      "fastapi_app/tests/index.json",
+      "fastapi_app/tests/index.md"
+    ],
+    "task_id": "LIB-PRO-003-C"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-003-c-git-handoff-source-evidence.json
+++ b/docs/verification/lib-pro-003-c-git-handoff-source-evidence.json
@@ -2,7 +2,7 @@
   "authorization": {
     "authority_source": {
       "kind": "USER_DELEGATION",
-      "observed_at_utc": "2026-08-22T10:43:10Z",
+      "observed_at_utc": "2026-08-22T10:57:58Z",
       "query_status": "OK",
       "reference": "task:LIB-PRO-003:user-request-continue-this-work",
       "status": "OBSERVED"
@@ -13,7 +13,7 @@
       "CREATE_OR_UPDATE_PR"
     ],
     "next_action": "COMMIT_INTENDED_PATHS",
-    "observed_at_utc": "2026-08-22T10:43:10Z",
+    "observed_at_utc": "2026-08-22T10:57:58Z",
     "prohibited_actions": [
       "PUBLISH_RELEASE",
       "CLAIM_PROFESSIONAL_APPROVAL",
@@ -32,7 +32,7 @@
         "CREATE_OR_UPDATE_PR"
       ],
       "branch": "codex/public-route-failure-contracts",
-      "head_sha": "e19b757ccb9922061369a236501f037ec20503ab",
+      "head_sha": "60ceb7b9af7ec91fd09a637816bd68166ac4a05d",
       "task_id": "LIB-PRO-003-C"
     }
   },
@@ -44,7 +44,7 @@
   "retention": {
     "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
     "holds": [],
-    "observed_at_utc": "2026-08-22T10:43:10Z",
+    "observed_at_utc": "2026-08-22T10:57:58Z",
     "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
     "query_status": "OK",
     "status": "OBSERVED"

--- a/docs/verification/lib-pro-003-c-git-handoff-source-evidence.json
+++ b/docs/verification/lib-pro-003-c-git-handoff-source-evidence.json
@@ -1,0 +1,55 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-22T10:43:10Z",
+      "query_status": "OK",
+      "reference": "task:LIB-PRO-003:user-request-continue-this-work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-22T10:43:10Z",
+    "prohibited_actions": [
+      "PUBLISH_RELEASE",
+      "CLAIM_PROFESSIONAL_APPROVAL",
+      "START_INDIA_3",
+      "START_ETABS_OR_DESKTOP_EXCEL",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR"
+      ],
+      "branch": "codex/public-route-failure-contracts",
+      "head_sha": "e19b757ccb9922061369a236501f037ec20503ab",
+      "task_id": "LIB-PRO-003-C"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-22T10:43:10Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/fastapi_app/index.json
+++ b/fastapi_app/index.json
@@ -264,7 +264,7 @@
         "paths",
         "tags"
       ],
-      "content_hash": "504473a458d3"
+      "content_hash": "306094953038"
     },
     {
       "name": "ruff.toml",
@@ -301,5 +301,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "9685a4bf482ba93d"
+  "content_hash": "b4286acd222eef35"
 }

--- a/fastapi_app/index.json
+++ b/fastapi_app/index.json
@@ -264,7 +264,7 @@
         "paths",
         "tags"
       ],
-      "content_hash": "bef2c56a65ed"
+      "content_hash": "504473a458d3"
     },
     {
       "name": "ruff.toml",
@@ -301,5 +301,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "eb774357e0f19ccf"
+  "content_hash": "9685a4bf482ba93d"
 }

--- a/fastapi_app/models/beam.py
+++ b/fastapi_app/models/beam.py
@@ -398,6 +398,7 @@ class EvidenceEnvelopeResponse(BaseModel):
     replay_receipt_hash: str
     governing_check: str
     exact_utilization: float | None
+    utilization_disposition: Literal["FINITE", "UNBOUNDED_FAILURE", "NOT_EVALUATED"]
     margin: float | None
     status: Literal["PASS", "FAIL", "HOLD"]
     generated_at: str

--- a/fastapi_app/models/boq.py
+++ b/fastapi_app/models/boq.py
@@ -2,7 +2,12 @@
 # Copyright (c) 2024-2026 Pravin Surawase
 """Pydantic models for Project BOQ endpoint."""
 
+from typing import Annotated
+
 from pydantic import BaseModel, Field
+
+PositiveConcreteGrade = Annotated[int, Field(gt=0)]
+PositiveRate = Annotated[float, Field(gt=0, allow_inf_nan=False)]
 
 
 class DatasetReference(BaseModel):
@@ -21,7 +26,7 @@ class BeamMetadata(BaseModel):
     b_mm: float = Field(..., gt=0, description="Beam width in mm")
     D_mm: float = Field(..., gt=0, description="Overall depth in mm")
     span_mm: float = Field(..., gt=0, description="Span length in mm")
-    fck: int = Field(default=25, description="Concrete grade (N/mm²)")
+    fck: PositiveConcreteGrade = Field(default=25, description="Concrete grade (N/mm²)")
     steel_weight_kg: float = Field(
         default=0.0, ge=0, description="Total steel weight for this beam in kg"
     )
@@ -34,8 +39,8 @@ class ProjectBOQRequest(BaseModel):
         default="Project", max_length=200, description="Display name"
     )
     beams: list[BeamMetadata] = Field(min_length=1, description="List of beam metadata")
-    steel_cost_per_kg: float = Field(default=60.0, gt=0, description="Steel rate ₹/kg")
-    concrete_costs: dict[int, float] | None = Field(
+    steel_cost_per_kg: PositiveRate = Field(default=60.0, description="Steel rate ₹/kg")
+    concrete_costs: dict[PositiveConcreteGrade, PositiveRate] | None = Field(
         default=None,
         description=(
             "Concrete costs by grade {fck: ₹/m³}. "

--- a/fastapi_app/models/index.json
+++ b/fastapi_app/models/index.json
@@ -79,8 +79,8 @@
     {
       "name": "beam.py",
       "type": "python",
-      "size_lines": 836,
-      "last_updated": "2026-08-17",
+      "size_lines": 837,
+      "last_updated": "2026-08-22",
       "description": "Beam Design and Detailing Pydantic Models.",
       "classes": [
         {
@@ -156,7 +156,7 @@
           "description": "Response model for beam design calculation."
         }
       ],
-      "content_hash": "bf3da07bf2f1"
+      "content_hash": "ced9425aba28"
     },
     {
       "name": "boq.py",
@@ -1137,5 +1137,5 @@
     "DuctilityCheckRequest",
     "DuctilityCheckResponse"
   ],
-  "content_hash": "2eeed4f1fc7bed16"
+  "content_hash": "b51ba87ccb6818e6"
 }

--- a/fastapi_app/models/index.json
+++ b/fastapi_app/models/index.json
@@ -2,7 +2,7 @@
   "folder": "fastapi_app/models",
   "type": "python-package",
   "description": "",
-  "last_updated": "2026-08-17",
+  "last_updated": "2026-08-22",
   "file_count": 22,
   "files": [
     {
@@ -161,8 +161,8 @@
     {
       "name": "boq.py",
       "type": "python",
-      "size_lines": 107,
-      "last_updated": "2026-08-17",
+      "size_lines": 112,
+      "last_updated": "2026-08-22",
       "description": "Pydantic models for Project BOQ endpoint.",
       "classes": [
         {
@@ -198,7 +198,7 @@
           "description": "BOQ response with aggregated quantities and costs."
         }
       ],
-      "content_hash": "cb7a0115d118"
+      "content_hash": "40232601cc62"
     },
     {
       "name": "capabilities.py",
@@ -734,8 +734,8 @@
     {
       "name": "library_core.py",
       "type": "python",
-      "size_lines": 370,
-      "last_updated": "2026-08-17",
+      "size_lines": 385,
+      "last_updated": "2026-08-22",
       "description": "Requests for the bounded footing and slab public-library workflows.",
       "classes": [
         {
@@ -787,19 +787,19 @@
           "description": "One explicit flexure or detailing comparison."
         },
         {
+          "name": "SlabCapacityFailureResponse",
+          "description": "Supported slab demand that exceeds its bounded flexural capacity."
+        },
+        {
           "name": "OneWaySlabFlexureResponse",
           "description": "Bounded one-way slab flexure result."
         },
         {
           "name": "OneWaySlabDetailingInputResponse",
           "description": "Inputs retained with a one-way slab detailing result."
-        },
-        {
-          "name": "OneWaySlabDetailingResponse",
-          "description": "Provided-bar checks and the serviceability review boundary."
         }
       ],
-      "content_hash": "f898466d53f1"
+      "content_hash": "73ed9f4a8a1b"
     },
     {
       "name": "metadata.py",
@@ -1137,5 +1137,5 @@
     "DuctilityCheckRequest",
     "DuctilityCheckResponse"
   ],
-  "content_hash": "ab57c4e379fcf157"
+  "content_hash": "2eeed4f1fc7bed16"
 }

--- a/fastapi_app/models/index.md
+++ b/fastapi_app/models/index.md
@@ -1,7 +1,7 @@
 # Models
 
 **Type:** Python Package
-**Last Updated:** 2026-08-17
+**Last Updated:** 2026-08-22
 **Files:** 22
 
 ## Public API
@@ -34,7 +34,7 @@
 | [__init__.py](__init__.py) | Pydantic Models Package. | 0 | 0 | 88 |
 | [analysis.py](analysis.py) | Smart Analysis Pydantic Models. | 11 | 0 | 306 |
 | [beam.py](beam.py) | Beam Design and Detailing Pydantic Models. | 15 | 0 | 836 |
-| [boq.py](boq.py) | Pydantic models for Project BOQ endpoint. | 8 | 0 | 107 |
+| [boq.py](boq.py) | Pydantic models for Project BOQ endpoint. | 8 | 0 | 112 |
 | [capabilities.py](capabilities.py) | Typed transport models for canonical IS 456 capability disco | 8 | 0 | 79 |
 | [catalog.py](catalog.py) | Typed transport models for the application workflow catalogu | 4 | 0 | 56 |
 | [column.py](column.py) | Column Design Pydantic Models. | 15 | 0 | 1195 |
@@ -45,7 +45,7 @@
 | [flat_slab.py](flat_slab.py) | Transport models for the bounded regular interior flat-slab  | 15 | 0 | 250 |
 | [footing.py](footing.py) | Transport models for the bounded concentric isolated-footing | 14 | 0 | 278 |
 | [geometry.py](geometry.py) | 3D Geometry Pydantic Models. | 15 | 0 | 494 |
-| [library_core.py](library_core.py) | Requests for the bounded footing and slab public-library wor | 15 | 0 | 370 |
+| [library_core.py](library_core.py) | Requests for the bounded footing and slab public-library wor | 15 | 0 | 385 |
 | [metadata.py](metadata.py) | Typed payload models for maintained static JSON metadata rou | 9 | 0 | 97 |
 | [optimization.py](optimization.py) | Cost Optimization Pydantic Models. | 9 | 0 | 298 |
 | [response.py](response.py) | Canonical FastAPI success, structural-result, and problem en | 6 | 2 | 162 |

--- a/fastapi_app/models/index.md
+++ b/fastapi_app/models/index.md
@@ -33,7 +33,7 @@
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) | Pydantic Models Package. | 0 | 0 | 88 |
 | [analysis.py](analysis.py) | Smart Analysis Pydantic Models. | 11 | 0 | 306 |
-| [beam.py](beam.py) | Beam Design and Detailing Pydantic Models. | 15 | 0 | 836 |
+| [beam.py](beam.py) | Beam Design and Detailing Pydantic Models. | 15 | 0 | 837 |
 | [boq.py](boq.py) | Pydantic models for Project BOQ endpoint. | 8 | 0 | 112 |
 | [capabilities.py](capabilities.py) | Typed transport models for canonical IS 456 capability disco | 8 | 0 | 79 |
 | [catalog.py](catalog.py) | Typed transport models for the application workflow catalogu | 4 | 0 | 56 |

--- a/fastapi_app/models/library_core.py
+++ b/fastapi_app/models/library_core.py
@@ -284,6 +284,21 @@ class SlabGoverningCheckResponse(BaseModel):
     passed: bool | None = None
 
 
+class SlabCapacityFailureResponse(BaseModel):
+    """Supported slab demand that exceeds its bounded flexural capacity."""
+
+    component: str
+    governing_region: str
+    factored_moment_knm: float
+    limiting_moment_knm: float
+    utilization_ratio: float
+    clause_refs: list[str]
+    source_refs: list[str]
+    status: Literal["FAIL"]
+    qualified_review_required: Literal[True]
+    result_envelope: dict[str, Any]
+
+
 class OneWaySlabFlexureResponse(BaseModel):
     """Bounded one-way slab flexure result."""
 
@@ -340,14 +355,14 @@ class OneWaySlabDetailingResponse(BaseModel):
 class OneWaySlabDesignResponse(BaseModel):
     """Complete bounded one-way slab flexure and detailing response."""
 
-    flexure: OneWaySlabFlexureResponse
-    detailing: OneWaySlabDetailingResponse
+    flexure: OneWaySlabFlexureResponse | SlabCapacityFailureResponse
+    detailing: OneWaySlabDetailingResponse | None
 
 
 class CompleteOneWaySlabDesignResponse(BaseModel):
     reinforcement: dict[str, Any]
-    shear: dict[str, Any]
-    serviceability: dict[str, Any]
+    shear: dict[str, Any] | None
+    serviceability: dict[str, Any] | None
     punching_shear_disposition: str
     complete_engineering_design_approved: bool
 
@@ -365,5 +380,5 @@ class ContinuousOneWaySlabDesignResponse(BaseModel):
 
 class TwoWaySlabPanelDesignResponse(BaseModel):
     panel: dict[str, Any]
-    serviceability: dict[str, Any]
+    serviceability: dict[str, Any] | None
     complete_engineering_design_approved: bool

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -3548,7 +3548,7 @@
         "description": "Request for additional moment calculation per IS 456 Cl 39.7.1.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area (mm\u00b2)",
+            "description": "Total steel area (mm²)",
             "examples": [
               2400.0
             ],
@@ -3596,7 +3596,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm\u00b2)",
+            "description": "Concrete strength (N/mm²)",
             "examples": [
               25.0
             ],
@@ -3606,7 +3606,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "examples": [
               415.0
             ],
@@ -3659,22 +3659,22 @@
             "type": "number"
           },
           "Max_kNm": {
-            "description": "Additional moment about x-axis (kN\u00b7m)",
+            "description": "Additional moment about x-axis (kN·m)",
             "title": "Max Knm",
             "type": "number"
           },
           "Max_reduced_kNm": {
-            "description": "Reduced additional moment x-axis (kN\u00b7m)",
+            "description": "Reduced additional moment x-axis (kN·m)",
             "title": "Max Reduced Knm",
             "type": "number"
           },
           "May_kNm": {
-            "description": "Additional moment about y-axis (kN\u00b7m)",
+            "description": "Additional moment about y-axis (kN·m)",
             "title": "May Knm",
             "type": "number"
           },
           "May_reduced_kNm": {
-            "description": "Reduced additional moment y-axis (kN\u00b7m)",
+            "description": "Reduced additional moment y-axis (kN·m)",
             "title": "May Reduced Knm",
             "type": "number"
           },
@@ -3806,14 +3806,14 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm\u00b2)",
+            "description": "Concrete strength (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -3821,7 +3821,7 @@
           },
           "has_standard_bend": {
             "default": true,
-            "description": "True if bar has 90\u00b0 bend at support",
+            "description": "True if bar has 90° bend at support",
             "title": "Has Standard Bend",
             "type": "boolean"
           },
@@ -4030,7 +4030,7 @@
         "description": "Reinforcement bar arrangement.",
         "properties": {
           "area_provided": {
-            "description": "Total area provided (mm\u00b2)",
+            "description": "Total area provided (mm²)",
             "title": "Area Provided",
             "type": "number"
           },
@@ -4069,7 +4069,7 @@
         "description": "Information about a single standard reinforcement bar.",
         "properties": {
           "area_mm2": {
-            "description": "Cross-sectional area in mm\u00b2",
+            "description": "Cross-sectional area in mm²",
             "title": "Area Mm2",
             "type": "number"
           },
@@ -4443,13 +4443,13 @@
         "properties": {
           "asc_provided": {
             "default": 0.0,
-            "description": "Provided compression reinforcement area Asc (mm\u00b2)",
+            "description": "Provided compression reinforcement area Asc (mm²)",
             "minimum": 0.0,
             "title": "Asc Provided",
             "type": "number"
           },
           "ast_provided": {
-            "description": "Provided tension reinforcement area Ast (mm\u00b2)",
+            "description": "Provided tension reinforcement area Ast (mm²)",
             "examples": [
               615.0,
               942.0,
@@ -4489,7 +4489,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm\u00b2)",
+            "description": "fck (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -4497,14 +4497,14 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm\u00b2)",
+            "description": "fy (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
             "type": "number"
           },
           "moment": {
-            "description": "Factored design moment Mu (kN\u00b7m)",
+            "description": "Factored design moment Mu (kN·m)",
             "minimum": 0.0,
             "title": "Moment",
             "type": "number"
@@ -4518,7 +4518,7 @@
           },
           "stirrup_area": {
             "default": 0.0,
-            "description": "Two-legged stirrup area Asv (mm\u00b2)",
+            "description": "Two-legged stirrup area Asv (mm²)",
             "examples": [
               100.5,
               157.0,
@@ -4572,7 +4572,7 @@
             "type": "string"
           },
           "moment_capacity": {
-            "description": "Moment capacity Mu,cap (kN\u00b7m)",
+            "description": "Moment capacity Mu,cap (kN·m)",
             "title": "Moment Capacity",
             "type": "number"
           },
@@ -4778,7 +4778,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
+            "description": "Characteristic compressive strength of concrete (N/mm²)",
             "examples": [
               20.0,
               25.0,
@@ -4792,7 +4792,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "Yield strength of reinforcement steel (N/mm\u00b2)",
+            "description": "Yield strength of reinforcement steel (N/mm²)",
             "examples": [
               415.0,
               500.0,
@@ -4818,7 +4818,7 @@
             "type": "number"
           },
           "moment": {
-            "description": "Factored design moment Mu (kN\u00b7m)",
+            "description": "Factored design moment Mu (kN·m)",
             "examples": [
               100.0,
               250.0,
@@ -4865,7 +4865,7 @@
                 "type": "null"
               }
             ],
-            "description": "Beam span (mm) \u2014 required when include_serviceability=True",
+            "description": "Beam span (mm) — required when include_serviceability=True",
             "title": "Span Mm"
           },
           "stirrup_dia_mm": {
@@ -4884,7 +4884,7 @@
           },
           "torsion": {
             "default": 0.0,
-            "description": "Factored design torsional moment Tu (kN\u00b7m)",
+            "description": "Factored design torsional moment Tu (kN·m)",
             "examples": [
               0.0,
               10.0,
@@ -4920,12 +4920,12 @@
         "properties": {
           "asc_total": {
             "default": 0.0,
-            "description": "Total compression steel (mm\u00b2)",
+            "description": "Total compression steel (mm²)",
             "title": "Asc Total",
             "type": "number"
           },
           "ast_total": {
-            "description": "Total tension steel required (mm\u00b2)",
+            "description": "Total tension steel required (mm²)",
             "title": "Ast Total",
             "type": "number"
           },
@@ -5061,20 +5061,20 @@
         "properties": {
           "asc_required": {
             "default": 0.0,
-            "description": "Required compression reinforcement area Asc (mm\u00b2)",
+            "description": "Required compression reinforcement area Asc (mm²)",
             "minimum": 0.0,
             "title": "Asc Required",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required tension reinforcement area Ast (mm\u00b2)",
+            "description": "Required tension reinforcement area Ast (mm²)",
             "exclusiveMinimum": 0.0,
             "title": "Ast Required",
             "type": "number"
           },
           "asv_required": {
             "default": 0.0,
-            "description": "Required stirrup area Asv (mm\u00b2/mm)",
+            "description": "Required stirrup area Asv (mm²/mm)",
             "minimum": 0.0,
             "title": "Asv Required",
             "type": "number"
@@ -5096,7 +5096,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm\u00b2)",
+            "description": "fck (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -5104,7 +5104,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm\u00b2)",
+            "description": "fy (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -5190,12 +5190,12 @@
           },
           "asc_provided": {
             "default": 0.0,
-            "description": "Compression steel provided (mm\u00b2)",
+            "description": "Compression steel provided (mm²)",
             "title": "Asc Provided",
             "type": "number"
           },
           "ast_provided": {
-            "description": "Total tension steel provided (mm\u00b2)",
+            "description": "Total tension steel provided (mm²)",
             "title": "Ast Provided",
             "type": "number"
           },
@@ -5300,21 +5300,21 @@
         "properties": {
           "ast_end": {
             "default": 500.0,
-            "description": "Tension steel at end (mm\u00b2)",
+            "description": "Tension steel at end (mm²)",
             "minimum": 0.0,
             "title": "Ast End",
             "type": "number"
           },
           "ast_mid": {
             "default": 400.0,
-            "description": "Tension steel at mid-span (mm\u00b2)",
+            "description": "Tension steel at mid-span (mm²)",
             "minimum": 0.0,
             "title": "Ast Mid",
             "type": "number"
           },
           "ast_start": {
             "default": 500.0,
-            "description": "Tension steel at start (mm\u00b2)",
+            "description": "Tension steel at start (mm²)",
             "minimum": 0.0,
             "title": "Ast Start",
             "type": "number"
@@ -5343,7 +5343,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm\u00b2)",
+            "description": "fck (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -5351,7 +5351,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm\u00b2)",
+            "description": "fy (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -5487,7 +5487,8 @@
           },
           "fck": {
             "default": 25,
-            "description": "Concrete grade (N/mm\u00b2)",
+            "description": "Concrete grade (N/mm²)",
+            "exclusiveMinimum": 0.0,
             "title": "Fck",
             "type": "integer"
           },
@@ -5532,7 +5533,7 @@
           },
           "ast_provided": {
             "default": 0.0,
-            "description": "Steel area provided (mm\u00b2)",
+            "description": "Steel area provided (mm²)",
             "title": "Ast Provided",
             "type": "number"
           },
@@ -5604,12 +5605,12 @@
             "type": "number"
           },
           "fck_mpa": {
-            "description": "Concrete strength in N/mm\u00b2",
+            "description": "Concrete strength in N/mm²",
             "title": "Fck Mpa",
             "type": "number"
           },
           "fy_mpa": {
-            "description": "Steel strength in N/mm\u00b2",
+            "description": "Steel strength in N/mm²",
             "title": "Fy Mpa",
             "type": "number"
           },
@@ -5620,7 +5621,7 @@
             "type": "string"
           },
           "mu_knm": {
-            "description": "Design moment in kN\u00b7m",
+            "description": "Design moment in kN·m",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -5706,12 +5707,12 @@
             "type": "number"
           },
           "fck_mpa": {
-            "description": "Concrete strength in N/mm\u00b2",
+            "description": "Concrete strength in N/mm²",
             "title": "Fck Mpa",
             "type": "number"
           },
           "fy_mpa": {
-            "description": "Steel strength in N/mm\u00b2",
+            "description": "Steel strength in N/mm²",
             "title": "Fy Mpa",
             "type": "number"
           },
@@ -5722,7 +5723,7 @@
             "type": "string"
           },
           "mu_knm": {
-            "description": "Design moment in kN\u00b7m",
+            "description": "Design moment in kN·m",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -5806,7 +5807,7 @@
         "description": "Request model for biaxial bending check per IS 456 Cl 39.6 (Bresler load contour).",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area in mm\u00b2",
+            "description": "Total steel area in mm²",
             "examples": [
               2400.0,
               3600.0,
@@ -5887,7 +5888,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete grade (N/mm\u00b2)",
+            "description": "Concrete grade (N/mm²)",
             "examples": [
               20.0,
               25.0,
@@ -5899,7 +5900,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "examples": [
               415.0,
               500.0
@@ -7976,7 +7977,7 @@
         ],
         "properties": {
           "Ag_mm2": {
-            "description": "Gross cross-sectional area of column (mm\u00b2)",
+            "description": "Gross cross-sectional area of column (mm²)",
             "examples": [
               90000.0,
               120000.0,
@@ -7988,7 +7989,7 @@
             "type": "number"
           },
           "Asc_mm2": {
-            "description": "Area of longitudinal reinforcement (mm\u00b2)",
+            "description": "Area of longitudinal reinforcement (mm²)",
             "examples": [
               1256.64,
               1800.0,
@@ -7999,7 +8000,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
+            "description": "Characteristic compressive strength of concrete (N/mm²)",
             "examples": [
               20.0,
               25.0,
@@ -8012,7 +8013,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Yield strength of reinforcement steel (N/mm\u00b2)",
+            "description": "Yield strength of reinforcement steel (N/mm²)",
             "examples": [
               415.0,
               500.0,
@@ -8037,17 +8038,17 @@
         "description": "Response model for short column axial capacity.",
         "properties": {
           "Ac_mm2": {
-            "description": "Net concrete area Ag - Asc (mm\u00b2)",
+            "description": "Net concrete area Ag - Asc (mm²)",
             "title": "Ac Mm2",
             "type": "number"
           },
           "Ag_mm2": {
-            "description": "Gross cross-sectional area (mm\u00b2)",
+            "description": "Gross cross-sectional area (mm²)",
             "title": "Ag Mm2",
             "type": "number"
           },
           "Asc_mm2": {
-            "description": "Area of longitudinal steel (mm\u00b2)",
+            "description": "Area of longitudinal steel (mm²)",
             "title": "Asc Mm2",
             "type": "number"
           },
@@ -8057,17 +8058,17 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength used (N/mm\u00b2)",
+            "description": "Concrete strength used (N/mm²)",
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength used (N/mm\u00b2)",
+            "description": "Steel yield strength used (N/mm²)",
             "title": "Fy",
             "type": "number"
           },
           "is_safe": {
-            "description": "Whether steel ratio is within IS 456 limits (0.8%\u20136%)",
+            "description": "Whether steel ratio is within IS 456 limits (0.8%–6%)",
             "title": "Is Safe",
             "type": "boolean"
           },
@@ -8166,7 +8167,7 @@
         "description": "Request for unified column design per IS 456.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area (mm\u00b2)",
+            "description": "Total steel area (mm²)",
             "examples": [
               2400.0
             ],
@@ -8310,7 +8311,7 @@
             "type": "string"
           },
           "fck": {
-            "description": "Concrete strength (N/mm\u00b2)",
+            "description": "Concrete strength (N/mm²)",
             "examples": [
               25.0
             ],
@@ -8320,7 +8321,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "examples": [
               415.0
             ],
@@ -8598,7 +8599,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "Concrete grade (N/mm\u00b2)",
+            "description": "Concrete grade (N/mm²)",
             "examples": [
               20.0,
               25.0,
@@ -8611,7 +8612,7 @@
           },
           "fy": {
             "default": 415.0,
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "examples": [
               415.0,
               500.0
@@ -8870,7 +8871,7 @@
                 "type": "null"
               }
             ],
-            "description": "Gross area of column (mm\u00b2). Defaults to b\u00d7D if omitted.",
+            "description": "Gross area of column (mm²). Defaults to b×D if omitted.",
             "examples": [
               200000.0
             ],
@@ -8886,14 +8887,14 @@
                 "type": "null"
               }
             ],
-            "description": "Confined core area to hoop centerline (mm\u00b2). Estimated if omitted.",
+            "description": "Confined core area to hoop centerline (mm²). Estimated if omitted.",
             "examples": [
               102400.0
             ],
             "title": "Ak Mm2"
           },
           "D_mm": {
-            "description": "Column depth \u2014 longer dimension (mm)",
+            "description": "Column depth — longer dimension (mm)",
             "examples": [
               400.0,
               500.0,
@@ -8905,7 +8906,7 @@
             "type": "number"
           },
           "b_mm": {
-            "description": "Column width \u2014 shorter dimension (mm)",
+            "description": "Column width — shorter dimension (mm)",
             "examples": [
               300.0,
               400.0,
@@ -8940,7 +8941,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic concrete strength (N/mm\u00b2)",
+            "description": "Characteristic concrete strength (N/mm²)",
             "examples": [
               20.0,
               25.0,
@@ -8952,7 +8953,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Yield strength of steel (N/mm\u00b2)",
+            "description": "Yield strength of steel (N/mm²)",
             "examples": [
               415.0,
               500.0
@@ -9084,7 +9085,7 @@
         "description": "Request model for short column uniaxial bending design per IS 456 Cl 39.5.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total longitudinal reinforcement area, symmetrically placed (mm\u00b2)",
+            "description": "Total longitudinal reinforcement area, symmetrically placed (mm²)",
             "examples": [
               2700.0,
               1800.0,
@@ -9153,7 +9154,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic concrete strength (N/mm\u00b2)",
+            "description": "Characteristic concrete strength (N/mm²)",
             "examples": [
               20.0,
               25.0,
@@ -9165,7 +9166,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "examples": [
               415.0,
               500.0
@@ -10861,14 +10862,28 @@
             "type": "object"
           },
           "serviceability": {
-            "additionalProperties": true,
-            "title": "Serviceability",
-            "type": "object"
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Serviceability"
           },
           "shear": {
-            "additionalProperties": true,
-            "title": "Shear",
-            "type": "object"
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shear"
           }
         },
         "required": [
@@ -10890,7 +10905,7 @@
             "type": "string"
           },
           "mu_knm": {
-            "description": "Factored moment (kN\u00b7m)",
+            "description": "Factored moment (kN·m)",
             "minimum": 0.0,
             "title": "Mu Knm",
             "type": "number"
@@ -10937,7 +10952,7 @@
             "type": "boolean"
           },
           "mu_knm": {
-            "description": "Applied moment (kN\u00b7m)",
+            "description": "Applied moment (kN·m)",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -10983,7 +10998,7 @@
           },
           "asv_mm2": {
             "default": 100.0,
-            "description": "Area of stirrup legs (mm\u00b2)",
+            "description": "Area of stirrup legs (mm²)",
             "minimum": 0.0,
             "title": "Asv Mm2",
             "type": "number"
@@ -11041,14 +11056,14 @@
             "description": "Default deflection parameters"
           },
           "fck_nmm2": {
-            "description": "Concrete strength (N/mm\u00b2)",
+            "description": "Concrete strength (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck Nmm2",
             "type": "number"
           },
           "fy_nmm2": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy Nmm2",
@@ -11703,7 +11718,7 @@
         "description": "Concrete quantities for one grade.",
         "properties": {
           "cost_inr": {
-            "description": "Cost in \u20b9",
+            "description": "Cost in ₹",
             "title": "Cost Inr",
             "type": "number"
           },
@@ -11713,7 +11728,7 @@
             "type": "string"
           },
           "total_volume_m3": {
-            "description": "Total volume in m\u00b3",
+            "description": "Total volume in m³",
             "title": "Total Volume M3",
             "type": "number"
           }
@@ -12002,27 +12017,27 @@
         "description": "Detailed cost breakdown.",
         "properties": {
           "concrete_cost": {
-            "description": "Cost of concrete (\u20b9)",
+            "description": "Cost of concrete (₹)",
             "title": "Concrete Cost",
             "type": "number"
           },
           "cost_per_meter": {
-            "description": "Cost per meter length (\u20b9/m)",
+            "description": "Cost per meter length (₹/m)",
             "title": "Cost Per Meter",
             "type": "number"
           },
           "formwork_cost": {
-            "description": "Cost of formwork (\u20b9)",
+            "description": "Cost of formwork (₹)",
             "title": "Formwork Cost",
             "type": "number"
           },
           "steel_cost": {
-            "description": "Cost of reinforcement (\u20b9)",
+            "description": "Cost of reinforcement (₹)",
             "title": "Steel Cost",
             "type": "number"
           },
           "total_cost": {
-            "description": "Total cost (\u20b9)",
+            "description": "Total cost (₹)",
             "title": "Total Cost",
             "type": "number"
           }
@@ -12050,7 +12065,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm\u00b2)",
+            "description": "fck (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -12058,7 +12073,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm\u00b2)",
+            "description": "fy (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -12079,7 +12094,7 @@
             "type": "integer"
           },
           "moment": {
-            "description": "Factored design moment Mu (kN\u00b7m)",
+            "description": "Factored design moment Mu (kN·m)",
             "minimum": 0.0,
             "title": "Moment",
             "type": "number"
@@ -12177,7 +12192,7 @@
         "properties": {
           "concrete_cost": {
             "default": 6000.0,
-            "description": "Cost of concrete per m\u00b3 (\u20b9/m\u00b3)",
+            "description": "Cost of concrete per m³ (₹/m³)",
             "examples": [
               5000.0,
               6000.0,
@@ -12189,7 +12204,7 @@
           },
           "formwork_cost": {
             "default": 400.0,
-            "description": "Cost of formwork per m\u00b2 (\u20b9/m\u00b2)",
+            "description": "Cost of formwork per m² (₹/m²)",
             "examples": [
               350.0,
               400.0,
@@ -12201,7 +12216,7 @@
           },
           "steel_cost": {
             "default": 60.0,
-            "description": "Cost of reinforcement steel per kg (\u20b9/kg)",
+            "description": "Cost of reinforcement steel per kg (₹/kg)",
             "examples": [
               55.0,
               60.0,
@@ -12297,7 +12312,7 @@
           },
           "es_nmm2": {
             "default": 200000.0,
-            "description": "Modulus of elasticity of steel (N/mm\u00b2)",
+            "description": "Modulus of elasticity of steel (N/mm²)",
             "exclusiveMinimum": 0.0,
             "title": "Es Nmm2",
             "type": "number"
@@ -12318,7 +12333,7 @@
                 "type": "null"
               }
             ],
-            "description": "Steel stress at service (N/mm\u00b2)",
+            "description": "Steel stress at service (N/mm²)",
             "title": "Fs Service Nmm2"
           },
           "h_mm": {
@@ -12736,7 +12751,7 @@
             "type": "integer"
           },
           "total_concrete_m3": {
-            "description": "Total concrete volume (m\u00b3)",
+            "description": "Total concrete volume (m³)",
             "title": "Total Concrete M3",
             "type": "number"
           },
@@ -13566,14 +13581,14 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm\u00b2)",
+            "description": "Concrete strength (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -13841,7 +13856,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
+            "description": "Characteristic compressive strength of concrete (N/mm²)",
             "examples": [
               20.0,
               25.0,
@@ -13890,22 +13905,22 @@
             "type": "number"
           },
           "is_capped": {
-            "description": "Whether \u03c4c' was capped at \u03c4c,max",
+            "description": "Whether τc' was capped at τc,max",
             "title": "Is Capped",
             "type": "boolean"
           },
           "tau_c_base": {
-            "description": "Base shear strength \u03c4c (N/mm\u00b2)",
+            "description": "Base shear strength τc (N/mm²)",
             "title": "Tau C Base",
             "type": "number"
           },
           "tau_c_enhanced": {
-            "description": "Enhanced shear strength \u03c4c' (N/mm\u00b2)",
+            "description": "Enhanced shear strength τc' (N/mm²)",
             "title": "Tau C Enhanced",
             "type": "number"
           },
           "tau_c_max": {
-            "description": "Maximum shear stress \u03c4c,max (N/mm\u00b2)",
+            "description": "Maximum shear stress τc,max (N/mm²)",
             "title": "Tau C Max",
             "type": "number"
           }
@@ -15192,13 +15207,13 @@
         "properties": {
           "asc_required": {
             "default": 0,
-            "description": "Required compression steel mm\u00b2",
+            "description": "Required compression steel mm²",
             "minimum": 0.0,
             "title": "Asc Required",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required tension steel mm\u00b2",
+            "description": "Required tension steel mm²",
             "minimum": 0.0,
             "title": "Ast Required",
             "type": "number"
@@ -15225,13 +15240,13 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete grade N/mm\u00b2",
+            "description": "Concrete grade N/mm²",
             "exclusiveMinimum": 0.0,
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel grade N/mm\u00b2",
+            "description": "Steel grade N/mm²",
             "exclusiveMinimum": 0.0,
             "title": "Fy",
             "type": "number"
@@ -15243,7 +15258,7 @@
           },
           "moment": {
             "default": 0,
-            "description": "Design moment kN\u00b7m",
+            "description": "Design moment kN·m",
             "minimum": 0.0,
             "title": "Moment",
             "type": "number"
@@ -16312,22 +16327,22 @@
         "properties": {
           "asc_required": {
             "default": 0.0,
-            "description": "Compression steel if needed (mm\u00b2)",
+            "description": "Compression steel if needed (mm²)",
             "title": "Asc Required",
             "type": "number"
           },
           "ast_max": {
-            "description": "Maximum allowed steel area (mm\u00b2)",
+            "description": "Maximum allowed steel area (mm²)",
             "title": "Ast Max",
             "type": "number"
           },
           "ast_min": {
-            "description": "Minimum required steel area (mm\u00b2)",
+            "description": "Minimum required steel area (mm²)",
             "title": "Ast Min",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required tension steel area (mm\u00b2)",
+            "description": "Required tension steel area (mm²)",
             "title": "Ast Required",
             "type": "number"
           },
@@ -16337,7 +16352,7 @@
             "type": "boolean"
           },
           "moment_capacity": {
-            "description": "Singly reinforced limiting moment Mu,lim (kN\u00b7m)",
+            "description": "Singly reinforced limiting moment Mu,lim (kN·m)",
             "title": "Moment Capacity",
             "type": "number"
           },
@@ -19810,7 +19825,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm\u00b2)",
+            "description": "Concrete strength (N/mm²)",
             "examples": [
               25.0
             ],
@@ -19820,7 +19835,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "examples": [
               415.0
             ],
@@ -20291,22 +20306,22 @@
         "description": "Torsion calculation details embedded in the primary beam result.",
         "properties": {
           "al_torsion": {
-            "description": "Longitudinal torsion steel (mm\u00b2)",
+            "description": "Longitudinal torsion steel (mm²)",
             "title": "Al Torsion",
             "type": "number"
           },
           "asv_shear": {
-            "description": "Shear stirrup demand (mm\u00b2/mm)",
+            "description": "Shear stirrup demand (mm²/mm)",
             "title": "Asv Shear",
             "type": "number"
           },
           "asv_torsion": {
-            "description": "Torsion stirrup demand (mm\u00b2/mm)",
+            "description": "Torsion stirrup demand (mm²/mm)",
             "title": "Asv Torsion",
             "type": "number"
           },
           "asv_total": {
-            "description": "Combined stirrup demand (mm\u00b2/mm)",
+            "description": "Combined stirrup demand (mm²/mm)",
             "title": "Asv Total",
             "type": "number"
           },
@@ -20345,17 +20360,17 @@
             "type": "number"
           },
           "tau_c": {
-            "description": "Concrete shear strength (N/mm\u00b2)",
+            "description": "Concrete shear strength (N/mm²)",
             "title": "Tau C",
             "type": "number"
           },
           "tau_c_max": {
-            "description": "Maximum shear stress (N/mm\u00b2)",
+            "description": "Maximum shear stress (N/mm²)",
             "title": "Tau C Max",
             "type": "number"
           },
           "tau_ve": {
-            "description": "Equivalent shear stress (N/mm\u00b2)",
+            "description": "Equivalent shear stress (N/mm²)",
             "title": "Tau Ve",
             "type": "number"
           }
@@ -20650,7 +20665,7 @@
         "description": "Request for long (slender) column design per IS 456 Cl 39.7.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area (mm\u00b2)",
+            "description": "Total steel area (mm²)",
             "examples": [
               2400.0
             ],
@@ -20739,7 +20754,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength (N/mm\u00b2)",
+            "description": "Concrete strength (N/mm²)",
             "examples": [
               25.0
             ],
@@ -20749,7 +20764,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength (N/mm\u00b2)",
+            "description": "Steel yield strength (N/mm²)",
             "examples": [
               415.0
             ],
@@ -21144,10 +21159,25 @@
         "description": "Complete bounded one-way slab flexure and detailing response.",
         "properties": {
           "detailing": {
-            "$ref": "#/components/schemas/OneWaySlabDetailingResponse"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OneWaySlabDetailingResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "flexure": {
-            "$ref": "#/components/schemas/OneWaySlabFlexureResponse"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OneWaySlabFlexureResponse"
+              },
+              {
+                "$ref": "#/components/schemas/SlabCapacityFailureResponse"
+              }
+            ],
+            "title": "Flexure"
           }
         },
         "required": [
@@ -21436,17 +21466,17 @@
         "properties": {
           "asc_required": {
             "default": 0.0,
-            "description": "Compression steel (mm\u00b2)",
+            "description": "Compression steel (mm²)",
             "title": "Asc Required",
             "type": "number"
           },
           "ast_required": {
-            "description": "Tension steel required (mm\u00b2)",
+            "description": "Tension steel required (mm²)",
             "title": "Ast Required",
             "type": "number"
           },
           "concrete_volume": {
-            "description": "Concrete volume (m\u00b3/m)",
+            "description": "Concrete volume (m³/m)",
             "title": "Concrete Volume",
             "type": "number"
           },
@@ -21459,7 +21489,7 @@
             "type": "number"
           },
           "formwork_area": {
-            "description": "Formwork area (m\u00b2/m)",
+            "description": "Formwork area (m²/m)",
             "title": "Formwork Area",
             "type": "number"
           },
@@ -21514,7 +21544,7 @@
         "description": "Request model for P-M interaction curve generation.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total area of longitudinal reinforcement (mm\u00b2)",
+            "description": "Total area of longitudinal reinforcement (mm²)",
             "examples": [
               2400.0,
               3000.0,
@@ -21561,7 +21591,7 @@
             "type": "number"
           },
           "fck": {
-            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
+            "description": "Characteristic compressive strength of concrete (N/mm²)",
             "examples": [
               25.0,
               30.0,
@@ -21573,7 +21603,7 @@
             "type": "number"
           },
           "fy": {
-            "description": "Characteristic yield strength of steel (N/mm\u00b2)",
+            "description": "Characteristic yield strength of steel (N/mm²)",
             "examples": [
               415.0,
               500.0
@@ -21611,7 +21641,7 @@
         "description": "Response model for P-M interaction curve.",
         "properties": {
           "Asc_mm2": {
-            "description": "Total steel area (mm\u00b2)",
+            "description": "Total steel area (mm²)",
             "title": "Asc Mm2",
             "type": "number"
           },
@@ -21621,12 +21651,12 @@
             "type": "number"
           },
           "Mu_0_kNm": {
-            "description": "Pure bending capacity (kN\u00b7m)",
+            "description": "Pure bending capacity (kN·m)",
             "title": "Mu 0 Knm",
             "type": "number"
           },
           "Mu_bal_kNm": {
-            "description": "Balanced point moment capacity (kN\u00b7m)",
+            "description": "Balanced point moment capacity (kN·m)",
             "title": "Mu Bal Knm",
             "type": "number"
           },
@@ -21657,12 +21687,12 @@
             "type": "number"
           },
           "fck": {
-            "description": "Concrete strength used (N/mm\u00b2)",
+            "description": "Concrete strength used (N/mm²)",
             "title": "Fck",
             "type": "number"
           },
           "fy": {
-            "description": "Steel yield strength used (N/mm\u00b2)",
+            "description": "Steel yield strength used (N/mm²)",
             "title": "Fy",
             "type": "number"
           },
@@ -21703,7 +21733,7 @@
         "description": "A single point on the P-M interaction curve.",
         "properties": {
           "Mu_kNm": {
-            "description": "Moment (kN\u00b7m)",
+            "description": "Moment (kN·m)",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -21729,12 +21759,12 @@
             "type": "integer"
           },
           "ast_provided": {
-            "description": "Provided steel area (mm\u00b2)",
+            "description": "Provided steel area (mm²)",
             "title": "Ast Provided",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required steel area (mm\u00b2)",
+            "description": "Required steel area (mm²)",
             "title": "Ast Required",
             "type": "number"
           },
@@ -21764,12 +21794,12 @@
             "type": "integer"
           },
           "fck_nmm2": {
-            "description": "Concrete grade (N/mm\u00b2)",
+            "description": "Concrete grade (N/mm²)",
             "title": "Fck Nmm2",
             "type": "integer"
           },
           "fy_nmm2": {
-            "description": "Steel grade (N/mm\u00b2)",
+            "description": "Steel grade (N/mm²)",
             "title": "Fy Nmm2",
             "type": "integer"
           },
@@ -21841,7 +21871,7 @@
             "type": "integer"
           },
           "mu_knm": {
-            "description": "Factored bending moment (kN\u00b7m)",
+            "description": "Factored bending moment (kN·m)",
             "examples": [
               120.0,
               200.0
@@ -22112,6 +22142,7 @@
             "anyOf": [
               {
                 "additionalProperties": {
+                  "exclusiveMinimum": 0.0,
                   "type": "number"
                 },
                 "type": "object"
@@ -22120,7 +22151,7 @@
                 "type": "null"
               }
             ],
-            "description": "Concrete costs by grade {fck: \u20b9/m\u00b3}. Defaults: {25: 6000, 30: 7000, 35: 8000, 40: 9500}",
+            "description": "Concrete costs by grade {fck: ₹/m³}. Defaults: {25: 6000, 30: 7000, 35: 8000, 40: 9500}",
             "title": "Concrete Costs"
           },
           "dataset": {
@@ -22143,7 +22174,7 @@
           },
           "steel_cost_per_kg": {
             "default": 60.0,
-            "description": "Steel rate \u20b9/kg",
+            "description": "Steel rate ₹/kg",
             "exclusiveMinimum": 0.0,
             "title": "Steel Cost Per Kg",
             "type": "number"
@@ -22178,12 +22209,12 @@
             "$ref": "#/components/schemas/BOQEvidenceResponse"
           },
           "grand_total_concrete_m3": {
-            "description": "Total concrete volume in m\u00b3",
+            "description": "Total concrete volume in m³",
             "title": "Grand Total Concrete M3",
             "type": "number"
           },
           "grand_total_cost_inr": {
-            "description": "Grand total cost in \u20b9",
+            "description": "Grand total cost in ₹",
             "title": "Grand Total Cost Inr",
             "type": "number"
           },
@@ -22502,7 +22533,7 @@
                 "type": "null"
               }
             ],
-            "description": "Steel area provided (mm\u00b2)",
+            "description": "Steel area provided (mm²)",
             "title": "Ast Provided Mm2"
           },
           "geometry": {
@@ -22658,7 +22689,7 @@
         "properties": {
           "ast_mm2": {
             "default": 0.0,
-            "description": "Steel area (mm\u00b2)",
+            "description": "Steel area (mm²)",
             "title": "Ast Mm2",
             "type": "number"
           },
@@ -22768,12 +22799,12 @@
         "properties": {
           "ast_provided": {
             "default": 0.0,
-            "description": "Current steel area (mm\u00b2)",
+            "description": "Current steel area (mm²)",
             "title": "Ast Provided",
             "type": "number"
           },
           "ast_required": {
-            "description": "Required steel area (mm\u00b2)",
+            "description": "Required steel area (mm²)",
             "minimum": 0.0,
             "title": "Ast Required",
             "type": "number"
@@ -22825,7 +22856,7 @@
             "type": "string"
           },
           "current_ast_mm2": {
-            "description": "Current steel area (mm\u00b2)",
+            "description": "Current steel area (mm²)",
             "title": "Current Ast Mm2",
             "type": "number"
           },
@@ -22840,7 +22871,7 @@
             "type": "string"
           },
           "min_ast_mm2": {
-            "description": "Minimum required steel area (mm\u00b2)",
+            "description": "Minimum required steel area (mm²)",
             "title": "Min Ast Mm2",
             "type": "number"
           },
@@ -23331,13 +23362,13 @@
         "description": "Shear design result.",
         "properties": {
           "asv_required": {
-            "description": "Required stirrup area (mm\u00b2/mm)",
+            "description": "Required stirrup area (mm²/mm)",
             "title": "Asv Required",
             "type": "number"
           },
           "asv_required_unit": {
-            "const": "mm\u00b2/mm",
-            "default": "mm\u00b2/mm",
+            "const": "mm²/mm",
+            "default": "mm²/mm",
             "description": "Unit of asv_required (stirrup area per unit spacing)",
             "title": "Asv Required Unit",
             "type": "string"
@@ -23358,17 +23389,17 @@
             "type": "number"
           },
           "tau_c": {
-            "description": "Concrete shear strength (N/mm\u00b2)",
+            "description": "Concrete shear strength (N/mm²)",
             "title": "Tau C",
             "type": "number"
           },
           "tau_c_max": {
-            "description": "Maximum shear stress limit (N/mm\u00b2)",
+            "description": "Maximum shear stress limit (N/mm²)",
             "title": "Tau C Max",
             "type": "number"
           },
           "tau_v": {
-            "description": "Nominal shear stress (N/mm\u00b2)",
+            "description": "Nominal shear stress (N/mm²)",
             "title": "Tau V",
             "type": "number"
           }
@@ -23744,6 +23775,74 @@
         "title": "SimplySupportedDeepBeamResponse",
         "type": "object"
       },
+      "SlabCapacityFailureResponse": {
+        "description": "Supported slab demand that exceeds its bounded flexural capacity.",
+        "properties": {
+          "clause_refs": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Clause Refs",
+            "type": "array"
+          },
+          "component": {
+            "title": "Component",
+            "type": "string"
+          },
+          "factored_moment_knm": {
+            "title": "Factored Moment Knm",
+            "type": "number"
+          },
+          "governing_region": {
+            "title": "Governing Region",
+            "type": "string"
+          },
+          "limiting_moment_knm": {
+            "title": "Limiting Moment Knm",
+            "type": "number"
+          },
+          "qualified_review_required": {
+            "const": true,
+            "title": "Qualified Review Required",
+            "type": "boolean"
+          },
+          "result_envelope": {
+            "additionalProperties": true,
+            "title": "Result Envelope",
+            "type": "object"
+          },
+          "source_refs": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Source Refs",
+            "type": "array"
+          },
+          "status": {
+            "const": "FAIL",
+            "title": "Status",
+            "type": "string"
+          },
+          "utilization_ratio": {
+            "title": "Utilization Ratio",
+            "type": "number"
+          }
+        },
+        "required": [
+          "component",
+          "governing_region",
+          "factored_moment_knm",
+          "limiting_moment_knm",
+          "utilization_ratio",
+          "clause_refs",
+          "source_refs",
+          "status",
+          "qualified_review_required",
+          "result_envelope"
+        ],
+        "title": "SlabCapacityFailureResponse",
+        "type": "object"
+      },
       "SlabGeometryResponse": {
         "description": "Normalized one-way slab geometry used by the service.",
         "properties": {
@@ -23967,7 +24066,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "fck (N/mm\u00b2)",
+            "description": "fck (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -23975,7 +24074,7 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "fy (N/mm\u00b2)",
+            "description": "fy (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
@@ -23994,7 +24093,7 @@
             "type": "boolean"
           },
           "moment": {
-            "description": "Factored moment Mu (kN\u00b7m)",
+            "description": "Factored moment Mu (kN·m)",
             "minimum": 0.0,
             "title": "Moment",
             "type": "number"
@@ -24392,7 +24491,7 @@
         "description": "Steel quantities for one grade.",
         "properties": {
           "cost_inr": {
-            "description": "Cost in \u20b9",
+            "description": "Cost in ₹",
             "title": "Cost Inr",
             "type": "number"
           },
@@ -24419,7 +24518,7 @@
         "description": "Stirrup arrangement.",
         "properties": {
           "area_per_meter": {
-            "description": "Asv/sv provided (mm\u00b2/mm)",
+            "description": "Asv/sv provided (mm²/mm)",
             "title": "Area Per Meter",
             "type": "number"
           },
@@ -24530,12 +24629,12 @@
             "type": "integer"
           },
           "concrete_m3": {
-            "description": "Total concrete in m\u00b3",
+            "description": "Total concrete in m³",
             "title": "Concrete M3",
             "type": "number"
           },
           "cost_inr": {
-            "description": "Total cost in \u20b9",
+            "description": "Total cost in ₹",
             "title": "Cost Inr",
             "type": "number"
           },
@@ -26919,7 +27018,7 @@
             "type": "object"
           },
           "title": {
-            "description": "Short title (e.g., '4\u00d816mm')",
+            "description": "Short title (e.g., '4Ø16mm')",
             "title": "Title",
             "type": "string"
           }
@@ -27188,7 +27287,7 @@
           },
           "fck": {
             "default": 25.0,
-            "description": "Characteristic compressive strength of concrete (N/mm\u00b2)",
+            "description": "Characteristic compressive strength of concrete (N/mm²)",
             "maximum": 80.0,
             "minimum": 15.0,
             "title": "Fck",
@@ -27196,14 +27295,14 @@
           },
           "fy": {
             "default": 500.0,
-            "description": "Yield strength of reinforcement steel (N/mm\u00b2)",
+            "description": "Yield strength of reinforcement steel (N/mm²)",
             "maximum": 600.0,
             "minimum": 250.0,
             "title": "Fy",
             "type": "number"
           },
           "moment": {
-            "description": "Factored bending moment Mu (kN\u00b7m)",
+            "description": "Factored bending moment Mu (kN·m)",
             "examples": [
               100.0,
               250.0
@@ -27240,7 +27339,7 @@
             "type": "number"
           },
           "torsion": {
-            "description": "Factored torsional moment Tu (kN\u00b7m)",
+            "description": "Factored torsional moment Tu (kN·m)",
             "examples": [
               5.0,
               15.0,
@@ -27276,22 +27375,22 @@
         "description": "Response model for torsion design.",
         "properties": {
           "al_torsion": {
-            "description": "Longitudinal steel for torsion (mm\u00b2)",
+            "description": "Longitudinal steel for torsion (mm²)",
             "title": "Al Torsion",
             "type": "number"
           },
           "asv_shear": {
-            "description": "Stirrup area for shear (mm\u00b2/mm)",
+            "description": "Stirrup area for shear (mm²/mm)",
             "title": "Asv Shear",
             "type": "number"
           },
           "asv_torsion": {
-            "description": "Stirrup area for torsion (mm\u00b2/mm)",
+            "description": "Stirrup area for torsion (mm²/mm)",
             "title": "Asv Torsion",
             "type": "number"
           },
           "asv_total": {
-            "description": "Total stirrup area (mm\u00b2/mm)",
+            "description": "Total stirrup area (mm²/mm)",
             "title": "Asv Total",
             "type": "number"
           },
@@ -27301,7 +27400,7 @@
             "type": "boolean"
           },
           "me_knm": {
-            "description": "Equivalent moment Me (kN\u00b7m)",
+            "description": "Equivalent moment Me (kN·m)",
             "title": "Me Knm",
             "type": "number"
           },
@@ -27311,7 +27410,7 @@
             "type": "string"
           },
           "mu_knm": {
-            "description": "Applied bending moment (kN\u00b7m)",
+            "description": "Applied bending moment (kN·m)",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -27332,22 +27431,22 @@
             "type": "boolean"
           },
           "tc": {
-            "description": "Concrete shear strength \u03c4c (N/mm\u00b2)",
+            "description": "Concrete shear strength τc (N/mm²)",
             "title": "Tc",
             "type": "number"
           },
           "tc_max": {
-            "description": "Maximum shear stress limit \u03c4c,max (N/mm\u00b2)",
+            "description": "Maximum shear stress limit τc,max (N/mm²)",
             "title": "Tc Max",
             "type": "number"
           },
           "tu_knm": {
-            "description": "Applied torsional moment (kN\u00b7m)",
+            "description": "Applied torsional moment (kN·m)",
             "title": "Tu Knm",
             "type": "number"
           },
           "tv_equiv": {
-            "description": "Equivalent shear stress \u03c4ve (N/mm\u00b2)",
+            "description": "Equivalent shear stress τve (N/mm²)",
             "title": "Tv Equiv",
             "type": "number"
           },
@@ -27684,9 +27783,16 @@
             "type": "object"
           },
           "serviceability": {
-            "additionalProperties": true,
-            "title": "Serviceability",
-            "type": "object"
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Serviceability"
           }
         },
         "required": [
@@ -28456,7 +28562,7 @@
           },
           "mu_knm": {
             "default": 100.0,
-            "description": "Design moment (kN\u00b7m)",
+            "description": "Design moment (kN·m)",
             "title": "Mu Knm",
             "type": "number"
           },
@@ -28523,7 +28629,7 @@
       "name": "Structural Engineering Library",
       "url": "https://github.com/yourusername/structural_engineering_lib"
     },
-    "description": "\n## IS 456:2000 Compliant Structural Engineering Library\n\nThis API exposes the library's route-specific supported IS 456:2000 reinforced\nconcrete calculations. Each result remains subject to the documented case\nboundary and qualified engineering review.\n\n### Features\n\n- **Beam Design**: Flexure, shear, and combined design calculations\n- **Column Design**: Bounded rectangular short/long-column workflows\n- **Footing Design**: Isolated-footing checks and concentric load transfer\n- **Slab Design**: Bounded simply supported one-way slab strip\n- **Staircase Design**: Bounded longitudinal straight waist-slab flight\n- **Wall Design**: Bounded Clause 32 braced-wall axial and reinforcement checks\n- **Deep-Beam Design**: Bounded Clause 29 simply supported positive-reinforcement checks\n- **Flat-Slab Design**: Bounded regular interior direct-design and punching checks\n- **Combined-Footing Design**: Bounded symmetric two-column rigid-footing checks\n- **Strap-Footing Design**: Bounded property-line no-soil-contact strap checks\n- **Detailing**: Reinforcement layout, spacing, and development lengths\n- **Optimization**: Cost-optimized beam cross-section selection\n- **Smart Analysis**: AI-assisted design suggestions and insights\n- **3D Geometry**: Visualization-ready mesh generation\n\n### Design Codes\n\n- IS 456:2000 - Plain and Reinforced Concrete\n- IS 13920 - Ductile Detailing for Seismic Resistance\n\n### Units\n\nAll inputs and outputs use consistent units:\n- **Length**: millimeters (mm)\n- **Force**: kilonewtons (kN)\n- **Moment**: kilonewton-meters (kN\u00b7m)\n- **Stress**: N/mm\u00b2 (MPa)\n- **Area**: mm\u00b2\n",
+    "description": "\n## IS 456:2000 Compliant Structural Engineering Library\n\nThis API exposes the library's route-specific supported IS 456:2000 reinforced\nconcrete calculations. Each result remains subject to the documented case\nboundary and qualified engineering review.\n\n### Features\n\n- **Beam Design**: Flexure, shear, and combined design calculations\n- **Column Design**: Bounded rectangular short/long-column workflows\n- **Footing Design**: Isolated-footing checks and concentric load transfer\n- **Slab Design**: Bounded simply supported one-way slab strip\n- **Staircase Design**: Bounded longitudinal straight waist-slab flight\n- **Wall Design**: Bounded Clause 32 braced-wall axial and reinforcement checks\n- **Deep-Beam Design**: Bounded Clause 29 simply supported positive-reinforcement checks\n- **Flat-Slab Design**: Bounded regular interior direct-design and punching checks\n- **Combined-Footing Design**: Bounded symmetric two-column rigid-footing checks\n- **Strap-Footing Design**: Bounded property-line no-soil-contact strap checks\n- **Detailing**: Reinforcement layout, spacing, and development lengths\n- **Optimization**: Cost-optimized beam cross-section selection\n- **Smart Analysis**: AI-assisted design suggestions and insights\n- **3D Geometry**: Visualization-ready mesh generation\n\n### Design Codes\n\n- IS 456:2000 - Plain and Reinforced Concrete\n- IS 13920 - Ductile Detailing for Seismic Resistance\n\n### Units\n\nAll inputs and outputs use consistent units:\n- **Length**: millimeters (mm)\n- **Force**: kilonewtons (kN)\n- **Moment**: kilonewton-meters (kN·m)\n- **Stress**: N/mm² (MPa)\n- **Area**: mm²\n",
     "license": {
       "name": "MIT License",
       "url": "https://opensource.org/licenses/MIT"
@@ -30098,7 +30204,7 @@
     },
     "/api/v1/design/beam/enhanced-shear": {
       "post": {
-        "description": "Calculate enhanced design shear strength \u03c4c' for sections close to supports per IS 456:2000 Cl 40.3. Applies when a concentrated load acts within 2d of the face of support.",
+        "description": "Calculate enhanced design shear strength τc' for sections close to supports per IS 456:2000 Cl 40.3. Applies when a concentrated load acts within 2d of the face of support.",
         "operationId": "enhanced_shear_api_v1_design_beam_enhanced_shear_post",
         "requestBody": {
           "content": {
@@ -30464,7 +30570,7 @@
     },
     "/api/v1/design/column": {
       "post": {
-        "description": "Complete column design check \u2014 classifies the column, computes effective length, applies minimum eccentricity, checks axial and bending capacity per the appropriate IS 456 clause.",
+        "description": "Complete column design check — classifies the column, computes effective length, applies minimum eccentricity, checks axial and bending capacity per the appropriate IS 456 clause.",
         "operationId": "design_column_api_v1_design_column_post",
         "requestBody": {
           "content": {
@@ -30586,7 +30692,7 @@
     },
     "/api/v1/design/column/additional-moment": {
       "post": {
-        "description": "Calculate additional moment Ma = Pu \u00d7 eadd for slender columns, where eadd = D \u00d7 (le/D)\u00b2 / 2000. Includes k-factor reduction per Cl 39.7.1.1.",
+        "description": "Calculate additional moment Ma = Pu × eadd for slender columns, where eadd = D × (le/D)² / 2000. Includes k-factor reduction per Cl 39.7.1.1.",
         "operationId": "additional_moment_api_v1_design_column_additional_moment_post",
         "requestBody": {
           "content": {
@@ -30708,7 +30814,7 @@
     },
     "/api/v1/design/column/axial": {
       "post": {
-        "description": "Calculate the axial load capacity of a short column under pure axial load (or minimum eccentricity) per IS 456:2000 Cl. 39.3: Pu = 0.4\u00b7fck\u00b7Ac + 0.67\u00b7fy\u00b7Asc.",
+        "description": "Calculate the axial load capacity of a short column under pure axial load (or minimum eccentricity) per IS 456:2000 Cl. 39.3: Pu = 0.4·fck·Ac + 0.67·fy·Asc.",
         "operationId": "column_axial_capacity_api_v1_design_column_axial_post",
         "requestBody": {
           "content": {
@@ -30830,7 +30936,7 @@
     },
     "/api/v1/design/column/biaxial-check": {
       "post": {
-        "description": "Check a column section under biaxial bending using the Bresler load contour method per IS 456:2000 Cl. 39.6. Returns the interaction ratio (Mux/Mux1)^\u03b1n + (Muy/Muy1)^\u03b1n and safety status.",
+        "description": "Check a column section under biaxial bending using the Bresler load contour method per IS 456:2000 Cl. 39.6. Returns the interaction ratio (Mux/Mux1)^αn + (Muy/Muy1)^αn and safety status.",
         "operationId": "biaxial_check_api_v1_design_column_biaxial_check_post",
         "requestBody": {
           "content": {
@@ -31440,7 +31546,7 @@
     },
     "/api/v1/design/column/effective-length": {
       "post": {
-        "description": "Calculate the effective length of a column based on end restraint conditions per IS 456:2000 Cl. 25.2, Table 28. Returns le = ratio \u00d7 l for seven standard end-condition cases.",
+        "description": "Calculate the effective length of a column based on end restraint conditions per IS 456:2000 Cl. 25.2, Table 28. Returns le = ratio × l for seven standard end-condition cases.",
         "operationId": "calculate_effective_length_api_v1_design_column_effective_length_post",
         "requestBody": {
           "content": {

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -14083,6 +14083,15 @@
           "unit_system": {
             "title": "Unit System",
             "type": "string"
+          },
+          "utilization_disposition": {
+            "enum": [
+              "FINITE",
+              "UNBOUNDED_FAILURE",
+              "NOT_EVALUATED"
+            ],
+            "title": "Utilization Disposition",
+            "type": "string"
           }
         },
         "required": [
@@ -14108,6 +14117,7 @@
           "replay_receipt_hash",
           "governing_check",
           "exact_utilization",
+          "utilization_disposition",
           "margin",
           "status",
           "generated_at",

--- a/fastapi_app/tests/index.json
+++ b/fastapi_app/tests/index.json
@@ -1218,8 +1218,8 @@
     {
       "name": "test_insights_dashboard.py",
       "type": "python",
-      "size_lines": 388,
-      "last_updated": "2026-08-17",
+      "size_lines": 436,
+      "last_updated": "2026-08-22",
       "description": "Tests for insights router endpoints.",
       "classes": [
         {
@@ -1257,6 +1257,8 @@
             "test_project_boq_basic",
             "test_project_boq_identity_binds_dataset_and_normalized_inputs",
             "test_project_boq_custom_costs",
+            "test_project_boq_rejects_negative_rates",
+            "test_project_boq_rejects_non_positive_concrete_grade",
             "test_project_boq_empty_beams"
           ]
         }
@@ -1266,7 +1268,7 @@
           "name": "client"
         }
       ],
-      "content_hash": "67ed5adf7cfa"
+      "content_hash": "5620dca4f971"
     },
     {
       "name": "test_integration.py",
@@ -1346,8 +1348,8 @@
     {
       "name": "test_library_core.py",
       "type": "python",
-      "size_lines": 397,
-      "last_updated": "2026-08-17",
+      "size_lines": 441,
+      "last_updated": "2026-08-22",
       "description": "Request-to-public-library evidence for the new footing and slab consumers.",
       "functions": [
         {
@@ -1382,6 +1384,12 @@
           ]
         },
         {
+          "name": "test_one_way_slab_capacity_miss_serializes_engineering_fail",
+          "params": [
+            "client"
+          ]
+        },
+        {
           "name": "test_complete_one_way_slab_endpoint_serializes_composed_workflow_truth",
           "params": [
             "client"
@@ -1401,6 +1409,12 @@
         },
         {
           "name": "test_two_way_slab_panel_endpoint_returns_b04_topology_and_torsion",
+          "params": [
+            "client"
+          ]
+        },
+        {
+          "name": "test_two_way_slab_capacity_miss_serializes_engineering_fail",
           "params": [
             "client"
           ]
@@ -1442,7 +1456,7 @@
           ]
         }
       ],
-      "content_hash": "592aac9e99a7"
+      "content_hash": "5a9a803f0be3"
     },
     {
       "name": "test_load.py",
@@ -2102,5 +2116,5 @@
   ],
   "subfolders": [],
   "has_init": true,
-  "content_hash": "bb5b13e63e28e937"
+  "content_hash": "0ee453d3d45c5113"
 }

--- a/fastapi_app/tests/index.json
+++ b/fastapi_app/tests/index.json
@@ -120,8 +120,8 @@
     {
       "name": "test_beam_primary_route.py",
       "type": "python",
-      "size_lines": 385,
-      "last_updated": "2026-08-17",
+      "size_lines": 388,
+      "last_updated": "2026-08-22",
       "description": "Focused FastAPI contract tests for the primary IS 456 beam route.",
       "functions": [
         {
@@ -216,7 +216,7 @@
           ]
         }
       ],
-      "content_hash": "e2b5ebd63d6d"
+      "content_hash": "3e4389e8c8fc"
     },
     {
       "name": "test_building_gravity.py",
@@ -812,8 +812,8 @@
     {
       "name": "test_endpoints.py",
       "type": "python",
-      "size_lines": 1242,
-      "last_updated": "2026-08-17",
+      "size_lines": 1244,
+      "last_updated": "2026-08-22",
       "description": "Integration Tests for FastAPI Endpoints.",
       "classes": [
         {
@@ -939,7 +939,7 @@
           ]
         }
       ],
-      "content_hash": "e13dcc9e94f8"
+      "content_hash": "8e02b7da1ecb"
     },
     {
       "name": "test_error_sanitization.py",
@@ -2116,5 +2116,5 @@
   ],
   "subfolders": [],
   "has_init": true,
-  "content_hash": "0ee453d3d45c5113"
+  "content_hash": "9e2f78fdf16bcdd8"
 }

--- a/fastapi_app/tests/index.md
+++ b/fastapi_app/tests/index.md
@@ -19,7 +19,7 @@ Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin
 | [__init__.py](__init__.py) | FastAPI Tests Package. | 0 | 0 | 6 |
 | [conftest.py](conftest.py) | Test Fixtures for FastAPI Tests. | 0 | 8 | 160 |
 | [test_auth.py](test_auth.py) | Tests for Authentication and Rate Limiting. | 3 | 2 | 243 |
-| [test_beam_primary_route.py](test_beam_primary_route.py) | Focused FastAPI contract tests for the primary IS 456 beam r | 0 | 14 | 385 |
+| [test_beam_primary_route.py](test_beam_primary_route.py) | Focused FastAPI contract tests for the primary IS 456 beam r | 0 | 14 | 388 |
 | [test_building_gravity.py](test_building_gravity.py) | REST semantic vectors for Building Gravity Workflow V1. | 0 | 3 | 271 |
 | [test_bundled_sample_evidence.py](test_bundled_sample_evidence.py) | Reproducible software evidence for the bundled 153-beam acce | 0 | 1 | 111 |
 | [test_capabilities.py](test_capabilities.py) | Cross-surface tests for canonical capability discovery. | 0 | 2 | 65 |
@@ -36,7 +36,7 @@ Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin
 | [test_deep_beam.py](test_deep_beam.py) | Contract tests for the bounded simply supported deep-beam Fa | 0 | 6 | 162 |
 | [test_design_compliance.py](test_design_compliance.py) | Tests for design router compliance endpoints. | 5 | 1 | 381 |
 | [test_detailing_anchorage.py](test_detailing_anchorage.py) | Tests for detailing router anchorage endpoint. | 1 | 1 | 98 |
-| [test_endpoints.py](test_endpoints.py) | Integration Tests for FastAPI Endpoints. | 11 | 0 | 1242 |
+| [test_endpoints.py](test_endpoints.py) | Integration Tests for FastAPI Endpoints. | 11 | 0 | 1244 |
 | [test_error_sanitization.py](test_error_sanitization.py) | Tests for error sanitization utilities (TASK-796). | 2 | 0 | 118 |
 | [test_excel_workbench.py](test_excel_workbench.py) | REST semantic vectors for Excel Routine Workbench V1. | 0 | 6 | 242 |
 | [test_export_bbs_dxf.py](test_export_bbs_dxf.py) | Tests for export router endpoints. | 3 | 2 | 202 |

--- a/fastapi_app/tests/index.md
+++ b/fastapi_app/tests/index.md
@@ -44,9 +44,9 @@ Tests for the FastAPI backend endpoints, authentication, WebSocket, and streamin
 | [test_footing.py](test_footing.py) | Contract tests for the isolated concentric-footing FastAPI s | 0 | 7 | 239 |
 | [test_geometry_full.py](test_geometry_full.py) | Tests for geometry router advanced endpoints. | 3 | 1 | 339 |
 | [test_imports_formats.py](test_imports_formats.py) | Tests for import router extended endpoints. | 2 | 1 | 98 |
-| [test_insights_dashboard.py](test_insights_dashboard.py) | Tests for insights router endpoints. | 4 | 1 | 388 |
+| [test_insights_dashboard.py](test_insights_dashboard.py) | Tests for insights router endpoints. | 4 | 1 | 436 |
 | [test_integration.py](test_integration.py) | Integration tests for FastAPI structural design endpoints. | 7 | 1 | 390 |
-| [test_library_core.py](test_library_core.py) | Request-to-public-library evidence for the new footing and s | 0 | 15 | 397 |
+| [test_library_core.py](test_library_core.py) | Request-to-public-library evidence for the new footing and s | 0 | 17 | 441 |
 | [test_load.py](test_load.py) | Load Tests for FastAPI Application. | 6 | 2 | 278 |
 | [test_maintenance_route_coverage.py](test_maintenance_route_coverage.py) | Direct contract coverage for routes identified by the MAINT- | 0 | 8 | 150 |
 | [test_optimization_pareto.py](test_optimization_pareto.py) | Tests for Pareto multi-objective beam optimization endpoint. | 1 | 0 | 158 |

--- a/fastapi_app/tests/test_beam_primary_route.py
+++ b/fastapi_app/tests/test_beam_primary_route.py
@@ -70,7 +70,7 @@ def test_safe_torsion_is_integrated_into_primary_demands(
     assert data["torsion"]["al_torsion"] > 0
     assert data["torsion"]["clause_refs"]["Me"] == "IS 456 Cl 41.4.2"
     assert data["evidence"]["support_status"] == "SUPPORTED"
-    assert data["evidence"]["artifact_schema_version"] == "3.0"
+    assert data["evidence"]["artifact_schema_version"] == "3.1"
     assert (
         data["evidence"]["normalized_input_hash"]
         != zero["evidence"]["normalized_input_hash"]
@@ -100,6 +100,9 @@ def test_unsafe_torsion_fails_primary_result(client) -> None:
     assert data["success"] is False
     assert data["result_envelope"]["engineering_status"] == "FAIL"
     assert data["result_envelope"]["overall_status"] == "FAIL"
+    assert data["evidence"]["status"] == "FAIL"
+    assert data["evidence"]["exact_utilization"] is None
+    assert data["evidence"]["utilization_disposition"] == "UNBOUNDED_FAILURE"
     assert data["torsion"]["is_safe"] is False
     assert any(error["code"] == "E_TORSION_001" for error in data["torsion"]["errors"])
 

--- a/fastapi_app/tests/test_endpoints.py
+++ b/fastapi_app/tests/test_endpoints.py
@@ -160,6 +160,7 @@ class TestDesignEndpoints:
             "normalized_input_hash",
             "calculation_identity",
             "exact_utilization",
+            "utilization_disposition",
             "margin",
             "status",
             "qualified_review_required",
@@ -186,7 +187,8 @@ class TestDesignEndpoints:
 
         assert evidence["support_status"] == "SUPPORTED"
         assert evidence["status"] == "FAIL"
-        assert evidence["exact_utilization"] > 1.0
+        assert evidence["exact_utilization"] is None
+        assert evidence["utilization_disposition"] == "UNBOUNDED_FAILURE"
         assert evidence["qualified_review_required"] is True
 
         report_response = client.post(

--- a/fastapi_app/tests/test_insights_dashboard.py
+++ b/fastapi_app/tests/test_insights_dashboard.py
@@ -380,6 +380,54 @@ class TestProjectBOQ:
         resp = client.post("/api/v1/insights/project-boq", json=payload)
         assert resp.status_code == 200
 
+    @pytest.mark.parametrize(
+        "payload_override",
+        [
+            {"concrete_costs": {25: -1000.0}},
+            {"steel_cost_per_kg": -60.0},
+        ],
+    )
+    def test_project_boq_rejects_negative_rates(self, client, payload_override):
+        payload = {
+            "beams": [
+                {
+                    "beam_id": "B1",
+                    "story": "GF",
+                    "b_mm": 300.0,
+                    "D_mm": 500.0,
+                    "span_mm": 1000.0,
+                    "fck": 25,
+                    "steel_weight_kg": 0.0,
+                }
+            ],
+            **payload_override,
+        }
+
+        response = client.post("/api/v1/insights/project-boq", json=payload)
+
+        assert response.status_code == 422
+        assert response.json()["success"] is False
+
+    def test_project_boq_rejects_non_positive_concrete_grade(self, client):
+        payload = {
+            "beams": [
+                {
+                    "beam_id": "B1",
+                    "story": "GF",
+                    "b_mm": 300.0,
+                    "D_mm": 500.0,
+                    "span_mm": 1000.0,
+                    "fck": -5,
+                    "steel_weight_kg": 0.0,
+                }
+            ]
+        }
+
+        response = client.post("/api/v1/insights/project-boq", json=payload)
+
+        assert response.status_code == 422
+        assert response.json()["success"] is False
+
     def test_project_boq_empty_beams(self, client):
         """Empty beams list should fail validation."""
         payload = {"beams": []}

--- a/fastapi_app/tests/test_library_core.py
+++ b/fastapi_app/tests/test_library_core.py
@@ -119,6 +119,36 @@ def test_one_way_slab_endpoint_rejects_two_way_geometry(client):
     assert response.json()["success"] is False
 
 
+def test_one_way_slab_capacity_miss_serializes_engineering_fail(client):
+    response = client.post(
+        "/api/v1/design/slab/one-way",
+        json={
+            "short_effective_span_mm": 3000,
+            "long_effective_span_mm": 7000,
+            "thickness_mm": 150,
+            "d_mm": 100,
+            "factored_area_load_kn_per_m2": 50,
+            "fck_n_per_mm2": 20,
+            "fy_n_per_mm2": 415,
+            "main_bar_diameter_mm": 10,
+            "main_bar_spacing_mm": 200,
+            "distribution_bar_diameter_mm": 8,
+            "distribution_bar_spacing_mm": 250,
+        },
+    )
+
+    assert response.status_code == 200, response.json()
+    data = _unwrap(response)
+    failure = data["flexure"]
+    assert failure["status"] == "FAIL"
+    assert failure["factored_moment_knm"] == pytest.approx(56.25)
+    assert failure["limiting_moment_knm"] == pytest.approx(27.5925, abs=0.001)
+    assert failure["result_envelope"]["intake_status"] == "VALID"
+    assert failure["result_envelope"]["calculation_status"] == "COMPLETED"
+    assert failure["result_envelope"]["engineering_status"] == "FAIL"
+    assert data["detailing"] is None
+
+
 def test_complete_one_way_slab_endpoint_serializes_composed_workflow_truth(client):
     response = client.post(
         "/api/v1/design/slab/one-way/complete",
@@ -283,6 +313,20 @@ def test_two_way_slab_panel_endpoint_returns_b04_topology_and_torsion(client):
     assert data["panel"]["corner_torsion"][0]["torsion_class"] == "full"
     assert data["panel"]["corner_torsion"][0]["zone_extent_from_each_edge_mm"] == 800
     assert data["panel"]["coefficient_correctness_verified_by_library"] is False
+
+
+def test_two_way_slab_capacity_miss_serializes_engineering_fail(client):
+    response = client.post(
+        "/api/v1/design/slab/two-way/panel",
+        json=_two_way_slab_payload(factored_area_load_kn_per_m2=100),
+    )
+
+    assert response.status_code == 200, response.json()
+    data = _unwrap(response)
+    assert data["panel"]["status"] == "FAIL"
+    assert data["panel"]["governing_region"] == "x_negative_continuous_edge"
+    assert data["panel"]["result_envelope"]["engineering_status"] == "FAIL"
+    assert data["serviceability"] is None
 
 
 def test_two_way_endpoint_rejects_topology_coefficient_mismatch(client):


### PR DESCRIPTION
## Summary

- return structured VALID/COMPLETED/FAIL results for supported one-way and two-way slab capacity misses
- reject malformed/non-finite generic CSV force cells instead of coercing or dropping them
- reject invalid BOQ grades/rates at Python and FastAPI boundaries
- propagate the new failure union safely through Gravity Workflow, release UAT, and OpenAPI

## Verification

- 122 focused slab/CSV/BOQ/FastAPI tests
- 214 independent slab/adapter/costing tests
- 20 API contract tests
- 13 downstream Gravity Workflow/release-UAT tests
- targeted mypy/Ruff/Black and git diff check
- quick gate 10/10
- normal hooks, including mypy over 243 source files
- clean-head session validation

## Holds

Packet D, cumulative broad acceptance, release authority, INDIA-3, ETABS, and professional-use approval remain out of scope and held.