### PR TITLE
ci(safety): make public route audit gates decisive

### DIFF
--- a/.github/agents/api-developer.agent.md
+++ b/.github/agents/api-developer.agent.md
@@ -62,7 +62,7 @@ docker compose -f docker-compose.dev.yml up            # Dev with hot reload
 grep -r "@router" fastapi_app/routers/ | head -30
 ```
 
-60 endpoints across 13 routers already exist. Do NOT duplicate.
+89 OpenAPI HTTP operations across 26 router modules already exist, plus the WebSocket route. Do NOT duplicate.
 
 ## Existing Routers
 

--- a/.github/instructions/fastapi.instructions.md
+++ b/.github/instructions/fastapi.instructions.md
@@ -10,7 +10,7 @@ applyTo: "**/fastapi_app/**"
 grep -r "@router" fastapi_app/routers/ | head -30
 ```
 
-Key existing routes (13 routers, 60 endpoints):
+Key existing routes (89 OpenAPI HTTP operations across 26 router modules, plus WebSocket):
 - `POST /api/v1/design/beam` — Beam design
 - `POST /api/v1/design/column` — Unified column design
 - `POST /api/v1/design/column/effective-length` — Effective length per IS 456 Table 28

--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -21,6 +21,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       fastapi: ${{ steps.filter.outputs.fastapi }}
       react: ${{ steps.filter.outputs.react }}
+      excel: ${{ steps.filter.outputs.excel }}
       control_plane: ${{ steps.filter.outputs.control_plane }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
@@ -43,6 +44,8 @@ jobs:
             react:
               - 'react_app/**'
               - '**/package-lock.json'
+            excel:
+              - 'excel_addin/**'
             control_plane:
               - 'scripts/**'
               - 'run.sh'
@@ -61,6 +64,7 @@ jobs:
               - 'docs/guidelines/ai-token-efficiency.md'
               - 'docs/research/git-governance/**'
               - 'Python/tests/test_agent_governance_automation.py'
+              - 'Python/tests/test_audit_readiness_truth.py'
               - 'Python/tests/test_ci_workflow_contract.py'
               - 'Python/tests/test_git_state.py'
               - 'Python/tests/test_git_handoff_receipt.py'
@@ -188,6 +192,25 @@ jobs:
           npm run build
           npx vitest run
 
+  excel-validation:
+    name: Excel Add-in Validation
+    needs: changes
+    if: needs.changes.outputs.excel == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Run all Excel add-in tests
+        working-directory: excel_addin
+        run: npm test
+
   control-plane-validation:
     name: Control Plane Validation
     needs: changes
@@ -220,6 +243,7 @@ jobs:
             Python/tests/test_session_store.py \
             Python/tests/test_pipeline_state.py \
             Python/tests/test_agent_governance_automation.py \
+            Python/tests/test_audit_readiness_truth.py \
             Python/tests/test_ci_workflow_contract.py \
             -q
 
@@ -314,6 +338,7 @@ jobs:
       - python-validation
       - fastapi-validation
       - react-validation
+      - excel-validation
       - control-plane-validation
       - documentation-validation
       - repository-validation
@@ -328,6 +353,8 @@ jobs:
           FASTAPI_RESULT: ${{ needs.fastapi-validation.result }}
           REACT_CHANGED: ${{ needs.changes.outputs.react }}
           REACT_RESULT: ${{ needs.react-validation.result }}
+          EXCEL_CHANGED: ${{ needs.changes.outputs.excel }}
+          EXCEL_RESULT: ${{ needs.excel-validation.result }}
           CONTROL_PLANE_CHANGED: ${{ needs.changes.outputs.control_plane }}
           CONTROL_PLANE_RESULT: ${{ needs.control-plane-validation.result }}
           DOCS_CHANGED: ${{ needs.changes.outputs.docs }}
@@ -362,6 +389,7 @@ jobs:
           require_component 'Python Validation' "$PYTHON_CHANGED" "$PYTHON_RESULT"
           require_component 'FastAPI Validation' "$FASTAPI_CHANGED" "$FASTAPI_RESULT"
           require_component 'React Validation' "$REACT_CHANGED" "$REACT_RESULT"
+          require_component 'Excel Add-in Validation' "$EXCEL_CHANGED" "$EXCEL_RESULT"
           require_component 'Control Plane Validation' "$CONTROL_PLANE_CHANGED" "$CONTROL_PLANE_RESULT"
           require_component 'Documentation Validation' "$DOCS_CHANGED" "$DOCS_RESULT"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 Open-source IS 456 RC beam design library. Full stack:
 - **Python core** (`Python/structural_lib/`) — Pure math, IS 456:2000 code
-- **FastAPI backend** (`fastapi_app/`) — REST + WebSocket API (60 endpoints, 13 routers)
+- **FastAPI backend** (`fastapi_app/`) — 89 OpenAPI HTTP operations across 26 router modules, plus a WebSocket route
 - **React 19 frontend** (`react_app/`) — R3F 3D visualization + Tailwind
 
 ## Owner Decision — Required IS Code Content and Distribution (2026-08-10/11)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,8 @@
 cff-version: 1.2.0
 title: "Structural Engineering Library (IS 456)"
 version: 0.23.1a2
-message: "Prepared Alpha candidate: not tagged or published at candidate freeze. Case-qualified IS 456 workflows still require independent verification and qualified professional review for engineering use."
+date-released: 2026-08-17
+message: "Public Alpha v0.23.1a2. This immutable artifact is case-qualified and still requires independent verification and qualified professional review for engineering use; later main changes are not included."
 repository-code: "https://github.com/Pravin-surawase/structural_engineering_lib"
 url: "https://pypi.org/project/structural-lib-is456/"
 authors:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,4 +260,4 @@ Then continue from where I left off.
 
 React hooks: `useCSVFileImport`, `useCSVTextImport`, `useDualCSVImport`, `useBatchDesign` (useCSVImport.ts) | `useBeamGeometry` | `useLiveDesign`, `useAutoDesign` | `useBuildingGeometry`, `useCrossSectionGeometry` (useGeometryAdvanced.ts) | `useExport` (BBS/DXF/report) | `useInsights`, `useCodeChecks`, `useRebarSuggestions` | `useRebarValidation`, `useRebarApply` | `useDesignWebSocket`
 
-FastAPI routers (13 routers, 60 endpoints): `design`, `detailing`, `analysis`, `geometry`, `imports`, `insights`, `optimization`, `rebar`, `export`, `streaming`, `websocket`, `health`, `column`
+FastAPI surface: 89 OpenAPI HTTP operations across 26 router modules, plus the separately maintained WebSocket route. Discover exact routes from `fastapi_app/routers/` and the generated OpenAPI contract.

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -502,8 +502,8 @@
     {
       "name": "test_audit_readiness_truth.py",
       "type": "python",
-      "size_lines": 83,
-      "last_updated": "2026-08-17",
+      "size_lines": 151,
+      "last_updated": "2026-08-22",
       "description": "Readiness must aggregate semantic truth instead of reporting false green.",
       "functions": [
         {
@@ -523,13 +523,41 @@
           "params": [
             "monkeypatch"
           ]
+        },
+        {
+          "name": "test_public_route_regression_failure_makes_readiness_fail",
+          "params": [
+            "monkeypatch"
+          ]
+        },
+        {
+          "name": "test_readiness_exit_code_is_decisive",
+          "params": [
+            "verdict",
+            "expected"
+          ]
+        },
+        {
+          "name": "test_owner_selected_documentation_hard_cap_is_500"
+        },
+        {
+          "name": "test_input_validation_diagnostic_exit_is_decisive",
+          "params": [
+            "high_risk",
+            "coverage",
+            "expected"
+          ]
         }
       ],
       "constants": [
         "_SCRIPT",
-        "_SPEC"
+        "_SPEC",
+        "_DOCS_SCRIPT",
+        "_DOCS_SPEC",
+        "_INPUT_AUDIT_SCRIPT",
+        "_INPUT_AUDIT_SPEC"
       ],
-      "content_hash": "a173f9b39747"
+      "content_hash": "538b5ef3d300"
     },
     {
       "name": "test_boq.py",
@@ -796,8 +824,8 @@
     {
       "name": "test_ci_workflow_contract.py",
       "type": "python",
-      "size_lines": 219,
-      "last_updated": "2026-08-17",
+      "size_lines": 242,
+      "last_updated": "2026-08-22",
       "description": "Regression tests for fail-closed PR workflow routing.",
       "functions": [
         {
@@ -839,7 +867,7 @@
         "PUBLISH",
         "BASE_GATE_ENV"
       ],
-      "content_hash": "9a4fa1290484"
+      "content_hash": "df9433c67dd6"
     },
     {
       "name": "test_clause_traceability.py",
@@ -4998,5 +5026,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "d4f3f1edbd1d6345"
+  "content_hash": "e7fb56558d7ed0d1"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -26,12 +26,12 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_api_surface_snapshot.py](test_api_surface_snapshot.py) | Snapshot regression tests — assert minimum API surface count | 5 | 0 | 122 |
 | [test_assertion_helpers.py](test_assertion_helpers.py) | Tests for the IS 456 test assertion helpers. | 3 | 0 | 82 |
 | [test_audit.py](test_audit.py) | Tests for audit module (TASK-278). | 6 | 0 | 471 |
-| [test_audit_readiness_truth.py](test_audit_readiness_truth.py) | Readiness must aggregate semantic truth instead of reporting | 0 | 3 | 83 |
+| [test_audit_readiness_truth.py](test_audit_readiness_truth.py) | Readiness must aggregate semantic truth instead of reporting | 0 | 7 | 151 |
 | [test_boq.py](test_boq.py) | Tests for the BOQ (Bill of Quantities) aggregation module. | 1 | 0 | 213 |
 | [test_branch_disposition.py](test_branch_disposition.py) | Outcome tests for the inspection-only branch disposition cla | 0 | 12 | 437 |
 | [test_bump_version_semantics.py](test_bump_version_semantics.py) | Regression coverage for candidate-version documentation sema | 0 | 1 | 66 |
 | [test_calculation_report.py](test_calculation_report.py) | Tests for the calculation_report module (TASK-277). | 9 | 4 | 745 |
-| [test_ci_workflow_contract.py](test_ci_workflow_contract.py) | Regression tests for fail-closed PR workflow routing. | 0 | 7 | 219 |
+| [test_ci_workflow_contract.py](test_ci_workflow_contract.py) | Regression tests for fail-closed PR workflow routing. | 0 | 7 | 242 |
 | [test_clause_traceability.py](test_clause_traceability.py) | Tests for IS 456 Traceability Module | 10 | 2 | 489 |
 | [test_column_axial.py](test_column_axial.py) | Tests for column axial module — effective_length() per IS 45 | 6 | 0 | 273 |
 | [test_column_biaxial.py](test_column_biaxial.py) | Tests for IS 456 Cl 39.6 biaxial bending check — TASK-635. | 8 | 0 | 958 |

--- a/Python/tests/integration/test_capability_semantics.py
+++ b/Python/tests/integration/test_capability_semantics.py
@@ -111,10 +111,17 @@ def _published_field_names(workflow: Callable[..., Any]) -> set[str]:
             )
 
     result_type = type_hints.get("return")
-    if not result_type or not dataclasses.is_dataclass(result_type):
+    if not result_type:
         return names
-
-    names.update(_nested_dataclass_field_names("", result_type))
+    result_dataclasses = (
+        (result_type,)
+        if dataclasses.is_dataclass(result_type)
+        else tuple(
+            item for item in get_args(result_type) if dataclasses.is_dataclass(item)
+        )
+    )
+    for result_dataclass in result_dataclasses:
+        names.update(_nested_dataclass_field_names("", result_dataclass))
     return names
 
 

--- a/Python/tests/integration/test_tables_and_materials_additional.py
+++ b/Python/tests/integration/test_tables_and_materials_additional.py
@@ -175,17 +175,16 @@ def test_flexure_calculate_ast_required_rejects_outside_stress_block_domain(
         flexure.calculate_ast_required(b=230, d=450, mu_knm=1e6, fck=20, fy=415)
 
 
-def test_flexure_singly_reinforced_hits_max_steel_exceeded():
+def test_flexure_singly_reinforced_rejects_unsupported_low_steel_grade():
     from structural_lib import flexure
 
-    # Keep geometry valid, but use an unrealistically low fy to push Ast_min
-    # above Ast_max and cover the max-steel branch deterministically.
+    # The maintained public route now rejects this artificial fy before using
+    # it to manufacture an otherwise unreachable maximum-steel branch.
     res = flexure.design_singly_reinforced(
         b=300, d=500, d_total=550, mu_knm=0.0, fck=25, fy=10
     )
     assert res.is_safe is False
-    # Check for max steel error in errors list
-    assert any("max" in err.message.lower() for err in res.errors)
+    assert any(err.code == "E_INPUT_019" for err in res.errors)
 
 
 def test_flexure_calculate_ast_required_over_reinforced_returns_minus_one():

--- a/Python/tests/property/strategies.py
+++ b/Python/tests/property/strategies.py
@@ -235,7 +235,10 @@ def shear_inputs(draw: st.DrawFn) -> dict[str, float]:
     Returns: {"b", "d", "fck", "fy", "vu_kn", "asv", "pt"}
     """
     section = draw(beam_section())
-    fck = float(draw(concrete_grade()))
+    # The maintained Table 19 design route supports M15-M40. Broader concrete
+    # grades remain useful to direct table/helper property tests, so constrain
+    # only this composed design-input strategy.
+    fck = float(draw(st.sampled_from([15, 20, 25, 30, 35, 40])))
     fy = float(draw(steel_grade()))
     # Shear force: 10-500 kN typical range
     vu_kn = draw(

--- a/Python/tests/test_audit_readiness_truth.py
+++ b/Python/tests/test_audit_readiness_truth.py
@@ -17,6 +17,24 @@ readiness = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = readiness
 _SPEC.loader.exec_module(readiness)
 
+_DOCS_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_docs.py"
+_DOCS_SPEC = importlib.util.spec_from_file_location("check_docs", _DOCS_SCRIPT)
+assert _DOCS_SPEC is not None and _DOCS_SPEC.loader is not None
+docs_check = importlib.util.module_from_spec(_DOCS_SPEC)
+sys.modules[_DOCS_SPEC.name] = docs_check
+_DOCS_SPEC.loader.exec_module(docs_check)
+
+_INPUT_AUDIT_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "audit_input_validation.py"
+)
+_INPUT_AUDIT_SPEC = importlib.util.spec_from_file_location(
+    "audit_input_validation", _INPUT_AUDIT_SCRIPT
+)
+assert _INPUT_AUDIT_SPEC is not None and _INPUT_AUDIT_SPEC.loader is not None
+input_audit = importlib.util.module_from_spec(_INPUT_AUDIT_SPEC)
+sys.modules[_INPUT_AUDIT_SPEC.name] = input_audit
+_INPUT_AUDIT_SPEC.loader.exec_module(input_audit)
+
 
 def _collect(monkeypatch, outcomes: dict[str, tuple[int, str, str]]):
     calls: list[tuple[str, tuple[str, ...]]] = []
@@ -37,6 +55,7 @@ def test_required_api_parity_failure_makes_readiness_fail(monkeypatch) -> None:
         monkeypatch,
         {
             "test_api_parity.py": (1, "3/3 parity vectors failed", ""),
+            "check_public_route_safety.py": (0, "20 targets passed", ""),
             "check_function_quality.py": (0, "Summary: 88 functions", ""),
             "audit_input_validation.py": (0, "Overall Grade: A", ""),
         },
@@ -53,6 +72,7 @@ def test_advisory_quality_debt_prevents_false_green(monkeypatch) -> None:
         monkeypatch,
         {
             "test_api_parity.py": (0, "3/3 parity vectors passed", ""),
+            "check_public_route_safety.py": (0, "20 targets passed", ""),
             "check_function_quality.py": (
                 1,
                 "Summary: 88 functions, 26 pass, 62 fail",
@@ -73,10 +93,58 @@ def test_all_contract_truth_controls_can_report_pass(monkeypatch) -> None:
         monkeypatch,
         {
             "test_api_parity.py": (0, "3/3 parity vectors passed", ""),
+            "check_public_route_safety.py": (0, "20 targets passed", ""),
             "check_function_quality.py": (0, "Summary: all pass", ""),
             "audit_input_validation.py": (0, "Overall Grade: A", ""),
         },
     )
 
-    assert report.passed == 3
+    assert report.passed == 4
     assert report.verdict == "PASS"
+
+
+def test_public_route_regression_failure_makes_readiness_fail(monkeypatch) -> None:
+    report, calls = _collect(
+        monkeypatch,
+        {
+            "test_api_parity.py": (0, "3/3 parity vectors passed", ""),
+            "check_public_route_safety.py": (1, "1 failed, 53 passed", ""),
+            "check_function_quality.py": (0, "Summary: all pass", ""),
+            "audit_input_validation.py": (0, "Overall Grade: A", ""),
+        },
+    )
+
+    safety = next(item for item in report.evidence if "Safety" in item.name)
+    assert safety.required is True
+    assert safety.status == "FAIL"
+    assert report.verdict == "FAIL"
+    assert ("scripts/check_public_route_safety.py", ()) in calls
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected"),
+    [("PASS", 0), ("FAIL", 1), ("PARTIAL", 2), ("UNKNOWN", 1)],
+)
+def test_readiness_exit_code_is_decisive(verdict: str, expected: int) -> None:
+    assert readiness.verdict_exit_code(verdict) == expected
+
+
+def test_owner_selected_documentation_hard_cap_is_500() -> None:
+    assert docs_check.DOC_BUDGET_WARN == 350
+    assert docs_check.DOC_BUDGET_FAIL == 500
+
+
+@pytest.mark.parametrize(
+    ("high_risk", "coverage", "expected"),
+    [(0, 90.0, 0), (1, 100.0, 1), (0, 89.9, 1)],
+)
+def test_input_validation_diagnostic_exit_is_decisive(
+    high_risk: int, coverage: float, expected: int
+) -> None:
+    report = {
+        "summary": {
+            "high_risk_count": high_risk,
+            "average_coverage_percent": coverage,
+        }
+    }
+    assert input_audit.diagnostic_exit_code(report) == expected

--- a/Python/tests/test_ci_workflow_contract.py
+++ b/Python/tests/test_ci_workflow_contract.py
@@ -25,6 +25,8 @@ BASE_GATE_ENV = {
     "FASTAPI_RESULT": "skipped",
     "REACT_CHANGED": "false",
     "REACT_RESULT": "skipped",
+    "EXCEL_CHANGED": "false",
+    "EXCEL_RESULT": "skipped",
     "CONTROL_PLANE_CHANGED": "false",
     "CONTROL_PLANE_RESULT": "skipped",
     "DOCS_CHANGED": "false",
@@ -124,6 +126,7 @@ def test_changed_path_routes_cover_controls_docs_and_their_tests():
         "Python/pyproject.toml",
         "Python/structural_lib/**",
     } == docs_paths
+    assert filters["excel"] == ["excel_addin/**"]
 
     exact_tests = {
         "Python/tests/test_git_state.py",
@@ -131,6 +134,7 @@ def test_changed_path_routes_cover_controls_docs_and_their_tests():
         "Python/tests/test_session_store.py",
         "Python/tests/test_pipeline_state.py",
         "Python/tests/test_agent_governance_automation.py",
+        "Python/tests/test_audit_readiness_truth.py",
         "Python/tests/test_ci_workflow_contract.py",
     }
     assert exact_tests <= control_paths
@@ -147,9 +151,11 @@ def test_pr_gate_topology_and_cancellation_are_scoped_per_pr():
         "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
     }
     assert {
+        "excel-validation",
         "control-plane-validation",
         "documentation-validation",
     } <= set(pr_gate["needs"])
+    assert jobs["excel-validation"]["if"] == ("needs.changes.outputs.excel == 'true'")
     assert jobs["documentation-validation"]["if"] == (
         "needs.changes.outputs.docs == 'true'"
     )
@@ -166,6 +172,19 @@ def test_pr_gate_topology_and_cancellation_are_scoped_per_pr():
     )
     assert docs_run == "mkdocs build --strict"
 
+    excel_steps = jobs["excel-validation"]["steps"]
+    excel_node = next(
+        step["with"]["node-version"]
+        for step in excel_steps
+        if step["name"] == "Set up Node.js 24"
+    )
+    excel_test = next(
+        step for step in excel_steps if step["name"] == "Run all Excel add-in tests"
+    )
+    assert excel_node == "24"
+    assert excel_test["working-directory"] == "excel_addin"
+    assert excel_test["run"] == "npm test"
+
     deploy_docs = DEPLOY_DOCS.read_text(encoding="utf-8")
     trigger_block = deploy_docs.partition("\non:\n")[2].partition("\npermissions:")[0]
     assert "pull_request:" not in trigger_block
@@ -175,6 +194,8 @@ def test_pr_gate_topology_and_cancellation_are_scoped_per_pr():
 
 def test_pr_gate_accepts_successful_applicable_routes():
     result = _run_pr_gate(
+        EXCEL_CHANGED="true",
+        EXCEL_RESULT="success",
         CONTROL_PLANE_CHANGED="true",
         CONTROL_PLANE_RESULT="success",
         DOCS_CHANGED="true",
@@ -188,6 +209,7 @@ def test_pr_gate_accepts_successful_applicable_routes():
 @pytest.mark.parametrize(
     ("changed_key", "result_key"),
     [
+        ("EXCEL_CHANGED", "EXCEL_RESULT"),
         ("CONTROL_PLANE_CHANGED", "CONTROL_PLANE_RESULT"),
         ("DOCS_CHANGED", "DOCS_RESULT"),
     ],
@@ -205,6 +227,7 @@ def test_pr_gate_rejects_non_successful_applicable_route(
 @pytest.mark.parametrize(
     ("changed_key", "result_key"),
     [
+        ("EXCEL_CHANGED", "EXCEL_RESULT"),
         ("CONTROL_PLANE_CHANGED", "CONTROL_PLANE_RESULT"),
         ("DOCS_CHANGED", "DOCS_RESULT"),
     ],

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ isolated-footing, and solid-slab workflows under IS 456:2000.
 > **v0.23.1a2 is an Alpha development preview.** Support is case-qualified,
 > not a claim of complete IS 456 coverage or professional design approval.
 > Outputs require independent review by a qualified structural engineer before
-> engineering or construction use. This source is a prepared release candidate;
-> it has not yet been tagged or published.
+> engineering or construction use. The exact `v0.23.1a2` artifact is public;
+> later Gravity, E1, and safety-closure changes on `main` are not included in it.
 
 ## One workflow, four useful surfaces
 
@@ -92,10 +92,10 @@ python3 -m pip install "structural-lib-is456===0.23.1a2"
 The package is installed as `structural-lib-is456` and imported as
 `structural_lib`.
 
-`0.23.1a2` is the prepared, unpublished candidate. The current public Alpha is
-`0.23.1a1`; the exact `0.23.1a2` pin above becomes available only if this
-candidate is later authorized and published. See the
-[release policy](docs/getting-started/releases.md) before selecting a candidate.
+`0.23.1a2` is the current public Alpha. Gravity Workflow V1, E1, and later
+public-route safety work merged after its immutable tag, so any future package
+must use a new version and fresh exact-artifact evidence. See the
+[release policy](docs/getting-started/releases.md) before selecting a release.
 
 ```python
 from structural_lib import api

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,115 @@
 
 ---
 
+## 2026-08-22 — Session: LIB-PRO-003-D decisive gates and cumulative safety closure
+
+**Agent:** Codex (`ops` + `governance`, sole writer)
+
+**Branch:** `codex/public-route-decisive-gates`, from exact hosted Packet C
+merge `027554457c58303f435dc4a9940dc683def22895`.
+
+**Git handoff receipt:**
+`docs/verification/lib-pro-003-d-git-handoff-receipt.json`
+
+**Focus:** Make Excel-only CI, public-route safety evidence, readiness exits,
+release/API wording, and documentation contracts decisive; then run one
+cumulative A-D product and repository acceptance sequence. No engineering
+formula, ETABS/desktop Excel, package publication, or professional approval was
+in scope.
+
+### Summary
+
+- Added an Excel add-in path classifier, Node 24 test job, and required PR-gate
+  result so an `excel_addin/**`-only change cannot bypass all 21 add-in tests.
+- Added a required public-route safety runner covering the reproduced Python
+  and FastAPI boundaries. The readiness report now returns 0 only for `PASS`,
+  1 for `FAIL`, and 2 for `PARTIAL`.
+- Made the legacy validation scanner non-green for high-risk findings or less
+  than 90% heuristic coverage; made front-matter and the active-file budget a
+  required readiness check. The owner changed the Markdown hard cap to 500.
+- Synchronized current `v0.23.1a2` publication truth, `CITATION.cff`, and the
+  distinct 89-operation/88-path API metrics without rewriting historical
+  release or E1 snapshots.
+- Reconciled four stale cumulative contracts exposed by A-C and regenerated
+  the public API manifest plus script discovery/index records.
+
+### Issues encountered
+
+- The first cumulative Python run had four failures: semantic introspection
+  ignored typed result unions; one flexure test intentionally used Fe10; the
+  shear property strategy generated M50 outside the maintained Table 19 route;
+  and release preflight still classified public `v0.23.1a2` as unpublished.
+- The first failed-only release repair validated the historical authorization
+  against the current dirty/post-release source tree, then exposed a stale
+  `CITATION.cff` publication message and date.
+- The second cumulative run found one older authorized-release fixture after
+  the release-ledger matcher had become too narrow.
+- The isolated worktree had no React `node_modules`; `./run.sh test --react`
+  stopped at `vitest: command not found`. Direct `npm ci` used the shell's Node
+  26 and emitted an engine warning before the maintained launcher selected
+  Node 24.19.0 for the actual test.
+- The first full repository gate passed 29/31 and correctly reported the API
+  manifest plus script index/automation map as stale.
+- A zsh result-capture probe used the reserved variable name `status` before
+  this packet's implementation began.
+
+### Root causes and resolutions
+
+- Root cause: the semantic test descended only when the entire return type was
+  a dataclass, while Packet C intentionally introduced a union of success and
+  typed capacity-failure dataclasses. Resolution: traverse every dataclass
+  member of the return union. Evidence: the semantic contract test and all
+  6,653 selected Python tests pass.
+- Root cause: two inherited tests generated domains that Packet B now rejects
+  before calculation. Resolution: assert the low-grade flexure domain error and
+  constrain only the composed shear-design strategy to M15-M40; direct helper
+  strategies remain broad. Evidence: both failed nodes and the full property
+  suite pass.
+- Root cause: source-surface release truth read a checklist phrase and
+  candidate-era `CITATION.cff`, despite the existing machine authorization and
+  public release ledger. Resolution: recognize the exact authorization record,
+  accept both published and historical authorized ledgers, and record the
+  actual release date/message. Evidence: current and temporary-fixture release
+  tests plus the full Python suite pass.
+- Root cause: linked worktrees do not share ignored npm dependencies.
+  Resolution: install the exact lockfile once and execute through the repository
+  Node 24 launcher. Evidence: 51 React files / 276 tests pass.
+  ⚠️ TERMINAL ISSUE: missing worktree-local `vitest` -> `npm ci`, then
+  `./run.sh frontend runtime` proved Node 24.19.0 before the green React run.
+- Root cause: Packet C's new typed slab union and Packet D's new safety script
+  had not yet been regenerated into their canonical inventories. Resolution:
+  regenerate the API manifest and scripts folder index after mapping the new
+  script. Evidence: the final repository gate passes 31/31.
+- Root cause: zsh reserves `status` as a shell parameter. Resolution: use the
+  task-specific `doc_exit` and `budget_exit` names; the documentation probe then
+  reported its exact exits.
+  ⚠️ TERMINAL ISSUE: zsh rejected assignment to `status` -> reran with
+  task-specific result variables.
+
+### Validation through content freeze
+
+- Public-route gate: 73 Python and 5 FastAPI adversarial cases pass; all 21
+  Excel add-in tests pass.
+- Cumulative product tests: 6,653 Python pass (3 skipped, 6 deselected), all
+  479 FastAPI tests pass, and all 276 React tests pass across 51 files.
+- Documentation: zero invalid front-matter values, 401/500 active Markdown
+  files, and zero broken links. Quick gate passes 10/10.
+- Full repository gate passes 31/31 after deterministic manifest/index refresh.
+- Readiness is truthfully `PARTIAL` with exit 2: 21/23 pass, zero fail, and two
+  warnings (62 function-quality diagnostic failures and F-rated heuristic input
+  validation). Therefore package release and professional/stable claims remain
+  `HOLD`; a green software regression set is not professional approval.
+
+### Remaining holds
+
+- Hosted PR checks, immutable candidate review, and exact candidate/merged tree
+  equality remain before Packet D merge closure.
+- The two advisory diagnostics require separate bounded truth triage before any
+  future release decision. INDIA-3-G0 may resume only after Packet D merge and
+  does not change the release/professional hold.
+
+---
+
 ## 2026-08-22 — Session: LIB-PRO-003-C public failure contracts
 
 **Agent:** Codex (`backend` + `api-developer`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-22 — LIB-PRO-003-B merged; Packet C failure-contract closure active
+**Updated:** 2026-08-22 — LIB-PRO-003-C merged; Packet D decisive-gate closure active
 
 ---
 
@@ -29,7 +29,7 @@
 | MAINT-006 | Enforce low-token Codex operation | P1 | ✅ DONE | User-selected parent model is preserved; Terra-first advisory routing, bounded worker packets, two-subagent cap, and quick-gate check pass |
 | MAINT-007 | Refresh onboarding, agents, tools, and usage telemetry | P1 | ✅ DONE | Terminal-only PR status, current bootstrap/counts, complete 14-skill discovery, honest usage checkpoints, and focused regressions pass |
 | MAINT-008 | Compact CI, maintenance controls, and agent entry paths | P0 | ✅ DONE | Four-lane workflow, truthful `PR Gate`, native Codex Git/GitHub lifecycle, and retired unsafe wrappers are merged |
-| LIB-PRO-001 | Remediate the professional library audit without repeating completed maintenance | P0 | ✅ SOFTWARE COMPLETE | T0 and R1-R8 are retained as evidence; bounded-product closeout continues under LIB-IS456-V1 |
+| LIB-PRO-001 | Remediate the historical professional library audit without repeating completed maintenance | P0 | ⏸ SUPERSEDED | T0 and R1-R8 remain historical evidence; later direct public-route replay reopened the release hold under LIB-PRO-003, so this row is not a current professional-readiness claim |
 
 ### Maintenance evidence captured 2026-08-07
 
@@ -69,8 +69,8 @@
 
 ## Current Release
 
-| **Current public release** | v0.23.1a1 | ✅ ALPHA RELEASED — exact CI/public artifact evidence recorded |
-- **Release evidence:** production run `31468341946`; tag `95bed562`; public installed-package UAT green
+| **Current public release** | v0.23.1a2 | ✅ ALPHA RELEASED — immutable tag/public artifacts recorded; later `main` work is not included |
+- **Release evidence:** tag target `09861d3d`; public wheel SHA-256 `279b8270…43a9`; public installed-package UAT green
 - **Strategy:** Incremental micro-releases — each focuses on one quality dimension (tests, API, security, performance)
 - **Focus:** API introspection → security hardening → performance baselines → stabilization
 - **Target:** keep later roadmap work inactive until separately activated
@@ -127,7 +127,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-003-C | Convert slab capacity, malformed legacy CSV, and negative BOQ inputs to structured fail-closed outcomes | backend + API developer + tester | M | P0 | 🚧 ACTIVE — 122 focused, 214 independent, and 20 API-contract tests pass; candidate gates pending |
+| LIB-PRO-003-D | Make Excel CI and readiness audits decisive and synchronize release/route-count/documentation truth | ops + governance | S | P0 | ✅ LOCAL CANDIDATE — 78 safety cases, 21 Excel, 6,653 Python, 479 FastAPI, 276 React, quick 10/10, and full 31/31 pass; hosted/exact-tree closure pending; readiness remains truthful PARTIAL/exit 2 and release HOLD |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. The reproduced public-route safety defects take priority over new
@@ -138,7 +138,9 @@ closes and their own packet is activated.
 `LIB-PRO-003-A` was accepted and exact-tree merged through PR #832 at
 `e7698a63b86d2db6db2f3970871122af1ce562f6`; Packet B was accepted and
 exact-tree merged through PR #833 at
-`e19b757ccb9922061369a236501f037ec20503ab`. `LIB-PRO-002-G0` was
+`e19b757ccb9922061369a236501f037ec20503ab`; Packet C was accepted and
+exact-tree merged through PR #834 at
+`027554457c58303f435dc4a9940dc683def22895`. `LIB-PRO-002-G0` was
 independently accepted and merged through PR #812 at
 `55104e11257937b0a42fb06f931a70b8484cef39`. Packet A was independently
 accepted and merged through PR #814 at
@@ -162,7 +164,6 @@ write-back/nightly work remain outside E1.
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-003-D | Make Excel CI and input audits decisive and synchronize release/route-count truth | ops + governance | S | P0 | ⏸ AFTER C |
 | INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | ⏸ AFTER LIB-PRO-003 — truth/benchmark/contract audit only; no new formulas or support claims |
 | SPARK-001-G0 | Reassess the stale Spark work-program proposal before any implementation | repository owner | review gate | P2 | ⏸ OWNER REVIEW — the 2026-08-11 model/preview assumptions and bulk wave require refresh or rejection |
 

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-17T22:10:26.211282",
-  "total_docs": 372,
+  "generated": "2026-08-22T16:59:39.968604",
+  "total_docs": 373,
   "docs": {
     "docs/SESSION_LOG.md": {
       "title": "Session Log",
@@ -10,18 +10,18 @@
       "folder": "root",
       "tags": [],
       "sections": [
-        "2026-08-17 \u2014 Session: v0.23.1a2 Release Candidate Preparation",
-        "2026-08-17 \u2014 Session: LIB-PRO-002-J Release Signal Convergence",
-        "2026-08-17 \u2014 Session: LIB-PRO-002-I Advertised CLI Convergence",
-        "2026-08-17 \u2014 Session: LIB-PRO-002 Post-Fix Usability Re-Audit",
-        "2026-08-17 \u2014 Session: LIB-PRO-002 B-G Cumulative Safety Integration",
-        "2026-08-17 \u2014 Session: LIB-PRO-002-A Strict Service Intake",
-        "2026-08-17 \u2014 Session: Implementation-First Verification Policy",
-        "2026-08-17 \u2014 Session: Pre-Release Input-Safety Contract Freeze",
-        "2026-08-16 \u2014 Session: Index Local-Artifact Determinism Repair",
-        "2026-08-16 \u2014 Session: Post-INDIA-2 Index Determinism Repair"
+        "2026-08-22 \u2014 Session: LIB-PRO-003-D decisive gates and cumulative safety closure",
+        "2026-08-22 \u2014 Session: LIB-PRO-003-C public failure contracts",
+        "2026-08-22 \u2014 Session: LIB-PRO-003-B domains and footing provenance",
+        "2026-08-22 \u2014 Session: LIB-PRO-003-A public numeric boundaries",
+        "2026-08-22 \u2014 Session: E1 G3 integration and roadmap closeout",
+        "2026-08-22 \u2014 Session: E1 desktop-Excel workbook-open repair",
+        "2026-08-22 \u2014 Session: E1 complete review-bundle export",
+        "2026-08-22 \u2014 Session: E1 blank-workbook guard repair",
+        "2026-08-21 \u2014 Session: E1 Windows W0 evidence and maintenance",
+        "2026-08-18 \u2014 Session: E1 Excel Routine Workbench V1 implementation"
       ],
-      "size_bytes": 175397
+      "size_bytes": 243792
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -61,7 +61,7 @@
         "Completed (Archived)",
         "External Audit Remediation \u2014 v0.21.6 \u2705 DONE"
       ],
-      "size_bytes": 57047
+      "size_bytes": 59755
     },
     "docs/WORKLOG.md": {
       "title": "Work Log",
@@ -324,7 +324,7 @@
         "Phase 4 routing",
         "Phase 3 acceptance gate"
       ],
-      "size_bytes": 16190
+      "size_bytes": 16194
     },
     "docs/research/git-governance/GIT-001-phase-7B-state-intake-kernel.md": {
       "title": "GIT-001 Phase 7B \u2014 Read-Only State and Intake Kernel",
@@ -1123,10 +1123,31 @@
       ],
       "size_bytes": 10183
     },
-    "docs/specs/building-gravity-v1.md": {
-      "title": "Building Gravity V1 Model and Load Contract",
+    "docs/specs/excel-routine-workbench-v1.md": {
+      "title": "Excel Routine Workbench V1",
       "type": "specification",
       "complexity": "intermediate",
+      "folder": "specs",
+      "tags": [
+        "design",
+        "requirements"
+      ],
+      "sections": [
+        "Outcome",
+        "Architecture and trust boundary",
+        "Exact artifact and installed identity",
+        "Selected-table intake",
+        "Review, passports, and freshness",
+        "User surfaces",
+        "Capability truth and held scope",
+        "Verification authority"
+      ],
+      "size_bytes": 6981
+    },
+    "docs/specs/building-gravity-v1.md": {
+      "title": "Building Gravity Workflow V1 Contract",
+      "type": "specification",
+      "complexity": "advanced",
       "folder": "specs",
       "tags": [
         "building-model",
@@ -1144,9 +1165,12 @@
         "Frozen load basis",
         "Load path and reconciliation",
         "Approved exclusions and holds",
-        "Hand example"
+        "Hand example",
+        "B2 request boundary",
+        "Exact member actions",
+        "Applicability before calculation"
       ],
-      "size_bytes": 5341
+      "size_bytes": 11220
     },
     "docs/specs/v0.9-job-schema.md": {
       "title": "v0.9 \u2014 Job Schema (Draft)",
@@ -1214,30 +1238,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 829
-    },
-    "docs/_archive/2026-08/workflow-professional-review.md": {
-      "title": "Git Workflow Professional Review & Recommendations",
-      "type": "documentation",
-      "complexity": "advanced",
-      "folder": "contributing",
-      "tags": [
-        "development",
-        "workflow"
-      ],
-      "sections": [
-        "Executive Summary",
-        "Detailed Analysis",
-        "Performance Analysis",
-        "Efficiency Scorecard",
-        "Professional Standards Comparison",
-        "Recommendations",
-        "v2.0 Preview",
-        "Migration Path",
-        "Final Verdict",
-        "Cost-Benefit Analysis"
-      ],
-      "size_bytes": 11762
+      "size_bytes": 968
     },
     "docs/contributing/quickstart-checklist.md": {
       "title": "Quick-Start Checklist (Solution 4 - Developer Guides)",
@@ -1404,29 +1405,6 @@
       ],
       "size_bytes": 3128
     },
-    "docs/_archive/2026-08/git-workflow-testing.md": {
-      "title": "Git Workflow Testing Strategy",
-      "type": "documentation",
-      "complexity": "advanced",
-      "folder": "contributing",
-      "tags": [
-        "development",
-        "workflow"
-      ],
-      "sections": [
-        "\ud83c\udfaf Goals",
-        "\ud83d\udee0\ufe0f Testing Tools",
-        "\ud83d\udcca Test Coverage",
-        "\ud83d\udd04 Conflict Prevention Strategy",
-        "\ud83d\udea8 Common Issues & Solutions",
-        "\ud83d\udcdd Best Practices",
-        "\ud83d\udd0d Running Tests Locally",
-        "\ud83d\udcc8 Success Metrics",
-        "\ud83c\udf93 Learning Resources",
-        "\ud83d\udd04 Continuous Improvement"
-      ],
-      "size_bytes": 8890
-    },
     "docs/contributing/solo-maintainer-operating-system.md": {
       "title": "Solo Maintainer Operating System (Public)",
       "type": "documentation",
@@ -1482,7 +1460,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 3105
+      "size_bytes": 2835
     },
     "docs/contributing/repo-professionalism.md": {
       "title": "Repo Professionalism Playbook",
@@ -2148,12 +2126,33 @@
         "tasks"
       ],
       "sections": [
-        "Latest handoff",
-        "Required Reading",
-        "Resume safely",
-        "Candidate evidence and next gate"
+        "Latest Handoff (auto)",
+        "E1 final acceptance",
+        "Correct next library packet",
+        "Other live work",
+        "Required Reading"
       ],
-      "size_bytes": 3853
+      "size_bytes": 4360
+    },
+    "docs/planning/public-route-safety-closure-plan.md": {
+      "title": "Public Route Safety Closure Plan",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "planning",
+      "tags": [
+        "public-api",
+        "release-hold",
+        "roadmap",
+        "safety",
+        "tasks",
+        "validation"
+      ],
+      "sections": [
+        "Audit decision",
+        "Frozen sequence",
+        "Non-goals"
+      ],
+      "size_bytes": 4536
     },
     "docs/planning/is456-solid-slabs-master-plan.md": {
       "title": "IS 456 Solid Slabs Expansion Master Plan",
@@ -2327,7 +2326,7 @@
         "Next Alpha Readiness Checklist",
         "Beta Readiness Checklist"
       ],
-      "size_bytes": 6510
+      "size_bytes": 6663
     },
     "docs/planning/README.md": {
       "title": "Planning",
@@ -2347,7 +2346,7 @@
         "Templates & Workflow",
         "Rules"
       ],
-      "size_bytes": 8553
+      "size_bytes": 8916
     },
     "docs/planning/memory.md": {
       "title": "Project Memory - Persistent Context",
@@ -2407,7 +2406,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 3117
+      "size_bytes": 3423
     },
     "docs/planning/india-2-next-session-publication-and-closeout-plan.md": {
       "title": "Next Session Git Reconciliation, Issue Repairs, and INDIA-2 Finish Plan",
@@ -2517,6 +2516,28 @@
       ],
       "size_bytes": 22535
     },
+    "docs/planning/e1-excel-routine-workbench-v1-plan.md": {
+      "title": "Excel Routine Workbench V1 Execution Plan",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "planning",
+      "tags": [
+        "roadmap",
+        "tasks"
+      ],
+      "sections": [
+        "Implementation status \u2014 2026-08-22",
+        "1. Outcome and start boundary",
+        "2. Accepted first user journey",
+        "3. Frozen `ExcelWorkbookContractV1`",
+        "4. Implementation map",
+        "5. Root causes E1 must close",
+        "6. Implementation sequence",
+        "7. Frozen validation selection",
+        "8. Gate G3 and stop rules"
+      ],
+      "size_bytes": 14666
+    },
     "docs/planning/democratization-vision.md": {
       "title": "Democratizing Structural Engineering",
       "type": "documentation",
@@ -2553,7 +2574,7 @@
         "Quick Links",
         "Related Documentation"
       ],
-      "size_bytes": 2885
+      "size_bytes": 2950
     },
     "docs/agents/index.md": {
       "title": "Agents",
@@ -2568,7 +2589,7 @@
         "Documentation Files",
         "Subfolders"
       ],
-      "size_bytes": 550
+      "size_bytes": 549
     },
     "docs/agents/sessions/2026-01/agent-8-week1-completion-summary.md": {
       "title": "Agent 8 Week 1 Completion Summary",
@@ -2625,23 +2646,6 @@
       ],
       "size_bytes": 21939
     },
-    "docs/_archive/2026-08/agent-6-quick-start.md": {
-      "title": "Agent 6 Quick Start (Streamlit UI Specialist)",
-      "type": "documentation",
-      "complexity": "intermediate",
-      "folder": "guides",
-      "tags": [],
-      "sections": [
-        "Your Mission",
-        "Quick Start (Copy-Paste Ready)",
-        "Key Files",
-        "Your Workflow",
-        "Quality Standards",
-        "Common Patterns",
-        "Next Step"
-      ],
-      "size_bytes": 2037
-    },
     "docs/agents/guides/agent-9-quick-start.md": {
       "title": "Agent 9 Quick Start - Governance & Documentation Structure",
       "type": "documentation",
@@ -2661,57 +2665,6 @@
         "Emergency Recovery"
       ],
       "size_bytes": 7880
-    },
-    "docs/_archive/2026-08/agent-8-git-ops.md": {
-      "title": "Agent 8: GIT OPERATIONS SPECIALIST",
-      "type": "documentation",
-      "complexity": "advanced",
-      "folder": "guides",
-      "tags": [],
-      "sections": [
-        "Mission Statement",
-        "Why This Agent is Critical",
-        "Core Responsibilities",
-        "14:23 - Background Agent 6 Handoff",
-        "14:24 - PR Created",
-        "14:25 - CI Passed",
-        "14:25 - Cleanup Complete",
-        "Fast Checks Performance",
-        "Full Test Matrix Performance",
-        "Handoff: [AGENT] \u2192 GIT OPERATIONS"
-      ],
-      "size_bytes": 37217
-    },
-    "docs/_archive/2026-08/agent-6-comprehensive-onboarding.md": {
-      "title": "Agent 6 Comprehensive Onboarding Guide",
-      "type": "documentation",
-      "complexity": "advanced",
-      "folder": "guides",
-      "tags": [],
-      "sections": [
-        "\ud83c\udfaf Mission Statement",
-        "\ud83d\ude80 Quick Start (60 Seconds)",
-        "\ud83d\udcc2 Your Codebase",
-        "\u26a0\ufe0f CRITICAL: Guard Rails (Read These!)",
-        "\ud83d\udd27 Development Workflow",
-        "\ud83d\udd0d Quality Tools",
-        "\ud83d\udcda Design System",
-        "\ud83c\udfd7\ufe0f Common Patterns",
-        "\ud83d\udccb Current Tasks (v0.17.5)",
-        "\ud83d\udd17 Quick Links"
-      ],
-      "size_bytes": 12922
-    },
-    "docs/_archive/2026-08/agent-8-operations-log-spec.md": {
-      "title": "Agent 8 Operations Log Spec",
-      "type": "specification",
-      "complexity": "beginner",
-      "folder": "guides",
-      "tags": [],
-      "sections": [
-        "2026-01-08 19:30 UTC \u2014 Agent 6 Research Commit"
-      ],
-      "size_bytes": 1422
     },
     "docs/agents/guides/agent-bootstrap-complete-review.md": {
       "title": "Agent Bootstrap - Complete Review & Link Analysis",
@@ -2762,18 +2715,18 @@
         "Agent 9 - Governance & Documentation Structure",
         "Adding New Agent Guides"
       ],
-      "size_bytes": 2474
+      "size_bytes": 2612
     },
     "docs/agents/guides/index.md": {
       "title": "Guides",
       "type": "documentation",
-      "complexity": "intermediate",
+      "complexity": "beginner",
       "folder": "guides",
       "tags": [],
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 2006
+      "size_bytes": 971
     },
     "docs/agents/guides/agent-workflow-master-guide.md": {
       "title": "Agent Workflow Master Guide",
@@ -2795,26 +2748,6 @@
       ],
       "size_bytes": 19829
     },
-    "docs/_archive/2026-08/agent-8-automation.md": {
-      "title": "Agent 8 Automation - Scripts & Tools Index",
-      "type": "documentation",
-      "complexity": "advanced",
-      "folder": "guides",
-      "tags": [],
-      "sections": [
-        "Quick Start (60 Seconds)",
-        "Script Location",
-        "Core Workflow Scripts",
-        "PR Management Scripts",
-        "Recovery & Validation Scripts",
-        "Environment Setup Scripts",
-        "Testing Scripts",
-        "Legacy Scripts (Backup)",
-        "Related Infrastructure",
-        "Script Dependencies"
-      ],
-      "size_bytes": 8665
-    },
     "docs/agents/guides/agent-9-governance-hub.md": {
       "title": "Agent 9 Governance Hub",
       "type": "documentation",
@@ -2832,64 +2765,6 @@
         "Need Help?"
       ],
       "size_bytes": 4007
-    },
-    "docs/_archive/2026-08/agent-8-mistakes-prevention-guide.md": {
-      "title": "Agent 8: Mistakes Prevention Guide (Lessons Learned)",
-      "type": "guide",
-      "complexity": "advanced",
-      "folder": "guides",
-      "tags": [],
-      "sections": [
-        "\ud83c\udfaf Purpose",
-        "\ud83d\udcca Mistake Database (Historical Analysis)",
-        "\ud83d\udee1\ufe0f Agent 8 Enhanced Prevention System",
-        "\ud83d\udccb Agent 8 Mistake Prevention Checklist",
-        "\ud83c\udf93 Mistake Prevention Patterns",
-        "\ud83d\udcca Success Metrics (Before vs After)",
-        "\ud83d\udea8 Emergency: If Mistake Happens Anyway",
-        "\ud83c\udfaf Agent 8 Mission: Zero Mistakes"
-      ],
-      "size_bytes": 30075
-    },
-    "docs/_archive/2026-08/agent-automation-system.md": {
-      "title": "Agent Automation System v1.1.0",
-      "type": "documentation",
-      "complexity": "advanced",
-      "folder": "guides",
-      "tags": [],
-      "sections": [
-        "Overview",
-        "What's Included",
-        "Quick Start",
-        "Testing",
-        "Features",
-        "Architecture",
-        "Script Details",
-        "Benefits",
-        "Troubleshooting",
-        "Maintenance"
-      ],
-      "size_bytes": 8859
-    },
-    "docs/_archive/2026-08/agent-8-multi-agent-coordination.md": {
-      "title": "Agent 8 Multi-Agent Coordination",
-      "type": "documentation",
-      "complexity": "intermediate",
-      "folder": "guides",
-      "tags": [],
-      "sections": [
-        "Overview",
-        "How It Works",
-        "Usage Patterns",
-        "Safety Guarantees",
-        "Workflow Examples",
-        "Integration with Week 1 Optimizations",
-        "Troubleshooting",
-        "Configuration",
-        "Implementation Status",
-        "Testing"
-      ],
-      "size_bytes": 7875
     },
     "docs/cookbook/README.md": {
       "title": "Cookbook",
@@ -3027,6 +2902,25 @@
       ],
       "size_bytes": 43515
     },
+    "docs/verification/e1-blank-workbook-guard-evidence.md": {
+      "title": "E1 Blank Workbook Guard Repair Evidence",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Candidate boundary",
+        "Observed failure and root cause",
+        "Repair contract",
+        "Implementation and focused evidence",
+        "First W2 exact-head result and consolidated repair",
+        "Windows revalidation result"
+      ],
+      "size_bytes": 6072
+    },
     "docs/verification/india-2-foundation-pile-cap-g0-hold-evidence.md": {
       "title": "INDIA-2 Foundation Pile-Cap G0 Hold Evidence",
       "type": "documentation",
@@ -3072,11 +2966,15 @@
       "complexity": "beginner",
       "folder": "verification",
       "tags": [
+        "evidence",
+        "identity",
+        "is456",
+        "provenance",
         "testing",
         "validation"
       ],
       "sections": [],
-      "size_bytes": 1450
+      "size_bytes": 1604
     },
     "docs/verification/india-2-deep-b-reinforcement-evidence.md": {
       "title": "INDIA-2-DEEP-B Reinforcement Evidence",
@@ -3219,6 +3117,32 @@
       ],
       "size_bytes": 9662
     },
+    "docs/verification/b2-gravity-workflow-v1-evidence.md": {
+      "title": "B2 Building Gravity Workflow V1 Evidence",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "actions",
+        "calculation-book",
+        "component-api",
+        "evidence",
+        "gravity",
+        "testing",
+        "validation",
+        "workflow"
+      ],
+      "sections": [
+        "Evidence boundary",
+        "Controlled implementation",
+        "Hand-calculation vector",
+        "Fail-closed component vectors",
+        "Transport and review evidence",
+        "Verification selection",
+        "Remaining gates"
+      ],
+      "size_bytes": 5016
+    },
     "docs/verification/india-2-deep-c-public-workflow-evidence.md": {
       "title": "INDIA-2-DEEP-C Public Python Workflow Evidence",
       "type": "documentation",
@@ -3271,6 +3195,25 @@
       ],
       "size_bytes": 2326
     },
+    "docs/verification/e1-windows-w0-setup-evidence.md": {
+      "title": "E1 Windows W0 Setup and Handoff Evidence",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Verdict",
+        "Windows host receipt",
+        "Blank-workbook outcome and confirmed root cause",
+        "Legacy VBA/API handoff on Windows",
+        "Disconnect and recovery record",
+        "Next controlled sequence"
+      ],
+      "size_bytes": 7931
+    },
     "docs/verification/india-2-flat-b-moment-evidence.md": {
       "title": "INDIA-2-FLAT-B Direct-Design Moment Evidence",
       "type": "documentation",
@@ -3287,6 +3230,26 @@
         "Verification and retained holds"
       ],
       "size_bytes": 3765
+    },
+    "docs/verification/e1-excel-routine-workbench-v1-evidence.md": {
+      "title": "Excel Routine Workbench V1 Evidence",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Candidate boundary",
+        "Frozen verification selection",
+        "Implemented evidence surfaces",
+        "Consolidated focused results",
+        "Workbook artifact receipt",
+        "Focused implementation diagnostics already completed",
+        "Current verdict"
+      ],
+      "size_bytes": 10256
     },
     "docs/verification/india-2-flat-d-punching-evidence.md": {
       "title": "INDIA-2-FLAT-D Centred Punching Evidence",
@@ -3343,6 +3306,29 @@
         "Focused verification"
       ],
       "size_bytes": 6939
+    },
+    "docs/verification/lib-pro-003-b-domain-provenance-evidence.md": {
+      "title": "LIB-PRO-003-B Domain and Provenance Evidence",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "beam",
+        "column",
+        "footing",
+        "provenance",
+        "safety",
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Identity and scope",
+        "Confirmed root causes and corrected outcomes",
+        "Direct adversarial replay",
+        "Focused and independent verification",
+        "Remaining release blockers"
+      ],
+      "size_bytes": 4082
     },
     "docs/verification/india-2-foundation-strap-b-strength-evidence.md": {
       "title": "INDIA-2 Foundation Strap B Strength Evidence",
@@ -3612,6 +3598,29 @@
       ],
       "size_bytes": 4364
     },
+    "docs/verification/e1-workbook-open-repair-evidence.md": {
+      "title": "E1 Desktop Excel Workbook-Open Repair Evidence",
+      "type": "documentation",
+      "complexity": "advanced",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Candidate boundary",
+        "Frozen diagnosis contract",
+        "D0 diagnostic receipt",
+        "Confirmed file-level root cause",
+        "Repair implementation",
+        "Generated artifact receipt",
+        "Frozen D2 verification",
+        "D2 results through implementation freeze",
+        "D3 Windows acceptance",
+        "Integration receipt"
+      ],
+      "size_bytes": 9324
+    },
     "docs/verification/india-2-cumulative-gate-evidence.md": {
       "title": "INDIA-2 Cumulative Gate Evidence",
       "type": "documentation",
@@ -3706,6 +3715,27 @@
       ],
       "size_bytes": 4826
     },
+    "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md": {
+      "title": "LIB-PRO-003-A Numeric Boundary Evidence",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "public-api",
+        "regression",
+        "safety",
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Identity and scope",
+        "Confirmed root causes and corrected outcomes",
+        "Compatibility and contracts",
+        "Focused verification",
+        "Remaining release blockers"
+      ],
+      "size_bytes": 3542
+    },
     "docs/verification/india-2-foundation-strap-d-publication-evidence.md": {
       "title": "INDIA-2-FOUNDATION-STRAP-D Publication Evidence",
       "type": "documentation",
@@ -3736,7 +3766,7 @@
         "Config Files",
         "Documentation Files"
       ],
-      "size_bytes": 23319
+      "size_bytes": 26973
     },
     "docs/verification/india-2-wall-d-publication-evidence.md": {
       "title": "INDIA-2-WALL-D Publication Evidence",
@@ -3912,6 +3942,27 @@
         "Root causes and resolutions"
       ],
       "size_bytes": 30193
+    },
+    "docs/verification/e1-review-bundle-export-evidence.md": {
+      "title": "E1 Complete Review Bundle Export Evidence",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "verification",
+      "tags": [
+        "testing",
+        "validation"
+      ],
+      "sections": [
+        "Candidate boundary",
+        "G3 blocker and confirmed root cause",
+        "Repair contract",
+        "Frozen verification selection",
+        "Windows acceptance after local closeout",
+        "Current verdict",
+        "Focused results through implementation freeze",
+        "External Windows G3 outcome"
+      ],
+      "size_bytes": 7975
     },
     "docs/verification/india-2c-staircase-design-evidence.md": {
       "title": "INDIA-2C Staircase Structural-Design Evidence",
@@ -4682,7 +4733,7 @@
         "v0.21.0",
         "v0.17.0"
       ],
-      "size_bytes": 53951
+      "size_bytes": 54965
     },
     "docs/getting-started/cost-optimization-guide.md": {
       "title": "Cost Optimization Guide",
@@ -4766,7 +4817,7 @@
         "Daily Workflow Commands",
         "Architecture Overview"
       ],
-      "size_bytes": 9480
+      "size_bytes": 9489
     },
     "docs/getting-started/agent-bootstrap.md": {
       "title": "Agent Bootstrap \u2014 structural_engineering_lib",
@@ -4789,7 +4840,7 @@
         "8. Key Scripts",
         "9. Golden Rules"
       ],
-      "size_bytes": 38163
+      "size_bytes": 38353
     },
     "docs/getting-started/python-quickstart.md": {
       "title": "Python Quickstart (Beginner-Friendly)",
@@ -5176,7 +5227,7 @@
         "9. Release Checklist",
         "10. Incident Response"
       ],
-      "size_bytes": 6924
+      "size_bytes": 6926
     },
     "docs/guidelines/documentation-standard.md": {
       "title": "API Documentation & Discoverability Standard",
@@ -6724,7 +6775,7 @@
         "Implementation Plan",
         "Migration Notes"
       ],
-      "size_bytes": 10993
+      "size_bytes": 11567
     },
     "docs/reference/fastapi-rest-api.md": {
       "title": "FastAPI REST API Reference",
@@ -6927,7 +6978,7 @@
         "Testing Automation Scripts",
         "Additional Resources"
       ],
-      "size_bytes": 15118
+      "size_bytes": 15133
     },
     "docs/reference/api-levels.md": {
       "title": "Which API Should I Use?",
@@ -6965,7 +7016,7 @@
         "SHEAR",
         "TORSION"
       ],
-      "size_bytes": 4247
+      "size_bytes": 4703
     },
     "docs/reference/third-party-licenses.md": {
       "title": "Third-Party Licenses",
@@ -7130,6 +7181,9 @@
         "docs/planning/india-2-remaining-is456-elements-plan.md",
         "docs/agents/README.md",
         "docs/agents/index.md",
+        "docs/verification/e1-blank-workbook-guard-evidence.md",
+        "docs/verification/lib-pro-003-b-domain-provenance-evidence.md",
+        "docs/verification/e1-workbook-open-repair-evidence.md",
         "docs/verification/india-2b-staircase-actions-evidence.md",
         "docs/verification/india-2c-staircase-design-evidence.md",
         "docs/verification/india-2d-staircase-publication-evidence.md",
@@ -7158,9 +7212,13 @@
         "docs/getting-started/python-quickstart.md",
         "docs/migration/02-library-research.md"
       ],
-      "excel_user": [],
+      "excel_user": [
+        "docs/specs/excel-routine-workbench-v1.md",
+        "docs/planning/e1-excel-routine-workbench-v1-plan.md",
+        "docs/verification/e1-excel-routine-workbench-v1-evidence.md",
+        "docs/verification/e1-workbook-open-repair-evidence.md"
+      ],
       "contributor": [
-        "docs/_archive/2026-08/workflow-professional-review.md",
         "docs/contributing/quickstart-checklist.md",
         "docs/contributing/development-guide.md",
         "docs/contributing/naming-conventions.md",
@@ -7169,7 +7227,6 @@
         "docs/contributing/agent-coding-standards.md",
         "docs/contributing/commit-message-conventions.md",
         "docs/contributing/learning-paths.md",
-        "docs/_archive/2026-08/git-workflow-testing.md",
         "docs/contributing/solo-maintainer-operating-system.md",
         "docs/contributing/github-workflow.md",
         "docs/contributing/index.md",
@@ -7240,6 +7297,7 @@
       ],
       "design": [
         "docs/specs/csv-import-schema.md",
+        "docs/specs/excel-routine-workbench-v1.md",
         "docs/specs/building-gravity-v1.md",
         "docs/specs/v0.9-job-schema.md",
         "docs/specs/README.md",
@@ -7261,6 +7319,7 @@
       ],
       "requirements": [
         "docs/specs/csv-import-schema.md",
+        "docs/specs/excel-routine-workbench-v1.md",
         "docs/specs/building-gravity-v1.md",
         "docs/specs/v0.9-job-schema.md",
         "docs/specs/README.md",
@@ -7272,20 +7331,22 @@
       ],
       "gravity": [
         "docs/specs/building-gravity-v1.md",
+        "docs/verification/b2-gravity-workflow-v1-evidence.md",
         "docs/verification/b1-gravity-model-load-ledger-evidence.md"
       ],
       "load-model": [
         "docs/specs/building-gravity-v1.md"
       ],
       "provenance": [
-        "docs/specs/building-gravity-v1.md"
+        "docs/specs/building-gravity-v1.md",
+        "docs/verification/lib-pro-002-e-evidence-identity.md",
+        "docs/verification/lib-pro-003-b-domain-provenance-evidence.md"
       ],
       "reconciliation": [
         "docs/specs/building-gravity-v1.md",
         "docs/verification/b1-gravity-model-load-ledger-evidence.md"
       ],
       "development": [
-        "docs/_archive/2026-08/workflow-professional-review.md",
         "docs/contributing/quickstart-checklist.md",
         "docs/contributing/development-guide.md",
         "docs/contributing/naming-conventions.md",
@@ -7294,7 +7355,6 @@
         "docs/contributing/agent-coding-standards.md",
         "docs/contributing/commit-message-conventions.md",
         "docs/contributing/learning-paths.md",
-        "docs/_archive/2026-08/git-workflow-testing.md",
         "docs/contributing/solo-maintainer-operating-system.md",
         "docs/contributing/github-workflow.md",
         "docs/contributing/index.md",
@@ -7311,7 +7371,6 @@
         "docs/contributing/changelog-deprecation-template.md"
       ],
       "workflow": [
-        "docs/_archive/2026-08/workflow-professional-review.md",
         "docs/contributing/quickstart-checklist.md",
         "docs/contributing/development-guide.md",
         "docs/contributing/naming-conventions.md",
@@ -7320,7 +7379,6 @@
         "docs/contributing/agent-coding-standards.md",
         "docs/contributing/commit-message-conventions.md",
         "docs/contributing/learning-paths.md",
-        "docs/_archive/2026-08/git-workflow-testing.md",
         "docs/contributing/solo-maintainer-operating-system.md",
         "docs/contributing/github-workflow.md",
         "docs/contributing/index.md",
@@ -7336,6 +7394,7 @@
         "docs/contributing/testing-strategy.md",
         "docs/contributing/changelog-deprecation-template.md",
         "docs/git-automation/git-workflow-single-source.md",
+        "docs/verification/b2-gravity-workflow-v1-evidence.md",
         "docs/verification/ui-experience-session-2-acceptance.md"
       ],
       "codex": [
@@ -7459,6 +7518,7 @@
       "roadmap": [
         "docs/planning/gpt-5-3-codex-spark-work-program.md",
         "docs/planning/next-session-brief.md",
+        "docs/planning/public-route-safety-closure-plan.md",
         "docs/planning/is456-solid-slabs-master-plan.md",
         "docs/planning/compact-modernization-plan.md",
         "docs/planning/ui-experience-foundation-master-plan.md",
@@ -7476,11 +7536,13 @@
         "docs/planning/pre-release-input-safety-and-professional-readiness-plan.md",
         "docs/planning/dependency-security-baseline.md",
         "docs/planning/india-2-remaining-is456-elements-plan.md",
+        "docs/planning/e1-excel-routine-workbench-v1-plan.md",
         "docs/planning/democratization-vision.md"
       ],
       "tasks": [
         "docs/planning/gpt-5-3-codex-spark-work-program.md",
         "docs/planning/next-session-brief.md",
+        "docs/planning/public-route-safety-closure-plan.md",
         "docs/planning/is456-solid-slabs-master-plan.md",
         "docs/planning/compact-modernization-plan.md",
         "docs/planning/ui-experience-foundation-master-plan.md",
@@ -7498,7 +7560,97 @@
         "docs/planning/pre-release-input-safety-and-professional-readiness-plan.md",
         "docs/planning/dependency-security-baseline.md",
         "docs/planning/india-2-remaining-is456-elements-plan.md",
+        "docs/planning/e1-excel-routine-workbench-v1-plan.md",
         "docs/planning/democratization-vision.md"
+      ],
+      "public-api": [
+        "docs/planning/public-route-safety-closure-plan.md",
+        "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md"
+      ],
+      "release-hold": [
+        "docs/planning/public-route-safety-closure-plan.md"
+      ],
+      "safety": [
+        "docs/planning/public-route-safety-closure-plan.md",
+        "docs/verification/lib-pro-003-b-domain-provenance-evidence.md",
+        "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md"
+      ],
+      "validation": [
+        "docs/planning/public-route-safety-closure-plan.md",
+        "docs/verification/indian-code-truth-baseline.md",
+        "docs/verification/india-2-final-closeout-evidence.md",
+        "docs/verification/examples.md",
+        "docs/verification/e1-blank-workbook-guard-evidence.md",
+        "docs/verification/india-2-foundation-pile-cap-g0-hold-evidence.md",
+        "docs/verification/india-1b-column-decision-evidence.md",
+        "docs/verification/lib-pro-002-e-evidence-identity.md",
+        "docs/verification/india-2-deep-b-reinforcement-evidence.md",
+        "docs/verification/india-2-flat-g0-scope-evidence.md",
+        "docs/verification/alpha-0231a2-local-prepublication-rehearsal.md",
+        "docs/verification/india-2-wall-g0-scope-evidence.md",
+        "docs/verification/india-2-foundation-raft-g0-hold-evidence.md",
+        "docs/verification/a2-lossless-intake-calculation-evidence.md",
+        "docs/verification/india-2-foundation-strap-family-acceptance-evidence.md",
+        "docs/verification/b2-gravity-workflow-v1-evidence.md",
+        "docs/verification/india-2-deep-c-public-workflow-evidence.md",
+        "docs/verification/india-2-deep-a-geometry-evidence.md",
+        "docs/verification/bundled-sample-boq-evidence.md",
+        "docs/verification/e1-windows-w0-setup-evidence.md",
+        "docs/verification/india-2-flat-b-moment-evidence.md",
+        "docs/verification/e1-excel-routine-workbench-v1-evidence.md",
+        "docs/verification/india-2-flat-d-punching-evidence.md",
+        "docs/verification/india-2-truth-hygiene-38-2-evidence.md",
+        "docs/verification/india-2-foundation-combined-c-public-workflow-evidence.md",
+        "docs/verification/lib-pro-003-b-domain-provenance-evidence.md",
+        "docs/verification/india-2-foundation-strap-b-strength-evidence.md",
+        "docs/verification/india-2-foundation-strap-a-analysis-evidence.md",
+        "docs/verification/india-2-flat-a-geometry-evidence.md",
+        "docs/verification/india-1a-beam-route-evidence.md",
+        "docs/verification/india-1-cumulative-gate-evidence.md",
+        "docs/verification/india-2-flat-e-publication-evidence.md",
+        "docs/verification/india-2-wall-c-public-workflow-evidence.md",
+        "docs/verification/india-2-foundation-combined-g0-scope-evidence.md",
+        "docs/verification/validation-pack.md",
+        "docs/verification/is456-slab-evidence.md",
+        "docs/verification/india-2-foundation-strap-g0-scope-evidence.md",
+        "docs/verification/ui-experience-session-2-acceptance.md",
+        "docs/verification/README.md",
+        "docs/verification/b1-gravity-model-load-ledger-evidence.md",
+        "docs/verification/e1-workbook-open-repair-evidence.md",
+        "docs/verification/india-2-cumulative-gate-evidence.md",
+        "docs/verification/india-2-wall-a-axial-kernel-evidence.md",
+        "docs/verification/a1-canonical-truth-transport-evidence.md",
+        "docs/verification/external-cli-test.md",
+        "docs/verification/india-2-foundation-combined-d-publication-evidence.md",
+        "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md",
+        "docs/verification/india-2-foundation-strap-d-publication-evidence.md",
+        "docs/verification/index.md",
+        "docs/verification/india-2-wall-d-publication-evidence.md",
+        "docs/verification/pack.md",
+        "docs/verification/india-2-foundation-strap-c-public-workflow-evidence.md",
+        "docs/verification/alpha-0231-local-prepublication-rehearsal.md",
+        "docs/verification/release-artifact-evidence-template.md",
+        "docs/verification/india-2-flat-family-acceptance-evidence.md",
+        "docs/verification/india-2b-staircase-actions-evidence.md",
+        "docs/verification/india-2-foundation-combined-a-analysis-evidence.md",
+        "docs/verification/column-pmm-benchmark.md",
+        "docs/verification/post-india2-cleanup-authorization-proposal.md",
+        "docs/verification/e1-review-bundle-export-evidence.md",
+        "docs/verification/india-2c-staircase-design-evidence.md",
+        "docs/verification/india-2-deep-family-acceptance-evidence.md",
+        "docs/verification/india-2-deep-d-publication-evidence.md",
+        "docs/verification/india-2d-staircase-publication-evidence.md",
+        "docs/verification/insights-verification-pack.md",
+        "docs/verification/india-1d-slab-boundary-evidence.md",
+        "docs/verification/india-2-foundation-combined-b-strength-evidence.md",
+        "docs/verification/india-2-deep-g0-scope-evidence.md",
+        "docs/verification/is456-library-first-evidence.md",
+        "docs/verification/india-2-foundation-combined-family-acceptance-evidence.md",
+        "docs/verification/india-2-flat-c-reinforcement-evidence.md",
+        "docs/verification/india-2a-staircase-scope-evidence.md",
+        "docs/verification/india-2-wall-b-reinforcement-evidence.md",
+        "docs/verification/india-2-wall-family-acceptance-evidence.md",
+        "docs/verification/india-1c-isolated-footing-workflow-evidence.md"
       ],
       "ai": [
         "docs/agents/README.md",
@@ -7526,6 +7678,7 @@
         "docs/verification/indian-code-truth-baseline.md",
         "docs/verification/india-2-final-closeout-evidence.md",
         "docs/verification/examples.md",
+        "docs/verification/e1-blank-workbook-guard-evidence.md",
         "docs/verification/india-2-foundation-pile-cap-g0-hold-evidence.md",
         "docs/verification/india-1b-column-decision-evidence.md",
         "docs/verification/lib-pro-002-e-evidence-identity.md",
@@ -7536,13 +7689,17 @@
         "docs/verification/india-2-foundation-raft-g0-hold-evidence.md",
         "docs/verification/a2-lossless-intake-calculation-evidence.md",
         "docs/verification/india-2-foundation-strap-family-acceptance-evidence.md",
+        "docs/verification/b2-gravity-workflow-v1-evidence.md",
         "docs/verification/india-2-deep-c-public-workflow-evidence.md",
         "docs/verification/india-2-deep-a-geometry-evidence.md",
         "docs/verification/bundled-sample-boq-evidence.md",
+        "docs/verification/e1-windows-w0-setup-evidence.md",
         "docs/verification/india-2-flat-b-moment-evidence.md",
+        "docs/verification/e1-excel-routine-workbench-v1-evidence.md",
         "docs/verification/india-2-flat-d-punching-evidence.md",
         "docs/verification/india-2-truth-hygiene-38-2-evidence.md",
         "docs/verification/india-2-foundation-combined-c-public-workflow-evidence.md",
+        "docs/verification/lib-pro-003-b-domain-provenance-evidence.md",
         "docs/verification/india-2-foundation-strap-b-strength-evidence.md",
         "docs/verification/india-2-foundation-strap-a-analysis-evidence.md",
         "docs/verification/india-2-flat-a-geometry-evidence.md",
@@ -7557,11 +7714,13 @@
         "docs/verification/ui-experience-session-2-acceptance.md",
         "docs/verification/README.md",
         "docs/verification/b1-gravity-model-load-ledger-evidence.md",
+        "docs/verification/e1-workbook-open-repair-evidence.md",
         "docs/verification/india-2-cumulative-gate-evidence.md",
         "docs/verification/india-2-wall-a-axial-kernel-evidence.md",
         "docs/verification/a1-canonical-truth-transport-evidence.md",
         "docs/verification/external-cli-test.md",
         "docs/verification/india-2-foundation-combined-d-publication-evidence.md",
+        "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md",
         "docs/verification/india-2-foundation-strap-d-publication-evidence.md",
         "docs/verification/index.md",
         "docs/verification/india-2-wall-d-publication-evidence.md",
@@ -7574,6 +7733,7 @@
         "docs/verification/india-2-foundation-combined-a-analysis-evidence.md",
         "docs/verification/column-pmm-benchmark.md",
         "docs/verification/post-india2-cleanup-authorization-proposal.md",
+        "docs/verification/e1-review-bundle-export-evidence.md",
         "docs/verification/india-2c-staircase-design-evidence.md",
         "docs/verification/india-2-deep-family-acceptance-evidence.md",
         "docs/verification/india-2-deep-d-publication-evidence.md",
@@ -7590,73 +7750,23 @@
         "docs/verification/india-2-wall-family-acceptance-evidence.md",
         "docs/verification/india-1c-isolated-footing-workflow-evidence.md"
       ],
-      "validation": [
-        "docs/verification/indian-code-truth-baseline.md",
-        "docs/verification/india-2-final-closeout-evidence.md",
-        "docs/verification/examples.md",
-        "docs/verification/india-2-foundation-pile-cap-g0-hold-evidence.md",
-        "docs/verification/india-1b-column-decision-evidence.md",
+      "evidence": [
         "docs/verification/lib-pro-002-e-evidence-identity.md",
-        "docs/verification/india-2-deep-b-reinforcement-evidence.md",
-        "docs/verification/india-2-flat-g0-scope-evidence.md",
-        "docs/verification/alpha-0231a2-local-prepublication-rehearsal.md",
-        "docs/verification/india-2-wall-g0-scope-evidence.md",
-        "docs/verification/india-2-foundation-raft-g0-hold-evidence.md",
         "docs/verification/a2-lossless-intake-calculation-evidence.md",
-        "docs/verification/india-2-foundation-strap-family-acceptance-evidence.md",
-        "docs/verification/india-2-deep-c-public-workflow-evidence.md",
-        "docs/verification/india-2-deep-a-geometry-evidence.md",
+        "docs/verification/b2-gravity-workflow-v1-evidence.md",
         "docs/verification/bundled-sample-boq-evidence.md",
-        "docs/verification/india-2-flat-b-moment-evidence.md",
-        "docs/verification/india-2-flat-d-punching-evidence.md",
-        "docs/verification/india-2-truth-hygiene-38-2-evidence.md",
-        "docs/verification/india-2-foundation-combined-c-public-workflow-evidence.md",
-        "docs/verification/india-2-foundation-strap-b-strength-evidence.md",
-        "docs/verification/india-2-foundation-strap-a-analysis-evidence.md",
-        "docs/verification/india-2-flat-a-geometry-evidence.md",
-        "docs/verification/india-1a-beam-route-evidence.md",
-        "docs/verification/india-1-cumulative-gate-evidence.md",
-        "docs/verification/india-2-flat-e-publication-evidence.md",
-        "docs/verification/india-2-wall-c-public-workflow-evidence.md",
-        "docs/verification/india-2-foundation-combined-g0-scope-evidence.md",
-        "docs/verification/validation-pack.md",
-        "docs/verification/is456-slab-evidence.md",
-        "docs/verification/india-2-foundation-strap-g0-scope-evidence.md",
-        "docs/verification/ui-experience-session-2-acceptance.md",
-        "docs/verification/README.md",
         "docs/verification/b1-gravity-model-load-ledger-evidence.md",
-        "docs/verification/india-2-cumulative-gate-evidence.md",
-        "docs/verification/india-2-wall-a-axial-kernel-evidence.md",
-        "docs/verification/a1-canonical-truth-transport-evidence.md",
-        "docs/verification/external-cli-test.md",
-        "docs/verification/india-2-foundation-combined-d-publication-evidence.md",
-        "docs/verification/india-2-foundation-strap-d-publication-evidence.md",
-        "docs/verification/index.md",
-        "docs/verification/india-2-wall-d-publication-evidence.md",
-        "docs/verification/pack.md",
-        "docs/verification/india-2-foundation-strap-c-public-workflow-evidence.md",
-        "docs/verification/alpha-0231-local-prepublication-rehearsal.md",
-        "docs/verification/release-artifact-evidence-template.md",
-        "docs/verification/india-2-flat-family-acceptance-evidence.md",
-        "docs/verification/india-2b-staircase-actions-evidence.md",
-        "docs/verification/india-2-foundation-combined-a-analysis-evidence.md",
-        "docs/verification/column-pmm-benchmark.md",
-        "docs/verification/post-india2-cleanup-authorization-proposal.md",
-        "docs/verification/india-2c-staircase-design-evidence.md",
-        "docs/verification/india-2-deep-family-acceptance-evidence.md",
-        "docs/verification/india-2-deep-d-publication-evidence.md",
-        "docs/verification/india-2d-staircase-publication-evidence.md",
-        "docs/verification/insights-verification-pack.md",
-        "docs/verification/india-1d-slab-boundary-evidence.md",
-        "docs/verification/india-2-foundation-combined-b-strength-evidence.md",
-        "docs/verification/india-2-deep-g0-scope-evidence.md",
-        "docs/verification/is456-library-first-evidence.md",
-        "docs/verification/india-2-foundation-combined-family-acceptance-evidence.md",
-        "docs/verification/india-2-flat-c-reinforcement-evidence.md",
-        "docs/verification/india-2a-staircase-scope-evidence.md",
-        "docs/verification/india-2-wall-b-reinforcement-evidence.md",
-        "docs/verification/india-2-wall-family-acceptance-evidence.md",
-        "docs/verification/india-1c-isolated-footing-workflow-evidence.md"
+        "docs/verification/a1-canonical-truth-transport-evidence.md"
+      ],
+      "identity": [
+        "docs/verification/lib-pro-002-e-evidence-identity.md",
+        "docs/reference/canonical-result-contract.md"
+      ],
+      "is456": [
+        "docs/verification/lib-pro-002-e-evidence-identity.md",
+        "docs/verification/india-1a-beam-route-evidence.md",
+        "docs/migration/01-adr-library-separation.md",
+        "docs/reference/fastapi-rest-api.md"
       ],
       "a2": [
         "docs/verification/a2-lossless-intake-calculation-evidence.md"
@@ -7664,12 +7774,6 @@
       "etabs": [
         "docs/verification/a2-lossless-intake-calculation-evidence.md",
         "docs/verification/bundled-sample-boq-evidence.md"
-      ],
-      "evidence": [
-        "docs/verification/a2-lossless-intake-calculation-evidence.md",
-        "docs/verification/bundled-sample-boq-evidence.md",
-        "docs/verification/b1-gravity-model-load-ledger-evidence.md",
-        "docs/verification/a1-canonical-truth-transport-evidence.md"
       ],
       "load-analysis": [
         "docs/verification/a2-lossless-intake-calculation-evidence.md"
@@ -7680,6 +7784,15 @@
       "smart-analysis": [
         "docs/verification/a2-lossless-intake-calculation-evidence.md"
       ],
+      "actions": [
+        "docs/verification/b2-gravity-workflow-v1-evidence.md"
+      ],
+      "calculation-book": [
+        "docs/verification/b2-gravity-workflow-v1-evidence.md"
+      ],
+      "component-api": [
+        "docs/verification/b2-gravity-workflow-v1-evidence.md"
+      ],
       "boq": [
         "docs/verification/bundled-sample-boq-evidence.md"
       ],
@@ -7689,18 +7802,20 @@
         "docs/verification/ui-experience-session-2-acceptance.md"
       ],
       "beam": [
+        "docs/verification/lib-pro-003-b-domain-provenance-evidence.md",
         "docs/verification/india-1a-beam-route-evidence.md"
+      ],
+      "column": [
+        "docs/verification/lib-pro-003-b-domain-provenance-evidence.md"
+      ],
+      "footing": [
+        "docs/verification/lib-pro-003-b-domain-provenance-evidence.md"
       ],
       "flanged": [
         "docs/verification/india-1a-beam-route-evidence.md"
       ],
       "india-1": [
         "docs/verification/india-1a-beam-route-evidence.md"
-      ],
-      "is456": [
-        "docs/verification/india-1a-beam-route-evidence.md",
-        "docs/migration/01-adr-library-separation.md",
-        "docs/reference/fastapi-rest-api.md"
       ],
       "fastapi": [
         "docs/verification/ui-experience-session-2-acceptance.md",
@@ -7760,6 +7875,9 @@
       "transport": [
         "docs/verification/a1-canonical-truth-transport-evidence.md",
         "docs/reference/canonical-result-contract.md"
+      ],
+      "regression": [
+        "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md"
       ],
       "structure": [
         "docs/architecture/unified-architecture-v1.md",
@@ -7908,9 +8026,6 @@
       ],
       "compatibility": [
         "docs/reference/api-stability.md"
-      ],
-      "identity": [
-        "docs/reference/canonical-result-contract.md"
       ],
       "status": [
         "docs/reference/canonical-result-contract.md"

--- a/docs/getting-started/agent-bootstrap.md
+++ b/docs/getting-started/agent-bootstrap.md
@@ -134,7 +134,9 @@ Core CANNOT import from Services or UI. Services CANNOT import from UI. Units al
 
 ### FastAPI Endpoints (`fastapi_app/routers/`)
 
-88 endpoints across 26 routers (59 REST + 1 WebSocket):
+89 OpenAPI HTTP operation endpoints across 26 router modules. The separate
+React-contract scanner currently matches 88 OpenAPI paths; that path metric is
+not the operation count. The WebSocket route is also outside OpenAPI:
 
 | Router | Endpoint | Purpose |
 |--------|----------|---------|
@@ -344,7 +346,7 @@ npm run dev
 # React is now at http://localhost:5173
 ```
 
-This builds and runs the FastAPI container with all Python dependencies + sample data (`Etabs_CSV/`). The `/docs` page auto-generates interactive Swagger UI for all 60 endpoints.
+This builds and runs the FastAPI container with all Python dependencies + sample data (`Etabs_CSV/`). The `/docs` page auto-generates interactive Swagger UI for all 89 current OpenAPI HTTP operations.
 
 For development with hot-reload (code changes reflect without rebuild):
 ```bash

--- a/docs/getting-started/index.json
+++ b/docs/getting-started/index.json
@@ -25,10 +25,10 @@
     {
       "name": "agent-bootstrap.md",
       "type": "documentation",
-      "size_lines": 753,
-      "last_updated": "2026-08-21",
+      "size_lines": 755,
+      "last_updated": "2026-08-22",
       "description": "> **This is THE canonical bootstrap for all AI agents.** Entry points (CLAUDE.md, .github/copilot-instructions.md) link here. | # | Critical Warning | Why it matters |",
-      "content_hash": "382b8bec2488"
+      "content_hash": "eda34736e0ad"
     },
     {
       "name": "agent-essentials.md",
@@ -114,9 +114,9 @@
       "name": "mac-mini-setup.md",
       "type": "documentation",
       "size_lines": 396,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-22",
       "description": "Complete instructions to clone and run the full stack on a fresh Mac Mini (Apple Silicon). This guide is designed so an AI agent or developer can follow it end-to-end without ambiguity.",
-      "content_hash": "8c4943b0ed59"
+      "content_hash": "66cc4e2fcac2"
     },
     {
       "name": "product-tour.md",
@@ -152,5 +152,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "a750d3aedabfe869"
+  "content_hash": "ea0e487bc2bd1f96"
 }

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -12,7 +12,7 @@ Quick onboarding guides for new users of the structural engineering library.
 |------|-------|-------------|-------|
 | [NEW-DEVELOPER-ONBOARDING.md](NEW-DEVELOPER-ONBOARDING.md) |  | This guide is for you if: - ✅ You're new to this project | 377 |
 | [README.md](README.md) | Getting Started | Quick onboarding guides for new users of the structural engi | 76 |
-| [agent-bootstrap.md](agent-bootstrap.md) |  | > **This is THE canonical bootstrap for all AI agents.** Ent | 753 |
+| [agent-bootstrap.md](agent-bootstrap.md) |  | > **This is THE canonical bootstrap for all AI agents.** Ent | 755 |
 | [agent-essentials.md](agent-essentials.md) |  | > **Merged.** This document's content has been consolidated  | 14 |
 | [ai-context-pack.md](ai-context-pack.md) |  | > **Merged.** This document's content has been consolidated  | 14 |
 | [beginners-guide.md](beginners-guide.md) |  | This guide is written for engineers and students who are new | 159 |

--- a/docs/getting-started/mac-mini-setup.md
+++ b/docs/getting-started/mac-mini-setup.md
@@ -274,7 +274,7 @@ structural_engineering_lib/
 │   ├── insights/               #   Design insights & analysis
 │   ├── visualization/          #   3D geometry generation
 │   └── reports/                #   Report templates
-├── fastapi_app/                # REST + WebSocket backend (60 endpoints)
+├── fastapi_app/                # REST backend (89 OpenAPI operations) + WebSocket
 │   └── routers/                #   13 routers (design, column, geometry, import, export...)
 ├── react_app/src/              # React 19 + TypeScript + R3F + Tailwind
 │   ├── components/             #   UI components by feature

--- a/docs/governance/maintenance-playbook.md
+++ b/docs/governance/maintenance-playbook.md
@@ -179,7 +179,7 @@ Enforced by `check_governance.py`:
 |------|-------|---------------|
 | Root folder files | ≤ 17 | `./run.sh check --quick` |
 | docs/ root files | ≤ 5 | `./run.sh check --quick` |
-| docs/ total files | < 400 | `.venv/bin/python scripts/check_docs.py --budget` |
+| docs/ total files | ≤ 500 | `.venv/bin/python scripts/check_docs.py --budget` |
 | WIP tasks | ≤ 2 | Review TASKS.md |
 | Draft docs age | ≤ 7 days | Archive or promote |
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4018,
+      "size_lines": 4127,
       "last_updated": "2026-08-22",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "0e04304abeae"
+      "content_hash": "dec7024fa54b"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 737,
+      "size_lines": 738,
       "last_updated": "2026-08-22",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "b0beb2e8e4ed"
+      "content_hash": "be2ad1f8797c"
     },
     {
       "name": "WORKLOG.md",
@@ -57,7 +57,7 @@
     {
       "name": "docs-index.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-22",
       "top_level_keys": [
         "version",
         "generated",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "2fe2985fdac0"
+      "content_hash": "c2b9207a18a6"
     }
   ],
   "subfolders": [
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 213,
+      "file_count": 216,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "e856922f3497aceb"
+  "content_hash": "c9d5b97c7de91d42"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4018 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 737 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4127 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 738 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 354 |
 
 ## Subfolders
@@ -48,4 +48,4 @@ Guides, references, evidence, and contributor material for the
 | [reference/](reference/) | 1793 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 8 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 213 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 216 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -34,8 +34,8 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
-| `public-route-safety-closure-plan.md` | 2026-08-22 | 🚧 LIB-PRO-003-C active after A-B merged; new release and professional/stable claims held through C-D |
-| `next-session-brief.md` | 2026-08-22 | 🚧 LIB-PRO-003-C failure contracts active; D and one cumulative gate follow |
+| `public-route-safety-closure-plan.md` | 2026-08-22 | ✅ LIB-PRO-003-D local candidate accepted; hosted/exact-tree closure pending; release and professional claims held by PARTIAL readiness |
+| `next-session-brief.md` | 2026-08-22 | 🚧 Publish/validate the immutable Packet D candidate, then resume read-only INDIA-3-G0 |
 | `pre-release-input-safety-and-professional-readiness-plan.md` | 2026-08-17 | 🚧 A-G merged; CLI, hosted-interpreter, preflight-verdict, and authorization holds remain through I-J |
 | `is456-solid-slabs-master-plan.md` | 2026-08-10 | 📋 Master plan ready; implementation has not started |
 | `ui-experience-foundation-master-plan.md` | 2026-08-10 | ✅ Two-session P0-P15 workbench/capability program accepted |

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -12,7 +12,7 @@
       "last_updated": "2026-08-22",
       "title": "Planning",
       "description": "Internal planning documents and research notes. | Document | Purpose |",
-      "content_hash": "101b542a6e4f"
+      "content_hash": "a76391854de0"
     },
     {
       "name": "compact-modernization-plan.md",
@@ -131,11 +131,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 81,
+      "size_lines": 82,
       "last_updated": "2026-08-22",
       "title": "Next Session Briefing",
       "description": "<!-- HANDOFF:START --> - Date: 2026-08-22",
-      "content_hash": "cef29437c349"
+      "content_hash": "72b49b372f62"
     },
     {
       "name": "pre-release-checklist.md",
@@ -167,10 +167,10 @@
     {
       "name": "public-route-safety-closure-plan.md",
       "type": "documentation",
-      "size_lines": 98,
+      "size_lines": 108,
       "last_updated": "2026-08-22",
       "description": "engineering-use approval until the bounded packets below close. The 2026-08-22 exact-tree replay confirmed that the bounded Gravity Workflow",
-      "content_hash": "7aa87d8149c5"
+      "content_hash": "c0c38d53a623"
     },
     {
       "name": "ui-experience-foundation-master-plan.md",
@@ -182,5 +182,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "263e398e3904f03d"
+  "content_hash": "daba22a754f6ebed"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -23,9 +23,9 @@
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 81 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 82 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Current source metadata: 0.23.1a2 Current public Alpha: v0.2 | 114 |
 | [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 742 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |
-| [public-route-safety-closure-plan.md](public-route-safety-closure-plan.md) |  | engineering-use approval until the bounded packets below clo | 98 |
+| [public-route-safety-closure-plan.md](public-route-safety-closure-plan.md) |  | engineering-use approval until the bounded packets below clo | 108 |
 | [ui-experience-foundation-master-plan.md](ui-experience-foundation-master-plan.md) |  | The product will move from a collection of equally weighted  | 2408 |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,17 +4,17 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-22
-- Focus: Close reproduced non-finite public calculation outcomes, empty
-- Git receipt: docs/verification/lib-pro-003-a-git-handoff-receipt.json | sha256:5f9f0b31deb4a96d04f826319cd8594a7f23e7a30d7e9820e9b80a7a43cbb57d | HOLD
-- Git identity: codex/public-route-numeric-boundaries@e40c0b564acae82f6696e204e8b382342fbf4321 | upstream=origin/main@e40c0b564acae82f6696e204e8b382342fbf4321 | base=origin/main@e40c0b564acae82f6696e204e8b382342fbf4321 | tree=dirty | operation=none
+- Focus: Make Excel-only CI, public-route safety evidence, readiness exits,
+- Git receipt: docs/verification/lib-pro-003-d-git-handoff-receipt.json | sha256:7f46984750c4f5ade6e5d5c1b16d7d4b27599496885dc9b588615e393e9264d0 | HOLD
+- Git identity: codex/public-route-decisive-gates@027554457c58303f435dc4a9940dc683def22895 | upstream=origin/main@027554457c58303f435dc4a9940dc683def22895 | base=origin/main@027554457c58303f435dc4a9940dc683def22895 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: COMMIT_INTENDED_PATHS
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `LIB-PRO-003-C` is active from exact hosted `main` at `e19b757c`: close slab-capacity, malformed CSV, and BOQ-rate failure contracts |
-| **Next** | Complete Packet D for decisive CI/audit/documentation truth, then run one cumulative broad acceptance sequence |
+| **Current** | `LIB-PRO-003-D` local candidate is accepted from exact Packet C merge `02755445`: 78 safety, 21 Excel, 6,653 Python, 479 FastAPI, 276 React, quick 10/10, and full 31/31 pass |
+| **Next** | Create the immutable candidate, pass hosted checks, verify exact candidate/merged tree equality, then resume read-only `INDIA-3-G0` |
 | **Why** | Direct replay reproduced 13 outcome-changing behaviours still exposed outside the newer bounded Gravity/E1 workflows |
 | **Held** | INDIA-3, new formulas/support claims, ETABS, package publication, stable/professional claims, and qualified approval remain separate and held |
 
@@ -42,18 +42,19 @@ authority. Results remain `NOT_REVIEWED` with
 
 ## Correct next library packet
 
-`LIB-PRO-003-C` is the active bounded implementation packet. Packets A-B were
-exact-tree merged through PRs #832-#833 at `e7698a63` and `e19b757c`.
+`LIB-PRO-003-D` is locally accepted and awaiting hosted/exact-tree closure.
+Packets A-C were
+exact-tree merged through PRs #832-#834 at `e7698a63`, `e19b757c`, and
+`02755445`.
 
-1. Return a typed `VALID/COMPLETED/FAIL` result when a supported one-way or
-   two-way slab demand exceeds capacity.
-2. Reject malformed or non-finite legacy CSV force cells instead of replacing
-   them with zero or dropping their rows.
-3. Reject non-positive concrete grades and non-finite/non-positive BOQ rates at
-   both the public Python and FastAPI boundaries.
+The implemented outcomes are: every `excel_addin/**` change reaches all add-in
+tests and the PR gate; frozen public-route regressions are required readiness
+evidence; `PARTIAL` is nonzero; release/API metrics are synchronized; and the
+owner-selected 500-file documentation cap is enforced. Readiness remains
+`PARTIAL` because two heuristic diagnostics are unresolved, so release and
+professional-use claims remain held.
 
-Packet D then closes decisive CI/audit/documentation truth before one
-cumulative broad acceptance run. Do not start
+Do not start
 new engineering formulas, IS 13920 expansion, IS 875, IS 1893, FEM, or ETABS.
 
 ## Other live work

--- a/docs/planning/public-route-safety-closure-plan.md
+++ b/docs/planning/public-route-safety-closure-plan.md
@@ -2,7 +2,7 @@
 owner: Main Agent
 status: active
 last_updated: 2026-08-22
-doc_type: plan
+doc_type: spec
 complexity: advanced
 tags: [safety, validation, public-api, release-hold]
 ---
@@ -70,8 +70,8 @@ a declared footing provenance origin.
 
 ### Packet C — Structured failure and intake truth
 
-**Status:** active on `codex/public-route-failure-contracts` from
-`e19b757c`; adversarial, focused, independent, and API-contract checks pass.
+**Status:** integrated through PR #834 at `02755445` with reviewed and merged
+trees equal.
 
 Return a structured slab capacity `FAIL`, make the legacy CSV route block
 malformed numeric cells without zero coercion or row loss, and reject negative
@@ -79,14 +79,24 @@ BOQ rates at the request boundary.
 
 ### Packet D — Decisive gates and repository truth
 
-Run the Excel add-in tests for `excel_addin/**` changes, make the input audit
-surface and exit result decisive, reconcile release and endpoint-count wording
-with clearly named metrics, and make the inherited documentation audit state
-truthful without weakening its gate.
+**Status:** local candidate accepted on `codex/public-route-decisive-gates`
+from exact hosted Packet C merge `02755445`; hosted and exact-tree merge
+closure remain.
+
+Run the Excel add-in tests for `excel_addin/**` changes, require the frozen
+public-route adversarial regressions in readiness evidence, return nonzero for
+both `PARTIAL` and `FAIL`, reconcile release and endpoint-count wording with
+clearly named metrics, and make documentation front-matter/budget part of the
+required audit. The owner-selected active Markdown hard cap is 500.
 
 After A-D pass focused, quick, broad, and hosted acceptance, the owner may
 resume `INDIA-3-G0`. A future package remains a separate versioned artifact and
 owner-authorized release operation.
+
+The local A-D regression set is green, but readiness remains `PARTIAL`/exit 2
+because two heuristic diagnostics remain unresolved. This preserves a package
+and professional-use `HOLD`; it does not block a later read-only INDIA-3 truth
+audit after Packet D merges.
 
 ## Non-goals
 

--- a/docs/reference/api-manifest.json
+++ b/docs/reference/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-17",
+  "generated": "2026-08-22",
   "module": "structural_lib.api",
   "python": "3.11.15",
   "count": 170,
@@ -77,7 +77,7 @@
     {
       "name": "CompleteOneWaySlabDesignResult",
       "kind": "class",
-      "signature": "(reinforcement: 'OneWaySlabDesignResult', shear: 'SlabShearResult', serviceability: 'SlabServiceabilityResult', punching_shear_disposition: 'str', complete_engineering_design_approved: 'bool' = False, load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
+      "signature": "(reinforcement: 'OneWaySlabDesignResult', shear: 'SlabShearResult | None', serviceability: 'SlabServiceabilityResult | None', punching_shear_disposition: 'str', complete_engineering_design_approved: 'bool' = False, load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
     },
     {
       "name": "ComplianceCaseResult",
@@ -242,7 +242,7 @@
     {
       "name": "OneWaySlabDesignResult",
       "kind": "class",
-      "signature": "(flexure: 'OneWaySlabFlexureResult', detailing: 'OneWaySlabDetailingResult', load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
+      "signature": "(flexure: 'OneWaySlabFlexureResult | SlabCapacityFailureResult', detailing: 'OneWaySlabDetailingResult | None', load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
     },
     {
       "name": "ParetoCandidate",
@@ -382,7 +382,7 @@
     {
       "name": "TwoWaySlabPanelWorkflowResult",
       "kind": "class",
-      "signature": "(panel: 'TwoWayPanelDesignResult', serviceability: 'SlabServiceabilityResult', complete_engineering_design_approved: 'bool' = False, load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
+      "signature": "(panel: 'TwoWayPanelDesignResult | SlabCapacityFailureResult', serviceability: 'SlabServiceabilityResult | None', complete_engineering_design_approved: 'bool' = False, load_envelope_status: 'str' = 'not_generated_single_caller_supplied_factored_udl_or_coefficient_basis') -> None"
     },
     {
       "name": "ValidationReport",
@@ -697,7 +697,7 @@
     {
       "name": "design_two_way_slab_is456",
       "kind": "function",
-      "signature": "(*, short_effective_span_mm: 'float', long_effective_span_mm: 'float', thickness_mm: 'float', alpha_x: 'float', alpha_y: 'float', coefficient_source_reference: 'str', coefficient_source_is_approved: 'bool', qualified_coefficient_acceptance_reference: 'str', qualified_coefficient_acceptance_acknowledged: 'bool', is_interior_solid_rectangular_panel: 'bool', all_four_edges_continuous: 'bool', factored_area_load_kn_per_m2: 'float', d_x_mm: 'float', d_y_mm: 'float', fck_n_per_mm2: 'float', fy_n_per_mm2: 'float', strip_width_mm: 'float' = 1000.0) -> 'TwoWaySlabFlexureResult'"
+      "signature": "(*, short_effective_span_mm: 'float', long_effective_span_mm: 'float', thickness_mm: 'float', alpha_x: 'float', alpha_y: 'float', coefficient_source_reference: 'str', coefficient_source_is_approved: 'bool', qualified_coefficient_acceptance_reference: 'str', qualified_coefficient_acceptance_acknowledged: 'bool', is_interior_solid_rectangular_panel: 'bool', all_four_edges_continuous: 'bool', factored_area_load_kn_per_m2: 'float', d_x_mm: 'float', d_y_mm: 'float', fck_n_per_mm2: 'float', fy_n_per_mm2: 'float', strip_width_mm: 'float' = 1000.0) -> 'TwoWaySlabFlexureResult | SlabCapacityFailureResult'"
     },
     {
       "name": "design_two_way_slab_panel_builtin_is456",

--- a/docs/reference/index.json
+++ b/docs/reference/index.json
@@ -67,7 +67,7 @@
     {
       "name": "api-manifest.json",
       "type": "config",
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-22",
       "top_level_keys": [
         "generated",
         "module",
@@ -75,7 +75,7 @@
         "count",
         "symbols"
       ],
-      "content_hash": "13b0d9723820"
+      "content_hash": "a40c65a57135"
     },
     {
       "name": "api-stability.md",
@@ -279,5 +279,5 @@
       "file_count": 1760
     }
   ],
-  "content_hash": "abcdf9bf13e28992"
+  "content_hash": "3212e9b0731538fc"
 }

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -3,7 +3,7 @@
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
   "last_updated": "2026-08-22",
-  "file_count": 211,
+  "file_count": 214,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -2302,7 +2302,7 @@
       "size_lines": 68,
       "last_updated": "2026-08-22",
       "description": "- Source base: hosted main at e40c0b564acae82f6696e204e8b382342fbf4321.",
-      "content_hash": "770c3d6c52a5"
+      "content_hash": "0956f04c3422"
     },
     {
       "name": "lib-pro-003-b-domain-provenance-evidence.md",
@@ -2310,7 +2310,7 @@
       "size_lines": 69,
       "last_updated": "2026-08-22",
       "description": "- Source base: hosted main at e7698a63b86d2db6db2f3970871122af1ce562f6, the exact-tree merge of",
-      "content_hash": "cc28148ec13f"
+      "content_hash": "17d32e186747"
     },
     {
       "name": "lib-pro-003-b-git-handoff-receipt.json",
@@ -2386,6 +2386,54 @@
         "task_archive"
       ],
       "content_hash": "1c53deea3c97"
+    },
+    {
+      "name": "lib-pro-003-d-decisive-gates-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "schema_version",
+        "packet",
+        "generated_at_utc",
+        "branch",
+        "base_commit",
+        "software_disposition",
+        "readiness_verdict",
+        "release_disposition",
+        "professional_use_disposition",
+        "changes"
+      ],
+      "content_hash": "216de29f6b12"
+    },
+    {
+      "name": "lib-pro-003-d-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "d85f03f075fc"
+    },
+    {
+      "name": "lib-pro-003-d-git-handoff-source-evidence.json",
+      "type": "config",
+      "last_updated": "2026-08-22",
+      "top_level_keys": [
+        "authorization",
+        "integration",
+        "retention",
+        "task_archive"
+      ],
+      "content_hash": "06d1e6f4e0e6"
     },
     {
       "name": "next-session-git-issues-plan-git-handoff-receipt.json",
@@ -2706,5 +2754,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "93ad80366ea2d8c1"
+  "content_hash": "0c9e2949a3f9eb92"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -4,7 +4,7 @@ Benchmark examples and verification packs for validating library calculations ag
 
 **Type:** Documentation
 **Last Updated:** 2026-08-22
-**Files:** 211
+**Files:** 214
 
 ## Config Files
 
@@ -129,6 +129,9 @@ Benchmark examples and verification packs for validating library calculations ag
 - [lib-pro-003-c-failure-contracts-evidence.json](lib-pro-003-c-failure-contracts-evidence.json)
 - [lib-pro-003-c-git-handoff-receipt.json](lib-pro-003-c-git-handoff-receipt.json)
 - [lib-pro-003-c-git-handoff-source-evidence.json](lib-pro-003-c-git-handoff-source-evidence.json)
+- [lib-pro-003-d-decisive-gates-evidence.json](lib-pro-003-d-decisive-gates-evidence.json)
+- [lib-pro-003-d-git-handoff-receipt.json](lib-pro-003-d-git-handoff-receipt.json)
+- [lib-pro-003-d-git-handoff-source-evidence.json](lib-pro-003-d-git-handoff-source-evidence.json)
 - [next-session-git-issues-plan-git-handoff-receipt.json](next-session-git-issues-plan-git-handoff-receipt.json)
 - [next-session-git-issues-plan-git-handoff-source-evidence.json](next-session-git-issues-plan-git-handoff-source-evidence.json)
 - [post-india2-cleanup-disposition-evidence.json](post-india2-cleanup-disposition-evidence.json)

--- a/docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md
+++ b/docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md
@@ -2,7 +2,7 @@
 owner: Main Agent
 status: active
 last_updated: 2026-08-22
-doc_type: verification
+doc_type: reference
 complexity: advanced
 tags: [safety, validation, public-api, regression]
 ---

--- a/docs/verification/lib-pro-003-b-domain-provenance-evidence.md
+++ b/docs/verification/lib-pro-003-b-domain-provenance-evidence.md
@@ -2,7 +2,7 @@
 owner: Main Agent
 status: active
 last_updated: 2026-08-22
-doc_type: verification
+doc_type: reference
 complexity: advanced
 tags: [safety, validation, beam, column, footing, provenance]
 ---

--- a/docs/verification/lib-pro-003-d-decisive-gates-evidence.json
+++ b/docs/verification/lib-pro-003-d-decisive-gates-evidence.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "lib-pro-003-d-decisive-gates/v1",
+  "packet": "LIB-PRO-003-D",
+  "generated_at_utc": "2026-08-22T11:23:32Z",
+  "branch": "codex/public-route-decisive-gates",
+  "base_commit": "027554457c58303f435dc4a9940dc683def22895",
+  "software_disposition": "PASS_LOCAL",
+  "readiness_verdict": "PARTIAL",
+  "release_disposition": "HOLD",
+  "professional_use_disposition": "HOLD",
+  "changes": {
+    "excel_ci": "excel_addin/** routes to all 21 add-in tests and the required PR gate",
+    "public_route_gate": "16 Python target groups and 4 FastAPI target groups are required audit evidence",
+    "audit_exit_contract": {
+      "PASS": 0,
+      "FAIL": 1,
+      "PARTIAL": 2
+    },
+    "documentation_hard_cap": 500,
+    "release_truth": "v0.23.1a2 is public; later main work requires a new version",
+    "api_metrics": {
+      "openapi_http_operations": 89,
+      "react_contract_openapi_paths": 88,
+      "openapi_schemas": 435,
+      "websocket_in_openapi": false
+    }
+  },
+  "validation": {
+    "public_route_safety": {
+      "status": "PASS",
+      "python_cases": 73,
+      "fastapi_cases": 5
+    },
+    "excel_addin": {
+      "status": "PASS",
+      "tests": 21
+    },
+    "python_broad": {
+      "status": "PASS",
+      "passed": 6653,
+      "skipped": 3,
+      "deselected": 6
+    },
+    "fastapi_full": {
+      "status": "PASS",
+      "passed": 479
+    },
+    "react_full": {
+      "status": "PASS",
+      "test_files": 51,
+      "passed": 276
+    },
+    "quick_gate": {
+      "status": "PASS",
+      "passed": 10,
+      "total": 10
+    },
+    "repository_gate": {
+      "status": "PASS",
+      "passed": 31,
+      "total": 31
+    },
+    "documentation_contract": {
+      "status": "PASS",
+      "non_archived_markdown": 401,
+      "hard_cap": 500,
+      "invalid_frontmatter": 0,
+      "broken_internal_links": 0
+    },
+    "readiness_audit": {
+      "status": "PARTIAL",
+      "exit_code": 2,
+      "passed": 21,
+      "warnings": 2,
+      "failed": 0,
+      "total": 23,
+      "warnings_detail": [
+        "Function Quality Diagnostic: 26/88 pass and 62 fail",
+        "Input Validation Diagnostic: F (0.0% heuristic average coverage)"
+      ]
+    }
+  },
+  "holds": [
+    "No version bump, tag, package upload, or GitHub Release is authorized.",
+    "No stable, professional-use, project-fitness, or qualified-engineer approval claim is authorized.",
+    "The two readiness diagnostics require a separate bounded truth triage before any future release decision.",
+    "Hosted PR validation and exact candidate/merged tree equality remain required before Packet D merge closure."
+  ]
+}

--- a/docs/verification/lib-pro-003-d-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-003-d-git-handoff-receipt.json
@@ -1,0 +1,241 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-22T11:27:24Z",
+      "query_status": "OK",
+      "reference": "task:LIB-PRO-003:user-request-continue-this-work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-22T11:27:24Z",
+    "prohibited_actions": [
+      "PUBLISH_RELEASE",
+      "CLAIM_PROFESSIONAL_APPROVAL",
+      "START_INDIA_3",
+      "START_ETABS_OR_DESKTOP_EXCEL",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR"
+      ],
+      "branch": "codex/public-route-decisive-gates",
+      "head_sha": "027554457c58303f435dc4a9940dc683def22895",
+      "task_id": "LIB-PRO-003-D"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "7f46984750c4f5ade6e5d5c1b16d7d4b27599496885dc9b588615e393e9264d0",
+    "state": {
+      "branch": "codex/public-route-decisive-gates",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "027554457c58303f435dc4a9940dc683def22895",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 108.132,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-public-route-decisive-gates",
+      "head_sha": "027554457c58303f435dc4a9940dc683def22895",
+      "hold_reasons": [
+        "changed paths: 47"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-22T11:29:33.086210+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-decisive-gates",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 47,
+        "modified_paths": [
+          ".github/agents/api-developer.agent.md",
+          ".github/instructions/fastapi.instructions.md",
+          ".github/workflows/fast-checks.yml",
+          "AGENTS.md",
+          "CITATION.cff",
+          "CLAUDE.md",
+          "Python/tests/index.json",
+          "Python/tests/index.md",
+          "Python/tests/integration/test_capability_semantics.py",
+          "Python/tests/integration/test_tables_and_materials_additional.py",
+          "Python/tests/property/strategies.py",
+          "Python/tests/test_audit_readiness_truth.py",
+          "Python/tests/test_ci_workflow_contract.py",
+          "README.md",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/docs-index.json",
+          "docs/getting-started/agent-bootstrap.md",
+          "docs/getting-started/index.json",
+          "docs/getting-started/index.md",
+          "docs/getting-started/mac-mini-setup.md",
+          "docs/governance/maintenance-playbook.md",
+          "docs/index.json",
+          "docs/index.md",
+          "docs/planning/README.md",
+          "docs/planning/index.json",
+          "docs/planning/index.md",
+          "docs/planning/next-session-brief.md",
+          "docs/planning/public-route-safety-closure-plan.md",
+          "docs/reference/api-manifest.json",
+          "docs/reference/index.json",
+          "docs/verification/index.json",
+          "docs/verification/index.md",
+          "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md",
+          "docs/verification/lib-pro-003-b-domain-provenance-evidence.md",
+          "run.sh",
+          "scripts/audit_input_validation.py",
+          "scripts/audit_readiness_report.py",
+          "scripts/automation-map.json",
+          "scripts/check_docs.py",
+          "scripts/index.json",
+          "scripts/index.md",
+          "scripts/release.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/lib-pro-003-d-decisive-gates-evidence.json",
+          "docs/verification/lib-pro-003-d-git-handoff-receipt.json",
+          "docs/verification/lib-pro-003-d-git-handoff-source-evidence.json",
+          "scripts/check_public_route_safety.py"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "027554457c58303f435dc4a9940dc683def22895",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-decisive-gates"
+    }
+  },
+  "local_state_receipt_hash": "sha256:7f46984750c4f5ade6e5d5c1b16d7d4b27599496885dc9b588615e393e9264d0",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-22T11:29:33.086382+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-22T11:27:24Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/**",
+      "fastapi_app/**",
+      "react_app/**",
+      "excel_addin/**",
+      ".github/workflows/release.yml"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      ".github/agents/api-developer.agent.md",
+      ".github/instructions/fastapi.instructions.md",
+      ".github/workflows/fast-checks.yml",
+      "AGENTS.md",
+      "CITATION.cff",
+      "CLAUDE.md",
+      "Python/tests/integration/test_capability_semantics.py",
+      "Python/tests/integration/test_tables_and_materials_additional.py",
+      "Python/tests/property/strategies.py",
+      "Python/tests/test_audit_readiness_truth.py",
+      "Python/tests/test_ci_workflow_contract.py",
+      "README.md",
+      "docs/getting-started/agent-bootstrap.md",
+      "docs/getting-started/mac-mini-setup.md",
+      "docs/governance/maintenance-playbook.md",
+      "docs/verification/lib-pro-003-a-numeric-boundaries-evidence.md",
+      "docs/verification/lib-pro-003-b-domain-provenance-evidence.md",
+      "docs/verification/lib-pro-003-d-decisive-gates-evidence.json",
+      "docs/verification/lib-pro-003-d-git-handoff-source-evidence.json",
+      "docs/verification/lib-pro-003-d-git-handoff-receipt.json",
+      "run.sh",
+      "scripts/audit_input_validation.py",
+      "scripts/audit_readiness_report.py",
+      "scripts/automation-map.json",
+      "scripts/check_docs.py",
+      "scripts/check_public_route_safety.py",
+      "scripts/release.py"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/README.md",
+      "docs/planning/next-session-brief.md",
+      "docs/planning/public-route-safety-closure-plan.md",
+      "docs/reference/api-manifest.json",
+      "scripts/index.json",
+      "scripts/index.md",
+      "docs/index.json",
+      "docs/index.md",
+      "docs/docs-index.json",
+      "docs/getting-started/index.json",
+      "docs/getting-started/index.md",
+      "docs/planning/index.json",
+      "docs/planning/index.md",
+      "docs/reference/index.json",
+      "docs/reference/index.md",
+      "docs/verification/index.json",
+      "docs/verification/index.md",
+      "Python/tests/index.json",
+      "Python/tests/index.md"
+    ],
+    "task_id": "LIB-PRO-003-D"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-003-d-git-handoff-source-evidence.json
+++ b/docs/verification/lib-pro-003-d-git-handoff-source-evidence.json
@@ -1,0 +1,55 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-22T11:27:24Z",
+      "query_status": "OK",
+      "reference": "task:LIB-PRO-003:user-request-continue-this-work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-22T11:27:24Z",
+    "prohibited_actions": [
+      "PUBLISH_RELEASE",
+      "CLAIM_PROFESSIONAL_APPROVAL",
+      "START_INDIA_3",
+      "START_ETABS_OR_DESKTOP_EXCEL",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE",
+      "DELETE_REF"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR"
+      ],
+      "branch": "codex/public-route-decisive-gates",
+      "head_sha": "027554457c58303f435dc4a9940dc683def22895",
+      "task_id": "LIB-PRO-003-D"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-22T11:27:24Z",
+    "owner": "Main Agent under repository retention policy; destructive cleanup remains separately owner-authorized",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -298,7 +298,7 @@ Usage: ./run.sh audit [options]
 Run readiness and governance audits.
 
 Options:
-  (no args)          Full readiness audit (25 checks)
+  (no args)          Full readiness audit (current evidence set)
   --score            Governance health score (weighted)
   --errors           Error handling coverage audit
   --inputs           Input validation coverage audit

--- a/scripts/audit_input_validation.py
+++ b/scripts/audit_input_validation.py
@@ -340,6 +340,17 @@ def print_report(report: dict, verbose: bool = False) -> None:
     print()
 
 
+def diagnostic_exit_code(report: dict) -> int:
+    """Return zero only when the heuristic has no high-risk or coverage debt."""
+
+    summary = report["summary"]
+    return (
+        1
+        if summary["high_risk_count"] > 0 or summary["average_coverage_percent"] < 90.0
+        else 0
+    )
+
+
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -382,10 +393,11 @@ def main():
     else:
         print_report(report, verbose=args.verbose)
 
-    # Exit code based on high-risk count
-    if report["summary"]["high_risk_count"] > 10:
-        return 1  # Too many high-risk functions
-    return 0
+    # This is a heuristic inventory, not proof of runtime safety. Any public
+    # parameterized function classified as high risk, or aggregate coverage
+    # below the audit's A threshold, keeps the diagnostic non-green until it is
+    # reviewed or the scanner is refined.
+    return diagnostic_exit_code(report)
 
 
 if __name__ == "__main__":

--- a/scripts/audit_readiness_report.py
+++ b/scripts/audit_readiness_report.py
@@ -94,10 +94,16 @@ class AuditReport:
 
         if required_failed > 0:
             self.verdict = "FAIL"
-        elif self.warnings > 0:
+        elif self.failed > 0 or self.warnings > 0:
             self.verdict = "PARTIAL"
         else:
             self.verdict = "PASS"
+
+
+def verdict_exit_code(verdict: str) -> int:
+    """Map report truth to a decisive process exit code."""
+
+    return {"PASS": 0, "FAIL": 1, "PARTIAL": 2}.get(verdict, 1)
 
 
 def run_script(script_path: str, args: List[str] = None) -> Tuple[int, str, str]:
@@ -358,6 +364,25 @@ def collect_contract_truth_evidence(report: AuditReport) -> None:
             )
         )
 
+    public_route_safety = Path("scripts/check_public_route_safety.py")
+    if (_REPO_ROOT / public_route_safety).exists():
+        code, stdout, stderr = run_script(str(public_route_safety))
+        passed = code == 0
+        report.add_evidence(
+            EvidenceItem(
+                category="ContractTruth",
+                name="Public Route Safety Regressions",
+                status="PASS" if passed else "FAIL",
+                required=True,
+                source=str(public_route_safety),
+                details=(
+                    "Frozen adversarial Python and FastAPI routes fail closed."
+                    if passed
+                    else _diagnostic_summary(stdout, stderr)
+                ),
+            )
+        )
+
     function_quality = Path("scripts/check_function_quality.py")
     if (_REPO_ROOT / function_quality).exists():
         code, stdout, stderr = run_script(
@@ -429,22 +454,24 @@ def collect_governance_evidence(report: AuditReport) -> None:
             )
         )
 
-    # Check doc metadata (consolidated into check_docs.py)
+    # Check active front-matter values and the enforced documentation budget.
     doc_checker = Path("scripts/check_docs.py")
     if doc_checker.exists():
-        code, stdout, stderr = run_script(str(doc_checker), ["--metadata"])
+        code, stdout, stderr = run_script(
+            str(doc_checker), ["--frontmatter", "--budget"]
+        )
         passed = code == 0
         report.add_evidence(
             EvidenceItem(
                 category="Governance",
-                name="Document Metadata",
-                status="PASS" if passed else "WARN",
+                name="Documentation Contract",
+                status="PASS" if passed else "FAIL",
                 required=True,
                 source=str(doc_checker),
                 details=(
-                    "All docs have required metadata"
+                    "Front-matter values and active-file budget are valid"
                     if passed
-                    else "Some docs missing metadata"
+                    else _diagnostic_summary(stdout, stderr)
                 ),
             )
         )
@@ -789,7 +816,7 @@ Examples:
     parser.add_argument(
         "--check-only",
         action="store_true",
-        help="Exit 0 if pass, 1 if fail (no output)",
+        help="Exit 0 only for PASS, 1 for FAIL, or 2 for PARTIAL (no output)",
     )
     parser.add_argument(
         "--json",
@@ -832,7 +859,7 @@ Examples:
 
     # Output
     if args.check_only:
-        return 0 if report.verdict != "FAIL" else 1
+        return verdict_exit_code(report.verdict)
 
     if args.json or args.export == "json":
         output = format_json(report)
@@ -847,7 +874,7 @@ Examples:
     else:
         print(output)
 
-    return 0 if report.verdict != "FAIL" else 1
+    return verdict_exit_code(report.verdict)
 
 
 if __name__ == "__main__":

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -2,7 +2,7 @@
   "_comment": "Task-to-script mapping - helps agents find the right automation for their task",
   "_updated": "2026-08-17",
   "_usage": "Run: ./scripts/python_runtime.sh scripts/find_automation.py \"task description\" — or --list for all",
-  "_coverage": "112/112 scripts mapped",
+  "_coverage": "113/113 scripts mapped",
   "tasks": {
     "resolve python runtime": {
       "group": "Infrastructure",
@@ -183,6 +183,12 @@
       "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/audit_input_validation.py",
       "description": "Audit input validation coverage for structural_lib"
+    },
+    "check public route safety": {
+      "group": "Quality",
+      "script": "./scripts/python_runtime.sh scripts/check_public_route_safety.py",
+      "description": "Run the frozen adversarial Python and FastAPI public-route safety regressions",
+      "permission": "ReadOnly"
     },
     "start session": {
       "group": "Session",

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -517,13 +517,13 @@ def check_index_links() -> int:
 # ═══════════════════════════════════════════════════════════════════════════
 
 DOC_BUDGET_WARN = 350
-DOC_BUDGET_FAIL = 400
+DOC_BUDGET_FAIL = 500
 
 
 def check_doc_budget() -> int:
     """Check that non-archived markdown files stay within budget.
 
-    Warns if count > 350, fails if > 400.
+    Warns if count > 350, fails if > 500.
     Returns exit code: 0 pass, 1 fail.
     """
     if not DOCS_DIR.exists():

--- a/scripts/check_public_route_safety.py
+++ b/scripts/check_public_route_safety.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Run the frozen adversarial regressions for maintained public safety routes."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PYTHON_TARGETS = (
+    "Python/tests/unit/test_input_validation.py::test_flexure_design_singly_reinforced_rejects_non_finite_inputs",
+    "Python/tests/unit/test_input_validation.py::test_shear_design_rejects_non_finite_inputs",
+    "Python/tests/unit/test_compliance_validation.py::test_public_compliance_report_rejects_empty_cases",
+    "Python/tests/unit/test_compliance_validation.py::test_compliance_case_rejects_non_finite_actions_before_calculation",
+    "Python/tests/unit/test_compliance_validation.py::test_compliance_case_rejects_nonpositive_supplied_shear_steel",
+    "Python/tests/test_is456_common.py::TestBeamFiniteNumericBoundary::test_design_rejects_unsupported_material_and_shear_domains",
+    "Python/tests/codes/is456/column/test_uniaxial.py::TestUniaxialErrors::test_unrounded_utilization_controls_safety_at_display_boundary",
+    "Python/tests/test_column_return_types.py::test_unified_column_rejects_infinite_moment_before_minimum_amplification",
+    "Python/tests/test_column_return_types.py::test_unified_column_uses_current_uniaxial_safety_key",
+    "Python/tests/test_column_return_types.py::test_unified_column_rejects_out_of_domain_reinforcement",
+    "Python/tests/test_footing_api.py::test_unknown_provenance_origins_are_rejected",
+    "Python/tests/codes/is456/slab/test_extended_workflows.py::test_complete_one_way_capacity_miss_returns_structured_fail",
+    "Python/tests/codes/is456/slab/test_extended_workflows.py::test_complete_two_way_capacity_miss_returns_structured_fail",
+    "Python/tests/unit/test_generic_csv_adapter.py::TestGenericCSVAdapterLoadForces::test_rejects_malformed_force_instead_of_coercing_zero",
+    "Python/tests/test_boq.py::TestAggregateProjectBOQ::test_rejects_invalid_cost_domains",
+    "Python/tests/test_evidence.py::test_unbounded_derived_utilization_is_a_structured_supported_failure",
+)
+
+FASTAPI_TARGETS = (
+    "fastapi_app/tests/test_insights_dashboard.py::TestProjectBOQ::test_project_boq_rejects_negative_rates",
+    "fastapi_app/tests/test_insights_dashboard.py::TestProjectBOQ::test_project_boq_rejects_non_positive_concrete_grade",
+    "fastapi_app/tests/test_library_core.py::test_one_way_slab_capacity_miss_serializes_engineering_fail",
+    "fastapi_app/tests/test_library_core.py::test_two_way_slab_capacity_miss_serializes_engineering_fail",
+)
+
+
+def _run_group(name: str, targets: tuple[str, ...], config: str | None = None) -> int:
+    command = [sys.executable, "-m", "pytest"]
+    if config is not None:
+        command.extend(("-c", config))
+    command.extend((*targets, "-q", "--tb=short"))
+
+    try:
+        result = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"ERROR: {name} timed out after 120 seconds", file=sys.stderr)
+        return 1
+
+    if result.stdout.strip():
+        print(result.stdout.rstrip())
+    if result.stderr.strip():
+        print(result.stderr.rstrip(), file=sys.stderr)
+    if result.returncode != 0:
+        print(f"ERROR: {name} failed with exit {result.returncode}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    """Return zero only when every frozen Python and FastAPI regression passes."""
+
+    groups = (
+        ("Python public-route safety regressions", PYTHON_TARGETS, None),
+        (
+            "FastAPI public-route safety regressions",
+            FASTAPI_TARGETS,
+            "fastapi_app/pytest.ini",
+        ),
+    )
+    for name, targets, config in groups:
+        if _run_group(name, targets, config) != 0:
+            return 1
+
+    print(
+        "Public-route safety gate passed "
+        f"({len(PYTHON_TARGETS)} Python targets, "
+        f"{len(FASTAPI_TARGETS)} FastAPI targets)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -3,7 +3,7 @@
   "type": "python-package",
   "description": "> Development, validation, discovery, release-preparation, and maintenance tools.",
   "last_updated": "2026-08-22",
-  "file_count": 115,
+  "file_count": 116,
   "files": [
     {
       "name": "README.md",
@@ -701,8 +701,8 @@
     {
       "name": "audit_input_validation.py",
       "type": "python",
-      "size_lines": 393,
-      "last_updated": "2026-08-17",
+      "size_lines": 405,
+      "last_updated": "2026-08-22",
       "description": "Audit Input Validation Coverage for structural_lib.",
       "classes": [
         {
@@ -755,11 +755,18 @@
           ]
         },
         {
+          "name": "diagnostic_exit_code",
+          "description": "Return zero only when the heuristic has no high-risk or coverage debt.",
+          "params": [
+            "report"
+          ]
+        },
+        {
           "name": "main",
           "description": "Main entry point."
         }
       ],
-      "content_hash": "789de215d60d"
+      "content_hash": "bb7b3e537d5f"
     },
     {
       "name": "audit_permissions.py",
@@ -808,8 +815,8 @@
     {
       "name": "audit_readiness_report.py",
       "type": "python",
-      "size_lines": 855,
-      "last_updated": "2026-08-17",
+      "size_lines": 882,
+      "last_updated": "2026-08-22",
       "description": "Audit Readiness Report Generator",
       "classes": [
         {
@@ -826,6 +833,13 @@
         }
       ],
       "functions": [
+        {
+          "name": "verdict_exit_code",
+          "description": "Map report truth to a decisive process exit code.",
+          "params": [
+            "verdict"
+          ]
+        },
         {
           "name": "run_script",
           "description": "Run a Python script and capture output.",
@@ -909,12 +923,12 @@
       "constants": [
         "_REPO_ROOT"
       ],
-      "content_hash": "e925aec86e17"
+      "content_hash": "ac5688567634"
     },
     {
       "name": "automation-map.json",
       "type": "config",
-      "last_updated": "2026-08-18",
+      "last_updated": "2026-08-22",
       "top_level_keys": [
         "_comment",
         "_updated",
@@ -922,7 +936,7 @@
         "_coverage",
         "tasks"
       ],
-      "content_hash": "ba9371486507"
+      "content_hash": "1bbc9d35df2d"
     },
     {
       "name": "batch_migrate_runner.py",
@@ -1571,7 +1585,7 @@
       "name": "check_docs.py",
       "type": "python",
       "size_lines": 675,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-22",
       "description": "Unified documentation checker — consolidates 4 doc validation scripts.",
       "functions": [
         {
@@ -1620,7 +1634,7 @@
         "META_REQUIRED_FIELDS",
         "META_VALID_VALUES"
       ],
-      "content_hash": "0e9f4fd9c930"
+      "content_hash": "6f66b7ee9f0d"
     },
     {
       "name": "check_fastapi_issues.py",
@@ -2170,6 +2184,25 @@
         "BASELINE_PATH"
       ],
       "content_hash": "ad352625ff27"
+    },
+    {
+      "name": "check_public_route_safety.py",
+      "type": "python",
+      "size_lines": 93,
+      "last_updated": "2026-08-22",
+      "description": "Run the frozen adversarial regressions for maintained public safety routes.",
+      "functions": [
+        {
+          "name": "main",
+          "description": "Return zero only when every frozen Python and FastAPI regression passes."
+        }
+      ],
+      "constants": [
+        "REPO_ROOT",
+        "PYTHON_TARGETS",
+        "FASTAPI_TARGETS"
+      ],
+      "content_hash": "b0e5feb57bea"
     },
     {
       "name": "check_python_version.py",
@@ -4241,8 +4274,8 @@
     {
       "name": "release.py",
       "type": "python",
-      "size_lines": 2252,
-      "last_updated": "2026-08-17",
+      "size_lines": 2276,
+      "last_updated": "2026-08-22",
       "description": "Unified release management CLI.",
       "functions": [
         {
@@ -4323,7 +4356,7 @@
         "PYPROJECT",
         "FASTAPI_INIT"
       ],
-      "content_hash": "cabad3db6d34"
+      "content_hash": "bafebb000103"
     },
     {
       "name": "repo_health_check.sh",
@@ -5613,5 +5646,5 @@
       "is_package": true
     }
   ],
-  "content_hash": "c0791c07d2b55c97"
+  "content_hash": "b0f2d0224bfcac44"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -4,7 +4,7 @@
 
 **Type:** Python Package
 **Last Updated:** 2026-08-22
-**Files:** 115
+**Files:** 116
 
 ## Config Files
 
@@ -29,9 +29,9 @@
 | [agent_session_collector.py](agent_session_collector.py) | Agent session collector — gather all session artifacts for s | 0 | 9 | 320 |
 | [agent_trends.py](agent_trends.py) | Agent trends — time series analysis and degradation detectio | 0 | 7 | 383 |
 | [audit_error_handling.py](audit_error_handling.py) | Audit error handling compliance across structural_lib module | 2 | 3 | 286 |
-| [audit_input_validation.py](audit_input_validation.py) | Audit Input Validation Coverage for structural_lib. | 2 | 5 | 393 |
+| [audit_input_validation.py](audit_input_validation.py) | Audit Input Validation Coverage for structural_lib. | 2 | 6 | 405 |
 | [audit_permissions.py](audit_permissions.py) | Permission audit report for all agents. | 3 | 3 | 468 |
-| [audit_readiness_report.py](audit_readiness_report.py) | Audit Readiness Report Generator | 2 | 12 | 855 |
+| [audit_readiness_report.py](audit_readiness_report.py) | Audit Readiness Report Generator | 2 | 13 | 882 |
 | [batch_migrate_runner.py](batch_migrate_runner.py) | Batch migration runner with per-operation rollback logs. | 1 | 2 | 467 |
 | [benchmark_api.py](benchmark_api.py) | API Performance Benchmark Script. | 4 | 9 | 837 |
 | [bump_version.py](bump_version.py) | Version Bump Script — Single Source of Truth | 0 | 4 | 484 |
@@ -56,6 +56,7 @@
 | [check_next_session_brief_length.py](check_next_session_brief_length.py) | Ensure next-session-brief.md stays concise. | 0 | 1 | 31 |
 | [check_openapi_drift.py](check_openapi_drift.py) | Check OpenAPI spec for drift against baseline. | 0 | 5 | 193 |
 | [check_openapi_snapshot.py](check_openapi_snapshot.py) | Check OpenAPI spec against baseline snapshot to detect API d | 0 | 1 | 231 |
+| [check_public_route_safety.py](check_public_route_safety.py) | Run the frozen adversarial regressions for maintained public | 0 | 1 | 93 |
 | [check_python_version.py](check_python_version.py) | Python Version Consistency Checker | 0 | 5 | 208 |
 | [check_repo_hygiene.py](check_repo_hygiene.py) | Fail if tracked hygiene artifacts exist in the repository. | 0 | 1 | 44 |
 | [check_scripts_index.py](check_scripts_index.py) | Ensure scripts/index.json and automation-map.json match the  | 0 | 1 | 223 |
@@ -95,7 +96,7 @@
 | [preflight.py](preflight.py) | Pre-flight check — catch common mistakes BEFORE they happen. | 0 | 9 | 203 |
 | [project_health.py](project_health.py) | Unified project health scanner with auto-fix capability. | 3 | 9 | 908 |
 | [prompt_router.py](prompt_router.py) | Prompt router — routes natural language queries to the best  | 1 | 5 | 700 |
-| [release.py](release.py) | Unified release management CLI. | 0 | 11 | 2252 |
+| [release.py](release.py) | Unified release management CLI. | 0 | 11 | 2276 |
 | [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
 | [session.py](session.py) | Unified session management CLI. | 0 | 20 | 2512 |

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -644,6 +644,28 @@ def _latest_documented_version(path: Path) -> str:
 
 def _release_authorization_recorded(expected: str) -> bool:
     """Return whether the owner-authorized publication sequence is recorded."""
+
+    try:
+        authorization = json.loads(
+            RELEASE_PUBLICATION_AUTHORIZATION.read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError):
+        authorization = None
+    if isinstance(authorization, dict):
+        targets = authorization.get("authorized_targets")
+        if (
+            authorization.get("schema_version")
+            == "release-publication-authorization/v1"
+            and authorization.get("decision") == "AUTHORIZED"
+            and authorization.get("version") == expected
+            and authorization.get("tag") == f"v{expected}"
+            and isinstance(targets, list)
+            and {"pypi", "github-release"} <= set(targets)
+        ):
+            return True
+
+    # Retain the historical checklist fallback for older release records that
+    # predate the machine-readable authorization contract.
     try:
         checklist_text = CHECKLIST_PATH.read_text(encoding="utf-8")
     except OSError:
@@ -708,7 +730,7 @@ def _source_surface_version_errors(
                 "CITATION.cff must declare date-released for an authorized release"
             )
         dated_header = re.search(
-            rf"^##\s*\[{re.escape(expected)}\]\s*[—-]\s*\d{{4}}-\d{{2}}-\d{{2}}\s*$",
+            rf"^##\s*\[{re.escape(expected)}\]\s*[—-].*\d{{4}}-\d{{2}}-\d{{2}}.*$",
             changelog_text,
             re.MULTILINE,
         )
@@ -716,12 +738,14 @@ def _source_surface_version_errors(
             errors.append(
                 f"CHANGELOG.md must give authorized v{expected} an ISO release date"
             )
-        authorized_release_markers = (
-            "release authorized",
-            "published to pypi and github releases",
-        )
-        if not any(
-            marker in release_text.lower() for marker in authorized_release_markers
+        release_lower = release_text.lower()
+        if not (
+            "release authorized" in release_lower
+            or (
+                "published" in release_lower
+                and "pypi" in release_lower
+                and "github release" in release_lower
+            )
         ):
             errors.append("release ledger must record the authorized release state")
     else:


### PR DESCRIPTION
## Outcome

Closes LIB-PRO-003-D and integrates the cumulative A-D public-route safety closure.

- requires Excel add-in tests for excel_addin-only changes
- adds a required 78-case public-route safety gate
- makes audit PASS, PARTIAL, and FAIL process exits decisive
- enforces the owner-selected 500 active-Markdown hard cap
- synchronizes v0.23.1a2 and 89-operation/88-path source truth
- preserves release and professional-use HOLD while two advisory diagnostics remain

## Verification

- public-route safety: 73 Python + 5 FastAPI cases passed
- cumulative Python: 6,653 passed, 3 skipped, 6 deselected
- FastAPI: 479 passed
- React: 276 passed across 51 files
- Excel add-in: 21 passed
- quick gate: 10/10
- full repository gate: 31/31
- docs: 401/500, zero invalid frontmatter, zero broken links
- readiness audit: PARTIAL, exit 2, 21/23 passed, zero failed, two warnings

No package release, professional approval, INDIA-3 implementation, ETABS, or desktop Excel work is included.