### PR TITLE
refactor: add canonical control registry (MAINT-012A)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,7 @@ Core CANNOT import from Services or UI.
 ### Agent Infrastructure
 
 - **Agent Registry:** `agents/agent_registry.json` — 16 agents with permissions, skills, keywords
+- **Control Registry:** `scripts/control-plane.json` — canonical operations, commands, aliases, permissions, and compatibility projection
 - **Tool Registry:** `scripts/tool_registry.py` — unified search across agents, skills, scripts
 - **Prompt Router:** `scripts/prompt_router.py` — NLP-based task → agent routing
 - **Permission Enforcement:** `scripts/tool_permissions.py` — programmatic access control

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ UI/IO        → react_app/, fastapi_app/
 ### Agent Infrastructure
 
 - **Agent Registry:** `agents/agent_registry.json` — 16 agents with permissions, skills, keywords
+- **Control Registry:** `scripts/control-plane.json` — canonical operations, commands, aliases, permissions, and compatibility projection
 - **Tool Registry:** `scripts/tool_registry.py` — unified search across agents, skills, scripts
 - **Prompt Router:** `scripts/prompt_router.py` — NLP-based task → agent routing
 - **Permission Enforcement:** `scripts/tool_permissions.py` — programmatic access control
@@ -171,7 +172,8 @@ ls react_app/src/hooks/                                         # Existing React
 grep -r "@router" fastapi_app/routers/ | head -30               # Existing API routes
 ./run.sh find --api <func>                                   # Public API exact signature (68 functions)
 ./scripts/python_runtime.sh scripts/discover_api_signatures.py <func>      # Exact param names (b_mm not width)
-./scripts/python_runtime.sh scripts/find_automation.py "task"              # Find existing automation (119 tasks)
+./scripts/python_runtime.sh scripts/find_automation.py "task"              # Find an active registered operation
+./run.sh control validate                                                   # Validate registry, permissions, targets, and projection
 ```
 
 ## Essential Commands (`./run.sh` — preferred entry point)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Core CANNOT import from Services or UI. Services CANNOT import from UI.
 ### Agent Infrastructure
 
 - **Agent Registry:** `agents/agent_registry.json` — 16 agents with permissions, skills, keywords
+- **Control Registry:** `scripts/control-plane.json` — canonical operations, commands, aliases, permissions, and compatibility projection
 - **Tool Registry:** `scripts/tool_registry.py` — unified search across agents, skills, scripts
 - **Prompt Router:** `scripts/prompt_router.py` — NLP-based task → agent routing
 - **Permission Enforcement:** `scripts/tool_permissions.py` — programmatic access control

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -1517,12 +1517,15 @@
     {
       "name": "test_control_plane.py",
       "type": "python",
-      "size_lines": 124,
+      "size_lines": 156,
       "last_updated": "2026-08-23",
       "description": "Contract tests for the canonical repository control plane.",
       "functions": [
         {
           "name": "test_current_registry_has_frozen_operation_and_script_parity"
+        },
+        {
+          "name": "test_control_validator_runs_without_site_packages"
         },
         {
           "name": "test_legacy_projection_is_exact_and_deterministic"
@@ -1540,6 +1543,9 @@
           "name": "test_schema_rejects_missing_permission"
         },
         {
+          "name": "test_schema_rejects_unknown_fields_wrong_types_and_missing_replacement"
+        },
+        {
           "name": "test_semantics_reject_alias_collision_missing_target_and_display_drift"
         },
         {
@@ -1553,7 +1559,7 @@
         "REPO_ROOT",
         "SCRIPTS_DIR"
       ],
-      "content_hash": "1761164accf4"
+      "content_hash": "0b4d69ec3dae"
     },
     {
       "name": "test_core.py",
@@ -5106,5 +5112,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "2252f5949ad2a25d"
+  "content_hash": "e61de0b51878cc8e"
 }

--- a/Python/tests/index.json
+++ b/Python/tests/index.json
@@ -2,8 +2,8 @@
   "folder": "Python/tests",
   "type": "python-package",
   "description": "This document describes the test taxonomy and structure for the structural_engineering_lib test suite.",
-  "last_updated": "2026-08-22",
-  "file_count": 75,
+  "last_updated": "2026-08-23",
+  "file_count": 76,
   "files": [
     {
       "name": "README.md",
@@ -64,8 +64,8 @@
     {
       "name": "test_agent_governance_automation.py",
       "type": "python",
-      "size_lines": 642,
-      "last_updated": "2026-08-22",
+      "size_lines": 640,
+      "last_updated": "2026-08-23",
       "description": "Regression tests for agent-governance automation controls.",
       "functions": [
         {
@@ -155,7 +155,7 @@
         "REPO_ROOT",
         "SCRIPTS_DIR"
       ],
-      "content_hash": "76d20b516a7f"
+      "content_hash": "96c6d18aaa24"
     },
     {
       "name": "test_api_classification.py",
@@ -1513,6 +1513,47 @@
         }
       ],
       "content_hash": "eff4f4a8aa06"
+    },
+    {
+      "name": "test_control_plane.py",
+      "type": "python",
+      "size_lines": 124,
+      "last_updated": "2026-08-23",
+      "description": "Contract tests for the canonical repository control plane.",
+      "functions": [
+        {
+          "name": "test_current_registry_has_frozen_operation_and_script_parity"
+        },
+        {
+          "name": "test_legacy_projection_is_exact_and_deterministic"
+        },
+        {
+          "name": "test_aliases_have_one_owner_and_drive_all_discovery_consumers"
+        },
+        {
+          "name": "test_permission_lookup_uses_explicit_canonical_defaults_and_modes"
+        },
+        {
+          "name": "test_structured_commands_do_not_store_shell_chains_as_one_step"
+        },
+        {
+          "name": "test_schema_rejects_missing_permission"
+        },
+        {
+          "name": "test_semantics_reject_alias_collision_missing_target_and_display_drift"
+        },
+        {
+          "name": "test_loader_rejects_duplicate_json_keys",
+          "params": [
+            "tmp_path"
+          ]
+        }
+      ],
+      "constants": [
+        "REPO_ROOT",
+        "SCRIPTS_DIR"
+      ],
+      "content_hash": "1761164accf4"
     },
     {
       "name": "test_core.py",
@@ -5065,5 +5106,5 @@
     }
   ],
   "has_init": true,
-  "content_hash": "9dd1f288ece63337"
+  "content_hash": "2252f5949ad2a25d"
 }

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -38,7 +38,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_column_helical.py](test_column_helical.py) | Tests for IS 456 Cl 39.4 helical reinforcement check. | 7 | 0 | 356 |
 | [test_column_long.py](test_column_long.py) | Tests for IS 456 Cl 39.7 long (slender) column design. | 15 | 0 | 662 |
 | [test_column_return_types.py](test_column_return_types.py) | Tests for UX-02: Column API return type unification. | 7 | 6 | 349 |
-| [test_control_plane.py](test_control_plane.py) | Contract tests for the canonical repository control plane. | 0 | 8 | 124 |
+| [test_control_plane.py](test_control_plane.py) | Contract tests for the canonical repository control plane. | 0 | 10 | 156 |
 | [test_core.py](test_core.py) | Tests for structural_lib.core module. | 6 | 0 | 176 |
 | [test_core_types.py](test_core_types.py) | Tests for core types and error dataclasses. | 11 | 0 | 391 |
 | [test_dashboard.py](test_dashboard.py) | Tests for the dashboard analytics module. | 4 | 0 | 259 |

--- a/Python/tests/index.md
+++ b/Python/tests/index.md
@@ -3,8 +3,8 @@
 This document describes the test taxonomy and structure for the structural_engineering_lib test suite.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-22
-**Files:** 75
+**Last Updated:** 2026-08-23
+**Files:** 76
 
 ## Documentation Files
 
@@ -18,7 +18,7 @@ This document describes the test taxonomy and structure for the structural_engin
 |------|-------------|---------|-----------|-------|
 | [__init__.py](__init__.py) |  | 0 | 0 | 1 |
 | [conftest.py](conftest.py) | Pytest configuration and Hypothesis profiles for the test su | 0 | 6 | 131 |
-| [test_agent_governance_automation.py](test_agent_governance_automation.py) | Regression tests for agent-governance automation controls. | 0 | 20 | 642 |
+| [test_agent_governance_automation.py](test_agent_governance_automation.py) | Regression tests for agent-governance automation controls. | 0 | 20 | 640 |
 | [test_api_classification.py](test_api_classification.py) | Executable truth checks for the Alpha API classification reg | 0 | 4 | 105 |
 | [test_api_manifest_tools.py](test_api_manifest_tools.py) | Regression tests for the single canonical public API manifes | 0 | 5 | 134 |
 | [test_api_results.py](test_api_results.py) | Tests for API result dataclasses. | 3 | 0 | 394 |
@@ -38,6 +38,7 @@ This document describes the test taxonomy and structure for the structural_engin
 | [test_column_helical.py](test_column_helical.py) | Tests for IS 456 Cl 39.4 helical reinforcement check. | 7 | 0 | 356 |
 | [test_column_long.py](test_column_long.py) | Tests for IS 456 Cl 39.7 long (slender) column design. | 15 | 0 | 662 |
 | [test_column_return_types.py](test_column_return_types.py) | Tests for UX-02: Column API return type unification. | 7 | 6 | 349 |
+| [test_control_plane.py](test_control_plane.py) | Contract tests for the canonical repository control plane. | 0 | 8 | 124 |
 | [test_core.py](test_core.py) | Tests for structural_lib.core module. | 6 | 0 | 176 |
 | [test_core_types.py](test_core_types.py) | Tests for core types and error dataclasses. | 11 | 0 | 391 |
 | [test_dashboard.py](test_dashboard.py) | Tests for the dashboard analytics module. | 4 | 0 | 259 |

--- a/Python/tests/test_agent_governance_automation.py
+++ b/Python/tests/test_agent_governance_automation.py
@@ -38,6 +38,7 @@ project_health = importlib.import_module("project_health")
 preflight = importlib.import_module("preflight")
 tool_permissions = importlib.import_module("tool_permissions")
 tool_registry = importlib.import_module("tool_registry")
+control_plane = importlib.import_module("control_plane")
 
 
 def test_python_runtime_launcher_uses_explicit_interpreter():
@@ -453,7 +454,7 @@ def test_tool_registry_does_not_infer_permission_from_git_text():
 
     assert registry["check git state"].permission == "ReadOnly"
     assert registry["project health"].permission_modes == {"--fix": "WorkspaceWrite"}
-    assert registry["governance health score"].permission is None
+    assert registry["governance health score"].permission == "ReadOnlyTerminal"
 
 
 @pytest.mark.parametrize(
@@ -477,10 +478,10 @@ def test_remaining_automation_permissions_match_modes(operation, mode, expected)
 
 
 def test_automation_discovery_metadata_is_single_source():
-    automation_map = json.loads(
-        (SCRIPTS_DIR / "automation-map.json").read_text(encoding="utf-8")
-    )
+    registry = control_plane.load_registry()
+    automation_map = control_plane.legacy_projection(registry)
 
+    assert control_plane.legacy_is_current(registry)
     assert check_scripts_index._automation_semantic_issues(automation_map) == {
         "legacy_categories": [],
         "missing_group": [],
@@ -625,17 +626,14 @@ def test_permission_metadata_audit_accepts_current_declarations():
     assert audit_permissions.audit_automation_permission_metadata() == []
 
 
-def test_permission_metadata_audit_rejects_modes_without_default(tmp_path, monkeypatch):
-    automation_map = tmp_path / "automation-map.json"
-    automation_map.write_text(
-        json.dumps(
-            {"tasks": {"broken": {"permission_modes": {"--fix": "WorkspaceWrite"}}}}
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(audit_permissions, "_AUTOMATION_MAP", automation_map)
+def test_permission_metadata_audit_rejects_missing_default(tmp_path, monkeypatch):
+    registry_data = control_plane.load_registry()
+    del registry_data["operations"]["project health"]["permission"]
+    registry_path = tmp_path / "control-plane.json"
+    registry_path.write_text(json.dumps(registry_data), encoding="utf-8")
+    monkeypatch.setattr(audit_permissions, "_CONTROL_PLANE", registry_path)
 
     anomalies = audit_permissions.audit_automation_permission_metadata()
 
     assert len(anomalies) == 1
-    assert "explicit default" in anomalies[0].message
+    assert "permission" in anomalies[0].message

--- a/Python/tests/test_control_plane.py
+++ b/Python/tests/test_control_plane.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import importlib
+import subprocess
 import sys
 from pathlib import Path
 
@@ -34,6 +35,24 @@ def test_current_registry_has_frozen_operation_and_script_parity():
         control_plane.top_level_scripts()
     )
     assert all(operation.get("permission") for operation in active_operations.values())
+
+
+def test_control_validator_runs_without_site_packages():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            str(SCRIPTS_DIR / "control_plane" / "cli.py"),
+            "validate",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Control plane: PASS" in result.stdout
 
 
 def test_legacy_projection_is_exact_and_deterministic():
@@ -99,6 +118,19 @@ def test_schema_rejects_missing_permission():
     errors = control_plane.validate_registry_data(registry)
 
     assert any("permission" in error for error in errors)
+
+
+def test_schema_rejects_unknown_fields_wrong_types_and_missing_replacement():
+    registry = copy.deepcopy(control_plane.load_registry())
+    registry["unexpected"] = True
+    registry["operations"]["project health"]["aliases"] = [42]
+    del registry["operations"]["compat branch guard"]["replacement"]
+
+    errors = control_plane.validate_registry_data(registry)
+
+    assert any("additional property" in error for error in errors)
+    assert any("expected string" in error for error in errors)
+    assert any("replacement" in error for error in errors)
 
 
 def test_semantics_reject_alias_collision_missing_target_and_display_drift():

--- a/Python/tests/test_control_plane.py
+++ b/Python/tests/test_control_plane.py
@@ -1,0 +1,123 @@
+"""Contract tests for the canonical repository control plane."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_only
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+control_plane = importlib.import_module("control_plane")
+find_automation = importlib.import_module("find_automation")
+tool_permissions = importlib.import_module("tool_permissions")
+tool_registry = importlib.import_module("tool_registry")
+
+
+def test_current_registry_has_frozen_operation_and_script_parity():
+    registry = control_plane.load_registry()
+    all_operations = control_plane.operation_map(registry)
+    active_operations = control_plane.operation_map(registry, active_only=True)
+
+    assert len(all_operations) == 128
+    assert len(active_operations) == 125
+    assert len(control_plane.top_level_scripts()) == 113
+    assert control_plane.referenced_top_level_scripts(registry) == (
+        control_plane.top_level_scripts()
+    )
+    assert all(operation.get("permission") for operation in active_operations.values())
+
+
+def test_legacy_projection_is_exact_and_deterministic():
+    registry = control_plane.load_registry()
+    first = control_plane.canonical_json(control_plane.legacy_projection(registry))
+    second = control_plane.canonical_json(control_plane.legacy_projection(registry))
+
+    assert first == second
+    assert control_plane.legacy_is_current(registry)
+    checked_in = (SCRIPTS_DIR / "automation-map.json").read_text(encoding="utf-8")
+    assert checked_in == first
+
+
+def test_aliases_have_one_owner_and_drive_all_discovery_consumers():
+    registry = control_plane.load_registry()
+    owners: dict[str, str] = {}
+    for name, operation in control_plane.operation_map(
+        registry, active_only=True
+    ).items():
+        for alias in operation.get("aliases", []):
+            assert alias not in owners
+            owners[alias] = name
+
+    assert owners["move"] == "move file"
+    assert control_plane.operation_name_for_alias("MOVE", registry) == "move file"
+    assert tool_registry.resolve_alias("move") == "move file"
+    legacy_view = find_automation.load_automation_map()
+    assert find_automation.find_task("move", legacy_view)[0][0] == "move file"
+
+
+def test_permission_lookup_uses_explicit_canonical_defaults_and_modes():
+    assert tool_permissions.resolve_required_permission("governance health score") == (
+        "ReadOnlyTerminal"
+    )
+    assert (
+        tool_permissions.resolve_required_permission(
+            "governance health score", mode="--output"
+        )
+        == "WorkspaceWrite"
+    )
+    assert tool_permissions.resolve_required_permission("delete file") == (
+        "DangerFullAccess"
+    )
+    assert tool_permissions.resolve_required_permission("unknown operation") == (
+        "DangerFullAccess"
+    )
+
+
+def test_structured_commands_do_not_store_shell_chains_as_one_step():
+    registry = control_plane.load_registry()
+    operations = control_plane.operation_map(registry)
+
+    assert len(operations["format code"]["command"]["steps"]) == 2
+    for operation in operations.values():
+        for step in operation["command"]["steps"]:
+            assert not ({"&&", "||", ";", "|"} & set(step["argv"]))
+
+
+def test_schema_rejects_missing_permission():
+    registry = copy.deepcopy(control_plane.load_registry())
+    del registry["operations"]["project health"]["permission"]
+
+    errors = control_plane.validate_registry_data(registry)
+
+    assert any("permission" in error for error in errors)
+
+
+def test_semantics_reject_alias_collision_missing_target_and_display_drift():
+    registry = copy.deepcopy(control_plane.load_registry())
+    registry["operations"]["move file"].setdefault("aliases", []).append("check")
+    registry["operations"]["move file"]["command"]["steps"][0]["argv"][
+        1
+    ] = "scripts/does_not_exist.py"
+
+    errors = control_plane.validate_registry_data(registry)
+
+    assert any("already belongs" in error for error in errors)
+    assert any("missing command target" in error for error in errors)
+    assert any("display command differs" in error for error in errors)
+
+
+def test_loader_rejects_duplicate_json_keys(tmp_path):
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema_version": 1, "schema_version": 1}', encoding="utf-8")
+
+    with pytest.raises(control_plane.ControlPlaneError, match="duplicate JSON key"):
+        control_plane.load_registry(path=path, validate=False)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,101 @@
 
 ---
 
+## 2026-08-23 — Session: MAINT-012A canonical control-registry foundation
+
+**Agent:** Codex (`governance`, sole writer)
+
+**Branch:** `codex/maint-012a-control-registry`, from exact `origin/main`
+commit `fc904511cc7b9683b2b464cdef71a45d2e9ee277`.
+
+**Git handoff receipt:**
+`docs/verification/maint-012a-git-handoff-receipt.json`
+
+**Focus:** Implement MAINT-012A canonical operation registry and compatibility projection.
+
+The versioned registry replaces duplicated and implicit metadata while
+preserving existing commands during migration.
+
+### Summary
+
+- Added the Draft 2020-12 control-plane schema, fail-closed loader, and
+  `./run.sh control` validation/search/list/statistics/projection interface.
+- Migrated discovery, tool search, prompt routing, permission enforcement and
+  audit, governance permission validation, script coverage, and session context
+  guidance to `scripts/control-plane.json`.
+- Represented 128 total/125 active operations and 113/113 top-level scripts;
+  all active operations now have explicit default permissions and structured
+  command steps. `automation-map.json` is an exact generated projection.
+- Froze MAINT-012B-D as separate successor packets for index architecture,
+  evidence reuse/validation scheduling, and scanner/script consolidation.
+
+### PRs Merged
+
+- None. MAINT-012A remains an unpushed local candidate until the post-freeze
+  local gates, exact-head review, required hosted checks, and merge complete.
+
+### Key Deliverables
+
+- `scripts/control-plane.json` and `scripts/control-plane.schema.json`
+- `scripts/control_plane/` validated loader and CLI
+- `Python/tests/test_control_plane.py` parity, schema, alias, permission,
+  structured-command, missing-target, duplicate-key, and determinism contracts
+- `docs/planning/maint-012-control-plane-modernization.md`
+- `docs/verification/maint-012a-git-handoff-receipt.json`
+
+### Issues encountered
+
+- The legacy map contained 78 active operations without default permissions,
+  plus three deprecated Git-compatibility operations omitted from the initial
+  active-only inventory. The first import therefore stopped fail-closed rather
+  than silently assigning them.
+- One legacy alias used mixed case (`release CI parity`), so canonical alias
+  normalization correctly rejected the first generated candidate.
+- Placing the loader and CLI as new top-level `.py` files would have changed the
+  frozen script inventory from 113 to 115 and forced self-registration churn.
+- The inherited next-session brief still described the uncommitted MAINT-011
+  candidate even though MAINT-011 was already merged.
+- Active bootstrap, automation-catalog, and cross-agent instruction surfaces
+  still named the legacy automation map without a canonical/projection boundary.
+- The first generated handoff block selected MAINT-011 instead of MAINT-012A.
+- The first staged session-doc hook rejected the new brief's lowercase
+  `Required reading` heading.
+
+### Root causes and resolutions
+
+- Permission metadata had been added incrementally to only 47 of 125 active
+  operations; absence was tolerated by discovery even though permission lookup
+  failed closed. Every canonical operation now declares one of the four known
+  levels, with explicit mode elevations for mixed read/write commands.
+- Aliases previously lived in both per-task fields and a hard-coded tool map,
+  with no normalization/ownership invariant. All aliases now live normalized in
+  the canonical registry; duplicate owners and operation collisions fail.
+- The script counter intentionally covers only active top-level tools. The new
+  implementation was placed in `scripts/control_plane/`, leaving 113/113
+  coverage exact while providing a namespaced control module.
+- The stale brief had no live-state guard after the predecessor merge. It now
+  records the exact MAINT-012A base, boundary, current parity, and next action.
+- Active entry documents now point to the control registry and compact validator;
+  historical audits, deprecated guides, and immutable receipts remain unchanged.
+- Session handoff discovery recognizes dated headings only when they retain the
+  `Session` marker. Restoring `Session: MAINT-012A` made the generated block bind
+  to the current entry and exact MAINT-012A receipt.
+- The session checker intentionally treats `Required Reading` as an exact
+  structural contract. Restoring that capitalization made the focused staged
+  hook decisive without weakening the checker.
+- Proof: `./run.sh control validate` reports PASS at 125 active operations and
+  113/113 scripts; the two focused control/governance files pass 61 tests; the
+  legacy projection check, tool stats, find alias smoke, and permission audit
+  pass. Final consolidated gates remain acceptance evidence outside the frozen
+  candidate content.
+
+### Notes
+
+- MAINT-012A does not retire indexes, cache test evidence, reschedule scanners,
+  delete/move legacy scripts, change CI topology, or alter product/release
+  behavior. Those boundaries remain separately reviewable.
+
+
 ## 2026-08-22 — Session: MAINT-011 developer gate hygiene
 
 **Agent:** Codex (`governance` + `ops`, sole writer)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -64,6 +64,8 @@ preserving existing commands during migration.
 - The first generated handoff block selected MAINT-011 instead of MAINT-012A.
 - The first staged session-doc hook rejected the new brief's lowercase
   `Required reading` heading.
+- The first hosted repository, Python, and control-plane jobs could not import
+  `jsonschema`; their aggregate PR Gate therefore failed.
 
 ### Root causes and resolutions
 
@@ -87,6 +89,11 @@ preserving existing commands during migration.
 - The session checker intentionally treats `Required Reading` as an exact
   structural contract. Restoring that capitalization made the focused staged
   hook decisive without weakening the checker.
+- `jsonschema` is an existing optional `validation` extra, while the affected
+  hosted lanes intentionally install `Python[dev]`. The local full environment
+  masked that difference. The loader now evaluates the exact schema keywords it
+  uses with the Python standard library, preserving strict validation without a
+  dependency or workflow change.
 - Proof: `./run.sh control validate` reports PASS at 125 active operations and
   113/113 scripts; the two focused control/governance files pass 61 tests; the
   legacy projection check, tool stats, find alias smoke, and permission audit

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-22 — LIB-PRO-005 merged; MAINT-011 complete on merge
+**Updated:** 2026-08-23 — MAINT-012A canonical control-registry foundation active
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| — | No active implementation packet after MAINT-011 merge | — | — | — | Next capability work requires a separately frozen scope |
+| MAINT-012A | Establish the canonical operation registry, schema, loader, CLI, explicit permissions, and deterministic compatibility projection | Main Agent + governance | M | P0 | 🔄 ACTIVE — isolated source-bound lane; implementation and focused contracts complete; consolidated closeout pending |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. The reproduced public-route safety packet is integrated. INDIA-3,
@@ -164,6 +164,7 @@ write-back/nightly work remain outside E1.
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
+| MAINT-012B | Replace high-churn generic indexes with authoritative manifests and on-demand summaries, preserving only proven-useful views | Main Agent + governance | M | P0 | ⏸ AFTER MAINT-012A — separate frozen candidate |
 | INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | ⏸ AFTER LIB-PRO-003 — truth/benchmark/contract audit only; no new formulas or support claims |
 | SPARK-001-G0 | Reassess the stale Spark work-program proposal before any implementation | repository owner | review gate | P2 | ⏸ OWNER REVIEW — the 2026-08-11 model/preview assumptions and bulk wave require refresh or rejection |
 

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-23T01:28:48.246879",
+  "generated": "2026-08-23T01:33:45.673839",
   "total_docs": 379,
   "docs": {
     "docs/SESSION_LOG.md": {
@@ -21,7 +21,7 @@
         "2026-08-22 \u2014 Session: E1 G3 integration and roadmap closeout",
         "2026-08-22 \u2014 Session: E1 desktop-Excel workbook-open repair"
       ],
-      "size_bytes": 281903
+      "size_bytes": 282390
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -2176,7 +2176,7 @@
         "Future maintenance policy",
         "MAINT-012A acceptance"
       ],
-      "size_bytes": 6394
+      "size_bytes": 6565
     },
     "docs/planning/is456-solid-slabs-master-plan.md": {
       "title": "IS 456 Solid Slabs Expansion Master Plan",

--- a/docs/docs-index.json
+++ b/docs/docs-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generated": "2026-08-22T23:12:29.619539",
-  "total_docs": 378,
+  "generated": "2026-08-23T01:28:48.246879",
+  "total_docs": 379,
   "docs": {
     "docs/SESSION_LOG.md": {
       "title": "Session Log",
@@ -10,6 +10,7 @@
       "folder": "root",
       "tags": [],
       "sections": [
+        "2026-08-23 \u2014 Session: MAINT-012A canonical control-registry foundation",
         "2026-08-22 \u2014 Session: MAINT-011 developer gate hygiene",
         "2026-08-22 \u2014 Session: LIB-PRO-005 confirmed release-safety closure",
         "2026-08-22 \u2014 Session: LIB-PRO-004 lower-level safety and diagnostic truth",
@@ -18,10 +19,9 @@
         "2026-08-22 \u2014 Session: LIB-PRO-003-B domains and footing provenance",
         "2026-08-22 \u2014 Session: LIB-PRO-003-A public numeric boundaries",
         "2026-08-22 \u2014 Session: E1 G3 integration and roadmap closeout",
-        "2026-08-22 \u2014 Session: E1 desktop-Excel workbook-open repair",
-        "2026-08-22 \u2014 Session: E1 complete review-bundle export"
+        "2026-08-22 \u2014 Session: E1 desktop-Excel workbook-open repair"
       ],
-      "size_bytes": 276890
+      "size_bytes": 281903
     },
     "docs/README.md": {
       "title": "Docs Index (Start Here)",
@@ -61,7 +61,7 @@
         "Completed (Archived)",
         "External Audit Remediation \u2014 v0.21.6 \u2705 DONE"
       ],
-      "size_bytes": 60770
+      "size_bytes": 61173
     },
     "docs/WORKLOG.md": {
       "title": "Work Log",
@@ -670,7 +670,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 1162
+      "size_bytes": 1002
     },
     "docs/blog-drafts/smart-design-analysis-deep-dive.md": {
       "title": "Smart Design Analysis Deep Dive: Unified Dashboard for Intelligent Structural Design",
@@ -751,7 +751,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 956
+      "size_bytes": 846
     },
     "docs/adr/0003-contract-testing-for-v3.md": {
       "title": "ADR 0003: Contract Testing for V3 Migration",
@@ -2127,11 +2127,10 @@
       ],
       "sections": [
         "Latest Handoff (auto)",
-        "Correct next library packet",
-        "Other live work",
+        "Exact MAINT-012A state",
         "Required Reading"
       ],
-      "size_bytes": 2751
+      "size_bytes": 2425
     },
     "docs/planning/public-route-safety-closure-plan.md": {
       "title": "Public Route Safety Closure Plan",
@@ -2152,6 +2151,32 @@
         "Non-goals"
       ],
       "size_bytes": 4516
+    },
+    "docs/planning/maint-012-control-plane-modernization.md": {
+      "title": "MAINT-012 Control-Plane Modernization",
+      "type": "documentation",
+      "complexity": "intermediate",
+      "folder": "planning",
+      "tags": [
+        "ci",
+        "control-plane",
+        "indexes",
+        "maintenance",
+        "roadmap",
+        "scanners",
+        "scripts",
+        "tasks"
+      ],
+      "sections": [
+        "Purpose",
+        "Frozen packet sequence",
+        "MAINT-012A frozen scope",
+        "Explicit MAINT-012A exclusions",
+        "Efficient operating contract",
+        "Future maintenance policy",
+        "MAINT-012A acceptance"
+      ],
+      "size_bytes": 6394
     },
     "docs/planning/is456-solid-slabs-master-plan.md": {
       "title": "IS 456 Solid Slabs Expansion Master Plan",
@@ -2428,7 +2453,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 3960
+      "size_bytes": 4121
     },
     "docs/planning/india-2-next-session-publication-and-closeout-plan.md": {
       "title": "Next Session Git Reconciliation, Issue Repairs, and INDIA-2 Finish Plan",
@@ -3834,7 +3859,7 @@
         "Config Files",
         "Documentation Files"
       ],
-      "size_bytes": 28036
+      "size_bytes": 28113
     },
     "docs/verification/india-2-wall-d-publication-evidence.md": {
       "title": "INDIA-2-WALL-D Publication Evidence",
@@ -4953,7 +4978,7 @@
         "8. Key Scripts",
         "9. Golden Rules"
       ],
-      "size_bytes": 38353
+      "size_bytes": 38471
     },
     "docs/getting-started/python-quickstart.md": {
       "title": "Python Quickstart (Beginner-Friendly)",
@@ -5696,7 +5721,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 816
+      "size_bytes": 720
     },
     "docs/legal/verification-checklist.md": {
       "title": "Independent Verification Checklist",
@@ -7165,7 +7190,7 @@
         "Git/GitHub is not repository automation",
         "Maintenance rule"
       ],
-      "size_bytes": 2137
+      "size_bytes": 2573
     },
     "docs/reference/insights-api.md": {
       "title": "Insights API Reference",
@@ -7263,7 +7288,7 @@
       "sections": [
         "Documentation Files"
       ],
-      "size_bytes": 848
+      "size_bytes": 728
     },
     "docs/developers/integration-examples.md": {
       "title": "Integration Examples: Real-World Code Samples",
@@ -7289,6 +7314,7 @@
         "docs/contributing/solo-maintainer-operating-system.md",
         "docs/contributing/git-workflow-ai-agents.md",
         "docs/learning/glossary.md",
+        "docs/planning/maint-012-control-plane-modernization.md",
         "docs/planning/compact-modernization-plan.md",
         "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
         "docs/planning/india-2-remaining-is456-elements-plan.md",
@@ -7627,6 +7653,7 @@
       ],
       "scripts": [
         "docs/git-automation/git-recovery-case-study-column-pmm.md",
+        "docs/planning/maint-012-control-plane-modernization.md",
         "docs/audit/automation-scripts-audit-2026-08-09.md",
         "docs/reference/automation-catalog.md"
       ],
@@ -7634,6 +7661,7 @@
         "docs/planning/gpt-5-3-codex-spark-work-program.md",
         "docs/planning/next-session-brief.md",
         "docs/planning/public-route-safety-closure-plan.md",
+        "docs/planning/maint-012-control-plane-modernization.md",
         "docs/planning/is456-solid-slabs-master-plan.md",
         "docs/planning/compact-modernization-plan.md",
         "docs/planning/ui-experience-foundation-master-plan.md",
@@ -7661,6 +7689,7 @@
         "docs/planning/gpt-5-3-codex-spark-work-program.md",
         "docs/planning/next-session-brief.md",
         "docs/planning/public-route-safety-closure-plan.md",
+        "docs/planning/maint-012-control-plane-modernization.md",
         "docs/planning/is456-solid-slabs-master-plan.md",
         "docs/planning/compact-modernization-plan.md",
         "docs/planning/ui-experience-foundation-master-plan.md",
@@ -7783,6 +7812,25 @@
         "docs/verification/india-2-wall-family-acceptance-evidence.md",
         "docs/verification/india-1c-isolated-footing-workflow-evidence.md"
       ],
+      "ci": [
+        "docs/planning/maint-012-control-plane-modernization.md",
+        "docs/planning/maint-011-developer-gate-hygiene-follow-up.md"
+      ],
+      "control-plane": [
+        "docs/planning/maint-012-control-plane-modernization.md"
+      ],
+      "indexes": [
+        "docs/planning/maint-012-control-plane-modernization.md"
+      ],
+      "maintenance": [
+        "docs/planning/maint-012-control-plane-modernization.md",
+        "docs/planning/maint-011-developer-gate-hygiene-follow-up.md",
+        "docs/audit/automation-scripts-audit-2026-08-09.md",
+        "docs/audit/maintenance-recovery-audit-2026-08-07.md"
+      ],
+      "scanners": [
+        "docs/planning/maint-012-control-plane-modernization.md"
+      ],
       "boq": [
         "docs/planning/lib-pro-005-release-safety-closure-plan.md",
         "docs/verification/bundled-sample-boq-evidence.md",
@@ -7803,16 +7851,8 @@
         "docs/planning/lib-pro-005-release-safety-closure-plan.md",
         "docs/verification/lib-pro-005-release-safety-closure-evidence.md"
       ],
-      "ci": [
-        "docs/planning/maint-011-developer-gate-hygiene-follow-up.md"
-      ],
       "developer-experience": [
         "docs/planning/maint-011-developer-gate-hygiene-follow-up.md"
-      ],
-      "maintenance": [
-        "docs/planning/maint-011-developer-gate-hygiene-follow-up.md",
-        "docs/audit/automation-scripts-audit-2026-08-09.md",
-        "docs/audit/maintenance-recovery-audit-2026-08-07.md"
       ],
       "pre-commit": [
         "docs/planning/maint-011-developer-gate-hygiene-follow-up.md"

--- a/docs/getting-started/agent-bootstrap.md
+++ b/docs/getting-started/agent-bootstrap.md
@@ -745,7 +745,8 @@ Load these only when working on that specific area:
 
 ### Machine-Readable Indexes
 
-- `scripts/automation-map.json` — task-to-script mapping
+- `scripts/control-plane.json` — canonical operation, command, alias, and permission registry
+- `scripts/automation-map.json` — generated temporary compatibility projection
 - `docs/docs-canonical.json` — topic-to-canonical-doc mapping
 - `scripts/index.json` — full automation catalog
 

--- a/docs/getting-started/index.json
+++ b/docs/getting-started/index.json
@@ -2,7 +2,7 @@
   "folder": "docs/getting-started",
   "type": "mixed",
   "description": "Quick onboarding guides for new users of the structural engineering library.",
-  "last_updated": "2026-08-22",
+  "last_updated": "2026-08-23",
   "file_count": 19,
   "files": [
     {
@@ -25,10 +25,10 @@
     {
       "name": "agent-bootstrap.md",
       "type": "documentation",
-      "size_lines": 755,
-      "last_updated": "2026-08-22",
+      "size_lines": 756,
+      "last_updated": "2026-08-23",
       "description": "> **This is THE canonical bootstrap for all AI agents.** Entry points (CLAUDE.md, .github/copilot-instructions.md) link here. | # | Critical Warning | Why it matters |",
-      "content_hash": "7ea501738857"
+      "content_hash": "f1e1c51233bc"
     },
     {
       "name": "agent-essentials.md",
@@ -152,5 +152,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "4558b3a2eb24b5fd"
+  "content_hash": "0a61d97bee8e1257"
 }

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -3,7 +3,7 @@
 Quick onboarding guides for new users of the structural engineering library.
 
 **Type:** Mixed
-**Last Updated:** 2026-08-22
+**Last Updated:** 2026-08-23
 **Files:** 19
 
 ## Documentation Files
@@ -12,7 +12,7 @@ Quick onboarding guides for new users of the structural engineering library.
 |------|-------|-------------|-------|
 | [NEW-DEVELOPER-ONBOARDING.md](NEW-DEVELOPER-ONBOARDING.md) |  | This guide is for you if: - ✅ You're new to this project | 377 |
 | [README.md](README.md) | Getting Started | Quick onboarding guides for new users of the structural engi | 76 |
-| [agent-bootstrap.md](agent-bootstrap.md) |  | > **This is THE canonical bootstrap for all AI agents.** Ent | 755 |
+| [agent-bootstrap.md](agent-bootstrap.md) |  | > **This is THE canonical bootstrap for all AI agents.** Ent | 756 |
 | [agent-essentials.md](agent-essentials.md) |  | > **Merged.** This document's content has been consolidated  | 14 |
 | [ai-context-pack.md](ai-context-pack.md) |  | > **Merged.** This document's content has been consolidated  | 14 |
 | [beginners-guide.md](beginners-guide.md) |  | This guide is written for engineers and students who are new | 159 |

--- a/docs/git-automation/live-git-guidance-index.json
+++ b/docs/git-automation/live-git-guidance-index.json
@@ -15,7 +15,7 @@
     "docs/learning-foundations/09-git.md",
     "agents/agent-9/KNOWLEDGE_BASE.md",
     "scripts/README.md",
-    "scripts/automation-map.json"
+    "scripts/control-plane.json"
   ],
   "live_globs": [
     ".github/agents/*.agent.md",

--- a/docs/index.json
+++ b/docs/index.json
@@ -2,7 +2,7 @@
   "folder": "docs",
   "type": "documentation",
   "description": "Guides, references, evidence, and contributor material for the",
-  "last_updated": "2026-08-22",
+  "last_updated": "2026-08-23",
   "file_count": 6,
   "files": [
     {
@@ -17,20 +17,20 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4652,
-      "last_updated": "2026-08-22",
+      "size_lines": 4747,
+      "last_updated": "2026-08-23",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "722e099733d2"
+      "content_hash": "917fdde8817c"
     },
     {
       "name": "TASKS.md",
       "type": "documentation",
-      "size_lines": 742,
-      "last_updated": "2026-08-22",
+      "size_lines": 743,
+      "last_updated": "2026-08-23",
       "title": "Task Board",
       "description": "> **Single source of truth for active work.** Keep it short and current. - **WIP = 2** (max 2 active tasks at once)",
-      "content_hash": "822d948e5769"
+      "content_hash": "d867fcf174f7"
     },
     {
       "name": "WORKLOG.md",
@@ -57,7 +57,7 @@
     {
       "name": "docs-index.json",
       "type": "config",
-      "last_updated": "2026-08-22",
+      "last_updated": "2026-08-23",
       "top_level_keys": [
         "version",
         "generated",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "a8a96943df55"
+      "content_hash": "1cd17720bfd9"
     }
   ],
   "subfolders": [
@@ -181,7 +181,7 @@
     {
       "name": "planning",
       "path": "planning/",
-      "file_count": 26
+      "file_count": 27
     },
     {
       "name": "publications",
@@ -208,9 +208,9 @@
     {
       "name": "verification",
       "path": "verification/",
-      "file_count": 226,
+      "file_count": 227,
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "a6accaf9f5c0599e"
+  "content_hash": "19c10ec87034127e"
 }

--- a/docs/index.json
+++ b/docs/index.json
@@ -17,11 +17,11 @@
     {
       "name": "SESSION_LOG.md",
       "type": "documentation",
-      "size_lines": 4747,
+      "size_lines": 4754,
       "last_updated": "2026-08-23",
       "title": "Session Log",
       "description": "> Append-only decision log for AI agent sessions. > Earlier sessions (1-100): SESSION_LOG_through_session_100.md",
-      "content_hash": "917fdde8817c"
+      "content_hash": "27ae59a1a2e2"
     },
     {
       "name": "TASKS.md",
@@ -65,7 +65,7 @@
         "docs",
         "navigation"
       ],
-      "content_hash": "1cd17720bfd9"
+      "content_hash": "cf688735e887"
     }
   ],
   "subfolders": [
@@ -212,5 +212,5 @@
       "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards."
     }
   ],
-  "content_hash": "19c10ec87034127e"
+  "content_hash": "bb6e2bafe6cf03bf"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 Guides, references, evidence, and contributor material for the
 
 **Type:** Documentation
-**Last Updated:** 2026-08-22
+**Last Updated:** 2026-08-23
 **Files:** 6
 
 ## Config Files
@@ -16,8 +16,8 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4652 |
-| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 742 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4747 |
+| [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 743 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 355 |
 
 ## Subfolders
@@ -43,9 +43,9 @@ Guides, references, evidence, and contributor material for the
 | [learning-foundations/](learning-foundations/) | 13 | These are NOT specific to this repo. They are universal concepts every developer |
 | [legal/](legal/) | 6 | Engineering certification templates and usage guidelines. |
 | [migration/](migration/) | 45 |  |
-| [planning/](planning/) | 26 |  |
+| [planning/](planning/) | 27 |  |
 | [publications/](publications/) | 10 | This directory contains blog posts, technical articles, and academic papers docu |
 | [reference/](reference/) | 1793 |  |
 | [research/](research/) | 36 |  |
 | [specs/](specs/) | 8 | Technical specifications for data formats and schemas. |
-| [verification/](verification/) | 226 | Benchmark examples and verification packs for validating library calculations ag |
+| [verification/](verification/) | 227 | Benchmark examples and verification packs for validating library calculations ag |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Guides, references, evidence, and contributor material for the
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
 | [README.md](README.md) | Docs Index (Start Here) | Guides, references, evidence, and contributor material for t | 253 |
-| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4747 |
+| [SESSION_LOG.md](SESSION_LOG.md) | Session Log | > Append-only decision log for AI agent sessions. > Earlier  | 4754 |
 | [TASKS.md](TASKS.md) | Task Board | > **Single source of truth for active work.** Keep it short  | 743 |
 | [WORKLOG.md](WORKLOG.md) |  | > **One line per item. Compact. Append-only.** > Format: DAT | 355 |
 

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -139,10 +139,10 @@
     {
       "name": "maint-012-control-plane-modernization.md",
       "type": "documentation",
-      "size_lines": 130,
+      "size_lines": 133,
       "last_updated": "2026-08-23",
       "description": "Modernize the old script, discovery, permission, index, scanner, and validation control system as one planned program without a repository-wide rewrite in one",
-      "content_hash": "4808c1762154"
+      "content_hash": "8d38402859f5"
     },
     {
       "name": "memory.md",
@@ -214,5 +214,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "0294813a769207d2"
+  "content_hash": "d1341c7213fd04b9"
 }

--- a/docs/planning/index.json
+++ b/docs/planning/index.json
@@ -2,8 +2,8 @@
   "folder": "docs/planning",
   "type": "documentation",
   "description": "",
-  "last_updated": "2026-08-22",
-  "file_count": 24,
+  "last_updated": "2026-08-23",
+  "file_count": 25,
   "files": [
     {
       "name": "README.md",
@@ -137,6 +137,14 @@
       "content_hash": "e98785dedb6b"
     },
     {
+      "name": "maint-012-control-plane-modernization.md",
+      "type": "documentation",
+      "size_lines": 130,
+      "last_updated": "2026-08-23",
+      "description": "Modernize the old script, discovery, permission, index, scanner, and validation control system as one planned program without a repository-wide rewrite in one",
+      "content_hash": "4808c1762154"
+    },
+    {
       "name": "memory.md",
       "type": "documentation",
       "size_lines": 411,
@@ -155,11 +163,11 @@
     {
       "name": "next-session-brief.md",
       "type": "documentation",
-      "size_lines": 47,
-      "last_updated": "2026-08-22",
+      "size_lines": 41,
+      "last_updated": "2026-08-23",
       "title": "Next Session Briefing",
-      "description": "<!-- HANDOFF:START --> - Date: 2026-08-22",
-      "content_hash": "b12807ca29e5"
+      "description": "<!-- HANDOFF:START --> - Date: 2026-08-23",
+      "content_hash": "d7368bc043ee"
     },
     {
       "name": "pre-release-checklist.md",
@@ -206,5 +214,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "555febd8f6dd499e"
+  "content_hash": "0294813a769207d2"
 }

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -24,7 +24,7 @@
 | [lib-pro-005-release-safety-closure-plan.md](lib-pro-005-release-safety-closure-plan.md) |  | Close the reproduced release-safety defects found after LIB- | 59 |
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [maint-011-developer-gate-hygiene-follow-up.md](maint-011-developer-gate-hygiene-follow-up.md) |  | Preserve the tooling and process defects encountered during  | 83 |
-| [maint-012-control-plane-modernization.md](maint-012-control-plane-modernization.md) |  | Modernize the old script, discovery, permission, index, scan | 130 |
+| [maint-012-control-plane-modernization.md](maint-012-control-plane-modernization.md) |  | Modernize the old script, discovery, permission, index, scan | 133 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
 | [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-23 | 41 |

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -1,8 +1,8 @@
 # Planning
 
 **Type:** Documentation
-**Last Updated:** 2026-08-22
-**Files:** 24
+**Last Updated:** 2026-08-23
+**Files:** 25
 
 ## Documentation Files
 
@@ -24,9 +24,10 @@
 | [lib-pro-005-release-safety-closure-plan.md](lib-pro-005-release-safety-closure-plan.md) |  | Close the reproduced release-safety defects found after LIB- | 59 |
 | [library-expansion-blueprint-v5.md](library-expansion-blueprint-v5.md) | Library Expansion Blueprint v5.0 — Multi | > Master plan for expanding structural_engineering_lib from  | 1121 |
 | [maint-011-developer-gate-hygiene-follow-up.md](maint-011-developer-gate-hygiene-follow-up.md) |  | Preserve the tooling and process defects encountered during  | 83 |
+| [maint-012-control-plane-modernization.md](maint-012-control-plane-modernization.md) |  | Modernize the old script, discovery, permission, index, scan | 130 |
 | [memory.md](memory.md) |  | - Development resumed after a four-month pause and a Mac lap | 411 |
 | [next-phase-improvements-plan.md](next-phase-improvements-plan.md) |  | > This document is a result of a full audit of the beam libr | 1445 |
-| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-22 | 47 |
+| [next-session-brief.md](next-session-brief.md) | Next Session Briefing | <!-- HANDOFF:START --> - Date: 2026-08-23 | 41 |
 | [pre-release-checklist.md](pre-release-checklist.md) | Pre-Release Checklist | Current source metadata: 0.23.1a2 Current public Alpha: v0.2 | 114 |
 | [pre-release-input-safety-and-professional-readiness-plan.md](pre-release-input-safety-and-professional-readiness-plan.md) | Pre-Release Input Safety and Professiona | fe4ab025419b834c6d0f840e9492c0604ae74201 after Packets A-G m | 742 |
 | [professional-library-remediation-plan.md](professional-library-remediation-plan.md) | Professional Library Remediation Plan | This document is no longer the active implementation plan. T | 562 |

--- a/docs/planning/maint-012-control-plane-modernization.md
+++ b/docs/planning/maint-012-control-plane-modernization.md
@@ -46,6 +46,9 @@ invent another operation list, permission table, alias store, or script parser.
   contract. Unknown fields, absent permissions, invalid statuses, and malformed
   commands fail closed.
 - `scripts/control_plane/` owns the validated Python loader and the control CLI.
+  Its evaluator covers the exact schema keywords used here with the Python
+  standard library, so minimal repository/control CI lanes need no optional
+  validation extra.
 - `scripts/automation-map.json` remains temporarily for compatibility, but it is
   generated deterministically from the canonical registry and must never be
   edited independently.

--- a/docs/planning/maint-012-control-plane-modernization.md
+++ b/docs/planning/maint-012-control-plane-modernization.md
@@ -1,0 +1,129 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-23
+doc_type: spec
+complexity: advanced
+tags: [maintenance, control-plane, scripts, indexes, scanners, ci]
+---
+
+# MAINT-012 Control-Plane Modernization
+
+## Purpose
+
+Modernize the old script, discovery, permission, index, scanner, and validation
+control system as one planned program without a repository-wide rewrite in one
+candidate. The program must reduce repeated AI inspection and redundant checks,
+keep existing commands working during migration, and leave one obvious source
+for each kind of truth.
+
+This is not a cosmetic cleanup. The confirmed failure mode is duplicated and
+partly implicit control metadata: agents repeatedly rediscover scripts, infer
+permissions, reread generated indexes, and rerun broad checks because no
+validated control contract explains what exists, what it may change, and which
+evidence a change invalidates.
+
+## Frozen packet sequence
+
+| Packet | Outcome | Boundary |
+|---|---|---|
+| `MAINT-012A` | Canonical control registry, schema, loader, CLI, complete permissions, structured commands, and deterministic legacy projection | Active implementation packet |
+| `MAINT-012B` | Replace broad generated folder-index dependence with small authoritative manifests and on-demand summaries; retain only indexes proven useful | Separate candidate after A is merged |
+| `MAINT-012C` | Add content-addressed impact/evidence reuse and migrate quick/full/hosted validation scheduling to explicit change domains | Separate candidate; no safety gate may be skipped without a proved input identity |
+| `MAINT-012D` | Consolidate scanners and retire/move obsolete scripts using live callers, ownership, runtime, and replacement evidence | Separate candidate; every deletion/move requires preservation-aware proof |
+
+The order is deliberate: B-D consume the registry contract from A. They must not
+invent another operation list, permission table, alias store, or script parser.
+
+## MAINT-012A frozen scope
+
+### Canonical files
+
+- `scripts/control-plane.json` is the versioned source of truth for operation
+  discovery, status, groups, aliases, display commands, structured command
+  steps, default permissions, mode permissions, and context documents.
+- `scripts/control-plane.schema.json` is the strict Draft 2020-12 shape
+  contract. Unknown fields, absent permissions, invalid statuses, and malformed
+  commands fail closed.
+- `scripts/control_plane/` owns the validated Python loader and the control CLI.
+- `scripts/automation-map.json` remains temporarily for compatibility, but it is
+  generated deterministically from the canonical registry and must never be
+  edited independently.
+
+### Migration result
+
+| Contract | Frozen value |
+|---|---:|
+| Total operations | 128 |
+| Active operations | 125 |
+| Deprecated compatibility operations | 3 |
+| Active top-level Python/shell scripts represented | 113/113 |
+| Active operations without a default permission | 0 |
+| Canonical shell-chain commands | 0; the formatter is two structured steps |
+
+The loader rejects duplicate JSON keys, schema violations, duplicate/colliding
+aliases, invalid deprecation replacements, missing local command targets,
+repository-escaping targets, unmapped scripts, and phantom scripts. Permission
+resolution remains fail-closed for an unknown operation or mode.
+
+### Compatibility and preserved commands
+
+- `./run.sh find`, `./run.sh tools`, prompt routing, permission enforcement,
+  permission audit, governance validation, and script coverage load the
+  canonical registry.
+- `./run.sh control validate` is the compact registry/parity verdict.
+- `./run.sh control find|list|stats` exposes the canonical data directly.
+- `./run.sh control export-legacy` checks the compatibility projection;
+  `--write` is the only supported refresh path.
+- Existing consumers that still inspect `automation-map.json` receive the same
+  task-shaped compatibility data while later packets migrate or retire them.
+
+## Explicit MAINT-012A exclusions
+
+- No generic folder-index retirement or repository-wide index regeneration
+  redesign.
+- No result cache, test cache, evidence reuse policy, or CI/pre-commit topology
+  change.
+- No scanner rescheduling, scanner consolidation, script deletion, archive
+  move, or command rename.
+- No structural arithmetic, public API, FastAPI, React, Excel, ETABS, package,
+  dependency, release, GitHub setting, or professional-approval change.
+
+## Efficient operating contract
+
+For an operation-metadata change, edit only `control-plane.json`, run
+`./run.sh control export-legacy --write`, then run
+`./run.sh control validate`. Discovery and permission consumers do not require
+separate synchronized edits. The compatibility check fails if either source
+drifts, so an AI does not need to compare the two files manually.
+
+Routine code work must continue to use the repository impact and verification
+rules. MAINT-012A makes control metadata cheap and deterministic; it does not
+claim that test results are reusable before MAINT-012C supplies content-bound
+evidence identities.
+
+## Future maintenance policy
+
+There is no calendar-based rewrite after “a few months.” Update the registry
+transactionally whenever an operation is added, removed, renamed, moved, or
+changes permission/execution behavior. Increment `schema_version` only for a
+breaking registry contract and provide a migration/projection path. A bounded
+quarterly review may look for obsolete operations, slow checks, and recurring
+fallbacks, but it should create work only from measured drift or repeated cost.
+
+Each successor packet must publish before/after evidence for AI orientation
+reads, affected-check time, full-gate time, generated churn, and false/stale
+scanner findings. If a proposed abstraction does not materially reduce one of
+those outcomes, it does not belong in MAINT-012.
+
+## MAINT-012A acceptance
+
+1. Schema, semantic, duplicate, alias, target, coverage, permission, and
+   determinism regressions pass.
+2. Exactly 125 active operations and 113 top-level scripts are represented; no
+   active permission is implicit.
+3. Existing discovery, routing, tool, and permission interfaces preserve their
+   user-facing commands.
+4. The compatibility projection is byte-deterministic and clearly generated.
+5. Focused tests, quick gate, full gate, ordinary commit hooks, and all required
+   hosted checks pass on one frozen candidate.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -3,44 +3,38 @@
 ## Latest Handoff (auto)
 
 <!-- HANDOFF:START -->
-- Date: 2026-08-22
-- Focus: Complete the 13 confirmed MAINT-011 findings plus any additional
-- Git receipt: docs/verification/maint-011-git-handoff-receipt.json | sha256:38d1d1642c7b89e61fe7050c6f3824e28761ea2678853840d26fd7e26617d5a1 | HOLD
-- Git identity: codex/maint-011-developer-gate-hygiene@3f61bd93d92b7092a55e25b8ca99eda4b3335ff1 | upstream=NONE@UNKNOWN | base=origin/main@3f61bd93d92b7092a55e25b8ca99eda4b3335ff1 | tree=dirty | operation=none
-- Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
-- Next action: COMMIT_INTENDED_PATHS
+- Date: 2026-08-23
+- Focus: Implement MAINT-012A canonical operation registry and compatibility projection.
+- Git receipt: docs/verification/maint-012a-git-handoff-receipt.json | sha256:6248eb1d1331a6629863e30d9edc868211aabdcaef71516332dbed7138635862 | HOLD
+- Git identity: codex/maint-012a-control-registry@fc904511cc7b9683b2b464cdef71a45d2e9ee277 | upstream=NONE@UNKNOWN | base=origin/main@fc904511cc7b9683b2b464cdef71a45d2e9ee277 | tree=dirty | operation=none
+- Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
+- Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `LIB-PRO-005` is merged through PR #837 at `3f61bd93`; MAINT-011 implements 15 developer-gate root-cause dispositions in one separate candidate |
-| **Next** | Let the frozen MAINT-011 local gates, exact-head review, required hosted checks, and merge decide acceptance; then select a new library packet separately |
-| **Why** | Ordinary staged and all-file hooks must be equally decisive and byte-clean before more library capability work begins |
-| **Held** | Remaining 361 unproven parameters, wider route remediation, INDIA-3 implementation, ETABS, package publication, stable/professional claims, and qualified approval remain separate and held |
+| **Current** | `MAINT-012A` replaces duplicated/implicit operation metadata with one strict registry while preserving the generated automation-map compatibility surface |
+| **Next** | Freeze docs/session/receipt, refresh affected indexes once, run consolidated local gates, create the immutable commit, then push and obtain required hosted evidence |
+| **Why** | Repeated script discovery, inferred permissions, and independently edited registries consume time and can disagree; A gives later index/scanner/cache packets one validated foundation |
+| **Held** | Index retirement, evidence caching, CI/scanner redesign, script deletion/moves, product/structural/API/UI/Excel/ETABS behavior, dependencies, publication, settings, and professional approval |
 
-## Correct next library packet
+## Exact MAINT-012A state
 
-Do not restart LIB-PRO-005 or MAINT-011 after their merge prerequisites pass.
-The next library decision should compare a bounded input-safety successor with
-INDIA-3-G0 earthquake-code truth/benchmark intake. It must start from exact
-maintained routes and controlled sources, not from the raw count of 361
-unproven parameters.
-
-## Other live work
-
-- PR #837 is integrated at `3f61bd93`. `v0.23.1a2` is already public; later
-  safety and maintenance work is not in that artifact, so never republish it.
-- `INDIA-3-G0` remains a planning/source/benchmark audit only until separately
-  activated; no earthquake formulas are part of MAINT-011.
-- The unrelated dirty detached worktree at `.codex/worktrees/e54a` remains
-  retained and untouched. Dependabot PRs are separate maintenance work.
-- The MAINT-011 candidate preserves vendored/frozen bytes, repairs JSONC and
-  Bandit dispositions, and makes dependency, discovery, audit, receipt, Excel,
-  and performance truth explicit without starting ETABS or Excel feature work.
+- Canonical registry: `scripts/control-plane.json`; strict schema:
+  `scripts/control-plane.schema.json`.
+- Loader/CLI: `scripts/control_plane/`; compact verdict:
+  `./run.sh control validate`.
+- Frozen parity: 128 total operations, 125 active operations, 3 deprecated
+  compatibility operations, 113/113 top-level scripts, and zero unspecified
+  active default permissions.
+- Migrated consumers: find automation, tool registry, prompt router, permission
+  enforcement/audit, governance permission validation, script coverage, and
+  session context guidance.
+- `scripts/automation-map.json` is generated compatibility data; refresh it only
+  with `./run.sh control export-legacy --write`.
 
 ## Required Reading
 
-1. [MAINT-011 tooling follow-up](maint-011-developer-gate-hygiene-follow-up.md)
-2. [LIB-PRO-005 evidence](../verification/lib-pro-005-release-safety-closure-evidence.md)
-3. [Current task board](../TASKS.md)
-4. [Git workflow single source](../git-automation/git-workflow-single-source.md)
+1. [MAINT-012 modernization plan](maint-012-control-plane-modernization.md)
+2. [Current task board](../TASKS.md)
+3. [Git workflow single source](../git-automation/git-workflow-single-source.md)

--- a/docs/reference/automation-catalog.md
+++ b/docs/reference/automation-catalog.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-09
+last_updated: 2026-08-23
 doc_type: reference
 complexity: intermediate
 tags: [automation, scripts, codex]
@@ -11,13 +11,19 @@ tags: [automation, scripts, codex]
 
 The exhaustive machine-generated script inventory is
 [scripts/index.json](../../scripts/index.json), with a readable companion at
-[scripts/index.md](../../scripts/index.md). Task-to-script discovery lives in
-[automation-map.json](../../scripts/automation-map.json) and is queried with:
+[scripts/index.md](../../scripts/index.md). Operation discovery, commands,
+aliases, and permissions live in the canonical
+[control-plane.json](../../scripts/control-plane.json) and are queried with:
 
 ```bash
 ./run.sh find "task description"
 ./run.sh find --list
+./run.sh control validate
 ```
+
+[automation-map.json](../../scripts/automation-map.json) is a deterministic
+temporary compatibility projection. Do not edit it directly; refresh it with
+`./run.sh control export-legacy --write` after changing the canonical registry.
 
 The detailed one-by-one maintenance assessment is
 [Automation Scripts Audit — 2026-08-09](../audit/automation-scripts-audit-2026-08-09.md).
@@ -34,6 +40,7 @@ The detailed one-by-one maintenance assessment is
 | Project audit | `./run.sh audit` |
 | Health scan | `./run.sh health` |
 | API discovery | `./run.sh find --api function_name` |
+| Control registry | `./run.sh control validate` |
 | Safe file move | `.venv/bin/python scripts/safe_file_move.py old new --dry-run` |
 | Safe file delete | `.venv/bin/python scripts/safe_file_delete.py file --dry-run` |
 | Regenerate indexes | `./run.sh generate indexes` |
@@ -54,7 +61,8 @@ custom `core.hooksPath` or reintroduce lifecycle wrappers. The read-only guard i
 
 ## Maintenance rule
 
-Before updating or archiving a script, consult its ledger row in the audit,
-verify active callers with `rg`, run its focused tests, and regenerate the
+Before updating or archiving a script, inspect its canonical operation entry,
+consult its ledger row in the audit, verify active callers with `rg`, run its
+focused tests, refresh the compatibility projection, and regenerate affected
 scripts indexes. Historical references may remain in archives, but active
 instructions and runtime callers must not invoke retired scripts.

--- a/docs/reference/index.json
+++ b/docs/reference/index.json
@@ -2,7 +2,7 @@
   "folder": "docs/reference",
   "type": "mixed",
   "description": "",
-  "last_updated": "2026-08-22",
+  "last_updated": "2026-08-23",
   "file_count": 31,
   "files": [
     {
@@ -96,10 +96,10 @@
     {
       "name": "automation-catalog.md",
       "type": "documentation",
-      "size_lines": 61,
-      "last_updated": "2026-08-17",
+      "size_lines": 69,
+      "last_updated": "2026-08-23",
       "description": "The exhaustive machine-generated script inventory is scripts/index.json, with a readable companion at",
-      "content_hash": "ac6d8967a1e8"
+      "content_hash": "2f0861ab3a5f"
     },
     {
       "name": "bbs-dxf-contract.md",
@@ -279,5 +279,5 @@
       "file_count": 1760
     }
   ],
-  "content_hash": "42d77b76c85f8a23"
+  "content_hash": "dfa89edc23b0a414"
 }

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,7 @@
 # Reference
 
 **Type:** Mixed
-**Last Updated:** 2026-08-22
+**Last Updated:** 2026-08-23
 **Files:** 31
 
 ## Config Files
@@ -22,7 +22,7 @@
 | [api-levels.md](api-levels.md) |  | structural_lib exposes three API levels. All are Alpha-previ | 134 |
 | [api-stability.md](api-stability.md) |  | StructLib is a pre-1.0 Alpha. No exported Python symbol curr | 81 |
 | [api.md](api.md) |  | The public result dataclasses api.ComplianceCaseResult, api. | 4513 |
-| [automation-catalog.md](automation-catalog.md) |  | The exhaustive machine-generated script inventory is scripts | 61 |
+| [automation-catalog.md](automation-catalog.md) |  | The exhaustive machine-generated script inventory is scripts | 69 |
 | [bbs-dxf-contract.md](bbs-dxf-contract.md) |  | This document defines the stable contracts for Bar Bending S | 116 |
 | [beam-tool-manifest.md](beam-tool-manifest.md) |  | The generated beam tool manifest describes the one approved  | 34 |
 | [canonical-result-contract.md](canonical-result-contract.md) |  | The reference beam journey uses three small, versioned contr | 74 |

--- a/docs/verification/index.json
+++ b/docs/verification/index.json
@@ -2,8 +2,8 @@
   "folder": "docs/verification",
   "type": "documentation",
   "description": "Benchmark examples and verification packs for validating library calculations against IS 456 standards.",
-  "last_updated": "2026-08-22",
-  "file_count": 224,
+  "last_updated": "2026-08-23",
+  "file_count": 225,
   "files": [
     {
       "name": "INDIA-0-git-handoff.json",
@@ -2572,6 +2572,24 @@
       "content_hash": "c4e55d570c7c"
     },
     {
+      "name": "maint-012a-git-handoff-receipt.json",
+      "type": "config",
+      "last_updated": "2026-08-23",
+      "top_level_keys": [
+        "authorization",
+        "holds",
+        "integration",
+        "local",
+        "local_state_receipt_hash",
+        "mutation_policy",
+        "observed_at_utc",
+        "pull_request",
+        "receipt_grants_authority",
+        "receipt_kind"
+      ],
+      "content_hash": "d18b391ec6e5"
+    },
+    {
       "name": "next-session-git-issues-plan-git-handoff-receipt.json",
       "type": "config",
       "last_updated": "2026-08-16",
@@ -2890,5 +2908,5 @@
     }
   ],
   "subfolders": [],
-  "content_hash": "0ce06c2de4e1952a"
+  "content_hash": "e3228c1fb22c07e3"
 }

--- a/docs/verification/index.md
+++ b/docs/verification/index.md
@@ -3,8 +3,8 @@
 Benchmark examples and verification packs for validating library calculations against IS 456 standards.
 
 **Type:** Documentation
-**Last Updated:** 2026-08-22
-**Files:** 224
+**Last Updated:** 2026-08-23
+**Files:** 225
 
 ## Config Files
 
@@ -140,6 +140,7 @@ Benchmark examples and verification packs for validating library calculations ag
 - [lib-pro-005-git-handoff-source-evidence.json](lib-pro-005-git-handoff-source-evidence.json)
 - [maint-011-git-handoff-receipt.json](maint-011-git-handoff-receipt.json)
 - [maint-011-git-handoff-source-evidence.json](maint-011-git-handoff-source-evidence.json)
+- [maint-012a-git-handoff-receipt.json](maint-012a-git-handoff-receipt.json)
 - [next-session-git-issues-plan-git-handoff-receipt.json](next-session-git-issues-plan-git-handoff-receipt.json)
 - [next-session-git-issues-plan-git-handoff-source-evidence.json](next-session-git-issues-plan-git-handoff-source-evidence.json)
 - [post-india2-cleanup-disposition-evidence.json](post-india2-cleanup-disposition-evidence.json)

--- a/docs/verification/maint-012a-git-handoff-receipt.json
+++ b/docs/verification/maint-012a-git-handoff-receipt.json
@@ -1,0 +1,162 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "6248eb1d1331a6629863e30d9edc868211aabdcaef71516332dbed7138635862",
+    "state": {
+      "branch": "codex/maint-012a-control-registry",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "fc904511cc7b9683b2b464cdef71a45d2e9ee277",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 99.5,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib5",
+      "head_sha": "fc904511cc7b9683b2b464cdef71a45d2e9ee277",
+      "hold_reasons": [
+        "changed paths: 27"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-22T19:54:41.212119+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/maint-012a/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 27,
+        "modified_paths": [
+          ".github/copilot-instructions.md",
+          "AGENTS.md",
+          "CLAUDE.md",
+          "Python/tests/test_agent_governance_automation.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/getting-started/agent-bootstrap.md",
+          "docs/git-automation/live-git-guidance-index.json",
+          "docs/planning/next-session-brief.md",
+          "docs/reference/automation-catalog.md",
+          "run.sh",
+          "scripts/README.md",
+          "scripts/audit_permissions.py",
+          "scripts/automation-map.json",
+          "scripts/check_governance.py",
+          "scripts/check_scripts_index.py",
+          "scripts/find_automation.py",
+          "scripts/prompt_router.py",
+          "scripts/session.py",
+          "scripts/tool_permissions.py",
+          "scripts/tool_registry.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "Python/tests/test_control_plane.py",
+          "docs/planning/maint-012-control-plane-modernization.md",
+          "scripts/control-plane.json",
+          "scripts/control-plane.schema.json",
+          "scripts/control_plane/__init__.py",
+          "scripts/control_plane/cli.py"
+        ]
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/maint-012a/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:6248eb1d1331a6629863e30d9edc868211aabdcaef71516332dbed7138635862",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-22T19:54:41.212319+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/**",
+      "fastapi_app/**",
+      "react_app/**",
+      "VBA/**",
+      "Excel/**",
+      ".github/workflows/**",
+      "requirements*.txt"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "AGENTS.md",
+      "CLAUDE.md",
+      ".github/copilot-instructions.md",
+      "run.sh",
+      "scripts/**",
+      "Python/tests/test_agent_governance_automation.py",
+      "Python/tests/test_control_plane.py",
+      "docs/planning/maint-012-control-plane-modernization.md",
+      "docs/getting-started/agent-bootstrap.md",
+      "docs/reference/automation-catalog.md",
+      "docs/git-automation/live-git-guidance-index.json",
+      "docs/verification/maint-012a-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md",
+      "docs/docs-index.json",
+      "**/index.json",
+      "**/index.md"
+    ],
+    "task_id": "MAINT-012A"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -20,6 +20,7 @@
 #   generate  Generate indexes, SDKs, manifests
 #   route     Route tasks to the right agent
 #   tools     Tool & script discovery
+#   control   Canonical control-plane registry
 #   pipeline  Pipeline state tracking
 #   parity    Cross-layer implementation/test parity dashboard
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -803,6 +804,13 @@ _cmd_tools() {
     esac
 }
 
+# ── Command: control ───────────────────────────────────────────────────────
+
+_cmd_control() {
+    _require_venv
+    "$VENV" "$SCRIPTS/control_plane/cli.py" "$@"
+}
+
 # ── Command: pipeline ──────────────────────────────────────────────────────
 
 _cmd_pipeline() {
@@ -934,6 +942,7 @@ _print_usage() {
     echo -e "  ${GREEN}route${NC}       Route natural language to the right agent"
     echo -e "  ${GREEN}task${NC}        Build a lane-safe task intake brief"
     echo -e "  ${GREEN}tools${NC}       Tool & script discovery (list, find,stats)"
+    echo -e "  ${GREEN}control${NC}     Validate and query the canonical operation registry"
     echo -e "  ${GREEN}pipeline${NC}    Pipeline state tracking (new, advance, show)"
     echo -e "  ${GREEN}coverage${NC}    Namespaced decorator registration report"
     echo -e "  ${GREEN}parity${NC}      Declared capability and cross-layer parity dashboard"
@@ -969,6 +978,7 @@ _dispatch_help() {
         route)    _cmd_route ;;
         task)     _help_task ;;
         tools)    _cmd_tools ;;
+        control)  _cmd_control --help ;;
         pipeline) _cmd_pipeline ;;
         coverage) _cmd_coverage ;;
         parity)   _help_parity ;;
@@ -1001,6 +1011,7 @@ _run_sh() {
         'route:Route tasks to the right agent'
         'task:Build a lane-safe task intake brief'
         'tools:Tool and script discovery'
+        'control:Canonical operation registry'
         'pipeline:Pipeline state tracking'
         'parity:Cross-layer parity dashboard'
         'efficiency:Validate low-token controls'
@@ -1019,6 +1030,7 @@ _run_sh() {
     local -a audit_opts=('--score' '--errors' '--inputs' '--diagnostics')
     local -a release_subs=('preflight' 'run' 'verify' 'check-docs' 'checklist' 'permission-check' 'footing-inclusion-check')
     local -a efficiency_subs=('check' 'prompt')
+    local -a control_subs=('validate' 'find' 'list' 'stats' 'export-legacy')
 
     if (( CURRENT == 2 )); then
         _describe 'command' commands
@@ -1036,6 +1048,7 @@ _run_sh() {
             audit) _values 'option' $audit_opts ;;
             release) _values 'subcommand' $release_subs ;;
             efficiency) _values 'subcommand' $efficiency_subs ;;
+            control) _values 'subcommand' $control_subs ;;
         esac
     elif (( CURRENT == 4 )); then
         case "${words[2]}" in
@@ -1101,6 +1114,7 @@ main() {
         route)    _cmd_route "$@" ;;
         task)     _cmd_task "$@" ;;
         tools)    _cmd_tools "$@" ;;
+        control)  _cmd_control "$@" ;;
         coverage) _cmd_coverage "$@" ;;
         parity)    _cmd_parity "$@" ;;
         diagnose) _require_venv; "$VENV" "$SCRIPTS/diagnose_ci.py" "$@" ;;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,6 +17,7 @@
 ./run.sh frontend check
 ./run.sh find "topic"
 ./run.sh find --api function_name
+./run.sh control validate
 ./run.sh audit
 ./run.sh health
 ./run.sh generate indexes
@@ -50,6 +51,7 @@ hook enforcement and scripts that automate the Git lifecycle are prohibited.
 | Task intake | `run.sh task brief` | Read-only lane, base, worktree, route, and safe-start summary |
 | Python runtime | `python_runtime.sh --diagnose` | Prove linked-worktree import identity with `source_bound=true` |
 | Discovery | `find_automation.py` | Find an existing project automation |
+| Control registry | `run.sh control` | Validate/query canonical operations, permissions, targets, and compatibility projection |
 | API discovery | `discover_api_signatures.py` | Exact Python API signatures |
 | Files | `safe_file_move.py` | Move files after a dry run and link scan |
 | Files | `safe_file_delete.py` | Delete files after a dry run and reference scan |
@@ -77,3 +79,7 @@ hook enforcement and scripts that automate the Git lifecycle are prohibited.
 The generated inventories [index.json](index.json) and [index.md](index.md) are
 the exhaustive script catalog. Regenerate them after adding, removing, or
 renaming scripts.
+
+Operation metadata is canonical in [control-plane.json](control-plane.json).
+[automation-map.json](automation-map.json) is generated compatibility data;
+refresh it only with `./run.sh control export-legacy --write`.

--- a/scripts/audit_permissions.py
+++ b/scripts/audit_permissions.py
@@ -14,13 +14,18 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _lib.output import StatusLine, print_json  # noqa: E402
+from control_plane import (  # noqa: E402
+    REGISTRY_PATH,
+    ControlPlaneError,
+    load_registry as load_control_registry,
+    operation_map,
+)
 from tool_permissions import (  # noqa: E402
     DANGER_OPS,
     READ_OPS,
@@ -66,7 +71,7 @@ class AuditReport:
 # Write-capable tool keywords
 _WRITE_TOOLS = {"editFiles", "edit", "write", "create"}
 _RUN_TOOLS = {"runInTerminal", "run", "terminal"}
-_AUTOMATION_MAP = Path(__file__).resolve().parent / "automation-map.json"
+_CONTROL_PLANE = REGISTRY_PATH
 _KNOWN_LEVELS = {"ReadOnly", "ReadOnlyTerminal", "WorkspaceWrite", "DangerFullAccess"}
 
 
@@ -81,27 +86,27 @@ def _has_run_tools(tools: list[str]) -> bool:
 
 
 def audit_automation_permission_metadata() -> list[Anomaly]:
-    """Validate only explicitly declared automation permission metadata."""
+    """Validate canonical operation permission metadata fail-closed."""
     try:
-        data = json.loads(_AUTOMATION_MAP.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        data = load_control_registry(path=_CONTROL_PLANE)
+    except ControlPlaneError as exc:
         return [
             Anomaly(
-                agent="automation-map",
+                agent="control-plane",
                 severity="CONFLICT",
                 message=f"Cannot load automation permission metadata: {exc}",
             )
         ]
 
     anomalies: list[Anomaly] = []
-    for task_name, task in data.get("tasks", {}).items():
+    for task_name, task in operation_map(data).items():
         if not isinstance(task, dict):
             continue
         default_level = task.get("permission")
         modes = task.get("permission_modes")
         subject = f"automation:{task_name}"
 
-        if default_level is not None and default_level not in _KNOWN_LEVELS:
+        if default_level not in _KNOWN_LEVELS:
             anomalies.append(
                 Anomaly(
                     agent=subject,
@@ -112,14 +117,6 @@ def audit_automation_permission_metadata() -> list[Anomaly]:
 
         if modes is None:
             continue
-        if default_level is None:
-            anomalies.append(
-                Anomaly(
-                    agent=subject,
-                    severity="CONFLICT",
-                    message="permission_modes requires an explicit default permission",
-                )
-            )
         if not isinstance(modes, dict):
             anomalies.append(
                 Anomaly(

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -1,26 +1,31 @@
 {
-  "_comment": "Task-to-script mapping - helps agents find the right automation for their task",
-  "_updated": "2026-08-17",
-  "_usage": "Run: ./scripts/python_runtime.sh scripts/find_automation.py \"task description\" — or --list for all",
-  "_coverage": "113/113 scripts mapped",
+  "_comment": "GENERATED compatibility projection from scripts/control-plane.json; do not edit directly",
+  "_usage": "Use ./run.sh find <query> or ./run.sh control find <query>",
+  "_source": "scripts/control-plane.json",
+  "_coverage": "113/113 top-level scripts registered",
   "tasks": {
     "resolve python runtime": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh --version",
+      "group": "Infrastructure",
       "description": "Resolve the approved Python interpreter across primary and linked Git worktrees",
       "permission": "ReadOnly"
     },
     "diagnose python runtime": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh --diagnose",
+      "group": "Infrastructure",
       "description": "Show the selected interpreter and prove structural_lib is bound to the invoking worktree",
-      "aliases": [".venv", "worktree python", "python source binding"],
-      "permission": "ReadOnly"
+      "permission": "ReadOnly",
+      "aliases": [
+        ".venv",
+        "worktree python",
+        "python source binding"
+      ]
     },
     "choose codex model": {
-      "group": "Agent Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/model_picker.py \"task description\"",
+      "group": "Agent Infrastructure",
       "description": "Recommend a GPT-5.6 model and reasoning level using the checked-in token-efficiency policy (also: ./run.sh model)",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "--table": "Compare all supported profiles",
         "--risk LEVEL": "Set auto, low, normal, high, or critical risk",
@@ -32,17 +37,18 @@
       }
     },
     "validate token efficiency": {
-      "group": "Agent Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/check_token_efficiency.py",
+      "group": "Agent Infrastructure",
       "description": "Validate project Codex defaults, model policy, context controls, and the reusable low-token prompt",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "--json": "Machine-readable policy report",
         "--prompt": "Print the reusable low-token task preamble"
       }
     },
     "run all checks": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_all.py",
+      "group": "Quality",
       "description": "Run all 30 validation checks across 8 categories in parallel (also: ./run.sh check)",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -55,16 +61,20 @@
         "--fix": "Auto-fix where possible",
         "--json": "JSON output for CI",
         "--serial": "Run sequentially (debugging)"
-      }
+      },
+      "aliases": [
+        "check"
+      ]
     },
     "validate script references": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/validate_script_refs.py",
-      "description": "Detect stale script references across docs and instruction files"
+      "group": "Quality",
+      "description": "Detect stale script references across docs and instruction files",
+      "permission": "ReadOnlyTerminal"
     },
     "diagnose ci failures": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/diagnose_ci.py",
+      "group": "Quality",
       "description": "Diagnose, reproduce, and auto-fix CI failures locally or for a specific PR",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -78,54 +88,73 @@
       }
     },
     "move file": {
-      "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/safe_file_move.py old.md new.md",
+      "group": "Docs",
       "description": "Move file and update all internal links automatically (870+ links preserved)",
+      "permission": "WorkspaceWrite",
+      "aliases": [
+        "move"
+      ],
       "never_use": [
         "mv",
         "git mv"
       ]
     },
     "delete file": {
-      "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/safe_file_delete.py file.md",
+      "group": "Docs",
       "description": "Delete file after checking for references",
+      "permission": "DangerFullAccess",
+      "aliases": [
+        "delete"
+      ],
       "never_use": [
         "rm",
         "git rm"
       ]
     },
     "create document": {
-      "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/create_doc.py path/file.md \"Title\"",
-      "description": "Create document with proper metadata headers"
+      "group": "Docs",
+      "description": "Create document with proper metadata headers",
+      "permission": "WorkspaceWrite"
     },
     "fix broken links": {
-      "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/check_links.py --fix",
-      "description": "Find and auto-fix broken internal links in markdown files"
+      "group": "Docs",
+      "description": "Find and auto-fix broken internal links in markdown files",
+      "permission": "WorkspaceWrite"
     },
     "check markdown links": {
-      "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/check_links.py",
+      "group": "Docs",
       "description": "Read-only validation of internal Markdown links",
-      "aliases": ["check_markdown_links.py", "markdown links"],
-      "permission": "ReadOnly"
+      "permission": "ReadOnly",
+      "aliases": [
+        "check_markdown_links.py",
+        "markdown links"
+      ]
     },
     "fix deleted file links": {
-      "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/fix_broken_links.py --dry-run",
-      "description": "Remove or convert broken links to deleted streamlit/vba/excel/xlwings files"
+      "group": "Docs",
+      "description": "Remove or convert broken links to deleted streamlit/vba/excel/xlwings files",
+      "permission": "ReadOnlyTerminal"
     },
     "run tests": {
-      "group": "Testing",
       "script": "./run.sh test",
-      "description": "Run the Python suite by default; use --fastapi, --react, or --all for explicit product-suite scope"
+      "group": "Testing",
+      "description": "Run the Python suite by default; use --fastapi, --react, or --all for explicit product-suite scope",
+      "permission": "ReadOnlyTerminal",
+      "aliases": [
+        "test"
+      ]
     },
     "select frontend node runtime": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/node_runtime.py --print",
+      "group": "Infrastructure",
       "description": "Select the healthy Node/npm pair pinned by .nvmrc (also: ./run.sh frontend runtime)",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "--print": "Show selected Node and npm versions",
         "--bin-dir": "Print only the selected binary directory",
@@ -133,25 +162,28 @@
       }
     },
     "watch tests": {
-      "group": "Testing",
       "script": "./scripts/watch_tests.sh",
+      "group": "Testing",
       "description": "Run tests in watch mode — re-runs on file changes",
       "permission": "ReadOnly"
     },
     "format code": {
-      "group": "Infrastructure",
       "script": "cd Python && ../scripts/python_runtime.sh -m black . && ../scripts/python_runtime.sh -m ruff check --fix .",
-      "description": "Auto-format Python code with black + ruff"
+      "group": "Infrastructure",
+      "description": "Auto-format Python code with black + ruff",
+      "permission": "WorkspaceWrite"
     },
     "check folder structure": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_governance.py --structure",
-      "description": "Validate project folder organization against governance rules"
+      "group": "Quality",
+      "description": "Validate project folder organization against governance rules",
+      "permission": "ReadOnlyTerminal"
     },
     "check governance": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_governance.py",
+      "group": "Quality",
       "description": "Run full governance check (folder structure + compliance)",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "--structure": "Folder structure only",
         "--compliance": "Compliance only",
@@ -160,14 +192,22 @@
       }
     },
     "governance health score": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/governance_health_score.py",
-      "description": "Calculate overall governance health score with breakdown"
+      "group": "Quality",
+      "description": "Calculate overall governance health score with breakdown",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--output": "WorkspaceWrite"
+      }
     },
     "generate audit report": {
-      "group": "Generation",
       "script": "./scripts/python_runtime.sh scripts/audit_readiness_report.py",
+      "group": "Generation",
       "description": "Generate audit evidence bundle (NIST SSDF aligned)",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--output": "WorkspaceWrite"
+      },
       "options": {
         "--check-only": "Quick pass/fail for CI",
         "--json": "Export as JSON",
@@ -175,29 +215,35 @@
       }
     },
     "audit error handling": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/audit_error_handling.py",
-      "description": "Audit error handling compliance across structural_lib modules"
+      "group": "Quality",
+      "description": "Audit error handling compliance across structural_lib modules",
+      "permission": "ReadOnlyTerminal"
     },
     "audit input validation": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/audit_input_validation.py",
-      "description": "Audit evidence-bearing input-validation ownership for maintained structural_lib routes"
+      "group": "Quality",
+      "description": "Audit evidence-bearing input-validation ownership for maintained structural_lib routes",
+      "permission": "ReadOnlyTerminal"
     },
     "check public route safety": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_public_route_safety.py",
+      "group": "Quality",
       "description": "Run the frozen adversarial Python and FastAPI public-route safety regressions",
       "permission": "ReadOnly"
     },
     "start session": {
-      "group": "Session",
       "script": "./scripts/agent_start.sh --quick",
-      "description": "Resolve the approved runtime, run preflight, and start a session without Git/GitHub lifecycle actions"
+      "group": "Session",
+      "description": "Resolve the approved runtime, run preflight, and start a session without Git/GitHub lifecycle actions",
+      "permission": "WorkspaceWrite",
+      "aliases": [
+        "session"
+      ]
     },
     "end session": {
-      "group": "Session",
       "script": "./scripts/python_runtime.sh scripts/session.py end",
+      "group": "Session",
       "description": "Validate session closeout without hidden writes",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -205,8 +251,8 @@
       }
     },
     "session summary": {
-      "group": "Session",
       "script": "./scripts/python_runtime.sh scripts/session.py summary",
+      "group": "Session",
       "description": "Preview a session summary from repository history",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -214,15 +260,9 @@
       }
     },
     "sync doc numbers": {
-      "group": "Session",
       "script": "./scripts/python_runtime.sh scripts/sync_numbers.py",
+      "group": "Session",
       "description": "Scan codebase metrics and report stale documentation counts; no flag is the read-only default",
-      "aliases": [
-        "sync_numbers.py",
-        "sync numbers",
-        "documentation counts",
-        "check stale counts"
-      ],
       "permission": "ReadOnly",
       "permission_modes": {
         "--fix": "WorkspaceWrite"
@@ -231,23 +271,31 @@
         "(no flag)": "Dry run — scan and report only",
         "--fix": "Apply updates to files",
         "--json": "Machine-readable output"
-      }
+      },
+      "aliases": [
+        "sync_numbers.py",
+        "sync numbers",
+        "documentation counts",
+        "check stale counts"
+      ]
     },
     "session handoff": {
-      "group": "Session",
       "script": "./scripts/python_runtime.sh scripts/session.py handoff",
+      "group": "Session",
       "description": "Validate a durable task-to-Git receipt and write next-session-brief.md for the next agent",
-      "aliases": ["session receipt handoff", "durable handoff"],
       "permission": "WorkspaceWrite",
       "options": {
         "--git-receipt PATH": "Validate and embed the versioned receipt identity"
-      }
+      },
+      "aliases": [
+        "session receipt handoff",
+        "durable handoff"
+      ]
     },
     "task git handoff receipt": {
-      "group": "Git",
       "script": "./scripts/python_runtime.sh scripts/git_handoff_receipt.py create",
+      "group": "Git",
       "description": "Build or validate a fail-closed task-to-Git handoff receipt from git_state.py plus caller-supplied hosted evidence",
-      "aliases": ["git receipt", "handoff receipt", "task to git"],
       "permission": "ReadOnly",
       "permission_modes": {
         "--output": "WorkspaceWrite"
@@ -255,16 +303,22 @@
       "options": {
         "create": "Build receipt; missing hosted facts remain UNKNOWN or NOT_CHECKED holds",
         "validate": "Validate schema, hashes, exact-head binding, and contradictions"
-      }
+      },
+      "aliases": [
+        "git receipt",
+        "handoff receipt",
+        "task to git"
+      ]
     },
     "session check": {
-      "group": "Session",
       "script": "./scripts/python_runtime.sh scripts/session.py check",
-      "description": "Verify session docs are consistent and complete"
+      "group": "Session",
+      "description": "Verify session docs are consistent and complete",
+      "permission": "ReadOnlyTerminal"
     },
     "check git state": {
-      "group": "Git",
       "script": "./scripts/python_runtime.sh scripts/git_state.py",
+      "group": "Git",
       "description": "Report typed local Git state, holds, base, upstream, operations, and locks without network or mutation",
       "permission": "ReadOnly",
       "options": {
@@ -274,31 +328,37 @@
       }
     },
     "check api signatures": {
-      "group": "Discovery",
       "script": "./scripts/python_runtime.sh scripts/check_api.py --all",
-      "description": "Verify API documentation matches code (signatures, docs, sync)"
+      "group": "Discovery",
+      "description": "Verify API documentation matches code (signatures, docs, sync)",
+      "permission": "ReadOnlyTerminal"
     },
     "discover api function": {
-      "group": "Discovery",
       "script": "./scripts/python_runtime.sh scripts/discover_api_signatures.py <function_name>",
+      "group": "Discovery",
       "description": "Get exact parameter names and types for any structural_lib function",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "--all": "Show all API signatures",
         "--filter <category>": "Filter by category (design, detail, geometry, etc.)"
       },
+      "aliases": [
+        "api"
+      ],
       "never_use": [
         "guess parameter names",
         "assume return types"
       ]
     },
     "generate api manifest": {
-      "group": "Discovery",
       "script": "./scripts/python_runtime.sh scripts/generate_api_manifest.py",
-      "description": "Regenerate API manifest (public function inventory)"
+      "group": "Discovery",
+      "description": "Regenerate API manifest (public function inventory)",
+      "permission": "WorkspaceWrite"
     },
     "generate api classification": {
-      "group": "Discovery",
       "script": "./scripts/python_runtime.sh scripts/generate_api_classification.py --check",
+      "group": "Discovery",
       "description": "Generate or validate the Alpha preview/compatibility/internal API classification registry",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -306,24 +366,28 @@
       }
     },
     "generate beam tool manifest": {
-      "group": "Discovery",
       "script": "./scripts/python_runtime.sh scripts/generate_beam_tool_manifest.py --write --check",
-      "description": "Regenerate and byte-check the catalogue-derived beam tool descriptor without activating AI execution"
+      "group": "Discovery",
+      "description": "Regenerate and byte-check the catalogue-derived beam tool descriptor without activating AI execution",
+      "permission": "WorkspaceWrite"
     },
     "check architecture boundaries": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_architecture_boundaries.py",
-      "description": "Enforce 4-layer architecture — core cannot import services/UI"
+      "group": "Quality",
+      "description": "Enforce 4-layer architecture — core cannot import services/UI",
+      "permission": "ReadOnlyTerminal"
     },
     "check codex git workflow": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_codex_git_workflow.py",
-      "description": "Ensure retired Git lifecycle wrappers and enforcement hooks stay removed"
+      "group": "Quality",
+      "description": "Ensure retired Git lifecycle wrappers and enforcement hooks stay removed",
+      "permission": "ReadOnlyTerminal"
     },
     "check element completeness": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_new_element_completeness.py",
+      "group": "Quality",
       "description": "Check completeness across 7 layers (types, math, tests, API, endpoint, UI, docs) for all structural elements",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "--element <name>": "Detailed report for specific element (beam, column, slab, etc.)",
         "--json": "Machine-readable JSON output",
@@ -331,73 +395,93 @@
       }
     },
     "check circular imports": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_circular_imports.py",
-      "description": "Detect circular imports in the Streamlit application"
+      "group": "Quality",
+      "description": "Detect circular imports in the Streamlit application",
+      "permission": "ReadOnlyTerminal"
     },
     "check fastapi issues": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_fastapi_issues.py",
-      "description": "AST-scan for common FastAPI issues (missing types, wrong patterns)"
+      "group": "Quality",
+      "description": "AST-scan for common FastAPI issues (missing types, wrong patterns)",
+      "permission": "ReadOnlyTerminal"
     },
     "check type annotations": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_type_annotations.py",
-      "description": "Check type annotation coverage in Streamlit application"
+      "group": "Quality",
+      "description": "Check type annotation coverage in Streamlit application",
+      "permission": "ReadOnlyTerminal"
     },
     "check docs": {
-      "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/check_docs.py",
-      "description": "Unified doc checker — index, links, metadata validation"
+      "group": "Docs",
+      "description": "Unified doc checker — index, links, metadata validation",
+      "permission": "ReadOnlyTerminal"
     },
     "check docs metadata": {
-      "group": "Docs",
       "script": "./scripts/python_runtime.sh scripts/check_docs.py --metadata --strict",
+      "group": "Docs",
       "description": "Validate required documentation metadata with the consolidated checker",
-      "aliases": ["check_doc_metadata.py", "doc metadata"],
-      "permission": "ReadOnly"
+      "permission": "ReadOnly",
+      "aliases": [
+        "check_doc_metadata.py",
+        "doc metadata"
+      ]
     },
     "validate imports": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/validate_imports.py",
-      "description": "Validate Python imports across the project (use after migrations)"
+      "group": "Quality",
+      "description": "Validate Python imports across the project (use after migrations)",
+      "permission": "ReadOnlyTerminal"
     },
     "validate api contracts": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/validate_api_contracts.py",
-      "description": "API contract testing — request/response schemas, status codes"
+      "group": "Quality",
+      "description": "API contract testing — request/response schemas, status codes",
+      "permission": "ReadOnlyTerminal"
     },
     "validate schema snapshots": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/validate_schema_snapshots.py",
-      "description": "Validate OpenAPI schema snapshots haven't changed unexpectedly"
+      "group": "Quality",
+      "description": "Validate OpenAPI schema snapshots haven't changed unexpectedly",
+      "permission": "ReadOnlyTerminal"
     },
     "check openapi drift": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_openapi_snapshot.py",
+      "group": "Quality",
       "description": "Compare live OpenAPI spec against baseline — detect endpoint/schema drift",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--update": "WorkspaceWrite"
+      },
       "options": {
         "--update": "Update baseline with current spec",
         "--json": "Machine-readable JSON output"
       }
     },
     "check openapi baseline drift": {
-      "group": "CI",
       "script": "./scripts/python_runtime.sh scripts/check_openapi_drift.py",
+      "group": "CI",
       "description": "CI guard — verify OpenAPI spec matches committed baseline (TASK-726)",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--update": "WorkspaceWrite"
+      },
       "options": {
         "--update": "Update the baseline file from live spec"
       }
     },
     "check docker config": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/check_docker_config.py",
-      "description": "Validate Dockerfile and docker-compose configuration"
+      "group": "Infrastructure",
+      "description": "Validate Dockerfile and docker-compose configuration",
+      "permission": "ReadOnlyTerminal"
     },
     "launch dev stack": {
-      "group": "Infrastructure",
       "script": "bash scripts/launch_stack.sh",
+      "group": "Infrastructure",
       "description": "Launch full-stack dev environment (FastAPI + React) with auto-detection of free ports",
+      "permission": "WorkspaceWrite",
       "options": {
         "--local": "Local mode (default): FastAPI + React processes",
         "--docker": "Docker mode via Colima",
@@ -409,24 +493,28 @@
       }
     },
     "check doc versions": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_doc_versions.py",
-      "description": "Detect stale library version references in docs (pre-commit hook)"
+      "group": "Quality",
+      "description": "Detect stale library version references in docs (pre-commit hook)",
+      "permission": "ReadOnlyTerminal"
     },
     "check bootstrap freshness": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_bootstrap_freshness.py",
-      "description": "Detect when bootstrap docs are stale — new hooks/routes/components not documented"
+      "group": "Quality",
+      "description": "Detect when bootstrap docs are stale — new hooks/routes/components not documented",
+      "permission": "ReadOnlyTerminal"
     },
     "check instruction drift": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_instruction_drift.py",
-      "description": "Detect content drift between .github/instructions/ and .claude/rules/ — warns when platforms diverge"
+      "group": "Quality",
+      "description": "Detect content drift between .github/instructions/ and .claude/rules/ — warns when platforms diverge",
+      "permission": "ReadOnlyTerminal"
     },
     "check tasks format": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_tasks_format.py",
+      "group": "Quality",
       "description": "Validate TASKS.md structure and WIP rules",
+      "permission": "ReadOnlyTerminal",
       "aliases": [
         "check_tasks.py",
         "check_tasks_format.py",
@@ -435,113 +523,130 @@
       ]
     },
     "check python version": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_python_version.py",
-      "description": "Enforce consistent Python version strings across configs"
+      "group": "Quality",
+      "description": "Enforce consistent Python version strings across configs",
+      "permission": "ReadOnlyTerminal"
     },
     "check version consistency": {
-      "group": "Quality",
       "script": "./scripts/check_version_consistency.sh",
+      "group": "Quality",
       "description": "Verify version strings match across maintained package metadata and docs",
       "permission": "ReadOnly"
     },
     "check wip limits": {
-      "group": "Quality",
       "script": "./scripts/check_wip_limits.sh",
-      "description": "Enforce WIP limits — max items in In Progress"
+      "group": "Quality",
+      "description": "Enforce WIP limits — max items in In Progress",
+      "permission": "ReadOnlyTerminal"
     },
     "check repo hygiene": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_repo_hygiene.py",
-      "description": "Fail if tracked hygiene artifacts exist (pre-commit hook)"
+      "group": "Quality",
+      "description": "Fail if tracked hygiene artifacts exist (pre-commit hook)",
+      "permission": "ReadOnlyTerminal"
     },
     "check cli reference": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_cli_reference.py",
-      "description": "Ensure CLI reference doc includes all required commands"
+      "group": "Quality",
+      "description": "Ensure CLI reference doc includes all required commands",
+      "permission": "ReadOnlyTerminal"
     },
     "check scripts index": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_scripts_index.py",
+      "group": "Quality",
       "description": "Ensure scripts/index.json and automation-map metadata match maintained scripts",
       "permission": "ReadOnly"
     },
     "check api compat": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_api_compat.py",
+      "group": "Quality",
       "description": "Check API backward compatibility against manifest",
       "permission": "ReadOnly"
     },
     "generate error docs": {
-      "group": "Generation",
       "script": "./scripts/python_runtime.sh scripts/generate_error_docs.py",
-      "description": "Generate error code documentation from source"
+      "group": "Generation",
+      "description": "Generate error code documentation from source",
+      "permission": "WorkspaceWrite"
     },
     "check next session brief": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_next_session_brief_length.py",
-      "description": "Ensure next-session-brief.md stays concise"
+      "group": "Quality",
+      "description": "Ensure next-session-brief.md stays concise",
+      "permission": "ReadOnlyTerminal"
     },
     "check root file count": {
-      "group": "Quality",
       "script": "./scripts/check_root_file_count.sh",
+      "group": "Quality",
       "description": "Warn if too many files in project root (sprawl detection)",
       "permission": "ReadOnly"
     },
     "check merge state": {
-      "group": "Git",
       "script": "./scripts/python_runtime.sh scripts/git_state.py --guard operation",
+      "group": "Git",
       "description": "Fail on an active or unknown Git operation, conflict, or lock",
       "permission": "ReadOnly"
     },
     "check branch safety": {
-      "group": "Git",
       "script": "./scripts/python_runtime.sh scripts/git_state.py --guard branch",
+      "group": "Git",
       "description": "Fail closed on main, detached HEAD, or unknown branch state",
       "permission": "ReadOnly"
     },
     "compat validate git state": {
-      "group": "Git",
       "script": "./scripts/validate_git_state.sh",
+      "group": "Git",
       "description": "Deprecated compatibility entrypoint delegated to check git state",
-      "deprecated": true,
-      "replacement": "check git state"
+      "permission": "ReadOnlyTerminal",
+      "replacement": "check git state",
+      "deprecated": true
     },
     "compat unfinished operation guard": {
-      "group": "Git",
       "script": "./scripts/check_unfinished_merge.sh",
+      "group": "Git",
       "description": "Deprecated compatibility entrypoint delegated to check merge state",
-      "deprecated": true,
-      "replacement": "check merge state"
+      "permission": "ReadOnlyTerminal",
+      "replacement": "check merge state",
+      "deprecated": true
     },
     "compat branch guard": {
-      "group": "Git",
       "script": "./scripts/check_not_main.sh",
+      "group": "Git",
       "description": "Deprecated compatibility entrypoint delegated to check branch safety",
-      "deprecated": true,
-      "replacement": "check branch safety"
+      "permission": "ReadOnlyTerminal",
+      "replacement": "check branch safety",
+      "deprecated": true
     },
     "migrate python module": {
-      "group": "Migration",
       "script": "./scripts/python_runtime.sh scripts/migrate_python_module.py <src> <dst> --dry-run",
+      "group": "Migration",
       "description": "Move Python module to new location + update all imports automatically",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "live": "WorkspaceWrite"
+      },
       "never_use": [
         "mv",
         "manual find-and-replace imports"
       ]
     },
     "migrate react component": {
-      "group": "Migration",
       "script": "./scripts/python_runtime.sh scripts/migrate_react_component.py <src> <dst> --dry-run",
+      "group": "Migration",
       "description": "Move React component to new feature-grouped folder + update imports",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "live": "WorkspaceWrite"
+      },
       "never_use": [
         "mv",
         "manual find-and-replace imports"
       ]
     },
     "batch migration": {
-      "group": "Migration",
       "script": "./scripts/python_runtime.sh scripts/batch_migrate_runner.py",
+      "group": "Migration",
       "description": "Run multiple migrations with per-operation rollback logs",
       "permission": "WorkspaceWrite",
       "permission_modes": {
@@ -550,9 +655,14 @@
       }
     },
     "bump version": {
-      "group": "Release",
       "script": "./scripts/python_runtime.sh scripts/bump_version.py",
+      "group": "Release",
       "description": "Bump version in pyproject.toml (single source of truth)",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--current": "ReadOnlyTerminal",
+        "VERSION": "WorkspaceWrite"
+      },
       "options": {
         "patch": "0.19.1 → 0.19.2",
         "minor": "0.19.1 → 0.20.0",
@@ -560,77 +670,86 @@
       }
     },
     "release": {
-      "group": "Release",
       "script": "./scripts/python_runtime.sh scripts/release.py",
-      "description": "Unified release management — preflight, artifact verification, and owner-gated publication"
+      "group": "Release",
+      "description": "Unified release management — preflight, artifact verification, and owner-gated publication",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "run": "DangerFullAccess",
+        "preflight": "ReadOnlyTerminal"
+      }
     },
     "release preflight": {
-      "group": "Release",
       "script": "./run.sh release preflight --wheel <exact-wheel-path>",
+      "group": "Release",
       "description": "Run clean-tree Python, FastAPI, React, version, permission, and exact-wheel release gates",
-      "aliases": ["candidate preflight", "release CI parity"],
       "permission": "ReadOnly",
-      "context_docs": [".github/skills/release-preflight/SKILL.md"]
+      "aliases": [
+        "candidate preflight",
+        "release ci parity"
+      ],
+      "context_docs": [
+        ".github/skills/release-preflight/SKILL.md"
+      ]
     },
     "benchmark api": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/benchmark_api.py",
-      "description": "API performance benchmark with latency measurements"
+      "group": "Testing",
+      "description": "API performance benchmark with latency measurements",
+      "permission": "WorkspaceWrite"
     },
     "test api parity": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/test_api_parity.py",
-      "description": "Verify library and FastAPI return identical results"
+      "group": "Testing",
+      "description": "Verify library and FastAPI return identical results",
+      "permission": "ReadOnlyTerminal"
     },
     "verify canonical transport artifact": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/verify_canonical_transport_artifact.py --wheel <exact-wheel-path>",
+      "group": "Testing",
       "description": "Verify A1 source-free Python and CLI plus exact-head FastAPI binding to one wheel",
       "permission": "ReadOnly"
     },
     "verify excel workbench artifact": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/verify_excel_workbench_artifact.py --wheel <exact-wheel-path>",
+      "group": "Testing",
       "description": "Verify the E1 workbook, manifest, installed identity, and canonical sample row from one source-free wheel",
       "permission": "ReadOnly"
     },
     "test import 3d pipeline": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/test_import_pipeline.py",
-      "description": "Compatibility alias for the maintained import, batch-design, and 3D geometry E2E test"
+      "group": "Testing",
+      "description": "Compatibility alias for the maintained import, batch-design, and 3D geometry E2E test",
+      "permission": "ReadOnlyTerminal"
     },
     "test import pipeline": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/test_import_pipeline.py",
-      "description": "E2E test: all 4 import endpoints (sample, single CSV, dual CSV, batch design)"
+      "group": "Testing",
+      "description": "E2E test: all 4 import endpoints (sample, single CSV, dual CSV, batch design)",
+      "permission": "ReadOnlyTerminal"
     },
     "external cli test": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/external_cli_test.py",
+      "group": "Testing",
       "description": "Exercise the installed package in a new isolated workspace",
       "permission": "WorkspaceWrite"
     },
     "create test scaffold": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/create_test_scaffold.py <module>",
-      "description": "Generate test file scaffold for a module"
+      "group": "Testing",
+      "description": "Generate test file scaffold for a module",
+      "permission": "WorkspaceWrite"
     },
     "update test stats": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/update_test_stats.py",
-      "description": "Update test_stats.json with current test counts"
+      "group": "Testing",
+      "description": "Update test_stats.json with current test counts",
+      "permission": "WorkspaceWrite"
     },
     "generate folder index": {
-      "group": "Generation",
       "script": "./scripts/python_runtime.sh scripts/generate_enhanced_index.py <folder>",
+      "group": "Generation",
       "description": "Update maintained index.json + index.md files from changed leaves through maintained parents; new index locations require explicit opt-in",
-      "aliases": [
-        "generate_folder_index.py",
-        "generate_enhanced_index.py",
-        "folder index",
-        "refresh index",
-        "leaf parent index"
-      ],
       "permission": "WorkspaceWrite",
       "permission_modes": {
         "--dry-run": "ReadOnly",
@@ -639,53 +758,63 @@
       "options": {
         "--all": "Regenerate all key-folder indexes",
         "--allow-new-index": "Permit intentional creation in a previously unmaintained folder"
-      }
+      },
+      "aliases": [
+        "generate_folder_index.py",
+        "generate_enhanced_index.py",
+        "folder index",
+        "refresh index",
+        "leaf parent index"
+      ]
     },
     "generate all indexes": {
-      "group": "Generation",
       "script": "./scripts/generate_all_indexes.sh",
-      "description": "Regenerate index.json + index.md for all research-relevant folders"
+      "group": "Generation",
+      "description": "Regenerate index.json + index.md for all research-relevant folders",
+      "permission": "WorkspaceWrite"
     },
     "generate docs index": {
-      "group": "Generation",
       "script": "./scripts/python_runtime.sh scripts/generate_docs_index.py",
+      "group": "Generation",
       "description": "Preview the global machine-readable documentation index; pass --write intentionally before refreshing parent folder indexes",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--write": "WorkspaceWrite"
+      },
       "aliases": [
         "generate_docs_index.py",
         "global docs index",
         "documentation index",
         "docs-index.json"
-      ],
-      "permission": "ReadOnly",
-      "permission_modes": {
-        "--write": "WorkspaceWrite"
-      }
+      ]
     },
     "generate client sdks": {
-      "group": "Generation",
       "script": "./scripts/python_runtime.sh scripts/generate_client_sdks.py",
-      "description": "Generate TypeScript/Python client SDKs from FastAPI OpenAPI spec"
+      "group": "Generation",
+      "description": "Generate TypeScript/Python client SDKs from FastAPI OpenAPI spec",
+      "permission": "WorkspaceWrite"
     },
     "preflight checks": {
-      "group": "Session",
       "script": "./scripts/python_runtime.sh scripts/preflight.py",
+      "group": "Session",
       "description": "Pre-flight checks before starting work (branch, runtime, ports, conflicts)",
       "permission": "ReadOnly"
     },
     "test changed files": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/test_changed.py",
+      "group": "Testing",
       "description": "Run tests only for changed files (auto-detect from git diff)",
       "permission": "ReadOnly"
     },
     "render dxf": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/dxf_render.py",
-      "description": "Render DXF drawings to PNG or PDF using ezdxf + matplotlib"
+      "group": "Infrastructure",
+      "description": "Render DXF drawings to PNG or PDF using ezdxf + matplotlib",
+      "permission": "WorkspaceWrite"
     },
     "archive old files": {
-      "group": "Docs",
       "script": "./scripts/archive_old_files.sh",
+      "group": "Docs",
       "description": "Move files older than 90 days from docs/_active/ to _archive/",
       "permission": "WorkspaceWrite",
       "permission_modes": {
@@ -693,67 +822,78 @@
       }
     },
     "classify branch disposition": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/classify_branch_disposition.py --all-local --json",
+      "group": "Infrastructure",
       "description": "Inspect branch/worktree disposition; remote and PR evidence are caller-supplied",
       "permission": "ReadOnly"
     },
     "collect diagnostics": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/collect_diagnostics.py",
-      "description": "Collect compact diagnostics bundle for debugging and support"
+      "group": "Infrastructure",
+      "description": "Collect compact diagnostics bundle for debugging and support",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--out": "WorkspaceWrite"
+      }
     },
     "collect metrics": {
-      "group": "Infrastructure",
       "script": "./scripts/collect_metrics.sh",
-      "description": "Collect project metrics — test counts, coverage, complexity, sizes"
+      "group": "Infrastructure",
+      "description": "Collect project metrics — test counts, coverage, complexity, sizes",
+      "permission": "WorkspaceWrite"
     },
     "local ci": {
-      "group": "Git",
       "script": "./scripts/ci_local.sh",
+      "group": "Git",
       "description": "Run canonical local validation without managing Git or environments",
       "permission": "WorkspaceWrite"
     },
     "repo health check": {
-      "group": "Governance",
       "script": "./scripts/repo_health_check.sh",
-      "description": "Quick overall repo health check"
+      "group": "Governance",
+      "description": "Quick overall repo health check",
+      "permission": "ReadOnlyTerminal"
     },
     "agent mistakes report": {
-      "group": "Governance",
       "script": "./scripts/agent_mistakes_report.sh",
-      "description": "Show common agent mistakes as a reminder at session start"
+      "group": "Governance",
+      "description": "Show common agent mistakes as a reminder at session start",
+      "permission": "ReadOnlyTerminal"
     },
     "find automation": {
-      "group": "Discovery",
       "script": "./scripts/python_runtime.sh scripts/find_automation.py \"task\"",
+      "group": "Discovery",
       "description": "Search this automation-map to find the right script for a task",
       "permission": "ReadOnly",
       "options": {
         "--list": "List all task categories",
         "--category <name>": "Show all tasks in a category",
         "--json": "JSON output"
-      }
+      },
+      "aliases": [
+        "find"
+      ]
     },
     "agent brief": {
-      "group": "Session",
       "script": "./scripts/agent_brief.sh --agent <name>",
-      "description": "Fast 20-line actionable brief for AI agent session start"
+      "group": "Session",
+      "description": "Fast 20-line actionable brief for AI agent session start",
+      "permission": "ReadOnlyTerminal"
     },
     "token efficiency": {
-      "group": "Session",
       "script": "./run.sh efficiency check",
+      "group": "Session",
       "description": "Validate low-token Codex defaults, subagent limits, and active instructions",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "prompt": "Print the reusable low-token task preamble",
         "--json": "Machine-readable policy check output"
       }
     },
     "model usage checkpoint": {
-      "group": "Session",
       "script": "./run.sh session usage",
+      "group": "Session",
       "description": "Record or summarize model, reasoning, elapsed time, agents, manual dashboard usage, verification, and Git state without estimating billing tokens",
-      "agent": "doc-master",
       "permission": "ReadOnly",
       "permission_modes": {
         "--checkpoint start|milestone|closeout": "WorkspaceWrite"
@@ -763,11 +903,12 @@
         "--summary": "Aggregate checkpoints by model/reasoning profile",
         "--hours N": "Limit display or summary to a recent time window",
         "--json": "Machine-readable output"
-      }
+      },
+      "agent": "doc-master"
     },
     "agent context": {
-      "group": "Session",
       "script": "./scripts/python_runtime.sh scripts/agent_context.py <agent_name>",
+      "group": "Session",
       "description": "Load tailored startup context for a specific agent",
       "permission": "ReadOnly",
       "options": {
@@ -775,17 +916,18 @@
       }
     },
     "agent feedback": {
-      "group": "Governance",
       "script": "./scripts/python_runtime.sh scripts/agent_feedback.py log --agent <name>",
+      "group": "Governance",
       "description": "Log agent feedback (stale docs, issues) for systemic improvement",
+      "permission": "WorkspaceWrite",
       "options": {
         "log": "Log a feedback entry",
         "summary": "Show feedback trends and recurring issues"
       }
     },
     "self evolve": {
-      "group": "Evolution",
       "script": "./scripts/python_runtime.sh scripts/evolve.py",
+      "group": "Evolution",
       "description": "Preview the self-evolution health and feedback analysis cycle",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -800,8 +942,8 @@
       }
     },
     "project health": {
-      "group": "Governance",
       "script": "./scripts/python_runtime.sh scripts/project_health.py",
+      "group": "Governance",
       "description": "Unified project health scanner across 5 categories (0-100 score)",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -810,17 +952,20 @@
       "options": {
         "--fix": "Auto-fix fixable issues",
         "--category <name>": "Scan specific category only"
-      }
+      },
+      "aliases": [
+        "health"
+      ]
     },
     "agent compliance check": {
-      "group": "Governance",
       "script": "./scripts/python_runtime.sh scripts/agent_compliance_checker.py",
+      "group": "Governance",
       "description": "Verify agents followed their .agent.md rules",
       "permission": "ReadOnly"
     },
     "agent drift detection": {
-      "group": "Governance",
       "script": "./scripts/python_runtime.sh scripts/agent_drift_detector.py",
+      "group": "Governance",
       "description": "Detect when agents deviate from prescribed behavior",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -829,23 +974,30 @@
       }
     },
     "agent evolve instructions": {
-      "group": "Evolution",
       "script": "./scripts/python_runtime.sh scripts/agent_evolve_instructions.py",
-      "description": "Self-improving agent customization files"
+      "group": "Evolution",
+      "description": "Self-improving agent customization files",
+      "permission": "WorkspaceWrite"
     },
     "agent scoring": {
-      "group": "Governance",
       "script": "./scripts/python_runtime.sh scripts/agent_scorer.py",
-      "description": "Score agents on 11 performance dimensions"
+      "group": "Governance",
+      "description": "Score agents on 11 performance dimensions",
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--session": "WorkspaceWrite",
+        "--view": "ReadOnlyTerminal"
+      }
     },
     "agent session collect": {
-      "group": "Governance",
       "script": "./scripts/python_runtime.sh scripts/agent_session_collector.py",
-      "description": "Gather all session artifacts for scoring"
+      "group": "Governance",
+      "description": "Gather all session artifacts for scoring",
+      "permission": "WorkspaceWrite"
     },
     "agent trends": {
-      "group": "Evolution",
       "script": "./scripts/python_runtime.sh scripts/agent_trends.py",
+      "group": "Evolution",
       "description": "Time series analysis and degradation detection for agent performance",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -854,30 +1006,32 @@
       }
     },
     "export paper data": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/export_paper_data.py",
-      "description": "Export agent performance data for academic paper"
+      "group": "Infrastructure",
+      "description": "Export agent performance data for academic paper",
+      "permission": "WorkspaceWrite"
     },
     "prompt routing": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/prompt_router.py",
+      "group": "Infrastructure",
       "description": "Route prompts to the best agent based on content analysis",
       "permission": "ReadOnly"
     },
     "tool permissions": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/tool_permissions.py",
+      "group": "Infrastructure",
       "description": "Resolve and validate explicit per-agent operation permissions",
       "permission": "ReadOnly"
     },
     "audit permissions": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/audit_permissions.py",
-      "description": "Audit tool permission usage and violations across agents"
+      "group": "Infrastructure",
+      "description": "Audit tool permission usage and violations across agents",
+      "permission": "ReadOnlyTerminal"
     },
     "pipeline state": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/pipeline_state.py list",
+      "group": "Infrastructure",
       "description": "Track multi-step pipeline state with checkpoints and parallelism",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -891,8 +1045,8 @@
       }
     },
     "config precedence": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/config_precedence.py list",
+      "group": "Infrastructure",
       "description": "Resolve configuration precedence across instruction layers",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -902,24 +1056,28 @@
       }
     },
     "skill tiers": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/skill_tiers.py",
-      "description": "Manage skill tier assignments and progression"
+      "group": "Infrastructure",
+      "description": "Manage skill tier assignments and progression",
+      "permission": "ReadOnlyTerminal"
     },
     "parity dashboard": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/parity_dashboard.py",
-      "description": "Declared Indian-code capability-family and cross-stack parity dashboard"
+      "group": "Quality",
+      "description": "Declared Indian-code capability-family and cross-stack parity dashboard",
+      "permission": "ReadOnlyTerminal"
     },
     "generate indian code manifest": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/generate_indian_code_manifest.py --check",
-      "description": "Verify the generated standard-namespaced Indian-code capability and registration manifest"
+      "group": "Quality",
+      "description": "Verify the generated standard-namespaced Indian-code capability and registration manifest",
+      "permission": "ReadOnlyTerminal"
     },
     "check clause coverage": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_clause_coverage.py",
+      "group": "Quality",
       "description": "Standard-namespaced decorator registration report; not implementation or engineering completeness",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "--gaps-only": "Show metadata-only and registration-only discrepancies",
         "--standard X": "Select a standard id or namespace",
@@ -930,9 +1088,10 @@
       }
     },
     "check function quality": {
-      "group": "Quality",
       "script": "./scripts/python_runtime.sh scripts/check_function_quality.py",
+      "group": "Quality",
       "description": "Outcome-critical and advisory IS 456 function checks — AST-based static analysis",
+      "permission": "ReadOnlyTerminal",
       "options": {
         "--strict": "Exit 1 on failures",
         "--module X": "Check specific module",
@@ -941,14 +1100,14 @@
       }
     },
     "cli smoke tests": {
-      "group": "Testing",
       "script": "./scripts/python_runtime.sh scripts/test_cli_smoke.py",
+      "group": "Testing",
       "description": "Smoke test all CLI entry points for basic functionality",
       "permission": "ReadOnly"
     },
     "session store": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/session_store.py list",
+      "group": "Infrastructure",
       "description": "Persistent session state store for cross-command context",
       "permission": "ReadOnly",
       "permission_modes": {
@@ -961,9 +1120,10 @@
       }
     },
     "tool registry": {
-      "group": "Infrastructure",
       "script": "./scripts/python_runtime.sh scripts/tool_registry.py",
-      "description": "Registry of available tools with metadata and permission mappings"
+      "group": "Infrastructure",
+      "description": "Registry of available tools with metadata and permission mappings",
+      "permission": "ReadOnlyTerminal"
     }
   }
 }

--- a/scripts/check_governance.py
+++ b/scripts/check_governance.py
@@ -883,7 +883,7 @@ def check_automation_permissions(report: GovernanceReport) -> None:
     for anomaly in anomalies:
         report.add_error(
             anomaly.message,
-            location="scripts/automation-map.json",
+            location="scripts/control-plane.json",
             rule=f"Permission metadata ({anomaly.agent})",
         )
 

--- a/scripts/check_scripts_index.py
+++ b/scripts/check_scripts_index.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Ensure scripts/index.json and automation-map.json match the scripts folder contents.
+"""Ensure script indexes and the canonical control plane match scripts on disk.
 
 When to use: After adding or removing scripts from the scripts/ folder.
-Verifies every script is indexed in both index.json and automation-map.json.
+Verifies every top-level script is indexed and registered, and that the legacy
+automation map is the exact deterministic compatibility projection.
 """
 
 from __future__ import annotations
@@ -10,13 +11,24 @@ from __future__ import annotations
 import argparse
 import ast
 import json
-import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from control_plane import (  # noqa: E402
+    LEGACY_PATH,
+    REGISTRY_PATH,
+    ControlPlaneError,
+    legacy_is_current,
+    legacy_projection,
+    load_registry,
+    referenced_top_level_scripts,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
 INDEX_PATH = SCRIPTS_DIR / "index.json"
-AUTOMATION_MAP_PATH = SCRIPTS_DIR / "automation-map.json"
+AUTOMATION_MAP_PATH = LEGACY_PATH
 SCRIPT_EXTENSIONS = {".py", ".sh"}
 
 
@@ -124,51 +136,58 @@ def main() -> int:
                         print(f"    - {name}")
             errors += 1
 
-    # Check automation-map.json
-    if not AUTOMATION_MAP_PATH.exists():
-        if not args.json:
-            print("WARNING: scripts/automation-map.json not found (skipping)")
-        report["checks"]["automation_map"] = {
-            "status": "skipped",
-            "reason": "file not found",
+    # Check canonical control plane and exact compatibility projection.
+    try:
+        control_registry = load_registry()
+    except ControlPlaneError as exc:
+        report["checks"]["control_plane"] = {
+            "status": "fail",
+            "reason": str(exc),
         }
+        if not args.json:
+            print(f"ERROR: canonical control plane is invalid: {exc}")
+        errors += 1
     else:
-        data = json.loads(AUTOMATION_MAP_PATH.read_text(encoding="utf-8"))
-        mapped_scripts: set[str] = set()
-        for _task, info in data.get("tasks", {}).items():
-            script = info.get("script", "")
-            for part in script.split():
-                if "scripts/" in part:
-                    mapped_scripts.add(os.path.basename(part))
+        mapped_scripts = referenced_top_level_scripts(control_registry)
         unmapped = sorted(actual - mapped_scripts)
         phantom = sorted(mapped_scripts - actual)
-        report["checks"]["automation_map"] = {
+        report["checks"]["control_plane"] = {
             "status": "fail" if (unmapped or phantom) else "pass",
             "mapped": len(mapped_scripts),
             "total": len(actual),
             "unmapped": unmapped,
             "phantom": phantom,
         }
-        if unmapped:
+        if unmapped or phantom:
+            errors += 1
             if not args.json:
-                print(f"ERROR: {len(unmapped)} script(s) not in automation-map.json:")
+                print("ERROR: scripts/control-plane.json script coverage differs.")
                 for name in unmapped:
-                    print(f"    - {name}")
-            errors += 1
-        if phantom:
-            if not args.json:
-                print(
-                    f"ERROR: {len(phantom)} phantom script(s) in automation-map.json:"
-                )
+                    print(f"  Unmapped: {name}")
                 for name in phantom:
-                    print(f"    - {name}")
-            errors += 1
-        if not unmapped and not phantom and not args.json:
+                    print(f"  Phantom: {name}")
+        elif not args.json:
             print(
-                f"✓ automation-map.json: {len(mapped_scripts)}/{len(actual)} scripts covered"
+                f"✓ control plane: {len(mapped_scripts)}/{len(actual)} scripts covered"
             )
 
-        semantic_issues = _automation_semantic_issues(data)
+        projection_current = legacy_is_current(control_registry)
+        report["checks"]["automation_projection"] = {
+            "status": "pass" if projection_current else "fail",
+            "source": str(REGISTRY_PATH.relative_to(REPO_ROOT)),
+            "target": str(AUTOMATION_MAP_PATH.relative_to(REPO_ROOT)),
+        }
+        if not projection_current:
+            errors += 1
+            if not args.json:
+                print(
+                    "ERROR: automation-map.json is not the exact generated projection."
+                )
+        elif not args.json:
+            print("✓ automation-map.json: deterministic compatibility projection")
+
+        projected = legacy_projection(control_registry)
+        semantic_issues = _automation_semantic_issues(projected)
         semantic_failed = any(semantic_issues.values())
         report["checks"]["automation_semantics"] = {
             "status": "fail" if semantic_failed else "pass",
@@ -177,12 +196,14 @@ def main() -> int:
         if semantic_failed:
             errors += 1
             if not args.json:
-                print("ERROR: automation discovery metadata is inconsistent.")
+                print("ERROR: operation discovery metadata is inconsistent.")
                 for issue_name, values in semantic_issues.items():
                     if values:
                         print(f"  {issue_name}: {', '.join(values)}")
         elif not args.json:
-            print(f"✓ automation discovery: {len(data.get('tasks', {}))} grouped tasks")
+            print(
+                f"✓ operation discovery: {len(projected.get('tasks', {}))} grouped tasks"
+            )
 
     # Check "When to use:" in Python script docstrings
     py_scripts = sorted(s for s in actual if s.endswith(".py"))

--- a/scripts/control-plane.json
+++ b/scripts/control-plane.json
@@ -1,0 +1,2722 @@
+{
+  "$schema": "./control-plane.schema.json",
+  "schema_version": 1,
+  "registry_kind": "structural-engineering-control-plane",
+  "metadata": {
+    "owner": "repository maintainers",
+    "purpose": "Canonical operation discovery, execution, and permission metadata",
+    "compatibility_projection": "scripts/automation-map.json",
+    "initial_import": "2026-08-23"
+  },
+  "operations": {
+    "resolve python runtime": {
+      "group": "Infrastructure",
+      "description": "Resolve the approved Python interpreter across primary and linked Git worktrees",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh --version",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "--version"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "diagnose python runtime": {
+      "group": "Infrastructure",
+      "description": "Show the selected interpreter and prove structural_lib is bound to the invoking worktree",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh --diagnose",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "--diagnose"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "aliases": [
+        ".venv",
+        "worktree python",
+        "python source binding"
+      ]
+    },
+    "choose codex model": {
+      "group": "Agent Infrastructure",
+      "description": "Recommend a GPT-5.6 model and reasoning level using the checked-in token-efficiency policy (also: ./run.sh model)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/model_picker.py \"task description\"",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/model_picker.py",
+              "task description"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "--table": "Compare all supported profiles",
+        "--risk LEVEL": "Set auto, low, normal, high, or critical risk",
+        "--repeatable": "Mark a task as deterministic and repeatable",
+        "--ambiguous": "Mark a task as requiring ambiguity resolution",
+        "--important": "Recommend an efficient profile for important work and approval-gate Sol",
+        "--orchestrator": "Always select Sol High for the main orchestrator",
+        "--json": "Machine-readable recommendation"
+      }
+    },
+    "validate token efficiency": {
+      "group": "Agent Infrastructure",
+      "description": "Validate project Codex defaults, model policy, context controls, and the reusable low-token prompt",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_token_efficiency.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_token_efficiency.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "--json": "Machine-readable policy report",
+        "--prompt": "Print the reusable low-token task preamble"
+      }
+    },
+    "run all checks": {
+      "group": "Quality",
+      "description": "Run all 30 validation checks across 8 categories in parallel (also: ./run.sh check)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_all.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_all.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      },
+      "options": {
+        "--quick": "Run 10 quick checks only (<30s)",
+        "--category X": "Run checks for specific category",
+        "--changed": "Auto-detect categories from git diff",
+        "--fix": "Auto-fix where possible",
+        "--json": "JSON output for CI",
+        "--serial": "Run sequentially (debugging)"
+      },
+      "aliases": [
+        "check"
+      ]
+    },
+    "validate script references": {
+      "group": "Quality",
+      "description": "Detect stale script references across docs and instruction files",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/validate_script_refs.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/validate_script_refs.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "diagnose ci failures": {
+      "group": "Quality",
+      "description": "Diagnose, reproduce, and auto-fix CI failures locally or for a specific PR",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/diagnose_ci.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/diagnose_ci.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--local --fix": "WorkspaceWrite"
+      },
+      "options": {
+        "--pr N": "Check specific PR CI status",
+        "--local": "Run checks locally",
+        "--local --fix": "Auto-fix formatting and lint issues",
+        "--last": "Last CI run on current branch"
+      }
+    },
+    "move file": {
+      "group": "Docs",
+      "description": "Move file and update all internal links automatically (870+ links preserved)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/safe_file_move.py old.md new.md",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/safe_file_move.py",
+              "old.md",
+              "new.md"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "never_use": [
+        "mv",
+        "git mv"
+      ],
+      "aliases": [
+        "move"
+      ]
+    },
+    "delete file": {
+      "group": "Docs",
+      "description": "Delete file after checking for references",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/safe_file_delete.py file.md",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/safe_file_delete.py",
+              "file.md"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "DangerFullAccess",
+      "never_use": [
+        "rm",
+        "git rm"
+      ],
+      "aliases": [
+        "delete"
+      ]
+    },
+    "create document": {
+      "group": "Docs",
+      "description": "Create document with proper metadata headers",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/create_doc.py path/file.md \"Title\"",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/create_doc.py",
+              "path/file.md",
+              "Title"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "fix broken links": {
+      "group": "Docs",
+      "description": "Find and auto-fix broken internal links in markdown files",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_links.py --fix",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_links.py",
+              "--fix"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "check markdown links": {
+      "group": "Docs",
+      "description": "Read-only validation of internal Markdown links",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_links.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_links.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "aliases": [
+        "check_markdown_links.py",
+        "markdown links"
+      ]
+    },
+    "fix deleted file links": {
+      "group": "Docs",
+      "description": "Remove or convert broken links to deleted streamlit/vba/excel/xlwings files",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/fix_broken_links.py --dry-run",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/fix_broken_links.py",
+              "--dry-run"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "run tests": {
+      "group": "Testing",
+      "description": "Run the Python suite by default; use --fastapi, --react, or --all for explicit product-suite scope",
+      "status": "active",
+      "command": {
+        "display": "./run.sh test",
+        "steps": [
+          {
+            "argv": [
+              "./run.sh",
+              "test"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "aliases": [
+        "test"
+      ]
+    },
+    "select frontend node runtime": {
+      "group": "Infrastructure",
+      "description": "Select the healthy Node/npm pair pinned by .nvmrc (also: ./run.sh frontend runtime)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/node_runtime.py --print",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/node_runtime.py",
+              "--print"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "--print": "Show selected Node and npm versions",
+        "--bin-dir": "Print only the selected binary directory",
+        "-- COMMAND": "Run a command in the selected Node environment"
+      }
+    },
+    "watch tests": {
+      "group": "Testing",
+      "description": "Run tests in watch mode — re-runs on file changes",
+      "status": "active",
+      "command": {
+        "display": "./scripts/watch_tests.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/watch_tests.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "format code": {
+      "group": "Infrastructure",
+      "description": "Auto-format Python code with black + ruff",
+      "status": "active",
+      "command": {
+        "display": "cd Python && ../scripts/python_runtime.sh -m black . && ../scripts/python_runtime.sh -m ruff check --fix .",
+        "steps": [
+          {
+            "argv": [
+              "../scripts/python_runtime.sh",
+              "-m",
+              "black",
+              "."
+            ],
+            "cwd": "Python"
+          },
+          {
+            "argv": [
+              "../scripts/python_runtime.sh",
+              "-m",
+              "ruff",
+              "check",
+              "--fix",
+              "."
+            ],
+            "cwd": "Python"
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "check folder structure": {
+      "group": "Quality",
+      "description": "Validate project folder organization against governance rules",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_governance.py --structure",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_governance.py",
+              "--structure"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check governance": {
+      "group": "Quality",
+      "description": "Run full governance check (folder structure + compliance)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_governance.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_governance.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "--structure": "Folder structure only",
+        "--compliance": "Compliance only",
+        "--json": "JSON output",
+        "--strict": "Fail on warnings"
+      }
+    },
+    "governance health score": {
+      "group": "Quality",
+      "description": "Calculate overall governance health score with breakdown",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/governance_health_score.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/governance_health_score.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--output": "WorkspaceWrite"
+      }
+    },
+    "generate audit report": {
+      "group": "Generation",
+      "description": "Generate audit evidence bundle (NIST SSDF aligned)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/audit_readiness_report.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/audit_readiness_report.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--output": "WorkspaceWrite"
+      },
+      "options": {
+        "--check-only": "Quick pass/fail for CI",
+        "--json": "Export as JSON",
+        "--export md": "Export as Markdown"
+      }
+    },
+    "audit error handling": {
+      "group": "Quality",
+      "description": "Audit error handling compliance across structural_lib modules",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/audit_error_handling.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/audit_error_handling.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "audit input validation": {
+      "group": "Quality",
+      "description": "Audit evidence-bearing input-validation ownership for maintained structural_lib routes",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/audit_input_validation.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/audit_input_validation.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check public route safety": {
+      "group": "Quality",
+      "description": "Run the frozen adversarial Python and FastAPI public-route safety regressions",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_public_route_safety.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_public_route_safety.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "start session": {
+      "group": "Session",
+      "description": "Resolve the approved runtime, run preflight, and start a session without Git/GitHub lifecycle actions",
+      "status": "active",
+      "command": {
+        "display": "./scripts/agent_start.sh --quick",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/agent_start.sh",
+              "--quick"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "aliases": [
+        "session"
+      ]
+    },
+    "end session": {
+      "group": "Session",
+      "description": "Validate session closeout without hidden writes",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/session.py end",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/session.py",
+              "end"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      }
+    },
+    "session summary": {
+      "group": "Session",
+      "description": "Preview a session summary from repository history",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/session.py summary",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/session.py",
+              "summary"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--write": "WorkspaceWrite"
+      }
+    },
+    "sync doc numbers": {
+      "group": "Session",
+      "description": "Scan codebase metrics and report stale documentation counts; no flag is the read-only default",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/sync_numbers.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/sync_numbers.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      },
+      "options": {
+        "(no flag)": "Dry run — scan and report only",
+        "--fix": "Apply updates to files",
+        "--json": "Machine-readable output"
+      },
+      "aliases": [
+        "sync_numbers.py",
+        "sync numbers",
+        "documentation counts",
+        "check stale counts"
+      ]
+    },
+    "session handoff": {
+      "group": "Session",
+      "description": "Validate a durable task-to-Git receipt and write next-session-brief.md for the next agent",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/session.py handoff",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/session.py",
+              "handoff"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "options": {
+        "--git-receipt PATH": "Validate and embed the versioned receipt identity"
+      },
+      "aliases": [
+        "session receipt handoff",
+        "durable handoff"
+      ]
+    },
+    "task git handoff receipt": {
+      "group": "Git",
+      "description": "Build or validate a fail-closed task-to-Git handoff receipt from git_state.py plus caller-supplied hosted evidence",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/git_handoff_receipt.py create",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/git_handoff_receipt.py",
+              "create"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--output": "WorkspaceWrite"
+      },
+      "options": {
+        "create": "Build receipt; missing hosted facts remain UNKNOWN or NOT_CHECKED holds",
+        "validate": "Validate schema, hashes, exact-head binding, and contradictions"
+      },
+      "aliases": [
+        "git receipt",
+        "handoff receipt",
+        "task to git"
+      ]
+    },
+    "session check": {
+      "group": "Session",
+      "description": "Verify session docs are consistent and complete",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/session.py check",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/session.py",
+              "check"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check git state": {
+      "group": "Git",
+      "description": "Report typed local Git state, holds, base, upstream, operations, and locks without network or mutation",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/git_state.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/git_state.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "options": {
+        "--json": "Machine-readable typed state",
+        "--worktrees": "Bounded current and sibling worktree inventory",
+        "--strict": "Fail unless the current lane is READY_LOCAL"
+      }
+    },
+    "check api signatures": {
+      "group": "Discovery",
+      "description": "Verify API documentation matches code (signatures, docs, sync)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_api.py --all",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_api.py",
+              "--all"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "discover api function": {
+      "group": "Discovery",
+      "description": "Get exact parameter names and types for any structural_lib function",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/discover_api_signatures.py <function_name>",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/discover_api_signatures.py",
+              "<function_name>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "--all": "Show all API signatures",
+        "--filter <category>": "Filter by category (design, detail, geometry, etc.)"
+      },
+      "never_use": [
+        "guess parameter names",
+        "assume return types"
+      ],
+      "aliases": [
+        "api"
+      ]
+    },
+    "generate api manifest": {
+      "group": "Discovery",
+      "description": "Regenerate API manifest (public function inventory)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/generate_api_manifest.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/generate_api_manifest.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "generate api classification": {
+      "group": "Discovery",
+      "description": "Generate or validate the Alpha preview/compatibility/internal API classification registry",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/generate_api_classification.py --check",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/generate_api_classification.py",
+              "--check"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "without --check": "WorkspaceWrite"
+      }
+    },
+    "generate beam tool manifest": {
+      "group": "Discovery",
+      "description": "Regenerate and byte-check the catalogue-derived beam tool descriptor without activating AI execution",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/generate_beam_tool_manifest.py --write --check",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/generate_beam_tool_manifest.py",
+              "--write",
+              "--check"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "check architecture boundaries": {
+      "group": "Quality",
+      "description": "Enforce 4-layer architecture — core cannot import services/UI",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_architecture_boundaries.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_architecture_boundaries.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check codex git workflow": {
+      "group": "Quality",
+      "description": "Ensure retired Git lifecycle wrappers and enforcement hooks stay removed",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_codex_git_workflow.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_codex_git_workflow.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check element completeness": {
+      "group": "Quality",
+      "description": "Check completeness across 7 layers (types, math, tests, API, endpoint, UI, docs) for all structural elements",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_new_element_completeness.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_new_element_completeness.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "--element <name>": "Detailed report for specific element (beam, column, slab, etc.)",
+        "--json": "Machine-readable JSON output",
+        "--verbose": "Show file paths for each check"
+      }
+    },
+    "check circular imports": {
+      "group": "Quality",
+      "description": "Detect circular imports in the Streamlit application",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_circular_imports.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_circular_imports.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check fastapi issues": {
+      "group": "Quality",
+      "description": "AST-scan for common FastAPI issues (missing types, wrong patterns)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_fastapi_issues.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_fastapi_issues.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check type annotations": {
+      "group": "Quality",
+      "description": "Check type annotation coverage in Streamlit application",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_type_annotations.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_type_annotations.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check docs": {
+      "group": "Docs",
+      "description": "Unified doc checker — index, links, metadata validation",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_docs.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_docs.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check docs metadata": {
+      "group": "Docs",
+      "description": "Validate required documentation metadata with the consolidated checker",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_docs.py --metadata --strict",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_docs.py",
+              "--metadata",
+              "--strict"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "aliases": [
+        "check_doc_metadata.py",
+        "doc metadata"
+      ]
+    },
+    "validate imports": {
+      "group": "Quality",
+      "description": "Validate Python imports across the project (use after migrations)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/validate_imports.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/validate_imports.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "validate api contracts": {
+      "group": "Quality",
+      "description": "API contract testing — request/response schemas, status codes",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/validate_api_contracts.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/validate_api_contracts.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "validate schema snapshots": {
+      "group": "Quality",
+      "description": "Validate OpenAPI schema snapshots haven't changed unexpectedly",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/validate_schema_snapshots.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/validate_schema_snapshots.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check openapi drift": {
+      "group": "Quality",
+      "description": "Compare live OpenAPI spec against baseline — detect endpoint/schema drift",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_openapi_snapshot.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_openapi_snapshot.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--update": "WorkspaceWrite"
+      },
+      "options": {
+        "--update": "Update baseline with current spec",
+        "--json": "Machine-readable JSON output"
+      }
+    },
+    "check openapi baseline drift": {
+      "group": "CI",
+      "description": "CI guard — verify OpenAPI spec matches committed baseline (TASK-726)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_openapi_drift.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_openapi_drift.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--update": "WorkspaceWrite"
+      },
+      "options": {
+        "--update": "Update the baseline file from live spec"
+      }
+    },
+    "check docker config": {
+      "group": "Infrastructure",
+      "description": "Validate Dockerfile and docker-compose configuration",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_docker_config.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_docker_config.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "launch dev stack": {
+      "group": "Infrastructure",
+      "description": "Launch full-stack dev environment (FastAPI + React) with auto-detection of free ports",
+      "status": "active",
+      "command": {
+        "display": "bash scripts/launch_stack.sh",
+        "steps": [
+          {
+            "argv": [
+              "bash",
+              "scripts/launch_stack.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "options": {
+        "--local": "Local mode (default): FastAPI + React processes",
+        "--docker": "Docker mode via Colima",
+        "--docker-dev": "Docker dev mode with hot reload",
+        "--kill-only": "Kill all dev services",
+        "--no-react": "FastAPI only",
+        "--no-fastapi": "React only",
+        "--open": "Open browser after launch"
+      }
+    },
+    "check doc versions": {
+      "group": "Quality",
+      "description": "Detect stale library version references in docs (pre-commit hook)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_doc_versions.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_doc_versions.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check bootstrap freshness": {
+      "group": "Quality",
+      "description": "Detect when bootstrap docs are stale — new hooks/routes/components not documented",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_bootstrap_freshness.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_bootstrap_freshness.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check instruction drift": {
+      "group": "Quality",
+      "description": "Detect content drift between .github/instructions/ and .claude/rules/ — warns when platforms diverge",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_instruction_drift.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_instruction_drift.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check tasks format": {
+      "group": "Quality",
+      "description": "Validate TASKS.md structure and WIP rules",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_tasks_format.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_tasks_format.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "aliases": [
+        "check_tasks.py",
+        "check_tasks_format.py",
+        "task board format",
+        "validate tasks"
+      ]
+    },
+    "check python version": {
+      "group": "Quality",
+      "description": "Enforce consistent Python version strings across configs",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_python_version.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_python_version.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check version consistency": {
+      "group": "Quality",
+      "description": "Verify version strings match across maintained package metadata and docs",
+      "status": "active",
+      "command": {
+        "display": "./scripts/check_version_consistency.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/check_version_consistency.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "check wip limits": {
+      "group": "Quality",
+      "description": "Enforce WIP limits — max items in In Progress",
+      "status": "active",
+      "command": {
+        "display": "./scripts/check_wip_limits.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/check_wip_limits.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check repo hygiene": {
+      "group": "Quality",
+      "description": "Fail if tracked hygiene artifacts exist (pre-commit hook)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_repo_hygiene.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_repo_hygiene.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check cli reference": {
+      "group": "Quality",
+      "description": "Ensure CLI reference doc includes all required commands",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_cli_reference.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_cli_reference.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check scripts index": {
+      "group": "Quality",
+      "description": "Ensure scripts/index.json and automation-map metadata match maintained scripts",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_scripts_index.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_scripts_index.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "check api compat": {
+      "group": "Quality",
+      "description": "Check API backward compatibility against manifest",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_api_compat.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_api_compat.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "generate error docs": {
+      "group": "Generation",
+      "description": "Generate error code documentation from source",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/generate_error_docs.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/generate_error_docs.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "check next session brief": {
+      "group": "Quality",
+      "description": "Ensure next-session-brief.md stays concise",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_next_session_brief_length.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_next_session_brief_length.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check root file count": {
+      "group": "Quality",
+      "description": "Warn if too many files in project root (sprawl detection)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/check_root_file_count.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/check_root_file_count.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "check merge state": {
+      "group": "Git",
+      "description": "Fail on an active or unknown Git operation, conflict, or lock",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/git_state.py --guard operation",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/git_state.py",
+              "--guard",
+              "operation"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "check branch safety": {
+      "group": "Git",
+      "description": "Fail closed on main, detached HEAD, or unknown branch state",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/git_state.py --guard branch",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/git_state.py",
+              "--guard",
+              "branch"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "compat validate git state": {
+      "group": "Git",
+      "description": "Deprecated compatibility entrypoint delegated to check git state",
+      "status": "deprecated",
+      "command": {
+        "display": "./scripts/validate_git_state.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/validate_git_state.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "replacement": "check git state"
+    },
+    "compat unfinished operation guard": {
+      "group": "Git",
+      "description": "Deprecated compatibility entrypoint delegated to check merge state",
+      "status": "deprecated",
+      "command": {
+        "display": "./scripts/check_unfinished_merge.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/check_unfinished_merge.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "replacement": "check merge state"
+    },
+    "compat branch guard": {
+      "group": "Git",
+      "description": "Deprecated compatibility entrypoint delegated to check branch safety",
+      "status": "deprecated",
+      "command": {
+        "display": "./scripts/check_not_main.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/check_not_main.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "replacement": "check branch safety"
+    },
+    "migrate python module": {
+      "group": "Migration",
+      "description": "Move Python module to new location + update all imports automatically",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/migrate_python_module.py <src> <dst> --dry-run",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/migrate_python_module.py",
+              "<src>",
+              "<dst>",
+              "--dry-run"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "live": "WorkspaceWrite"
+      },
+      "never_use": [
+        "mv",
+        "manual find-and-replace imports"
+      ]
+    },
+    "migrate react component": {
+      "group": "Migration",
+      "description": "Move React component to new feature-grouped folder + update imports",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/migrate_react_component.py <src> <dst> --dry-run",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/migrate_react_component.py",
+              "<src>",
+              "<dst>",
+              "--dry-run"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "live": "WorkspaceWrite"
+      },
+      "never_use": [
+        "mv",
+        "manual find-and-replace imports"
+      ]
+    },
+    "batch migration": {
+      "group": "Migration",
+      "description": "Run multiple migrations with per-operation rollback logs",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/batch_migrate_runner.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/batch_migrate_runner.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "permission_modes": {
+        "--dry-run": "ReadOnly",
+        "--auto-rollback": "WorkspaceWrite"
+      }
+    },
+    "bump version": {
+      "group": "Release",
+      "description": "Bump version in pyproject.toml (single source of truth)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/bump_version.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/bump_version.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--current": "ReadOnlyTerminal",
+        "VERSION": "WorkspaceWrite"
+      },
+      "options": {
+        "patch": "0.19.1 → 0.19.2",
+        "minor": "0.19.1 → 0.20.0",
+        "major": "0.19.1 → 1.0.0"
+      }
+    },
+    "release": {
+      "group": "Release",
+      "description": "Unified release management — preflight, artifact verification, and owner-gated publication",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/release.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/release.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "run": "DangerFullAccess",
+        "preflight": "ReadOnlyTerminal"
+      }
+    },
+    "release preflight": {
+      "group": "Release",
+      "description": "Run clean-tree Python, FastAPI, React, version, permission, and exact-wheel release gates",
+      "status": "active",
+      "command": {
+        "display": "./run.sh release preflight --wheel <exact-wheel-path>",
+        "steps": [
+          {
+            "argv": [
+              "./run.sh",
+              "release",
+              "preflight",
+              "--wheel",
+              "<exact-wheel-path>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "context_docs": [
+        ".github/skills/release-preflight/SKILL.md"
+      ],
+      "aliases": [
+        "candidate preflight",
+        "release ci parity"
+      ]
+    },
+    "benchmark api": {
+      "group": "Testing",
+      "description": "API performance benchmark with latency measurements",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/benchmark_api.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/benchmark_api.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "test api parity": {
+      "group": "Testing",
+      "description": "Verify library and FastAPI return identical results",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/test_api_parity.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/test_api_parity.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "verify canonical transport artifact": {
+      "group": "Testing",
+      "description": "Verify A1 source-free Python and CLI plus exact-head FastAPI binding to one wheel",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/verify_canonical_transport_artifact.py --wheel <exact-wheel-path>",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/verify_canonical_transport_artifact.py",
+              "--wheel",
+              "<exact-wheel-path>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "verify excel workbench artifact": {
+      "group": "Testing",
+      "description": "Verify the E1 workbook, manifest, installed identity, and canonical sample row from one source-free wheel",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/verify_excel_workbench_artifact.py --wheel <exact-wheel-path>",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/verify_excel_workbench_artifact.py",
+              "--wheel",
+              "<exact-wheel-path>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "test import 3d pipeline": {
+      "group": "Testing",
+      "description": "Compatibility alias for the maintained import, batch-design, and 3D geometry E2E test",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/test_import_pipeline.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/test_import_pipeline.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "test import pipeline": {
+      "group": "Testing",
+      "description": "E2E test: all 4 import endpoints (sample, single CSV, dual CSV, batch design)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/test_import_pipeline.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/test_import_pipeline.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "external cli test": {
+      "group": "Testing",
+      "description": "Exercise the installed package in a new isolated workspace",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/external_cli_test.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/external_cli_test.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "create test scaffold": {
+      "group": "Testing",
+      "description": "Generate test file scaffold for a module",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/create_test_scaffold.py <module>",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/create_test_scaffold.py",
+              "<module>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "update test stats": {
+      "group": "Testing",
+      "description": "Update test_stats.json with current test counts",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/update_test_stats.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/update_test_stats.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "generate folder index": {
+      "group": "Generation",
+      "description": "Update maintained index.json + index.md files from changed leaves through maintained parents; new index locations require explicit opt-in",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/generate_enhanced_index.py <folder>",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/generate_enhanced_index.py",
+              "<folder>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "permission_modes": {
+        "--dry-run": "ReadOnly",
+        "--check": "ReadOnly"
+      },
+      "options": {
+        "--all": "Regenerate all key-folder indexes",
+        "--allow-new-index": "Permit intentional creation in a previously unmaintained folder"
+      },
+      "aliases": [
+        "generate_folder_index.py",
+        "generate_enhanced_index.py",
+        "folder index",
+        "refresh index",
+        "leaf parent index"
+      ]
+    },
+    "generate all indexes": {
+      "group": "Generation",
+      "description": "Regenerate index.json + index.md for all research-relevant folders",
+      "status": "active",
+      "command": {
+        "display": "./scripts/generate_all_indexes.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/generate_all_indexes.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "generate docs index": {
+      "group": "Generation",
+      "description": "Preview the global machine-readable documentation index; pass --write intentionally before refreshing parent folder indexes",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/generate_docs_index.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/generate_docs_index.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--write": "WorkspaceWrite"
+      },
+      "aliases": [
+        "generate_docs_index.py",
+        "global docs index",
+        "documentation index",
+        "docs-index.json"
+      ]
+    },
+    "generate client sdks": {
+      "group": "Generation",
+      "description": "Generate TypeScript/Python client SDKs from FastAPI OpenAPI spec",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/generate_client_sdks.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/generate_client_sdks.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "preflight checks": {
+      "group": "Session",
+      "description": "Pre-flight checks before starting work (branch, runtime, ports, conflicts)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/preflight.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/preflight.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "test changed files": {
+      "group": "Testing",
+      "description": "Run tests only for changed files (auto-detect from git diff)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/test_changed.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/test_changed.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "render dxf": {
+      "group": "Infrastructure",
+      "description": "Render DXF drawings to PNG or PDF using ezdxf + matplotlib",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/dxf_render.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/dxf_render.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "archive old files": {
+      "group": "Docs",
+      "description": "Move files older than 90 days from docs/_active/ to _archive/",
+      "status": "active",
+      "command": {
+        "display": "./scripts/archive_old_files.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/archive_old_files.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "permission_modes": {
+        "--dry-run": "ReadOnly"
+      }
+    },
+    "classify branch disposition": {
+      "group": "Infrastructure",
+      "description": "Inspect branch/worktree disposition; remote and PR evidence are caller-supplied",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/classify_branch_disposition.py --all-local --json",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/classify_branch_disposition.py",
+              "--all-local",
+              "--json"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "collect diagnostics": {
+      "group": "Infrastructure",
+      "description": "Collect compact diagnostics bundle for debugging and support",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/collect_diagnostics.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/collect_diagnostics.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--out": "WorkspaceWrite"
+      }
+    },
+    "collect metrics": {
+      "group": "Infrastructure",
+      "description": "Collect project metrics — test counts, coverage, complexity, sizes",
+      "status": "active",
+      "command": {
+        "display": "./scripts/collect_metrics.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/collect_metrics.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "local ci": {
+      "group": "Git",
+      "description": "Run canonical local validation without managing Git or environments",
+      "status": "active",
+      "command": {
+        "display": "./scripts/ci_local.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/ci_local.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "repo health check": {
+      "group": "Governance",
+      "description": "Quick overall repo health check",
+      "status": "active",
+      "command": {
+        "display": "./scripts/repo_health_check.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/repo_health_check.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "agent mistakes report": {
+      "group": "Governance",
+      "description": "Show common agent mistakes as a reminder at session start",
+      "status": "active",
+      "command": {
+        "display": "./scripts/agent_mistakes_report.sh",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/agent_mistakes_report.sh"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "find automation": {
+      "group": "Discovery",
+      "description": "Search this automation-map to find the right script for a task",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/find_automation.py \"task\"",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/find_automation.py",
+              "task"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "options": {
+        "--list": "List all task categories",
+        "--category <name>": "Show all tasks in a category",
+        "--json": "JSON output"
+      },
+      "aliases": [
+        "find"
+      ]
+    },
+    "agent brief": {
+      "group": "Session",
+      "description": "Fast 20-line actionable brief for AI agent session start",
+      "status": "active",
+      "command": {
+        "display": "./scripts/agent_brief.sh --agent <name>",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/agent_brief.sh",
+              "--agent",
+              "<name>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "token efficiency": {
+      "group": "Session",
+      "description": "Validate low-token Codex defaults, subagent limits, and active instructions",
+      "status": "active",
+      "command": {
+        "display": "./run.sh efficiency check",
+        "steps": [
+          {
+            "argv": [
+              "./run.sh",
+              "efficiency",
+              "check"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "prompt": "Print the reusable low-token task preamble",
+        "--json": "Machine-readable policy check output"
+      }
+    },
+    "model usage checkpoint": {
+      "group": "Session",
+      "description": "Record or summarize model, reasoning, elapsed time, agents, manual dashboard usage, verification, and Git state without estimating billing tokens",
+      "status": "active",
+      "command": {
+        "display": "./run.sh session usage",
+        "steps": [
+          {
+            "argv": [
+              "./run.sh",
+              "session",
+              "usage"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--checkpoint start|milestone|closeout": "WorkspaceWrite"
+      },
+      "options": {
+        "--checkpoint start|milestone|closeout": "Append a local checkpoint",
+        "--summary": "Aggregate checkpoints by model/reasoning profile",
+        "--hours N": "Limit display or summary to a recent time window",
+        "--json": "Machine-readable output"
+      },
+      "agent": "doc-master"
+    },
+    "agent context": {
+      "group": "Session",
+      "description": "Load tailored startup context for a specific agent",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/agent_context.py <agent_name>",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/agent_context.py",
+              "<agent_name>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "options": {
+        "--list": "List available agents"
+      }
+    },
+    "agent feedback": {
+      "group": "Governance",
+      "description": "Log agent feedback (stale docs, issues) for systemic improvement",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/agent_feedback.py log --agent <name>",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/agent_feedback.py",
+              "log",
+              "--agent",
+              "<name>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "options": {
+        "log": "Log a feedback entry",
+        "summary": "Show feedback trends and recurring issues"
+      }
+    },
+    "self evolve": {
+      "group": "Evolution",
+      "description": "Preview the self-evolution health and feedback analysis cycle",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/evolve.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/evolve.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite",
+        "--report": "WorkspaceWrite",
+        "--review weekly --report": "WorkspaceWrite",
+        "--review monthly --report": "WorkspaceWrite"
+      },
+      "options": {
+        "--fix": "Apply fixes and commit",
+        "--review weekly": "Weekly auto-maintenance review"
+      }
+    },
+    "project health": {
+      "group": "Governance",
+      "description": "Unified project health scanner across 5 categories (0-100 score)",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/project_health.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/project_health.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--fix": "WorkspaceWrite"
+      },
+      "options": {
+        "--fix": "Auto-fix fixable issues",
+        "--category <name>": "Scan specific category only"
+      },
+      "aliases": [
+        "health"
+      ]
+    },
+    "agent compliance check": {
+      "group": "Governance",
+      "description": "Verify agents followed their .agent.md rules",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/agent_compliance_checker.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/agent_compliance_checker.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "agent drift detection": {
+      "group": "Governance",
+      "description": "Detect when agents deviate from prescribed behavior",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/agent_drift_detector.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/agent_drift_detector.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--write": "WorkspaceWrite",
+        "--output": "WorkspaceWrite"
+      }
+    },
+    "agent evolve instructions": {
+      "group": "Evolution",
+      "description": "Self-improving agent customization files",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/agent_evolve_instructions.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/agent_evolve_instructions.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "agent scoring": {
+      "group": "Governance",
+      "description": "Score agents on 11 performance dimensions",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/agent_scorer.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/agent_scorer.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "permission_modes": {
+        "--session": "WorkspaceWrite",
+        "--view": "ReadOnlyTerminal"
+      }
+    },
+    "agent session collect": {
+      "group": "Governance",
+      "description": "Gather all session artifacts for scoring",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/agent_session_collector.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/agent_session_collector.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "agent trends": {
+      "group": "Evolution",
+      "description": "Time series analysis and degradation detection for agent performance",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/agent_trends.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/agent_trends.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "--write": "WorkspaceWrite",
+        "--output": "WorkspaceWrite"
+      }
+    },
+    "export paper data": {
+      "group": "Infrastructure",
+      "description": "Export agent performance data for academic paper",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/export_paper_data.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/export_paper_data.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite"
+    },
+    "prompt routing": {
+      "group": "Infrastructure",
+      "description": "Route prompts to the best agent based on content analysis",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/prompt_router.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/prompt_router.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "tool permissions": {
+      "group": "Infrastructure",
+      "description": "Resolve and validate explicit per-agent operation permissions",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/tool_permissions.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/tool_permissions.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "audit permissions": {
+      "group": "Infrastructure",
+      "description": "Audit tool permission usage and violations across agents",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/audit_permissions.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/audit_permissions.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "pipeline state": {
+      "group": "Infrastructure",
+      "description": "Track multi-step pipeline state with checkpoints and parallelism",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/pipeline_state.py list",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/pipeline_state.py",
+              "list"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "new": "WorkspaceWrite",
+        "advance": "WorkspaceWrite",
+        "advance-parallel": "WorkspaceWrite",
+        "fail": "WorkspaceWrite",
+        "show": "ReadOnly",
+        "list": "ReadOnly",
+        "resume": "ReadOnly"
+      }
+    },
+    "config precedence": {
+      "group": "Infrastructure",
+      "description": "Resolve configuration precedence across instruction layers",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/config_precedence.py list",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/config_precedence.py",
+              "list"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "show": "ReadOnly",
+        "audit": "ReadOnly",
+        "list": "ReadOnly"
+      }
+    },
+    "skill tiers": {
+      "group": "Infrastructure",
+      "description": "Manage skill tier assignments and progression",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/skill_tiers.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/skill_tiers.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "parity dashboard": {
+      "group": "Quality",
+      "description": "Declared Indian-code capability-family and cross-stack parity dashboard",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/parity_dashboard.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/parity_dashboard.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "generate indian code manifest": {
+      "group": "Quality",
+      "description": "Verify the generated standard-namespaced Indian-code capability and registration manifest",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/generate_indian_code_manifest.py --check",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/generate_indian_code_manifest.py",
+              "--check"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    },
+    "check clause coverage": {
+      "group": "Quality",
+      "description": "Standard-namespaced decorator registration report; not implementation or engineering completeness",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_clause_coverage.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_clause_coverage.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "--gaps-only": "Show metadata-only and registration-only discrepancies",
+        "--standard X": "Select a standard id or namespace",
+        "--category X": "Filter by category (e.g. flexure)",
+        "--json": "Machine-readable output",
+        "--summary": "Just totals",
+        "--registered": "Show only registered known references"
+      }
+    },
+    "check function quality": {
+      "group": "Quality",
+      "description": "Outcome-critical and advisory IS 456 function checks — AST-based static analysis",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/check_function_quality.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/check_function_quality.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal",
+      "options": {
+        "--strict": "Exit 1 on failures",
+        "--module X": "Check specific module",
+        "--json": "Machine-readable output",
+        "--summary": "Just totals"
+      }
+    },
+    "cli smoke tests": {
+      "group": "Testing",
+      "description": "Smoke test all CLI entry points for basic functionality",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/test_cli_smoke.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/test_cli_smoke.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly"
+    },
+    "session store": {
+      "group": "Infrastructure",
+      "description": "Persistent session state store for cross-command context",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/session_store.py list",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/session_store.py",
+              "list"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "new": "WorkspaceWrite",
+        "end": "WorkspaceWrite",
+        "list": "ReadOnly",
+        "show": "ReadOnly",
+        "resume": "ReadOnly",
+        "active": "ReadOnly"
+      }
+    },
+    "tool registry": {
+      "group": "Infrastructure",
+      "description": "Registry of available tools with metadata and permission mappings",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/tool_registry.py",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/tool_registry.py"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnlyTerminal"
+    }
+  }
+}

--- a/scripts/control-plane.schema.json
+++ b/scripts/control-plane.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://structural-engineering-lib.dev/schemas/control-plane-v1.json",
+  "title": "Structural Engineering Library Control Plane",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "registry_kind",
+    "metadata",
+    "operations"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "./control-plane.schema.json"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "registry_kind": {
+      "const": "structural-engineering-control-plane"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "purpose", "compatibility_projection"],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        },
+        "compatibility_projection": {
+          "const": "scripts/automation-map.json"
+        },
+        "initial_import": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "operations": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z0-9][a-z0-9 ._:/+-]*$"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/operation"
+      }
+    }
+  },
+  "$defs": {
+    "permission": {
+      "enum": [
+        "ReadOnly",
+        "ReadOnlyTerminal",
+        "WorkspaceWrite",
+        "DangerFullAccess"
+      ]
+    },
+    "stringList": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "commandStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["argv", "cwd"],
+      "properties": {
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "cwd": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["display", "steps"],
+      "properties": {
+        "display": {
+          "type": "string",
+          "minLength": 1
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/commandStep"
+          }
+        }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "group",
+        "description",
+        "status",
+        "command",
+        "permission"
+      ],
+      "properties": {
+        "group": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["active", "deprecated"]
+        },
+        "command": {
+          "$ref": "#/$defs/command"
+        },
+        "permission": {
+          "$ref": "#/$defs/permission"
+        },
+        "permission_modes": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/permission"
+          }
+        },
+        "options": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "aliases": {
+          "$ref": "#/$defs/stringList"
+        },
+        "never_use": {
+          "$ref": "#/$defs/stringList"
+        },
+        "context_docs": {
+          "$ref": "#/$defs/stringList"
+        },
+        "replacement": {
+          "type": "string",
+          "minLength": 1
+        },
+        "agent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prereq": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "deprecated"
+              }
+            }
+          },
+          "then": {
+            "required": ["replacement"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/control_plane/__init__.py
+++ b/scripts/control_plane/__init__.py
@@ -8,11 +8,11 @@ or the temporary ``automation-map.json`` compatibility projection.
 from __future__ import annotations
 
 import json
+import re
 import shlex
+from datetime import date
 from pathlib import Path
 from typing import Any
-
-from jsonschema import Draft202012Validator, FormatChecker
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
@@ -59,15 +59,165 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 def _schema_errors(data: dict[str, Any], schema_path: Path) -> list[str]:
     schema = _read_json(schema_path)
-    validator = Draft202012Validator(schema, format_checker=FormatChecker())
-    return [
-        f"schema:{'/'.join(str(part) for part in error.absolute_path) or '<root>'}: "
-        f"{error.message}"
-        for error in sorted(
-            validator.iter_errors(data),
-            key=lambda item: tuple(str(part) for part in item.path),
+    return _validate_schema_value(data, schema, schema, ())
+
+
+def _schema_path(path: tuple[str | int, ...]) -> str:
+    return "/".join(str(part) for part in path) or "<root>"
+
+
+def _schema_error(path: tuple[str | int, ...], message: str) -> str:
+    return f"schema:{_schema_path(path)}: {message}"
+
+
+def _resolve_schema_ref(reference: str, root_schema: dict[str, Any]) -> dict[str, Any]:
+    if not reference.startswith("#/"):
+        raise ControlPlaneError(f"unsupported external schema reference: {reference}")
+    current: Any = root_schema
+    for token in reference[2:].split("/"):
+        token = token.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or token not in current:
+            raise ControlPlaneError(f"unresolved schema reference: {reference}")
+        current = current[token]
+    if not isinstance(current, dict):
+        raise ControlPlaneError(f"schema reference is not an object: {reference}")
+    return current
+
+
+def _matches_type(value: Any, expected: str) -> bool:
+    return {
+        "object": lambda: isinstance(value, dict),
+        "array": lambda: isinstance(value, list),
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda: isinstance(value, (int, float))
+        and not isinstance(value, bool),
+        "boolean": lambda: isinstance(value, bool),
+        "null": lambda: value is None,
+    }.get(expected, lambda: False)()
+
+
+def _validate_schema_value(
+    value: Any,
+    schema: dict[str, Any],
+    root_schema: dict[str, Any],
+    path: tuple[str | int, ...],
+) -> list[str]:
+    """Evaluate the JSON Schema keywords used by control-plane.schema.json."""
+    if "$ref" in schema:
+        target = _resolve_schema_ref(str(schema["$ref"]), root_schema)
+        return _validate_schema_value(value, target, root_schema, path)
+
+    errors: list[str] = []
+    expected_type = schema.get("type")
+    if isinstance(expected_type, str) and not _matches_type(value, expected_type):
+        return [
+            _schema_error(path, f"expected {expected_type}, got {type(value).__name__}")
+        ]
+
+    if "const" in schema and value != schema["const"]:
+        errors.append(_schema_error(path, f"expected constant {schema['const']!r}"))
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(
+            _schema_error(path, f"value {value!r} is not in the allowed enum")
         )
-    ]
+
+    if isinstance(value, str):
+        min_length = schema.get("minLength")
+        if isinstance(min_length, int) and len(value) < min_length:
+            errors.append(_schema_error(path, f"string is shorter than {min_length}"))
+        pattern = schema.get("pattern")
+        if isinstance(pattern, str) and re.search(pattern, value) is None:
+            errors.append(_schema_error(path, f"string does not match {pattern!r}"))
+        if schema.get("format") == "date":
+            try:
+                parsed = date.fromisoformat(value)
+            except ValueError:
+                errors.append(_schema_error(path, "value is not an ISO date"))
+            else:
+                if parsed.isoformat() != value:
+                    errors.append(
+                        _schema_error(path, "value is not a canonical ISO date")
+                    )
+
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        if isinstance(min_items, int) and len(value) < min_items:
+            errors.append(
+                _schema_error(path, f"array has fewer than {min_items} items")
+            )
+        if schema.get("uniqueItems"):
+            encoded = [json.dumps(item, sort_keys=True) for item in value]
+            if len(encoded) != len(set(encoded)):
+                errors.append(_schema_error(path, "array items must be unique"))
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                errors.extend(
+                    _validate_schema_value(
+                        item, item_schema, root_schema, (*path, index)
+                    )
+                )
+
+    if isinstance(value, dict):
+        min_properties = schema.get("minProperties")
+        if isinstance(min_properties, int) and len(value) < min_properties:
+            errors.append(
+                _schema_error(
+                    path, f"object has fewer than {min_properties} properties"
+                )
+            )
+        required = schema.get("required", [])
+        if isinstance(required, list):
+            for key in required:
+                if key not in value:
+                    errors.append(
+                        _schema_error(path, f"required property is missing: {key}")
+                    )
+
+        property_names = schema.get("propertyNames")
+        if isinstance(property_names, dict):
+            for key in value:
+                errors.extend(
+                    _validate_schema_value(
+                        key, property_names, root_schema, (*path, key)
+                    )
+                )
+
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            properties = {}
+        for key, property_schema in properties.items():
+            if key in value and isinstance(property_schema, dict):
+                errors.extend(
+                    _validate_schema_value(
+                        value[key], property_schema, root_schema, (*path, key)
+                    )
+                )
+
+        additional = schema.get("additionalProperties", True)
+        for key in value.keys() - properties.keys():
+            if additional is False:
+                errors.append(
+                    _schema_error((*path, key), "additional property is not allowed")
+                )
+            elif isinstance(additional, dict):
+                errors.extend(
+                    _validate_schema_value(
+                        value[key], additional, root_schema, (*path, key)
+                    )
+                )
+
+    for subschema in schema.get("allOf", []):
+        if isinstance(subschema, dict):
+            errors.extend(_validate_schema_value(value, subschema, root_schema, path))
+
+    condition = schema.get("if")
+    then_schema = schema.get("then")
+    if isinstance(condition, dict) and isinstance(then_schema, dict):
+        if not _validate_schema_value(value, condition, root_schema, path):
+            errors.extend(_validate_schema_value(value, then_schema, root_schema, path))
+    return errors
 
 
 def operation_map(

--- a/scripts/control_plane/__init__.py
+++ b/scripts/control_plane/__init__.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Canonical control-plane registry loader and validator.
+
+When to use: Load operation discovery, permissions, aliases, executable targets,
+or the temporary ``automation-map.json`` compatibility projection.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+REGISTRY_PATH = SCRIPTS_DIR / "control-plane.json"
+SCHEMA_PATH = SCRIPTS_DIR / "control-plane.schema.json"
+LEGACY_PATH = SCRIPTS_DIR / "automation-map.json"
+PERMISSION_LEVELS = (
+    "ReadOnly",
+    "ReadOnlyTerminal",
+    "WorkspaceWrite",
+    "DangerFullAccess",
+)
+SCRIPT_EXTENSIONS = {".py", ".sh"}
+
+
+class ControlPlaneError(ValueError):
+    """Raised when the canonical registry is unavailable or invalid."""
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ControlPlaneError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=_reject_duplicate_keys
+        )
+    except FileNotFoundError as exc:
+        raise ControlPlaneError(f"registry file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ControlPlaneError(f"invalid JSON in {path}: {exc}") from exc
+    except OSError as exc:
+        raise ControlPlaneError(f"cannot read {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ControlPlaneError(f"expected a JSON object in {path}")
+    return data
+
+
+def _schema_errors(data: dict[str, Any], schema_path: Path) -> list[str]:
+    schema = _read_json(schema_path)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    return [
+        f"schema:{'/'.join(str(part) for part in error.absolute_path) or '<root>'}: "
+        f"{error.message}"
+        for error in sorted(
+            validator.iter_errors(data),
+            key=lambda item: tuple(str(part) for part in item.path),
+        )
+    ]
+
+
+def operation_map(
+    registry: dict[str, Any], *, active_only: bool = False
+) -> dict[str, dict[str, Any]]:
+    """Return operation metadata, optionally excluding deprecated aliases."""
+    operations = registry.get("operations", {})
+    if not isinstance(operations, dict):
+        return {}
+    if not active_only:
+        return operations
+    return {
+        name: info
+        for name, info in operations.items()
+        if isinstance(info, dict) and info.get("status") == "active"
+    }
+
+
+def get_operation(
+    name: str, registry: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
+    """Resolve an exact operation name or alias, case-insensitively."""
+    loaded = registry if registry is not None else load_registry()
+    normalized = name.lower().strip()
+    operations = operation_map(loaded)
+    direct = operations.get(normalized)
+    if isinstance(direct, dict):
+        return direct
+    for info in operations.values():
+        aliases = {str(alias).lower() for alias in info.get("aliases", [])}
+        if normalized in aliases:
+            return info
+    return None
+
+
+def operation_name_for_alias(
+    alias: str, registry: dict[str, Any] | None = None
+) -> str | None:
+    """Return the active operation owning an alias."""
+    loaded = registry if registry is not None else load_registry()
+    normalized = alias.lower().strip()
+    for name, info in operation_map(loaded, active_only=True).items():
+        if normalized in {str(item).lower() for item in info.get("aliases", [])}:
+            return name
+    return None
+
+
+def _resolve_local_target(cwd: str, token: str) -> Path | None:
+    if "<" in token or ">" in token:
+        return None
+    if not (token.startswith("./") or token.startswith("../")):
+        if not (
+            token.startswith("scripts/") and token.endswith(tuple(SCRIPT_EXTENSIONS))
+        ):
+            return None
+    return (REPO_ROOT / cwd / token).resolve()
+
+
+def command_targets(registry: dict[str, Any]) -> dict[str, set[Path]]:
+    """Return local executable/script targets referenced by each operation."""
+    result: dict[str, set[Path]] = {}
+    for name, info in operation_map(registry).items():
+        targets: set[Path] = set()
+        for step in info.get("command", {}).get("steps", []):
+            cwd = str(step.get("cwd", "."))
+            for token in step.get("argv", []):
+                target = _resolve_local_target(cwd, str(token))
+                if target is not None:
+                    targets.add(target)
+        result[name] = targets
+    return result
+
+
+def top_level_scripts() -> set[str]:
+    """Return active top-level Python and shell scripts on disk."""
+    return {
+        path.name
+        for path in SCRIPTS_DIR.iterdir()
+        if path.is_file()
+        and path.suffix in SCRIPT_EXTENSIONS
+        and not path.name.startswith(".")
+    }
+
+
+def referenced_top_level_scripts(registry: dict[str, Any]) -> set[str]:
+    """Return top-level scripts reached by structured operation commands."""
+    return {
+        target.name
+        for targets in command_targets(registry).values()
+        for target in targets
+        if target.parent == SCRIPTS_DIR
+    }
+
+
+def semantic_errors(data: dict[str, Any]) -> list[str]:
+    """Validate invariants that JSON Schema cannot express."""
+    errors: list[str] = []
+    operations = operation_map(data)
+    operation_names = set(operations)
+    active_names = {
+        name for name, info in operations.items() if info.get("status") == "active"
+    }
+    alias_owners: dict[str, str] = {}
+
+    for name, info in operations.items():
+        if name != name.lower().strip():
+            errors.append(f"operation:{name}: name must be normalized lowercase")
+        for alias in info.get("aliases", []):
+            normalized = str(alias).lower().strip()
+            if normalized != alias:
+                errors.append(f"operation:{name}: alias must be normalized: {alias}")
+            if normalized in operation_names and normalized != name:
+                errors.append(
+                    f"operation:{name}: alias collides with operation: {normalized}"
+                )
+            owner = alias_owners.get(normalized)
+            if owner is not None and owner != name:
+                errors.append(
+                    f"operation:{name}: alias '{normalized}' already belongs to {owner}"
+                )
+            alias_owners[normalized] = name
+
+        if info.get("status") == "deprecated":
+            replacement = info.get("replacement")
+            if replacement not in active_names:
+                errors.append(
+                    f"operation:{name}: replacement is not an active operation: {replacement}"
+                )
+
+        command = info.get("command", {})
+        display = str(command.get("display", ""))
+        steps = command.get("steps", [])
+        expected_tokens: list[str] = []
+        previous_cwd: str | None = None
+        for step in steps:
+            cwd = str(step.get("cwd", "."))
+            if cwd != "." and cwd != previous_cwd:
+                expected_tokens.extend(["cd", cwd, "&&"])
+            expected_tokens.extend(str(token) for token in step.get("argv", []))
+            expected_tokens.append("&&")
+            previous_cwd = cwd
+        if expected_tokens:
+            expected_tokens.pop()
+        try:
+            display_tokens = shlex.split(display)
+        except ValueError as exc:
+            errors.append(f"operation:{name}: invalid display command: {exc}")
+        else:
+            if display_tokens != expected_tokens:
+                errors.append(
+                    f"operation:{name}: display command differs from structured steps"
+                )
+
+    for name, targets in command_targets(data).items():
+        for target in sorted(targets):
+            try:
+                target.relative_to(REPO_ROOT)
+            except ValueError:
+                errors.append(f"operation:{name}: target escapes repository: {target}")
+                continue
+            if not target.exists():
+                errors.append(f"operation:{name}: missing command target: {target}")
+
+    actual = top_level_scripts()
+    referenced = referenced_top_level_scripts(data)
+    for missing in sorted(actual - referenced):
+        errors.append(
+            f"coverage: top-level script is not registered: scripts/{missing}"
+        )
+    for phantom in sorted(referenced - actual):
+        errors.append(f"coverage: registered script is not on disk: scripts/{phantom}")
+    return errors
+
+
+def validate_registry_data(
+    data: dict[str, Any], *, schema_path: Path = SCHEMA_PATH
+) -> list[str]:
+    """Return all schema and semantic errors for registry data."""
+    errors = _schema_errors(data, schema_path)
+    if not errors:
+        errors.extend(semantic_errors(data))
+    return errors
+
+
+def load_registry(
+    path: Path = REGISTRY_PATH,
+    *,
+    schema_path: Path = SCHEMA_PATH,
+    validate: bool = True,
+) -> dict[str, Any]:
+    """Load the canonical registry and fail closed on invalid content."""
+    data = _read_json(path)
+    if validate:
+        errors = validate_registry_data(data, schema_path=schema_path)
+        if errors:
+            raise ControlPlaneError("invalid control plane:\n- " + "\n- ".join(errors))
+    return data
+
+
+def legacy_tasks(registry: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Project canonical operations into the temporary legacy task shape."""
+    result: dict[str, dict[str, Any]] = {}
+    field_order = (
+        "group",
+        "description",
+        "permission",
+        "permission_modes",
+        "options",
+        "aliases",
+        "never_use",
+        "context_docs",
+        "agent",
+        "prereq",
+        "replacement",
+    )
+    for name, operation in operation_map(registry).items():
+        task: dict[str, Any] = {
+            "script": operation["command"]["display"],
+        }
+        for field in field_order:
+            if field in operation:
+                task[field] = operation[field]
+        if operation["status"] == "deprecated":
+            task["deprecated"] = True
+        result[name] = task
+    return result
+
+
+def legacy_projection(registry: dict[str, Any]) -> dict[str, Any]:
+    """Build the deterministic compatibility projection."""
+    actual = top_level_scripts()
+    referenced = referenced_top_level_scripts(registry)
+    return {
+        "_comment": (
+            "GENERATED compatibility projection from scripts/control-plane.json; "
+            "do not edit directly"
+        ),
+        "_usage": "Use ./run.sh find <query> or ./run.sh control find <query>",
+        "_source": "scripts/control-plane.json",
+        "_coverage": f"{len(referenced)}/{len(actual)} top-level scripts registered",
+        "tasks": legacy_tasks(registry),
+    }
+
+
+def canonical_json(data: dict[str, Any]) -> str:
+    """Serialize registry/projection content deterministically."""
+    return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+
+def legacy_is_current(
+    registry: dict[str, Any], *, legacy_path: Path = LEGACY_PATH
+) -> bool:
+    """Return whether the checked-in compatibility projection is exact."""
+    try:
+        current = legacy_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return current == canonical_json(legacy_projection(registry))

--- a/scripts/control_plane/cli.py
+++ b/scripts/control_plane/cli.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Inspect and validate the canonical repository control plane.
+
+When to use: Validate operation metadata, search registered commands, inspect
+permissions, or verify/regenerate the temporary automation-map projection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from control_plane import (  # noqa: E402
+    LEGACY_PATH,
+    ControlPlaneError,
+    canonical_json,
+    legacy_is_current,
+    legacy_projection,
+    load_registry,
+    operation_map,
+    referenced_top_level_scripts,
+    top_level_scripts,
+)
+
+
+def _find(query: str, registry: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    active = operation_map(registry, active_only=True)
+    normalized = query.lower().strip()
+    if normalized in active:
+        return [(normalized, active[normalized])]
+    matches = []
+    for name, info in active.items():
+        aliases = [str(alias).lower() for alias in info.get("aliases", [])]
+        haystack = f"{name} {info.get('description', '')}".lower()
+        if normalized in haystack or any(normalized in alias for alias in aliases):
+            matches.append((name, info))
+    if matches:
+        return matches
+    close = get_close_matches(normalized, list(active), n=3, cutoff=0.4)
+    return [(name, active[name]) for name in close]
+
+
+def _print_operation(name: str, info: dict[str, Any]) -> None:
+    print(f"{name} [{info['group']}]")
+    print(f"  {info['description']}")
+    print(f"  command: {info['command']['display']}")
+    print(f"  permission: {info['permission']}")
+    if info.get("permission_modes"):
+        modes = ", ".join(
+            f"{mode}={level}" for mode, level in info["permission_modes"].items()
+        )
+        print(f"  modes: {modes}")
+    if info.get("aliases"):
+        print(f"  aliases: {', '.join(info['aliases'])}")
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    try:
+        registry = load_registry()
+    except ControlPlaneError as exc:
+        if args.json:
+            print(json.dumps({"status": "fail", "errors": str(exc).splitlines()}))
+        else:
+            print(f"ERROR: {exc}")
+        return 1
+    errors = []
+    if not legacy_is_current(registry):
+        errors.append(
+            "scripts/automation-map.json is not the exact generated projection"
+        )
+    result = {
+        "status": "fail" if errors else "pass",
+        "schema_version": registry["schema_version"],
+        "operations": len(operation_map(registry)),
+        "active_operations": len(operation_map(registry, active_only=True)),
+        "top_level_scripts": len(top_level_scripts()),
+        "registered_top_level_scripts": len(referenced_top_level_scripts(registry)),
+        "legacy_projection_current": not errors,
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2))
+    elif errors:
+        print("Control plane: FAIL")
+        for error in errors:
+            print(f"- {error}")
+    else:
+        print(
+            "Control plane: PASS "
+            f"({result['active_operations']} active operations; "
+            f"{result['registered_top_level_scripts']}/{result['top_level_scripts']} scripts)"
+        )
+    return 1 if errors else 0
+
+
+def _cmd_export(args: argparse.Namespace) -> int:
+    try:
+        registry = load_registry()
+    except ControlPlaneError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    content = canonical_json(legacy_projection(registry))
+    if args.write:
+        LEGACY_PATH.write_text(content, encoding="utf-8")
+        print(f"Wrote {LEGACY_PATH}")
+        return 0
+    if legacy_is_current(registry):
+        print("automation-map.json projection is current")
+        return 0
+    print("automation-map.json projection differs", file=sys.stderr)
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    validate = sub.add_parser("validate", help="Validate registry and projection")
+    validate.add_argument("--json", action="store_true")
+    validate.set_defaults(handler=_cmd_validate)
+
+    find = sub.add_parser("find", help="Find active operations")
+    find.add_argument("query")
+    find.add_argument("--json", action="store_true")
+
+    listing = sub.add_parser("list", help="List active operations")
+    listing.add_argument("--group")
+    listing.add_argument("--json", action="store_true")
+
+    stats = sub.add_parser("stats", help="Show registry counts")
+    stats.add_argument("--json", action="store_true")
+
+    export = sub.add_parser(
+        "export-legacy", help="Check or write automation-map compatibility projection"
+    )
+    export.add_argument("--write", action="store_true")
+    export.set_defaults(handler=_cmd_export)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if hasattr(args, "handler"):
+        return args.handler(args)
+    try:
+        registry = load_registry()
+    except ControlPlaneError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.command == "find":
+        matches = _find(args.query, registry)
+        if args.json:
+            print(
+                json.dumps([{"name": name, **info} for name, info in matches], indent=2)
+            )
+        else:
+            for name, info in matches:
+                _print_operation(name, info)
+        return 0 if matches else 1
+
+    active = operation_map(registry, active_only=True)
+    if args.command == "list":
+        selected = {
+            name: info
+            for name, info in active.items()
+            if not args.group or info["group"].lower() == args.group.lower()
+        }
+        if args.json:
+            print(json.dumps(selected, indent=2))
+        else:
+            for name, info in selected.items():
+                _print_operation(name, info)
+        return 0
+
+    permissions: dict[str, int] = {}
+    groups: dict[str, int] = {}
+    aliases = 0
+    for info in active.values():
+        permissions[info["permission"]] = permissions.get(info["permission"], 0) + 1
+        groups[info["group"]] = groups.get(info["group"], 0) + 1
+        aliases += len(info.get("aliases", []))
+    result = {
+        "operations": len(operation_map(registry)),
+        "active_operations": len(active),
+        "deprecated_operations": len(operation_map(registry)) - len(active),
+        "groups": groups,
+        "permissions": permissions,
+        "aliases": aliases,
+        "top_level_scripts": len(top_level_scripts()),
+    }
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/find_automation.py
+++ b/scripts/find_automation.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Find the right automation script for a task.
+Find the right registered operation for a task.
 
-When to use: When you need a script but do not know which one. Searches the
-current non-deprecated automation tasks and derives categories from their
-canonical `group` metadata.
+When to use: When you need a script but do not know which one. Searches current
+non-deprecated control-plane operations and derives categories from canonical
+`group` metadata.
 
 Usage:
     ./scripts/python_runtime.sh scripts/find_automation.py "move file"
@@ -20,18 +20,17 @@ import sys
 from difflib import get_close_matches
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from control_plane import ControlPlaneError, legacy_projection, load_registry
+
 
 def load_automation_map() -> dict:
-    """Load the automation map."""
-    script_dir = Path(__file__).parent
-    map_path = script_dir / "automation-map.json"
-
-    if not map_path.exists():
-        print("❌ automation-map.json not found")
+    """Return the legacy-shaped view generated from the canonical registry."""
+    try:
+        return legacy_projection(load_registry())
+    except ControlPlaneError as exc:
+        print(f"❌ control-plane registry is invalid: {exc}")
         sys.exit(1)
-
-    with open(map_path, "r", encoding="utf-8") as f:
-        return json.load(f)
 
 
 def active_tasks(automation_map: dict) -> dict[str, dict]:

--- a/scripts/index.json
+++ b/scripts/index.json
@@ -2,17 +2,17 @@
   "folder": "scripts",
   "type": "python-package",
   "description": "> Development, validation, discovery, release-preparation, and maintenance tools.",
-  "last_updated": "2026-08-22",
-  "file_count": 116,
+  "last_updated": "2026-08-23",
+  "file_count": 118,
   "files": [
     {
       "name": "README.md",
       "type": "documentation",
-      "size_lines": 80,
-      "last_updated": "2026-08-17",
+      "size_lines": 86,
+      "last_updated": "2026-08-23",
       "title": "Scripts",
       "description": "> Development, validation, discovery, release-preparation, and maintenance tools. > Git/GitHub lifecycle wrappers were retired on 2026-08-09; Codex owns that",
-      "content_hash": "fdbadaf7daa1"
+      "content_hash": "0ea3bd3f5b98"
     },
     {
       "name": "agent_brief.sh",
@@ -787,8 +787,8 @@
     {
       "name": "audit_permissions.py",
       "type": "python",
-      "size_lines": 468,
-      "last_updated": "2026-08-17",
+      "size_lines": 465,
+      "last_updated": "2026-08-23",
       "description": "Permission audit report for all agents.",
       "classes": [
         {
@@ -807,7 +807,7 @@
       "functions": [
         {
           "name": "audit_automation_permission_metadata",
-          "description": "Validate only explicitly declared automation permission metadata."
+          "description": "Validate canonical operation permission metadata fail-closed."
         },
         {
           "name": "audit_permissions",
@@ -823,10 +823,10 @@
       "constants": [
         "_WRITE_TOOLS",
         "_RUN_TOOLS",
-        "_AUTOMATION_MAP",
+        "_CONTROL_PLANE",
         "_KNOWN_LEVELS"
       ],
-      "content_hash": "eb0554d88a5b"
+      "content_hash": "b64e5bc14879"
     },
     {
       "name": "audit_readiness_report.py",
@@ -944,15 +944,15 @@
     {
       "name": "automation-map.json",
       "type": "config",
-      "last_updated": "2026-08-22",
+      "last_updated": "2026-08-23",
       "top_level_keys": [
         "_comment",
-        "_updated",
         "_usage",
+        "_source",
         "_coverage",
         "tasks"
       ],
-      "content_hash": "73e9fbfe2870"
+      "content_hash": "1adffba8d581"
     },
     {
       "name": "batch_migrate_runner.py",
@@ -1799,7 +1799,7 @@
       "name": "check_governance.py",
       "type": "python",
       "size_lines": 1042,
-      "last_updated": "2026-08-17",
+      "last_updated": "2026-08-23",
       "description": "Unified governance checker — folder structure + compliance validation.",
       "classes": [
         {
@@ -1953,7 +1953,7 @@
         "DEFAULT_RULES",
         "RULES"
       ],
-      "content_hash": "451b50e738a1"
+      "content_hash": "f8fb48767430"
     },
     {
       "name": "check_instruction_drift.py",
@@ -2295,9 +2295,9 @@
     {
       "name": "check_scripts_index.py",
       "type": "python",
-      "size_lines": 223,
-      "last_updated": "2026-08-17",
-      "description": "Ensure scripts/index.json and automation-map.json match the scripts folder contents.",
+      "size_lines": 244,
+      "last_updated": "2026-08-23",
+      "description": "Ensure script indexes and the canonical control plane match scripts on disk.",
       "functions": [
         {
           "name": "main"
@@ -2310,7 +2310,7 @@
         "AUTOMATION_MAP_PATH",
         "SCRIPT_EXTENSIONS"
       ],
-      "content_hash": "1531f18bde50"
+      "content_hash": "90c9c1af7a2f"
     },
     {
       "name": "check_tasks_format.py",
@@ -2593,6 +2593,35 @@
         }
       ],
       "content_hash": "c584f427c308"
+    },
+    {
+      "name": "control-plane.json",
+      "type": "config",
+      "last_updated": "2026-08-23",
+      "top_level_keys": [
+        "$schema",
+        "schema_version",
+        "registry_kind",
+        "metadata",
+        "operations"
+      ],
+      "content_hash": "548958e4e9f3"
+    },
+    {
+      "name": "control-plane.schema.json",
+      "type": "config",
+      "last_updated": "2026-08-23",
+      "top_level_keys": [
+        "$schema",
+        "$id",
+        "title",
+        "type",
+        "additionalProperties",
+        "required",
+        "properties",
+        "$defs"
+      ],
+      "content_hash": "80229b1c082c"
     },
     {
       "name": "create_doc.py",
@@ -3025,13 +3054,13 @@
     {
       "name": "find_automation.py",
       "type": "python",
-      "size_lines": 192,
-      "last_updated": "2026-08-17",
-      "description": "Find the right automation script for a task.",
+      "size_lines": 191,
+      "last_updated": "2026-08-23",
+      "description": "Find the right registered operation for a task.",
       "functions": [
         {
           "name": "load_automation_map",
-          "description": "Load the automation map."
+          "description": "Return the legacy-shaped view generated from the canonical registry."
         },
         {
           "name": "active_tasks",
@@ -3082,7 +3111,7 @@
           "name": "main"
         }
       ],
-      "content_hash": "f204343ade3b"
+      "content_hash": "198a3584a2fe"
     },
     {
       "name": "fix_broken_links.py",
@@ -4242,8 +4271,8 @@
     {
       "name": "prompt_router.py",
       "type": "python",
-      "size_lines": 700,
-      "last_updated": "2026-08-17",
+      "size_lines": 697,
+      "last_updated": "2026-08-23",
       "description": "Prompt router — routes natural language queries to the best agent + skills.",
       "classes": [
         {
@@ -4282,11 +4311,10 @@
         }
       ],
       "constants": [
-        "AUTOMATION_MAP_PATH",
         "STOPWORDS",
         "GENERIC_TASK_WORDS"
       ],
-      "content_hash": "74fff5403eef"
+      "content_hash": "bdbaed7dbf78"
     },
     {
       "name": "python_runtime.sh",
@@ -4492,7 +4520,7 @@
       "name": "session.py",
       "type": "python",
       "size_lines": 2580,
-      "last_updated": "2026-08-22",
+      "last_updated": "2026-08-23",
       "description": "Unified session management CLI.",
       "functions": [
         {
@@ -4607,7 +4635,7 @@
         "HANDOFF_DATE_RE",
         "COMMIT_HASH_RE"
       ],
-      "content_hash": "3096c0f11f01"
+      "content_hash": "45380a77d517"
     },
     {
       "name": "session_store.py",
@@ -5144,8 +5172,8 @@
     {
       "name": "tool_permissions.py",
       "type": "python",
-      "size_lines": 437,
-      "last_updated": "2026-08-17",
+      "size_lines": 454,
+      "last_updated": "2026-08-23",
       "description": "Tool permission enforcement for agent operations.",
       "classes": [
         {
@@ -5195,16 +5223,15 @@
       ],
       "constants": [
         "_PERMISSION_LEVELS",
-        "_REGISTRY_PATH",
-        "_AUTOMATION_MAP_PATH"
+        "_REGISTRY_PATH"
       ],
-      "content_hash": "0642c1206c41"
+      "content_hash": "c7f8b3cd8b71"
     },
     {
       "name": "tool_registry.py",
       "type": "python",
-      "size_lines": 559,
-      "last_updated": "2026-08-22",
+      "size_lines": 540,
+      "last_updated": "2026-08-23",
       "description": "Unified tool registry — connects agents, skills, scripts, and operations.",
       "classes": [
         {
@@ -5223,7 +5250,7 @@
         },
         {
           "name": "load_registry",
-          "description": "Load unified tool registry from agent_registry.json and automation-map.json."
+          "description": "Load unified tools from the agent and canonical control registries."
         },
         {
           "name": "infer_agent_from_task",
@@ -5302,10 +5329,9 @@
         }
       ],
       "constants": [
-        "TOOL_ALIASES",
         "STOPWORDS"
       ],
-      "content_hash": "aa83afa41096"
+      "content_hash": "d4d93888cabd"
     },
     {
       "name": "update_test_stats.py",
@@ -5665,11 +5691,17 @@
   ],
   "subfolders": [
     {
+      "name": "control_plane",
+      "path": "control_plane/",
+      "file_count": 2,
+      "is_package": true
+    },
+    {
       "name": "hooks",
       "path": "hooks/",
       "file_count": 3,
       "is_package": true
     }
   ],
-  "content_hash": "3c1a1215f364e643"
+  "content_hash": "da46d3aa131b4d25"
 }

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -3,18 +3,20 @@
 > Development, validation, discovery, release-preparation, and maintenance tools.
 
 **Type:** Python Package
-**Last Updated:** 2026-08-22
-**Files:** 116
+**Last Updated:** 2026-08-23
+**Files:** 118
 
 ## Config Files
 
 - [automation-map.json](automation-map.json)
+- [control-plane.json](control-plane.json)
+- [control-plane.schema.json](control-plane.schema.json)
 
 ## Documentation Files
 
 | File | Title | Description | Lines |
 |------|-------|-------------|-------|
-| [README.md](README.md) | Scripts | > Development, validation, discovery, release-preparation, a | 80 |
+| [README.md](README.md) | Scripts | > Development, validation, discovery, release-preparation, a | 86 |
 
 ## Python Files
 
@@ -30,7 +32,7 @@
 | [agent_trends.py](agent_trends.py) | Agent trends — time series analysis and degradation detectio | 0 | 7 | 383 |
 | [audit_error_handling.py](audit_error_handling.py) | Audit error handling compliance across structural_lib module | 2 | 3 | 286 |
 | [audit_input_validation.py](audit_input_validation.py) | Audit validation ownership across maintained IS 456 calculat | 4 | 5 | 588 |
-| [audit_permissions.py](audit_permissions.py) | Permission audit report for all agents. | 3 | 3 | 468 |
+| [audit_permissions.py](audit_permissions.py) | Permission audit report for all agents. | 3 | 3 | 465 |
 | [audit_readiness_report.py](audit_readiness_report.py) | Audit Readiness Report Generator | 2 | 13 | 930 |
 | [batch_migrate_runner.py](batch_migrate_runner.py) | Batch migration runner with per-operation rollback logs. | 1 | 2 | 467 |
 | [benchmark_api.py](benchmark_api.py) | API Performance Benchmark Script. | 4 | 9 | 837 |
@@ -59,7 +61,7 @@
 | [check_public_route_safety.py](check_public_route_safety.py) | Run the frozen adversarial regressions for maintained public | 0 | 1 | 97 |
 | [check_python_version.py](check_python_version.py) | Python Version Consistency Checker | 0 | 5 | 208 |
 | [check_repo_hygiene.py](check_repo_hygiene.py) | Fail if tracked hygiene artifacts exist in the repository. | 0 | 1 | 44 |
-| [check_scripts_index.py](check_scripts_index.py) | Ensure scripts/index.json and automation-map.json match the  | 0 | 1 | 223 |
+| [check_scripts_index.py](check_scripts_index.py) | Ensure script indexes and the canonical control plane match  | 0 | 1 | 244 |
 | [check_tasks_format.py](check_tasks_format.py) | Validate docs/TASKS.md structure and WIP rules. | 0 | 1 | 161 |
 | [check_token_efficiency.py](check_token_efficiency.py) | Validate repository-side Codex token-efficiency controls. | 0 | 2 | 206 |
 | [check_type_annotations.py](check_type_annotations.py) | Type Annotation Checker for the Python Structural Library | 4 | 1 | 542 |
@@ -74,7 +76,7 @@
 | [evolve.py](evolve.py) | Self-evolution engine — orchestrates project health, feedbac | 0 | 12 | 552 |
 | [export_paper_data.py](export_paper_data.py) | Export agent performance data for academic paper. | 0 | 8 | 388 |
 | [external_cli_test.py](external_cli_test.py) | External CLI smoke test (S-007). | 1 | 1 | 401 |
-| [find_automation.py](find_automation.py) | Find the right automation script for a task. | 0 | 8 | 192 |
+| [find_automation.py](find_automation.py) | Find the right registered operation for a task. | 0 | 8 | 191 |
 | [fix_broken_links.py](fix_broken_links.py) | Fix broken internal links in markdown files. | 0 | 6 | 268 |
 | [generate_api_classification.py](generate_api_classification.py) | Generate or validate the Alpha public API classification reg | 0 | 2 | 314 |
 | [generate_api_manifest.py](generate_api_manifest.py) | Generate or validate the public API manifest for structural_ | 0 | 1 | 159 |
@@ -95,7 +97,7 @@
 | [pipeline_state.py](pipeline_state.py) | Pipeline state tracking for multi-step agent workflows. | 2 | 17 | 868 |
 | [preflight.py](preflight.py) | Pre-flight check — catch common mistakes BEFORE they happen. | 0 | 10 | 219 |
 | [project_health.py](project_health.py) | Unified project health scanner with auto-fix capability. | 3 | 9 | 908 |
-| [prompt_router.py](prompt_router.py) | Prompt router — routes natural language queries to the best  | 1 | 5 | 700 |
+| [prompt_router.py](prompt_router.py) | Prompt router — routes natural language queries to the best  | 1 | 5 | 697 |
 | [release.py](release.py) | Unified release management CLI. | 0 | 11 | 2276 |
 | [safe_file_delete.py](safe_file_delete.py) | Safe file delete script with reference checking. | 0 | 5 | 355 |
 | [safe_file_move.py](safe_file_move.py) | Safe file move script with automatic link updates. | 0 | 6 | 500 |
@@ -107,8 +109,8 @@
 | [test_changed.py](test_changed.py) | Smart test runner — run only tests related to changed files. | 0 | 3 | 219 |
 | [test_cli_smoke.py](test_cli_smoke.py) | CLI Smoke Tests — validate all key scripts work correctly. | 0 | 3 | 298 |
 | [test_import_pipeline.py](test_import_pipeline.py) | End-to-end test of all import paths. | 0 | 20 | 412 |
-| [tool_permissions.py](tool_permissions.py) | Tool permission enforcement for agent operations. | 1 | 5 | 437 |
-| [tool_registry.py](tool_registry.py) | Unified tool registry — connects agents, skills, scripts, an | 1 | 12 | 559 |
+| [tool_permissions.py](tool_permissions.py) | Tool permission enforcement for agent operations. | 1 | 5 | 454 |
+| [tool_registry.py](tool_registry.py) | Unified tool registry — connects agents, skills, scripts, an | 1 | 12 | 540 |
 | [update_test_stats.py](update_test_stats.py) | Update Test Stats — Dynamic test count updater. | 0 | 5 | 211 |
 | [validate_api_contracts.py](validate_api_contracts.py) | API Contract Validator. | 2 | 9 | 647 |
 | [validate_imports.py](validate_imports.py) | Validate Python imports across the project after migration. | 0 | 6 | 365 |
@@ -141,4 +143,5 @@
 
 | Folder | Files | Description |
 |--------|-------|-------------|
+| [control_plane/](control_plane/) 📦 | 2 |  |
 | [hooks/](hooks/) 📦 | 3 |  |

--- a/scripts/prompt_router.py
+++ b/scripts/prompt_router.py
@@ -28,10 +28,9 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent))
 from _lib.output import StatusLine, print_json
 from _lib.utils import REPO_ROOT
+from control_plane import load_registry as load_control_registry, operation_map
 from git_state import collect_worktree_inventory
 from tool_registry import ToolEntry, find_tools, load_registry
-
-AUTOMATION_MAP_PATH = REPO_ROOT / "scripts" / "automation-map.json"
 
 
 @dataclass
@@ -535,9 +534,7 @@ def _initial_context(
         path = f".github/skills/{skill}/SKILL.md"
         if (REPO_ROOT / path).exists():
             context.append(path)
-    task_map = json.loads(AUTOMATION_MAP_PATH.read_text(encoding="utf-8")).get(
-        "tasks", {}
-    )
+    task_map = operation_map(load_control_registry())
     for tool, _score in tools:
         for path in task_map.get(tool.name, {}).get("context_docs", []):
             if path not in context and (REPO_ROOT / path).exists():

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -477,7 +477,7 @@ def cmd_start(args: argparse.Namespace) -> int:
     print(
         '🧭 Automation lookup: ./scripts/python_runtime.sh scripts/find_automation.py "your task"'
     )
-    print("📚 Context routing: scripts/automation-map.json (context_docs per task)")
+    print("📚 Context routing: scripts/control-plane.json (context_docs per operation)")
     print(
         "📖 Read first: docs/planning/next-session-brief.md → docs/getting-started/agent-bootstrap.md"
     )

--- a/scripts/tool_permissions.py
+++ b/scripts/tool_permissions.py
@@ -21,11 +21,18 @@ import fnmatch
 import json
 import sys
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _lib.output import print_json  # noqa: E402
 from _lib.utils import REPO_ROOT  # noqa: E402
+from control_plane import (  # noqa: E402
+    REGISTRY_PATH,
+    ControlPlaneError,
+    load_registry as load_control_registry,
+    operation_map,
+)
 
 # ---------------------------------------------------------------------------
 # Operation classifications
@@ -102,7 +109,6 @@ def _level_rank(level: str) -> int:
 # ---------------------------------------------------------------------------
 
 _REGISTRY_PATH = REPO_ROOT / "agents" / "agent_registry.json"
-_AUTOMATION_MAP_PATH = REPO_ROOT / "scripts" / "automation-map.json"
 
 
 def _load_registry() -> list[dict]:
@@ -128,14 +134,25 @@ def _find_agent(agents: list[dict], name: str) -> dict | None:
     return None
 
 
-def _load_automation_tasks() -> dict[str, dict]:
-    """Load explicit operation metadata from the automation map."""
+@lru_cache(maxsize=4)
+def _load_cached_automation_tasks(
+    modified_ns: int, size: int
+) -> dict[str, dict]:
+    """Load validated operation metadata for one exact registry file state."""
+    del modified_ns, size
     try:
-        data = json.loads(_AUTOMATION_MAP_PATH.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return operation_map(load_control_registry())
+    except ControlPlaneError:
         return {}
-    tasks = data.get("tasks", {})
-    return tasks if isinstance(tasks, dict) else {}
+
+
+def _load_automation_tasks() -> dict[str, dict]:
+    """Load operation metadata, revalidating only when registry bytes change."""
+    try:
+        stat = REGISTRY_PATH.stat()
+    except OSError:
+        return {}
+    return _load_cached_automation_tasks(stat.st_mtime_ns, stat.st_size)
 
 
 def resolve_required_permission(operation: str, *, mode: str | None = None) -> str:

--- a/scripts/tool_registry.py
+++ b/scripts/tool_registry.py
@@ -4,7 +4,7 @@ Unified tool registry — connects agents, skills, scripts, and operations.
 
 Loads from:
 - agents/agent_registry.json (16 agents)
-- scripts/automation-map.json (task and script operation metadata)
+- scripts/control-plane.json (operation, command, alias, and permission metadata)
 
 Usage:
     python scripts/tool_registry.py --list
@@ -29,6 +29,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 from _lib.output import StatusLine
 from _lib.utils import REPO_ROOT
+from control_plane import (
+    load_registry as load_control_registry,
+    operation_map,
+    operation_name_for_alias,
+)
 
 
 @dataclass
@@ -46,22 +51,6 @@ class ToolEntry:
     skill: str | None = None
     aliases: list[str] = field(default_factory=list)
 
-
-# Tool aliases — common shortcuts
-TOOL_ALIASES = {
-    "design": "design_beam_is456",
-    "detail": "detail_beam_is456",
-    "check": "run all checks",
-    "test": "run tests",
-    "commit": "commit code",
-    "move": "move file",
-    "delete": "delete file",
-    "find": "find automation",
-    "api": "discover api function",
-    "session": "start session",
-    "health": "project health",
-    "parity": "is456 parity dashboard",
-}
 
 # Stopwords for keyword extraction
 STOPWORDS = {
@@ -117,7 +106,7 @@ def extract_keywords(name: str, description: str) -> list[str]:
 
 
 def load_registry() -> dict[str, ToolEntry]:
-    """Load unified tool registry from agent_registry.json and automation-map.json."""
+    """Load unified tools from the agent and canonical control registries."""
     registry: dict[str, ToolEntry] = {}
 
     # Load agent registry
@@ -194,48 +183,38 @@ def load_registry() -> dict[str, ToolEntry]:
             aliases=[],
         )
 
-    # Load automation map
-    automation_map_path = REPO_ROOT / "scripts" / "automation-map.json"
-    if automation_map_path.exists():
-        with open(automation_map_path, "r", encoding="utf-8") as f:
-            automation_data = json.load(f)
+    # Add canonical script operations.
+    control_registry = load_control_registry()
+    for task_name, task_info in operation_map(
+        control_registry, active_only=True
+    ).items():
+        script = task_info.get("command", {}).get("display", "")
+        description = task_info.get("description", "")
+        group = task_info.get("group", "Uncategorized")
 
-        # Add script tasks
-        for task_name, task_info in automation_data.get("tasks", {}).items():
-            if task_info.get("deprecated", False):
-                continue
-            script = task_info.get("script", "")
-            description = task_info.get("description", "")
-            group = task_info.get("group", "Uncategorized")
+        permission = task_info.get("permission")
+        permission_modes = task_info.get("permission_modes", {})
 
-            permission = task_info.get("permission")
-            permission_modes = task_info.get("permission_modes", {})
+        # Extract keywords
+        keywords = extract_keywords(task_name, description)
 
-            # Extract keywords
-            keywords = extract_keywords(task_name, description)
+        # Determine primary agent based on task characteristics
+        agent = task_info.get("agent") or infer_agent_from_task(
+            task_name, description, group
+        )
 
-            # Determine primary agent based on task characteristics
-            agent = task_info.get("agent") or infer_agent_from_task(
-                task_name, description, group
-            )
-
-            registry[task_name] = ToolEntry(
-                name=task_name,
-                description=description,
-                agent=agent,
-                category=group,
-                script=script,
-                permission=permission,
-                permission_modes=permission_modes,
-                keywords=keywords,
-                skill=None,
-                aliases=[str(alias) for alias in task_info.get("aliases", [])],
-            )
-
-    # Add aliases to entries
-    for alias, target in TOOL_ALIASES.items():
-        if target in registry:
-            registry[target].aliases.append(alias)
+        registry[task_name] = ToolEntry(
+            name=task_name,
+            description=description,
+            agent=agent,
+            category=group,
+            script=script,
+            permission=permission,
+            permission_modes=permission_modes,
+            keywords=keywords,
+            skill=None,
+            aliases=[str(alias) for alias in task_info.get("aliases", [])],
+        )
 
     return registry
 
@@ -345,7 +324,7 @@ def get_tools_by_permission(
 
 def resolve_alias(alias: str) -> str | None:
     """Resolve an alias to the full tool name."""
-    return TOOL_ALIASES.get(alias.lower())
+    return operation_name_for_alias(alias)
 
 
 def print_tool(tool: ToolEntry, show_score: bool = False, score: float = 0.0):
@@ -355,6 +334,7 @@ def print_tool(tool: ToolEntry, show_score: bool = False, score: float = 0.0):
     permission_label = tool.permission or "Unspecified"
     permission_icon = {
         "ReadOnly": "🔍",
+        "ReadOnlyTerminal": "🖥️",
         "WorkspaceWrite": "✏️",
         "DangerFullAccess": "⚠️",
     }.get(permission_label, "❓")
@@ -433,7 +413,7 @@ def show_stats(registry: dict[str, ToolEntry]):
     print(f"   - Script-backed operations: {has_script}")
     print(f"   - Skills: {has_skill}")
     print(f"   - Agents: {is_agent}")
-    print(f"   - Aliases: {len(TOOL_ALIASES)}")
+    print(f"   - Aliases: {sum(len(tool.aliases) for tool in registry.values())}")
 
     print("\n📂 By Category:")
     for category in sorted(by_category.keys()):
@@ -447,6 +427,7 @@ def show_stats(registry: dict[str, ToolEntry]):
     for permission in sorted(by_permission.keys()):
         icon = {
             "ReadOnly": "🔍",
+            "ReadOnlyTerminal": "🖥️",
             "WorkspaceWrite": "✏️",
             "DangerFullAccess": "⚠️",
         }.get(permission, "")


### PR DESCRIPTION
## Summary

- establish scripts/control-plane.json and a strict Draft 2020-12 schema as the canonical source for 125 active operations
- add a fail-closed loader and ./run.sh control CLI with schema, target, alias, permission, coverage, and projection validation
- migrate discovery, prompt routing, tool lookup, permission enforcement, audits, and script coverage to the canonical loader
- retain scripts/automation-map.json only as an exact deterministic compatibility projection
- freeze MAINT-012B through MAINT-012D as separate index, evidence-reuse, scanner, and script-cleanup packets

## Verification

- 261 focused control, governance, session, efficiency, Git-guidance, and surface tests passed
- CLI compatibility smoke: 13 of 13 passed
- token-efficiency policy: PASS
- quick gate: 10 of 10 passed
- full gate: 31 of 31 passed
- normal staged pre-commit hooks: PASS
- final session closeout: PASS and READY_LOCAL
- source binding: true

## Boundary

No structural calculations, public API, FastAPI, React, Excel, ETABS, dependency, release, CI topology, repository setting, scanner scheduling, index retirement, or script deletion behavior changes in MAINT-012A.