### PR TITLE
refactor(ci): add exact verification evidence

### DIFF
--- a/.github/actions/verification-evidence/action.yml
+++ b/.github/actions/verification-evidence/action.yml
@@ -1,0 +1,85 @@
+name: Exact verification PASS evidence
+description: Restore and independently verify one content-addressed PASS receipt.
+
+inputs:
+  domain:
+    description: Canonical verification domain
+    required: true
+  profile:
+    description: Versioned hosted validation profile
+    required: true
+  identity-command:
+    description: Stable command identity for the hosted job
+    required: true
+  cache-name:
+    description: Stable cache/receipt label
+    required: true
+  receipt:
+    description: Absolute receipt path below runner.temp/verification-evidence
+    required: true
+  runtime-file:
+    description: Optional additional Node/runner runtime identity file
+    required: false
+    default: ''
+
+outputs:
+  valid:
+    description: true only when the restored receipt exactly matches
+    value: ${{ steps.probe.outputs.valid }}
+  fingerprint:
+    description: Exact current evidence fingerprint
+    value: ${{ steps.identity.outputs.fingerprint }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute exact evidence identity
+      id: identity
+      shell: bash
+      env:
+        DOMAIN: ${{ inputs.domain }}
+        PROFILE: ${{ inputs.profile }}
+        IDENTITY_COMMAND: ${{ inputs.identity-command }}
+        RUNTIME_FILE: ${{ inputs.runtime-file }}
+      run: |
+        args=(
+          fingerprint
+          --profile "$PROFILE"
+          --domain "$DOMAIN"
+          --identity-command "$IDENTITY_COMMAND"
+          --github-output "$GITHUB_OUTPUT"
+        )
+        if [[ -n "$RUNTIME_FILE" ]]; then
+          args+=(--runtime-file "$RUNTIME_FILE")
+        fi
+        python scripts/verification.py "${args[@]}"
+
+    - name: Restore exact PASS receipt
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: ${{ inputs.receipt }}
+        key: verification-pass-v1-${{ runner.os }}-${{ inputs.cache-name }}-${{ steps.identity.outputs.fingerprint }}
+
+    - name: Verify restored receipt
+      id: probe
+      shell: bash
+      env:
+        DOMAIN: ${{ inputs.domain }}
+        PROFILE: ${{ inputs.profile }}
+        IDENTITY_COMMAND: ${{ inputs.identity-command }}
+        RECEIPT: ${{ inputs.receipt }}
+        RUNTIME_FILE: ${{ inputs.runtime-file }}
+      run: |
+        args=(
+          probe
+          --profile "$PROFILE"
+          --domain "$DOMAIN"
+          --identity-command "$IDENTITY_COMMAND"
+          --receipt "$RECEIPT"
+          --github-output "$GITHUB_OUTPUT"
+        )
+        if [[ -n "$RUNTIME_FILE" ]]; then
+          args+=(--runtime-file "$RUNTIME_FILE")
+        fi
+        python scripts/verification.py "${args[@]}"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,24 +11,38 @@ checks:
 
 | Check | When it runs | Evidence |
 |---|---|---|
-| `Detect Changes` | Every PR | Classifies Python, FastAPI, and React inputs |
-| `Repository Validation` | Every PR | YAML, docs, scripts, architecture, and agent-control policy |
+| `Detect Changes` | Every PR | Loads the canonical seven-domain manifest; unknown impact selects all domains |
+| `Repository Validation` | Repository-policy inputs | YAML, hygiene, and maintenance-script contracts |
 | `Python Validation` | Python inputs | Format, lint, types, contracts, focused core tests, architecture policy |
-| `FastAPI Validation` | API or deployment inputs | Format, lint, API tests, contracts, Docker/OpenAPI configuration |
+| `FastAPI Validation` | API or deployment inputs | Format, lint, API tests, architecture, contracts, Docker/OpenAPI configuration |
 | `React Validation` | React inputs | Lint, production build, and Vitest |
+| `Excel Add-in Validation` | Excel add-in inputs | Complete dependency-free Node test suite |
+| `Control Plane Validation` | Agent, script, session, Git, or workflow controls | Registries, CLI/reference policy, and exact control regression set |
+| `Documentation Validation` | Documentation or imported API-doc inputs | Versions, task format, links, and strict MkDocs build |
 | `PR Gate` | Every PR, with `if: always()` | Rejects any failed or cancelled applicable job |
 
-The component checks may be skipped when their layer is unchanged. `Repository
-Validation` never skips, so a docs-only or control-plane PR still receives real
-validation. `PR Gate` checks each component result against the detected paths; a
-skipped applicable check cannot produce a green gate.
+Checks may be skipped only when the canonical impact plan marks their domain
+unchanged. `scripts/verification-manifest.json` owns the path rules used by both
+local commands and this workflow; there is no second YAML filter list. Unknown
+paths or Git-query failures select all seven domains. `PR Gate` rejects missing
+applicability values, partial fail-closed plans, and skipped applicable jobs.
+The same rules also define each domain's fingerprint inputs, preventing a
+scheduler/evidence ownership drift.
 
-For example, `Excel Add-in Validation` is expected to show `skipped` when no
-`excel_addin/**` path changed. That is a successful path-classification outcome,
-not missing validation: `PR Gate` verifies both the classifier result and the
-skip. A cross-product safety packet that relies on unchanged Excel behavior
+Every applicable job resolves its runtime and dependencies before computing an
+evidence identity. An exact-key `actions/cache` entry may then skip only the
+validation body, and only after the restored PASS receipt independently matches
+the current command, runtime/dependency identity, and domain input bytes. Cache
+misses, malformed receipts, partial keys, failed runs, and changed inputs execute
+normally. The cache never uses prefix restore keys.
+
+For example, `Excel Add-in Validation` is expected to show `skipped` when the
+plan marks `excel` unchanged—normally when no `excel_addin/**`, `.nvmrc`, or
+shared verification-control path changed. That is a successful classification
+outcome, not missing validation: `PR Gate` verifies both the planner result and
+the skip. A cross-product safety packet that relies on unchanged Excel behavior
 still runs the complete local Excel suite when its acceptance contract requires
-that evidence; the path-filtered hosted job does not replace that local proof.
+that evidence; the planned hosted job does not replace that local proof.
 
 The active main-branch ruleset requires `PR Gate`. Do not rename that check without
 updating and verifying the ruleset in the same approved operation.
@@ -37,7 +51,7 @@ updating and verifying the ruleset in the same approved operation.
 
 | Workflow | Trigger | Responsibility |
 |---|---|---|
-| `fast-checks.yml` | Pull requests and short main-branch verification | Path-aware Python, FastAPI, React, and repository validation with required `PR Gate` |
+| `fast-checks.yml` | Pull requests and short main-branch verification | Manifest-planned Python, FastAPI, React, Excel, control, docs, and repository validation with required `PR Gate` |
 | `nightly.yml` | Weekly schedule and manual dispatch | Full Ubuntu verification, clean-wheel/CLI checks, dependency audits, Docker health, and optional manual cross-platform smoke |
 | `publish.yml` | Version tag or manual dispatch | Build/install/SBOM verification; manual TestPyPI publication; tag-only production PyPI and GitHub Release |
 | `deploy-docs.yml` | Relevant main-branch documentation changes or manual dispatch | Strict MkDocs build validation; no public deployment until the owner enables and verifies GitHub Pages |

--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -18,65 +18,32 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      python: ${{ steps.filter.outputs.python }}
-      fastapi: ${{ steps.filter.outputs.fastapi }}
-      react: ${{ steps.filter.outputs.react }}
-      excel: ${{ steps.filter.outputs.excel }}
-      control_plane: ${{ steps.filter.outputs.control_plane }}
-      docs: ${{ steps.filter.outputs.docs }}
+      python: ${{ steps.impact.outputs.python }}
+      fastapi: ${{ steps.impact.outputs.fastapi }}
+      react: ${{ steps.impact.outputs.react }}
+      excel: ${{ steps.impact.outputs.excel }}
+      control_plane: ${{ steps.impact.outputs.control_plane }}
+      docs: ${{ steps.impact.outputs.docs }}
+      repository: ${{ steps.impact.outputs.repository }}
+      fail_closed: ${{ steps.impact.outputs.fail_closed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Classify changed paths
-        uses: dorny/paths-filter@v4
-        id: filter
         with:
-          filters: |
-            python:
-              - 'Python/**'
-              - 'Python/pyproject.toml'
-            fastapi:
-              - 'fastapi_app/**'
-              - 'requirements*.txt'
-              - 'Dockerfile.fastapi'
-              - 'docker-compose*.yml'
-            react:
-              - 'react_app/**'
-              - '**/package-lock.json'
-            excel:
-              - 'excel_addin/**'
-            control_plane:
-              - 'scripts/**'
-              - 'run.sh'
-              - 'agents/**'
-              - '.codex/**'
-              - '.github/agents/**'
-              - '.github/instructions/**'
-              - '.github/prompts/**'
-              - '.github/skills/**'
-              - '.github/workflows/**'
-              - '.github/copilot-instructions.md'
-              - '.pre-commit-config.yaml'
-              - 'AGENTS.md'
-              - 'CLAUDE.md'
-              - 'docs/git-automation/**'
-              - 'docs/guidelines/ai-token-efficiency.md'
-              - 'docs/research/git-governance/**'
-              - 'Python/tests/test_agent_governance_automation.py'
-              - 'Python/tests/test_audit_readiness_truth.py'
-              - 'Python/tests/test_ci_workflow_contract.py'
-              - 'Python/tests/test_git_state.py'
-              - 'Python/tests/test_git_handoff_receipt.py'
-              - 'Python/tests/test_git_guidance_semantics.py'
-              - 'Python/tests/test_pipeline_state.py'
-              - 'Python/tests/test_session_automation.py'
-              - 'Python/tests/test_session_store.py'
-            docs:
-              - 'docs/**'
-              - 'mkdocs.yml'
-              - 'Python/pyproject.toml'
-              - 'Python/structural_lib/**'
+          fetch-depth: 0
+
+      - name: Plan exact validation domains
+        id: impact
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          python scripts/verification.py plan \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --no-worktree \
+            --github-output "$GITHUB_OUTPUT" \
+            --json
 
   python-validation:
     name: Python Validation
@@ -100,16 +67,29 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e 'Python/[dev]'
 
+      - name: Probe exact Python PASS evidence
+        id: evidence
+        uses: ./.github/actions/verification-evidence
+        with:
+          domain: python
+          profile: hosted-python-validation-v1
+          identity-command: fast-checks:python-validation
+          cache-name: python
+          receipt: ${{ runner.temp }}/verification-evidence/python.json
+
       - name: Format and lint
+        if: steps.evidence.outputs.valid != 'true'
         run: |
           python -m black --check Python
           python -m ruff check Python
 
       - name: Type check
+        if: steps.evidence.outputs.valid != 'true'
         working-directory: Python
         run: python -m mypy
 
       - name: Contract and core tests
+        if: steps.evidence.outputs.valid != 'true'
         run: |
           python -m pytest Python/tests/integration/test_contracts.py -m contract -v
           python -m pytest \
@@ -119,10 +99,21 @@ jobs:
             -v --strict-markers
 
       - name: Architecture and code-quality policy
+        if: steps.evidence.outputs.valid != 'true'
         run: |
           python scripts/check_type_annotations.py --fail-threshold 50 --json > /dev/null
+          python scripts/check_architecture_boundaries.py
           python scripts/check_circular_imports.py
           python scripts/check_governance.py --structure --json > /tmp/governance-structure.json
+
+      - name: Record exact Python PASS evidence
+        if: steps.evidence.outputs.valid != 'true'
+        run: |
+          python scripts/verification.py record \
+            --profile hosted-python-validation-v1 \
+            --domain python \
+            --identity-command fast-checks:python-validation \
+            --receipt "$RUNNER_TEMP/verification-evidence/python.json"
 
   fastapi-validation:
     name: FastAPI Validation
@@ -149,20 +140,43 @@ jobs:
           python -m pip install -e 'Python/[dev]'
           python -m pip install -r requirements.txt
 
+      - name: Probe exact FastAPI PASS evidence
+        id: evidence
+        uses: ./.github/actions/verification-evidence
+        with:
+          domain: fastapi
+          profile: hosted-fastapi-validation-v1
+          identity-command: fast-checks:fastapi-validation
+          cache-name: fastapi
+          receipt: ${{ runner.temp }}/verification-evidence/fastapi.json
+
       - name: Format and lint
+        if: steps.evidence.outputs.valid != 'true'
         run: |
           python -m black --check fastapi_app
           python -m ruff check fastapi_app
 
       - name: FastAPI tests
+        if: steps.evidence.outputs.valid != 'true'
         run: python -m pytest -c fastapi_app/pytest.ini fastapi_app/tests -v --tb=short -m "not slow and not performance"
 
       - name: API and deployment contracts
+        if: steps.evidence.outputs.valid != 'true'
         run: |
           python scripts/validate_api_contracts.py
+          python scripts/check_architecture_boundaries.py
           python scripts/check_fastapi_issues.py
           python scripts/check_docker_config.py
           python scripts/check_openapi_snapshot.py
+
+      - name: Record exact FastAPI PASS evidence
+        if: steps.evidence.outputs.valid != 'true'
+        run: |
+          python scripts/verification.py record \
+            --profile hosted-fastapi-validation-v1 \
+            --domain fastapi \
+            --identity-command fast-checks:fastapi-validation \
+            --receipt "$RUNNER_TEMP/verification-evidence/fastapi.json"
 
   react-validation:
     name: React Validation
@@ -185,12 +199,42 @@ jobs:
         working-directory: react_app
         run: npm ci
 
+      - name: Record React runtime identity
+        run: |
+          {
+            node --version
+            npm --version
+            printf '%s\n' "${ImageOS:-unknown}" "${ImageVersion:-unknown}"
+          } > "$RUNNER_TEMP/react-runtime.txt"
+
+      - name: Probe exact React PASS evidence
+        id: evidence
+        uses: ./.github/actions/verification-evidence
+        with:
+          domain: react
+          profile: hosted-react-validation-v1
+          identity-command: fast-checks:react-validation
+          cache-name: react
+          receipt: ${{ runner.temp }}/verification-evidence/react.json
+          runtime-file: ${{ runner.temp }}/react-runtime.txt
+
       - name: Lint, build, and test
+        if: steps.evidence.outputs.valid != 'true'
         working-directory: react_app
         run: |
           npm run lint
           npm run build
           npx vitest run
+
+      - name: Record exact React PASS evidence
+        if: steps.evidence.outputs.valid != 'true'
+        run: |
+          python scripts/verification.py record \
+            --profile hosted-react-validation-v1 \
+            --domain react \
+            --identity-command fast-checks:react-validation \
+            --runtime-file "$RUNNER_TEMP/react-runtime.txt" \
+            --receipt "$RUNNER_TEMP/verification-evidence/react.json"
 
   excel-validation:
     name: Excel Add-in Validation
@@ -207,9 +251,39 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Record Excel add-in runtime identity
+        run: |
+          {
+            node --version
+            npm --version
+            printf '%s\n' "${ImageOS:-unknown}" "${ImageVersion:-unknown}"
+          } > "$RUNNER_TEMP/excel-runtime.txt"
+
+      - name: Probe exact Excel add-in PASS evidence
+        id: evidence
+        uses: ./.github/actions/verification-evidence
+        with:
+          domain: excel
+          profile: hosted-excel-validation-v1
+          identity-command: fast-checks:excel-validation
+          cache-name: excel
+          receipt: ${{ runner.temp }}/verification-evidence/excel.json
+          runtime-file: ${{ runner.temp }}/excel-runtime.txt
+
       - name: Run all Excel add-in tests
+        if: steps.evidence.outputs.valid != 'true'
         working-directory: excel_addin
         run: npm test
+
+      - name: Record exact Excel add-in PASS evidence
+        if: steps.evidence.outputs.valid != 'true'
+        run: |
+          python scripts/verification.py record \
+            --profile hosted-excel-validation-v1 \
+            --domain excel \
+            --identity-command fast-checks:excel-validation \
+            --runtime-file "$RUNNER_TEMP/excel-runtime.txt" \
+            --receipt "$RUNNER_TEMP/verification-evidence/excel.json"
 
   control-plane-validation:
     name: Control Plane Validation
@@ -231,9 +305,25 @@ jobs:
       - name: Install control-plane test dependencies
         run: python -m pip install -e 'Python/[dev]' PyYAML
 
+      - name: Probe exact control-plane PASS evidence
+        id: evidence
+        uses: ./.github/actions/verification-evidence
+        with:
+          domain: control_plane
+          profile: hosted-control-plane-validation-v1
+          identity-command: fast-checks:control-plane-validation
+          cache-name: control-plane
+          receipt: ${{ runner.temp }}/verification-evidence/control-plane.json
+
       - name: Validate Git, intake, session, and governance controls
+        if: steps.evidence.outputs.valid != 'true'
         run: |
           STRUCTURAL_LIB_PYTHON="$(command -v python)" python scripts/check_codex_git_workflow.py
+          python scripts/check_scripts_index.py
+          python scripts/validate_script_refs.py
+          STRUCTURAL_LIB_PYTHON="$(command -v python)" python scripts/test_cli_smoke.py
+          python scripts/check_token_efficiency.py
+          python scripts/skill_tiers.py validate
           STRUCTURAL_LIB_PYTHON="$(command -v python)" python -m pytest \
             Python/tests/test_git_state.py \
             Python/tests/test_git_handoff_receipt.py \
@@ -245,7 +335,17 @@ jobs:
             Python/tests/test_agent_governance_automation.py \
             Python/tests/test_audit_readiness_truth.py \
             Python/tests/test_ci_workflow_contract.py \
+            Python/tests/test_verification_control.py \
             -q
+
+      - name: Record exact control-plane PASS evidence
+        if: steps.evidence.outputs.valid != 'true'
+        run: |
+          python scripts/verification.py record \
+            --profile hosted-control-plane-validation-v1 \
+            --domain control_plane \
+            --identity-command fast-checks:control-plane-validation \
+            --receipt "$RUNNER_TEMP/verification-evidence/control-plane.json"
 
   documentation-validation:
     name: Documentation Validation
@@ -269,12 +369,37 @@ jobs:
           python -m pip install "mkdocs-material>=9.5,<10" "mkdocstrings[python]>=0.25,<1"
           python -m pip install -e Python/
 
+      - name: Probe exact documentation PASS evidence
+        id: evidence
+        uses: ./.github/actions/verification-evidence
+        with:
+          domain: docs
+          profile: hosted-documentation-validation-v1
+          identity-command: fast-checks:documentation-validation
+          cache-name: docs
+          receipt: ${{ runner.temp }}/verification-evidence/docs.json
+
       - name: Build documentation strictly
-        run: mkdocs build --strict
+        if: steps.evidence.outputs.valid != 'true'
+        run: |
+          python scripts/check_doc_versions.py --ci
+          python scripts/check_tasks_format.py
+          python scripts/check_links.py
+          mkdocs build --strict
+
+      - name: Record exact documentation PASS evidence
+        if: steps.evidence.outputs.valid != 'true'
+        run: |
+          python scripts/verification.py record \
+            --profile hosted-documentation-validation-v1 \
+            --domain docs \
+            --identity-command fast-checks:documentation-validation \
+            --receipt "$RUNNER_TEMP/verification-evidence/docs.json"
 
   repository-validation:
     name: Repository Validation
     needs: changes
+    if: needs.changes.outputs.repository == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
@@ -295,7 +420,18 @@ jobs:
       - name: Install validation dependencies
         run: python -m pip install -e 'Python/[dev]' PyYAML
 
+      - name: Probe exact repository PASS evidence
+        id: evidence
+        uses: ./.github/actions/verification-evidence
+        with:
+          domain: repository
+          profile: hosted-repository-validation-v1
+          identity-command: fast-checks:repository-validation
+          cache-name: repository
+          receipt: ${{ runner.temp }}/verification-evidence/repository.json
+
       - name: Validate YAML syntax
+        if: steps.evidence.outputs.valid != 'true'
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -310,18 +446,12 @@ jobs:
           PY
 
       - name: Validate repository policy
+        if: steps.evidence.outputs.valid != 'true'
         run: |
-          python scripts/check_doc_versions.py --ci
-          python scripts/check_tasks_format.py
-          python scripts/check_links.py
-          python scripts/check_scripts_index.py
-          python scripts/validate_script_refs.py
-          STRUCTURAL_LIB_PYTHON="$(command -v python)" python scripts/test_cli_smoke.py
-          python scripts/check_token_efficiency.py
-          python scripts/check_architecture_boundaries.py
-          python scripts/skill_tiers.py validate
+          python scripts/check_repo_hygiene.py
 
       - name: Validate maintenance scripts
+        if: steps.evidence.outputs.valid != 'true'
         run: |
           bash -n scripts/validate_git_state.sh
           bash -n scripts/check_unfinished_merge.sh
@@ -329,6 +459,15 @@ jobs:
           bash -n scripts/agent_start.sh
           python scripts/git_state.py --json > /dev/null
           python -m pytest tests/integration/test_migration_scripts.py -q
+
+      - name: Record exact repository PASS evidence
+        if: steps.evidence.outputs.valid != 'true'
+        run: |
+          python scripts/verification.py record \
+            --profile hosted-repository-validation-v1 \
+            --domain repository \
+            --identity-command fast-checks:repository-validation \
+            --receipt "$RUNNER_TEMP/verification-evidence/repository.json"
 
   pr-gate:
     name: PR Gate
@@ -359,7 +498,9 @@ jobs:
           CONTROL_PLANE_RESULT: ${{ needs.control-plane-validation.result }}
           DOCS_CHANGED: ${{ needs.changes.outputs.docs }}
           DOCS_RESULT: ${{ needs.documentation-validation.result }}
+          REPOSITORY_CHANGED: ${{ needs.changes.outputs.repository }}
           REPOSITORY_RESULT: ${{ needs.repository-validation.result }}
+          FAIL_CLOSED: ${{ needs.changes.outputs.fail_closed }}
         run: |
           failed=0
 
@@ -376,7 +517,10 @@ jobs:
             local name="$1"
             local changed="$2"
             local result="$3"
-            if [[ "$changed" == 'true' ]]; then
+            if [[ "$changed" != 'true' && "$changed" != 'false' ]]; then
+              echo "ERROR: $name applicability is '$changed', expected true or false"
+              failed=1
+            elif [[ "$changed" == 'true' ]]; then
               require_success "$name" "$result"
             elif [[ "$result" != 'skipped' ]]; then
               echo "ERROR: $name should be skipped for this change set, got '$result'"
@@ -384,14 +528,35 @@ jobs:
             fi
           }
 
+          require_fail_closed_all() {
+            if [[ "$FAIL_CLOSED" != 'true' && "$FAIL_CLOSED" != 'false' ]]; then
+              echo "ERROR: fail-closed output is '$FAIL_CLOSED', expected true or false"
+              failed=1
+              return
+            fi
+            if [[ "$FAIL_CLOSED" == 'true' ]]; then
+              for changed in \
+                "$PYTHON_CHANGED" "$FASTAPI_CHANGED" "$REACT_CHANGED" \
+                "$EXCEL_CHANGED" "$CONTROL_PLANE_CHANGED" "$DOCS_CHANGED" \
+                "$REPOSITORY_CHANGED"; do
+                if [[ "$changed" != 'true' ]]; then
+                  echo 'ERROR: unknown impact did not select every validation domain'
+                  failed=1
+                  return
+                fi
+              done
+            fi
+          }
+
           require_success 'Detect Changes' "$CHANGES_RESULT"
-          require_success 'Repository Validation' "$REPOSITORY_RESULT"
+          require_fail_closed_all
           require_component 'Python Validation' "$PYTHON_CHANGED" "$PYTHON_RESULT"
           require_component 'FastAPI Validation' "$FASTAPI_CHANGED" "$FASTAPI_RESULT"
           require_component 'React Validation' "$REACT_CHANGED" "$REACT_RESULT"
           require_component 'Excel Add-in Validation' "$EXCEL_CHANGED" "$EXCEL_RESULT"
           require_component 'Control Plane Validation' "$CONTROL_PLANE_CHANGED" "$CONTROL_PLANE_RESULT"
           require_component 'Documentation Validation' "$DOCS_CHANGED" "$DOCS_RESULT"
+          require_component 'Repository Validation' "$REPOSITORY_CHANGED" "$REPOSITORY_RESULT"
 
           if [[ "$failed" -ne 0 ]]; then
             exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,25 +90,12 @@ repos:
         files: ^Python/structural_lib/(api|data_types|beam_pipeline)\.py$
         verbose: true
 
-  # Doc version drift check (local script, non-blocking)
+  # Consolidated quick gate plus two non-overlapping commit-only controls.
   - repo: local
     hooks:
-      - id: check-unfinished-merge
-        name: Check for unfinished merge
-        entry: bash scripts/check_unfinished_merge.sh --allow-operation-completion
-        language: system
-        pass_filenames: false
-        always_run: true
-      - id: check-repo-hygiene
-        name: Check repo hygiene artifacts
-        entry: ./scripts/python_runtime.sh scripts/check_repo_hygiene.py
-        language: system
-        pass_filenames: false
-        always_run: true
-        verbose: true
-      - id: check-doc-versions
-        name: Check doc version drift
-        entry: ./scripts/python_runtime.sh scripts/check_doc_versions.py
+      - id: verification-quick
+        name: Reuse or run the exact quick validation set
+        entry: ./scripts/python_runtime.sh scripts/check_all.py --quick --allow-operation-completion
         language: system
         pass_filenames: false
         always_run: true
@@ -190,13 +177,6 @@ repos:
         pass_filenames: false
         files: ^(Python/structural_lib/services/(workflow_catalog|tool_manifest)\.py|scripts/generate_beam_tool_manifest\.py|docs/reference/beam-tool-manifest\.json)$
         verbose: true
-      - id: check-next-session-brief-length
-        name: Check next-session brief length
-        entry: ./scripts/python_runtime.sh scripts/check_next_session_brief_length.py
-        language: system
-        pass_filenames: false
-        always_run: true
-        verbose: true
       - id: check-cli-reference
         name: Check CLI reference commands
         entry: ./scripts/python_runtime.sh scripts/check_cli_reference.py
@@ -205,7 +185,7 @@ repos:
         always_run: true
         verbose: true
       - id: check-scripts-index
-        name: Check control and context registries
+        name: Check control, context, and verification registries
         entry: ./scripts/python_runtime.sh scripts/check_scripts_index.py
         language: system
         pass_filenames: false
@@ -217,13 +197,6 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-        verbose: true
-      - id: check-markdown-links
-        name: Check markdown internal links
-        entry: ./scripts/python_runtime.sh scripts/check_links.py
-        language: system
-        pass_filenames: false
-        files: ^docs/.*\.md$
         verbose: true
       - id: check-api-signatures
         name: Check React/FastAPI endpoint contract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,7 @@ grep -r "@router" fastapi_app/routers/ | head -30               # Existing API r
 ./run.sh audit                      # Full readiness audit
 ./run.sh context validate           # Validate canonical context and index retirement
 ./run.sh context summary <area>     # Summarize live worktree files on demand
+./run.sh verification plan          # Show whole-candidate validation domains
 ./run.sh health                     # Project health scan (0-100 score)
 ./run.sh health --fix               # Auto-fix fixable issues
 ./run.sh feedback log --agent X     # Log concrete feedback when found

--- a/Python/tests/test_agent_governance_automation.py
+++ b/Python/tests/test_agent_governance_automation.py
@@ -146,13 +146,13 @@ def test_control_paths_use_python_runtime_launcher():
     workflow = (REPO_ROOT / ".github" / "workflows" / "fast-checks.yml").read_text(
         encoding="utf-8"
     )
-    repository_validation = workflow.partition("  repository-validation:\n")[
+    control_validation = workflow.partition("  control-plane-validation:\n")[
         2
-    ].partition("  pr-gate:\n")[0]
-    install_offset = repository_validation.index(
+    ].partition("  documentation-validation:\n")[0]
+    install_offset = control_validation.index(
         "python -m pip install -e 'Python/[dev]' PyYAML"
     )
-    smoke_offset = repository_validation.index("python scripts/test_cli_smoke.py")
+    smoke_offset = control_validation.index("python scripts/test_cli_smoke.py")
     assert install_offset < smoke_offset
 
 

--- a/Python/tests/test_ci_workflow_contract.py
+++ b/Python/tests/test_ci_workflow_contract.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import fnmatch
+import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -16,6 +19,10 @@ FAST_CHECKS = REPO_ROOT / ".github" / "workflows" / "fast-checks.yml"
 DEPLOY_DOCS = REPO_ROOT / ".github" / "workflows" / "deploy-docs.yml"
 NIGHTLY = REPO_ROOT / ".github" / "workflows" / "nightly.yml"
 PUBLISH = REPO_ROOT / ".github" / "workflows" / "publish.yml"
+EVIDENCE_ACTION = (
+    REPO_ROOT / ".github" / "actions" / "verification-evidence" / "action.yml"
+)
+VERIFICATION_MANIFEST = REPO_ROOT / "scripts" / "verification-manifest.json"
 
 BASE_GATE_ENV = {
     "CHANGES_RESULT": "success",
@@ -31,7 +38,9 @@ BASE_GATE_ENV = {
     "CONTROL_PLANE_RESULT": "skipped",
     "DOCS_CHANGED": "false",
     "DOCS_RESULT": "skipped",
-    "REPOSITORY_RESULT": "success",
+    "REPOSITORY_CHANGED": "false",
+    "REPOSITORY_RESULT": "skipped",
+    "FAIL_CLOSED": "false",
 }
 
 
@@ -104,39 +113,30 @@ def _run_pr_gate(**overrides: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_changed_path_routes_cover_controls_docs_and_their_tests():
+def test_hosted_change_routing_uses_the_canonical_fail_closed_planner():
     workflow = _workflow()
     jobs = workflow["jobs"]
-    filters_text = next(
-        step["with"]["filters"]
+    plan = next(
+        step
         for step in jobs["changes"]["steps"]
-        if step["name"] == "Classify changed paths"
+        if step["name"] == "Plan exact validation domains"
     )
-    filters = yaml.safe_load(filters_text)
-    control_paths = set(filters["control_plane"])
-    docs_paths = set(filters["docs"])
     control_command = next(
         step["run"]
         for step in jobs["control-plane-validation"]["steps"]
         if step["name"] == "Validate Git, intake, session, and governance controls"
     )
 
-    assert {
-        "scripts/**",
-        "run.sh",
-        "agents/**",
-        ".github/agents/**",
-        ".github/workflows/**",
-        "docs/git-automation/**",
-        "docs/research/git-governance/**",
-    } <= control_paths
-    assert {
-        "docs/**",
-        "mkdocs.yml",
-        "Python/pyproject.toml",
-        "Python/structural_lib/**",
-    } == docs_paths
-    assert filters["excel"] == ["excel_addin/**"]
+    assert "dorny/paths-filter" not in FAST_CHECKS.read_text(encoding="utf-8")
+    assert "python scripts/verification.py plan" in plan["run"]
+    assert '--github-output "$GITHUB_OUTPUT"' in plan["run"]
+    assert plan["env"] == {
+        "BASE_SHA": "${{ github.event.pull_request.base.sha || github.event.before }}",
+        "HEAD_SHA": "${{ github.event.pull_request.head.sha || github.sha }}",
+    }
+    assert jobs["changes"]["outputs"]["fail_closed"] == (
+        "${{ steps.impact.outputs.fail_closed }}"
+    )
 
     exact_tests = {
         "Python/tests/test_git_state.py",
@@ -146,8 +146,8 @@ def test_changed_path_routes_cover_controls_docs_and_their_tests():
         "Python/tests/test_agent_governance_automation.py",
         "Python/tests/test_audit_readiness_truth.py",
         "Python/tests/test_ci_workflow_contract.py",
+        "Python/tests/test_verification_control.py",
     }
-    assert exact_tests <= control_paths
     assert all(test_path in control_command for test_path in exact_tests)
 
 
@@ -169,6 +169,9 @@ def test_pr_gate_topology_and_cancellation_are_scoped_per_pr():
     assert jobs["documentation-validation"]["if"] == (
         "needs.changes.outputs.docs == 'true'"
     )
+    assert jobs["repository-validation"]["if"] == (
+        "needs.changes.outputs.repository == 'true'"
+    )
     docs_python = next(
         step["with"]["python-version"]
         for step in jobs["documentation-validation"]["steps"]
@@ -180,7 +183,10 @@ def test_pr_gate_topology_and_cancellation_are_scoped_per_pr():
         for step in jobs["documentation-validation"]["steps"]
         if step["name"] == "Build documentation strictly"
     )
-    assert docs_run == "mkdocs build --strict"
+    assert "python scripts/check_doc_versions.py --ci" in docs_run
+    assert "python scripts/check_tasks_format.py" in docs_run
+    assert "python scripts/check_links.py" in docs_run
+    assert docs_run.rstrip().endswith("mkdocs build --strict")
 
     excel_steps = jobs["excel-validation"]["steps"]
     excel_node = next(
@@ -202,13 +208,135 @@ def test_pr_gate_topology_and_cancellation_are_scoped_per_pr():
     assert "group: deploy-docs" not in deploy_docs
 
 
+def test_hosted_validation_checks_are_split_by_natural_domain_without_loss():
+    python_policy = _named_step_run(
+        FAST_CHECKS, "python-validation", "Architecture and code-quality policy"
+    )
+    fastapi_policy = _named_step_run(
+        FAST_CHECKS, "fastapi-validation", "API and deployment contracts"
+    )
+    control_policy = _named_step_run(
+        FAST_CHECKS,
+        "control-plane-validation",
+        "Validate Git, intake, session, and governance controls",
+    )
+    docs_policy = _named_step_run(
+        FAST_CHECKS, "documentation-validation", "Build documentation strictly"
+    )
+    repository_policy = _named_step_run(
+        FAST_CHECKS, "repository-validation", "Validate repository policy"
+    )
+
+    assert "check_architecture_boundaries.py" in python_policy
+    assert "check_architecture_boundaries.py" in fastapi_policy
+    for command in (
+        "check_scripts_index.py",
+        "validate_script_refs.py",
+        "test_cli_smoke.py",
+        "check_token_efficiency.py",
+        "skill_tiers.py validate",
+    ):
+        assert command in control_policy
+    for command in (
+        "check_doc_versions.py --ci",
+        "check_tasks_format.py",
+        "check_links.py",
+        "mkdocs build --strict",
+    ):
+        assert command in docs_policy
+    assert repository_policy.strip() == "python scripts/check_repo_hygiene.py"
+
+
+def test_every_hosted_command_file_is_an_input_of_its_scheduled_domain():
+    workflow = _workflow()
+    manifest = json.loads(VERIFICATION_MANIFEST.read_text(encoding="utf-8"))
+    scheduled = {
+        "python-validation": "python",
+        "fastapi-validation": "fastapi",
+        "react-validation": "react",
+        "excel-validation": "excel",
+        "control-plane-validation": "control_plane",
+        "documentation-validation": "docs",
+        "repository-validation": "repository",
+    }
+
+    for job_name, domain in scheduled.items():
+        run_source = "\n".join(
+            step.get("run", "") for step in workflow["jobs"][job_name]["steps"]
+        )
+        command_paths = set(
+            re.findall(
+                r"\b(?:scripts/[A-Za-z0-9_./-]+\.(?:py|sh)|Python/tests/[A-Za-z0-9_./*-]+\.py)\b",
+                run_source,
+            )
+        )
+        assert command_paths
+        for path in command_paths:
+            owners = {
+                owner
+                for rule in manifest["rules"]
+                if any(fnmatch.fnmatchcase(path, pattern) for pattern in rule["paths"])
+                for owner in rule["domains"]
+            }
+            assert domain in owners, f"{job_name} reads unbound input {path}"
+
+
+def test_every_scheduled_job_reuses_only_an_exact_verified_pass_receipt():
+    jobs = _workflow()["jobs"]
+    scheduled = {
+        "python-validation": "python",
+        "fastapi-validation": "fastapi",
+        "react-validation": "react",
+        "excel-validation": "excel",
+        "control-plane-validation": "control-plane",
+        "documentation-validation": "docs",
+        "repository-validation": "repository",
+    }
+
+    for job_name, cache_name in scheduled.items():
+        steps = jobs[job_name]["steps"]
+        evidence = next(step for step in steps if step.get("id") == "evidence")
+        record = next(step for step in steps if step["name"].startswith("Record exact"))
+        validation_steps = [
+            step
+            for step in steps
+            if step.get("if") == "steps.evidence.outputs.valid != 'true'"
+        ]
+
+        assert evidence["uses"] == "./.github/actions/verification-evidence"
+        assert evidence["with"]["cache-name"] == cache_name
+        assert evidence["with"]["domain"] == cache_name.replace("-", "_")
+        assert steps.index(evidence) < steps.index(record)
+        assert f"--profile {evidence['with']['profile']}" in record["run"]
+        assert f"--domain {evidence['with']['domain']}" in record["run"]
+        assert (
+            f"--identity-command {evidence['with']['identity-command']}"
+            in record["run"]
+        )
+        assert "verification.py record" in record["run"]
+        assert record["if"] == "steps.evidence.outputs.valid != 'true'"
+        assert len(validation_steps) >= 2
+
+    action = yaml.safe_load(EVIDENCE_ACTION.read_text(encoding="utf-8"))
+    steps = action["runs"]["steps"]
+    restore = next(step for step in steps if step.get("id") == "cache")
+    probe = next(step for step in steps if step.get("id") == "probe")
+
+    assert restore["uses"] == "actions/cache@v6"
+    assert "restore-keys" not in restore["with"]
+    assert "steps.identity.outputs.fingerprint" in restore["with"]["key"]
+    assert "verification.py" in probe["run"]
+    assert "probe" in probe["run"]
+
+
 def test_workflow_guidance_explains_excel_skip_and_performance_authorities():
     guidance = (REPO_ROOT / ".github" / "workflows" / "README.md").read_text(
         encoding="utf-8"
     )
 
     assert "Excel Add-in Validation` is expected to show `skipped`" in guidance
-    assert "`excel_addin/**` path changed" in guidance
+    assert "plan marks `excel` unchanged" in guidance
+    assert "`excel_addin/**`, `.nvmrc`" in guidance
     assert "complete local Excel suite" in guidance
     assert "fastapi_app/tests/test_load.py" in guidance
     assert "executable latency and degradation thresholds" in guidance
@@ -223,6 +351,8 @@ def test_pr_gate_accepts_successful_applicable_routes():
         CONTROL_PLANE_RESULT="success",
         DOCS_CHANGED="true",
         DOCS_RESULT="success",
+        REPOSITORY_CHANGED="true",
+        REPOSITORY_RESULT="success",
     )
 
     assert result.returncode == 0, result.stderr
@@ -232,9 +362,13 @@ def test_pr_gate_accepts_successful_applicable_routes():
 @pytest.mark.parametrize(
     ("changed_key", "result_key"),
     [
+        ("PYTHON_CHANGED", "PYTHON_RESULT"),
+        ("FASTAPI_CHANGED", "FASTAPI_RESULT"),
+        ("REACT_CHANGED", "REACT_RESULT"),
         ("EXCEL_CHANGED", "EXCEL_RESULT"),
         ("CONTROL_PLANE_CHANGED", "CONTROL_PLANE_RESULT"),
         ("DOCS_CHANGED", "DOCS_RESULT"),
+        ("REPOSITORY_CHANGED", "REPOSITORY_RESULT"),
     ],
 )
 @pytest.mark.parametrize("bad_result", ["failure", "cancelled", "skipped", "timed_out"])
@@ -250,9 +384,13 @@ def test_pr_gate_rejects_non_successful_applicable_route(
 @pytest.mark.parametrize(
     ("changed_key", "result_key"),
     [
+        ("PYTHON_CHANGED", "PYTHON_RESULT"),
+        ("FASTAPI_CHANGED", "FASTAPI_RESULT"),
+        ("REACT_CHANGED", "REACT_RESULT"),
         ("EXCEL_CHANGED", "EXCEL_RESULT"),
         ("CONTROL_PLANE_CHANGED", "CONTROL_PLANE_RESULT"),
         ("DOCS_CHANGED", "DOCS_RESULT"),
+        ("REPOSITORY_CHANGED", "REPOSITORY_RESULT"),
     ],
 )
 def test_pr_gate_rejects_unexpected_non_applicable_execution(
@@ -262,3 +400,35 @@ def test_pr_gate_rejects_unexpected_non_applicable_execution(
 
     assert result.returncode == 1
     assert "should be skipped" in result.stdout
+
+
+def test_pr_gate_rejects_missing_applicability_and_partial_fail_closed_plan():
+    missing = _run_pr_gate(PYTHON_CHANGED="")
+    assert missing.returncode == 1
+    assert "applicability is ''" in missing.stdout
+
+    partial = _run_pr_gate(FAIL_CLOSED="true")
+    assert partial.returncode == 1
+    assert "unknown impact did not select every validation domain" in partial.stdout
+
+
+def test_pr_gate_accepts_fail_closed_all_domain_success():
+    result = _run_pr_gate(
+        FAIL_CLOSED="true",
+        PYTHON_CHANGED="true",
+        PYTHON_RESULT="success",
+        FASTAPI_CHANGED="true",
+        FASTAPI_RESULT="success",
+        REACT_CHANGED="true",
+        REACT_RESULT="success",
+        EXCEL_CHANGED="true",
+        EXCEL_RESULT="success",
+        CONTROL_PLANE_CHANGED="true",
+        CONTROL_PLANE_RESULT="success",
+        DOCS_CHANGED="true",
+        DOCS_RESULT="success",
+        REPOSITORY_CHANGED="true",
+        REPOSITORY_RESULT="success",
+    )
+
+    assert result.returncode == 0, result.stdout

--- a/Python/tests/test_control_plane.py
+++ b/Python/tests/test_control_plane.py
@@ -28,13 +28,16 @@ def test_current_registry_has_frozen_operation_and_script_parity():
     all_operations = control_plane.operation_map(registry)
     active_operations = control_plane.operation_map(registry, active_only=True)
 
-    assert len(all_operations) == 129
-    assert len(active_operations) == 123
-    assert len(control_plane.top_level_scripts()) == 114
+    assert len(all_operations) == 130
+    assert len(active_operations) == 124
+    assert len(control_plane.top_level_scripts()) == 115
     assert control_plane.referenced_top_level_scripts(registry) == (
         control_plane.top_level_scripts()
     )
     assert all(operation.get("permission") for operation in active_operations.values())
+    assert active_operations["verification impact"]["command"]["display"] == (
+        "./scripts/python_runtime.sh scripts/verification.py validate"
+    )
 
 
 def test_control_validator_runs_without_site_packages():
@@ -98,6 +101,12 @@ def test_permission_lookup_uses_explicit_canonical_defaults_and_modes():
     )
     assert tool_permissions.resolve_required_permission("unknown operation") == (
         "DangerFullAccess"
+    )
+    assert (
+        tool_permissions.resolve_required_permission(
+            "verification impact", mode="record"
+        )
+        == "WorkspaceWrite"
     )
 
 

--- a/Python/tests/test_verification_control.py
+++ b/Python/tests/test_verification_control.py
@@ -1,0 +1,385 @@
+"""Regression tests for fail-closed impact planning and exact PASS reuse."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+import subprocess
+import sys
+from concurrent.futures import Future
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_only
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+verification = importlib.import_module("verification")
+check_all = importlib.import_module("check_all")
+test_changed = importlib.import_module("test_changed")
+
+
+def test_live_verification_manifest_is_strict_and_covers_every_path():
+    manifest = verification.load_manifest()
+
+    assert tuple(manifest["domains"]) == verification.REQUIRED_DOMAINS
+    assert manifest["metadata"]["unknown_impact"] == "all_domains"
+    assert {info["hosted_job"] for info in manifest["domains"].values()} == {
+        "python-validation",
+        "fastapi-validation",
+        "react-validation",
+        "excel-validation",
+        "control-plane-validation",
+        "documentation-validation",
+        "repository-validation",
+    }
+
+
+def test_manifest_rejects_duplicate_keys_and_unknown_fields(tmp_path):
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version": 1, "schema_version": 1}\n')
+    with pytest.raises(verification.VerificationError, match="duplicate JSON key"):
+        verification.load_manifest(duplicate, inventory=())
+
+    manifest = copy.deepcopy(verification.load_manifest())
+    manifest["unexpected"] = True
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps(manifest))
+    with pytest.raises(verification.VerificationError, match="additional property"):
+        verification.load_manifest(invalid, inventory=())
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (
+            "Python/structural_lib/services/api.py",
+            {"python", "fastapi", "docs"},
+        ),
+        ("fastapi_app/main.py", {"fastapi"}),
+        ("react_app/src/App.tsx", {"react"}),
+        ("excel_addin/taskpane.mjs", {"excel"}),
+        ("docs/contributing/testing-strategy.md", {"docs"}),
+        ("mkdocs.yml", {"docs", "repository"}),
+        ("scripts/check_all.py", set(verification.REQUIRED_DOMAINS)),
+        (
+            "scripts/check_openapi_snapshot.py",
+            {"fastapi", "control_plane"},
+        ),
+        ("scripts/safe_file_move.py", {"control_plane", "repository"}),
+        ("scripts/check_links.py", {"control_plane", "docs"}),
+        (
+            ".github/actions/verification-evidence/action.yml",
+            set(verification.REQUIRED_DOMAINS),
+        ),
+    ],
+)
+def test_known_paths_map_to_explicit_domains(path, expected):
+    manifest = verification.load_manifest()
+    plan = verification.classify_paths([path], manifest)
+
+    assert set(plan.domains) == expected
+    assert plan.fail_closed is False
+    assert plan.unknown_paths == ()
+
+
+def test_unknown_path_and_git_query_failure_select_every_domain(monkeypatch):
+    manifest = verification.load_manifest()
+    unknown = verification.classify_paths(["future/unowned.file"], manifest)
+
+    assert unknown.fail_closed is True
+    assert unknown.unknown_paths == ("future/unowned.file",)
+    assert unknown.domains == verification.REQUIRED_DOMAINS
+
+    def fail_query(**_kwargs):
+        raise verification.VerificationError("simulated Git failure")
+
+    monkeypatch.setattr(verification, "changed_paths", fail_query)
+    failed = verification.plan_changes(manifest)
+    assert failed.fail_closed is True
+    assert failed.domains == verification.REQUIRED_DOMAINS
+    assert failed.failure_reasons == ("simulated Git failure",)
+
+
+def test_unknown_live_path_is_plannable_but_strict_validation_rejects_it():
+    manifest = verification.load_manifest()
+    inventory = ("future/unowned.file",)
+
+    verification.validate_manifest(
+        manifest,
+        inventory=inventory,
+        require_coverage=False,
+    )
+    with pytest.raises(verification.VerificationError, match="lack an impact rule"):
+        verification.validate_manifest(manifest, inventory=inventory)
+
+    plan = verification.classify_paths(inventory, manifest)
+    assert plan.fail_closed is True
+    assert plan.domains == verification.REQUIRED_DOMAINS
+
+
+def test_changed_paths_cover_the_whole_candidate_and_untracked_work(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "verification@example.invalid"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Verification Test"],
+        cwd=tmp_path,
+        check=True,
+    )
+    initial = tmp_path / "README.md"
+    initial.write_text("base\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=tmp_path, check=True)
+    base = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True
+    ).strip()
+
+    docs = tmp_path / "docs" / "first.md"
+    docs.parent.mkdir()
+    docs.write_text("first\n")
+    subprocess.run(["git", "add", "docs/first.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "first"], cwd=tmp_path, check=True)
+
+    source = tmp_path / "Python" / "second.py"
+    source.parent.mkdir()
+    source.write_text("second = True\n")
+    subprocess.run(["git", "add", "Python/second.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "second"], cwd=tmp_path, check=True)
+
+    untracked = tmp_path / "react_app" / "pending.ts"
+    untracked.parent.mkdir()
+    untracked.write_text("export {}\n")
+
+    assert verification.changed_paths(root=tmp_path, base=base) == (
+        "Python/second.py",
+        "docs/first.md",
+        "react_app/pending.ts",
+    )
+
+
+def test_fingerprint_binds_relevant_bytes_command_and_runtime(tmp_path):
+    manifest = verification.load_manifest()
+    python_file = tmp_path / "Python" / "structural_lib" / "sample.py"
+    docs_file = tmp_path / "docs" / "note.md"
+    python_file.parent.mkdir(parents=True)
+    docs_file.parent.mkdir(parents=True)
+    python_file.write_text("value = 1\n")
+    docs_file.write_text("first\n")
+    inventory = (
+        "Python/structural_lib/sample.py",
+        "docs/note.md",
+    )
+
+    first_context = verification.FingerprintContext(
+        manifest, root=tmp_path, runtime_extra=b"runtime-a", inventory=inventory
+    )
+    first = first_context.identity(
+        profile="local-check:test",
+        domains=("python",),
+        command=("tool", "--check"),
+    )
+    same = first_context.identity(
+        profile="local-check:test",
+        domains=("python",),
+        command=("tool", "--check"),
+    )
+    assert same == first
+
+    docs_file.write_text("second\n")
+    docs_only_change = verification.FingerprintContext(
+        manifest, root=tmp_path, runtime_extra=b"runtime-a", inventory=inventory
+    ).identity(
+        profile="local-check:test",
+        domains=("python",),
+        command=("tool", "--check"),
+    )
+    assert docs_only_change.fingerprint == first.fingerprint
+
+    python_file.write_text("value = 2\n")
+    relevant_change = verification.FingerprintContext(
+        manifest, root=tmp_path, runtime_extra=b"runtime-a", inventory=inventory
+    ).identity(
+        profile="local-check:test",
+        domains=("python",),
+        command=("tool", "--check"),
+    )
+    assert relevant_change.fingerprint != first.fingerprint
+
+    python_file.unlink()
+    deletion = verification.FingerprintContext(
+        manifest, root=tmp_path, runtime_extra=b"runtime-a", inventory=inventory
+    ).identity(
+        profile="local-check:test",
+        domains=("python",),
+        command=("tool", "--check"),
+    )
+    assert deletion.fingerprint != relevant_change.fingerprint
+
+    command_change = first_context.identity(
+        profile="local-check:test",
+        domains=("python",),
+        command=("tool", "--different"),
+    )
+    assert command_change.fingerprint != first.fingerprint
+
+    runtime_change = verification.FingerprintContext(
+        manifest, root=tmp_path, runtime_extra=b"runtime-b", inventory=inventory
+    ).identity(
+        profile="local-check:test",
+        domains=("python",),
+        command=("tool", "--check"),
+    )
+    assert runtime_change.fingerprint != first.fingerprint
+
+
+def test_unknown_input_bytes_invalidate_every_domain_fingerprint(tmp_path):
+    manifest = verification.load_manifest()
+    unknown = tmp_path / "future" / "unowned.file"
+    unknown.parent.mkdir()
+    unknown.write_text("first\n")
+
+    first = verification.FingerprintContext(
+        manifest,
+        root=tmp_path,
+        inventory=("future/unowned.file",),
+    ).identity(profile="unknown", domains=("excel",), command=("test",))
+    unknown.write_text("second\n")
+    second = verification.FingerprintContext(
+        manifest,
+        root=tmp_path,
+        inventory=("future/unowned.file",),
+    ).identity(profile="unknown", domains=("excel",), command=("test",))
+
+    assert second.fingerprint != first.fingerprint
+
+
+def test_only_exact_pass_receipt_is_reused(tmp_path):
+    manifest = verification.load_manifest()
+    source = tmp_path / "Python" / "sample.py"
+    source.parent.mkdir()
+    source.write_text("value = 1\n")
+    context = verification.FingerprintContext(
+        manifest, root=tmp_path, inventory=("Python/sample.py",)
+    )
+    command = (sys.executable, "-c", "raise SystemExit(7)")
+    identity = context.identity(
+        profile="local-check:receipt",
+        domains=("python",),
+        command=command,
+    )
+    receipt = tmp_path / "receipt.json"
+    verification.write_receipt(receipt, identity)
+
+    valid, reason = verification.probe_receipt(receipt, identity)
+    assert (valid, reason) == (True, "exact-pass")
+
+    wrong = replace(identity, fingerprint="0" * 64)
+    assert verification.probe_receipt(receipt, wrong) == (
+        False,
+        "receipt-identity",
+    )
+
+    payload = json.loads(receipt.read_text())
+    payload["status"] = "fail"
+    receipt.write_text(json.dumps(payload))
+    assert verification.probe_receipt(receipt, identity) == (
+        False,
+        "receipt-identity",
+    )
+    verification.write_receipt(receipt, identity)
+
+    reused = check_all._run_check(
+        check_all.Check("receipt", list(command)),
+        "api",
+        identity=identity,
+        receipt_path=receipt,
+    )
+    assert reused.passed is True
+    assert reused.reused is True
+
+    fresh = check_all._run_check(
+        check_all.Check("receipt", list(command)),
+        "api",
+        identity=identity,
+        receipt_path=receipt,
+        reuse=False,
+    )
+    assert fresh.passed is False
+    assert fresh.exit_code == 7
+    assert fresh.reused is False
+
+
+def test_aggregate_runner_omission_is_an_explicit_failure():
+    future = Future()
+    results = []
+
+    check_all._append_missing_results(
+        results,
+        {future: (check_all.Check("missing", ["true"]), "docs")},
+    )
+
+    assert future.cancelled()
+    assert len(results) == 1
+    assert results[0].passed is False
+    assert results[0].timed_out is True
+    assert results[0].error == "aggregate runner did not return a result"
+
+
+def test_shared_precommit_gate_preserves_merge_completion_exception():
+    original = check_all._collect_checks(None, True)
+    adapted = check_all._allow_operation_completion(original)
+
+    original_commands = {check.name: check.cmd for check, _category in original}
+    adapted_commands = {check.name: check.cmd for check, _category in adapted}
+    assert adapted_commands["Unfinished operation"] == [
+        *original_commands["Unfinished operation"],
+        "--allow-operation-completion",
+    ]
+    assert adapted_commands["Git state"] == original_commands["Git state"]
+
+
+def test_changed_test_files_map_to_themselves_without_forcing_a_broad_suite():
+    paths = {
+        "Python/tests/test_verification_control.py",
+        "fastapi_app/tests/test_config.py",
+    }
+
+    assert test_changed.map_to_tests(sorted(paths)) == paths
+
+
+def test_cli_receipt_write_scope_is_bounded(tmp_path, monkeypatch):
+    manifest = verification.load_manifest()
+    context = verification.FingerprintContext(manifest, root=tmp_path, inventory=())
+    identity = context.identity(
+        profile="hosted-test", domains=("excel",), command=("test",)
+    )
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path / "runner"))
+
+    assert verification._cli_receipt_is_allowed(
+        tmp_path / "runner" / "verification-evidence" / "excel.json", identity
+    )
+    assert not verification._cli_receipt_is_allowed(
+        tmp_path / "tracked-result.json", identity
+    )
+
+
+def test_changed_mode_manifest_failure_runs_every_domain(monkeypatch):
+    def fail_manifest(**_kwargs):
+        raise verification.VerificationError("broken manifest")
+
+    monkeypatch.setattr(check_all, "load_manifest", fail_manifest)
+    domains, fail_closed, reasons = check_all._detect_changed_domains()
+
+    assert domains == set(verification.REQUIRED_DOMAINS)
+    assert fail_closed is True
+    assert reasons == ("broken manifest",)

--- a/agents/agent-9/workflows/LINK_GOVERNANCE.md
+++ b/agents/agent-9/workflows/LINK_GOVERNANCE.md
@@ -1,7 +1,7 @@
 ---
 owner: Governance Agent
 status: active
-last_updated: 2026-08-07
+last_updated: 2026-08-23
 doc_type: guide
 complexity: advanced
 tags: [agents, governance]
@@ -31,30 +31,33 @@ Internal markdown links break when:
 
 ### Layer 1: Pre-Commit Hook (Automatic)
 
-**Trigger:** Any commit that modifies `docs/**/*.md`
+**Trigger:** Every commit through the consolidated quick hook
 
 **Behavior:**
-- Runs `scripts/check_links.py`
+- Runs the quick orchestrator, whose `Broken links` check calls
+  `scripts/check_links.py`
 - Blocks commit if broken links detected in active docs
 - Excludes planning/archive/research directories
+- Reuses only an exact current-candidate PASS receipt; otherwise executes
 
 **Configuration:** `.pre-commit-config.yaml`
 ```yaml
-- id: check-markdown-links
-  name: Check markdown internal links
-  entry: python3 scripts/check_links.py
-  files: ^docs/.*\.md$
+- id: verification-quick
+  name: Reuse or run the exact quick validation set
+  entry: ./scripts/python_runtime.sh scripts/check_all.py --quick --allow-operation-completion
+  always_run: true
 ```
 
 ### Layer 2: CI Validation (Safety Net)
 
-**Trigger:** Every push to main, every PR
+**Trigger:** A PR/main candidate whose canonical plan includes `docs`
 
 **Workflow:** `.github/workflows/fast-checks.yml`
 ```yaml
-- name: Doc checks (parallel)
+- name: Build documentation strictly
   run: |
-    python scripts/check_links.py &
+    python scripts/check_links.py
+    mkdocs build --strict
 ```
 
 **Behavior:** Fails PR if broken links introduced.
@@ -69,10 +72,10 @@ Internal markdown links break when:
 **Command:**
 ```bash
 # Full check (includes archive/planning/research)
-python scripts/check_links.py --all
+./scripts/python_runtime.sh scripts/check_links.py --all
 
 # Active docs only (default)
-python scripts/check_links.py
+./scripts/python_runtime.sh scripts/check_links.py
 ```
 
 ---

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,140 @@
 
 ---
 
+## 2026-08-23 — Session: MAINT-012C evidence scheduling and exact PASS reuse
+
+**Agent:** Codex (`governance`, sole writer)
+
+**Branch:** `codex/maint-012c-evidence-scheduling`, from exact merged
+`origin/main` commit `646660e323b65118a805b554c6cf4dbef46ef479`.
+
+**Git handoff receipt:**
+`docs/verification/maint-012c-git-handoff-receipt.json`
+
+**Focus:** Modernize validation scheduling and reuse only exact PASS evidence.
+
+### Summary
+
+- Added a strict seven-domain verification manifest and one read-only CLI for
+  validation planning, fingerprints, receipt probing, and PASS recording.
+- Migrated local changed checks/tests and hosted applicability to the same
+  whole-candidate plan. Unknown paths or Git-query failures select every domain.
+- Added shared-Git local PASS reuse, exact-key hosted evidence reuse after
+  runtime/dependency resolution, a fresh-run override, and one consolidated
+  quick pre-commit hook. Git-state checks always execute.
+- Product behavior, dependencies, scanners, physical compatibility scripts,
+  release authority, settings, and professional approval remain unchanged.
+
+### Issues encountered
+
+- The startup command batch executed in the primary checkout after creating the
+  new linked worktree, so its first session/source/Git proof described `main`
+  instead of the 12C lane.
+- The inherited local changed-check path used only `HEAD~1..HEAD` and returned
+  no work for unmapped paths or Git-query failures; hosted CI separately owned a
+  second YAML path map.
+- The first partial-tree quick diagnostic failed CLI discovery because the new
+  top-level verification script existed before its control-registry transaction
+  and generated compatibility projection were complete.
+- The first focused workflow-test batch retained one assertion for the removed
+  YAML path-filter variable, so that test failed after the canonical planner
+  replaced the duplicate filter.
+- Inspection found that the parallel check runner could reach its aggregate
+  timeout without adding a result for each unfinished future; the final total
+  could therefore omit required checks.
+- The initial manifest draft routed every known `scripts/**` change to all seven
+  product domains, which was safe but would preserve unnecessary broad reruns.
+- The old unconditional repository job mixed docs, architecture, registries,
+  CLI policy, YAML, and migration checks, so making it conditional without
+  reallocating ownership would either skip evidence or keep broad scheduling.
+- The active link-governance and CI learning guides still taught the retired
+  per-link hook, `dorny/paths-filter`, 28-check/17-workflow topology, bare
+  `.venv` commands, and a retired commit helper.
+- The first consolidated focused selection found one governance test still
+  looking for CLI smoke in the repository job after that check moved to its
+  natural control-plane owner.
+- Preparation produced an incomplete auto-handoff focus because the session
+  entry's `Focus` value wrapped onto continuation lines.
+- The cumulative full gate initially passed 30/31; the Git-workflow checker
+  still required the retired standalone merge hook and literal YAML
+  `scripts/**`/`docs/**` filters.
+- The repaired checker passed as a script but its focused semantic-test import
+  initially failed to resolve the sibling verification module.
+
+### Root causes and resolutions
+
+- Confirmed root cause: one terminal call has a static working directory;
+  creating a worktree does not retarget later commands in that call. Resolution:
+  rerun session brief/start, context routing, source diagnosis, and Git-state
+  authority with the 12C worktree as the explicit working directory; it reported
+  `source_bound=true` and `READY_LOCAL`, while primary `main` remained clean.
+  ⚠️ TERMINAL ISSUE: post-creation startup commands stayed in primary `main` ->
+  reran the complete startup proof with the explicit 12C worktree.
+- Confirmed root cause: local and hosted classification evolved independently
+  from prefix/path filters with no coverage invariant or fail-closed unknown
+  state. Resolution: both now load the strict manifest, compare the whole
+  candidate, and expand unknown/query-failed impact to all seven domains; PR
+  Gate rejects missing flags and partial fallback.
+- Confirmed root cause: top-level script coverage intentionally fails during an
+  incomplete registry transaction. Resolution: add the active read-only
+  `verification impact` operation, refresh the deterministic legacy projection,
+  and add the CLI smoke contract. Control validation then reported 124 active
+  operations and 115/115 scripts.
+- Confirmed root cause: the workflow test refactor removed the local
+  `control_paths` collection but left one membership assertion behind.
+  Resolution: replace it with assertions against the canonical planner command
+  and exact control-test command; the failed node and then the complete focused
+  workflow/control selection passed.
+- Confirmed root cause: `as_completed(...)` returned only observed futures, and
+  the timeout handler cancelled the rest without materializing failed results.
+  Resolution: every missing future now becomes an explicit timed-out failure;
+  a regression proves an omitted result cannot produce a green total.
+- Confirmed root cause: a blanket script rule confused verification-engine
+  changes with known domain-specific check scripts. Resolution: one rule set now
+  drives both scheduling and fingerprint inputs; verification-engine changes
+  select all domains, known API/docs/control scripts select their affected
+  domains, and only unknown paths use the all-domain fallback.
+- Confirmed root cause: repository validation had accumulated checks belonging
+  to four other authorities because it was previously always-run. Resolution:
+  documentation now owns versions/tasks/links, Python/FastAPI own architecture,
+  control owns registries/CLI policy, and repository owns YAML, hygiene, and
+  exact maintenance-script contracts. Workflow regressions prove no command was
+  lost and every command file belongs to its fingerprint domain.
+- Confirmed root cause: the two active teaching guides were not migrated when
+  MAINT-008 consolidated workflows and the current packet consolidated hooks.
+  Resolution: update both to the 10/31-check topology, manifest planner,
+  repository runtime commands, exact quick hook, four retained workflow lanes,
+  and explicit release authority.
+- Confirmed root cause: the runtime-launcher regression encoded the old job
+  location rather than the check's ownership contract. Resolution: retarget it
+  to the control-plane job while retaining the required install-before-smoke
+  assertion; the failed node and consolidated focused selection then passed.
+- Confirmed root cause: the handoff formatter reads the physical `Focus` line,
+  not Markdown continuation lines. Resolution: make the bounded focus a single
+  complete line and regenerate the preparation handoff block.
+- Confirmed root cause: the Git-workflow checker duplicated the pre-12C hook
+  and hosted path-routing topology instead of consuming their new authorities.
+  Resolution: require the consolidated quick hook's explicit completion flag,
+  require the workflow planner outputs, and verify script/docs ownership through
+  the canonical manifest. The failed check and then the cumulative gate passed.
+- Confirmed root cause: direct script execution adds `scripts/` to `sys.path`,
+  while importing it as `scripts.check_codex_git_workflow` from pytest does not.
+  Resolution: bind the checker's own script directory before importing the
+  sibling verification control; direct and package-import regressions passed.
+
+### Validation through content freeze
+
+- Focused verification/control/workflow/Git/session/migration regression
+  selection: PASS after the recorded ownership-test repair.
+- Black and Ruff on every changed Python file: PASS. YAML compose validation:
+  PASS. `git diff --check`: PASS.
+- Verification manifest: PASS, 7 domains and 24 rules; control plane: PASS,
+  124 active operations and 115/115 scripts; context manifest: PASS, 10 areas
+  and zero generated folder indexes; CLI smoke: 16/16; token efficiency: PASS.
+- Pre-commit handoff receipt: valid fail-closed `HOLD`, local-state hash
+  `sha256:f4662fdc2b557aeb1c0011ce4f7aac795b09a4cb7cd704923e9dd4b0054da485`.
+- Pending final quick, cumulative full, hook, exact-head, and hosted evidence.
+
 ## 2026-08-23 — Session: MAINT-012B index architecture and retirement
 
 **Agent:** Codex (`governance`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -127,7 +127,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| MAINT-012B | Replace high-churn generic indexes with a small validated context manifest and read-only on-demand summaries | Main Agent + governance | M | P0 | 🔄 ACTIVE — content frozen; consolidated local/hosted closeout pending |
+| MAINT-012C | Add content-addressed impact/evidence reuse and migrate local/hosted validation scheduling to explicit change domains | Main Agent + governance | M | P0 | 🔄 ACTIVE — isolated candidate; unknown impact runs every domain |
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. The reproduced public-route safety packet is integrated. INDIA-3,
@@ -164,7 +164,7 @@ write-back/nightly work remain outside E1.
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| MAINT-012C | Add content-addressed impact/evidence reuse and migrate local/hosted validation scheduling to explicit change domains | Main Agent + governance | M | P0 | ⏸ AFTER MAINT-012B — separate frozen candidate; unknown impact fails closed |
+| MAINT-012D | Consolidate scanners and retire/move obsolete compatibility scripts using live callers, ownership, runtime, and replacement evidence | Main Agent + governance | M | P0 | ⏸ AFTER MAINT-012C — separate frozen candidate; preservation-aware proof required |
 | INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | ⏸ AFTER LIB-PRO-003 — truth/benchmark/contract audit only; no new formulas or support claims |
 | SPARK-001-G0 | Reassess the stale Spark work-program proposal before any implementation | repository owner | review gate | P2 | ⏸ OWNER REVIEW — the 2026-08-11 model/preview assumptions and bulk wave require refresh or rejection |
 

--- a/docs/_internal/git-governance.md
+++ b/docs/_internal/git-governance.md
@@ -107,7 +107,8 @@ Solo default:
 
 **Rules Enabled:**
 - ✅ Required status checks must pass on `main`:
-  - `PR Gate` — path-aware PR checks plus always-run repository validation
+  - `PR Gate` — manifest-planned PR checks; unknown impact selects every
+    domain and the gate rejects any skipped applicable job
 - ✅ Force pushes disabled
 - ✅ Branch deletion disabled
 - ✅ PR-first: required for code/CI/deps; docs-only direct commits allowed

--- a/docs/contributing/testing-strategy.md
+++ b/docs/contributing/testing-strategy.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-03-30
+last_updated: 2026-08-23
 doc_type: guide
 complexity: intermediate
 tags: []
@@ -14,7 +14,7 @@ tags: []
 **Status:** Production Ready
 **Importance:** High
 **Created:** 2025-01-01
-**Last Updated:** 2026-03-29
+**Last Updated:** 2026-08-23
 
 ---
 
@@ -35,10 +35,17 @@ tags: []
 **How to run locally (fast):**
 - From `Python/`: `python -m pytest -q`
 
-**Fast checks before commit (pick what changed):**
-- Docs-only: from repo root, `.venv/bin/python scripts/check_doc_versions.py`
-- Links touched: from repo root, `.venv/bin/python scripts/check_links.py`
-- Code + tests: from `Python/`, `python -m pytest -q`
+**Fast checks before commit:**
+
+- `./run.sh verification plan` shows the whole candidate's explicit domains.
+- `./run.sh check --changed` runs the mapped repository checks; an unknown path
+  or failed Git query expands to every domain.
+- `./run.sh test --changed` keeps focused Python/FastAPI mappings where proved,
+  runs the React/Excel suites for those domains, and falls back to complete
+  product suites when test ownership is unclear.
+- `./run.sh check --quick` remains the required pre-commit gate. Exact prior
+  PASS receipts are reused only when command, runtime, dependency set, and
+  current input bytes have the same content address.
 
 **How to run with coverage:**
 - From `Python/`: `python -m pytest --cov=structural_lib --cov-report=term-missing --cov-report=xml`
@@ -53,6 +60,11 @@ Workflows: `.github/workflows/fast-checks.yml` and
 
 - Pull requests receive path-aware format, lint, type, contract, focused test,
   frontend, API, and repository checks under the required `PR Gate`.
+- Local and hosted scheduling load `scripts/verification-manifest.json`; the
+  workflow does not maintain a second path-filter list. Applicable jobs may
+  reuse an exact PASS receipt only after their current runtime/dependencies are
+  resolved and fingerprinted. Cache misses, malformed receipts, and identity
+  changes execute the job normally.
 - Weekly/manual verification runs the full Ubuntu Python/FastAPI/React suite,
   branch coverage gate, clean-wheel/CLI verification, dependency audits, and
   Docker health checks.

--- a/docs/guidelines/ai-token-efficiency.md
+++ b/docs/guidelines/ai-token-efficiency.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-17
+last_updated: 2026-08-23
 doc_type: guide
 ---
 
@@ -162,6 +162,8 @@ is an exception used to guide or debug the change, not a ritual after each edit.
    together as one consolidated selection.
 6. Add one or two independent reviews only when risk justifies them, then run
    `./run.sh check --quick` once before committing and allow normal hooks to run.
+   The hook calls the same quick orchestrator, so exact PASS receipts are reused
+   instead of rerunning unchanged checks; Git-state checks always execute fresh.
 7. If verification exposes an outcome-changing defect, repair its root cause,
    rerun the failed or affected narrow evidence, and repeat the consolidated
    gate once for the new frozen candidate.
@@ -173,7 +175,14 @@ is an exception used to guide or debug the change, not a ritual after each edit.
    Repeat only a failed portion unless the fix can affect other categories.
 10. Run either broad gate before cumulative closeout only when an
    outcome-changing failure or repository-wide surface makes it necessary.
-   Required hosted checks are never deferred or bypassed.
+Required hosted checks are never deferred or bypassed.
+
+Content-addressed reuse is evidence reuse, not a weakened gate. A receipt is
+accepted only for the same check command, declared domains, current input bytes,
+Python/platform/dependency identity, and verification contract. Failed or
+malformed evidence is never stored or reused. Use `./run.sh check --no-reuse`
+when a genuinely fresh execution is required; changing the input invalidates the
+receipt automatically, so calendar-based cache resets are unnecessary.
 
 For work requiring independent acceptance, use these stricter efficiency
 controls:

--- a/docs/migration/learning/day-23-ci-cd.md
+++ b/docs/migration/learning/day-23-ci-cd.md
@@ -5,9 +5,9 @@
 **Status:** Active
 **Importance:** Critical
 **Created:** 2026-04-08
-**Last Updated:** 2026-04-08
+**Last Updated:** 2026-08-23
 **Prerequisites:** Day 22 (Git Automation), Day 12 (Testing Patterns)
-**Library files:** `scripts/check_all.py`, `.github/workflows/fast-checks.yml`, `.github/workflows/python-tests.yml`, `.github/workflows/publish.yml`
+**Library files:** `scripts/check_all.py`, `scripts/verification-manifest.json`, `.github/workflows/fast-checks.yml`, `.github/workflows/nightly.yml`, `.github/workflows/publish.yml`
 **Related scripts:** `scripts/diagnose_ci.py`, `scripts/check_architecture_boundaries.py`, `scripts/validate_imports.py`
 
 ---
@@ -16,8 +16,8 @@
 
 By the end of this module you'll understand:
 - What CI/CD means and why it matters for a structural engineering library
-- The 28 automated checks that guard this codebase (and what each one validates)
-- The difference between `--quick` (8 checks, <30s) and full validation (28 checks)
+- The 31 automated checks that guard this codebase (and what each one validates)
+- The difference between `--quick` (10 checks, <30s) and full validation (31 checks)
 - How GitHub Actions workflows trigger on push, PR, and release
 - The 3 quality gate levels: commit, PR, and release
 - How to diagnose and fix CI failures without panic
@@ -32,19 +32,21 @@ By the end of this module you'll understand:
 
 **CI (Continuous Integration):** Every time someone commits code, automated tests run immediately. If anything is broken, the team knows within minutes — not days or weeks later when a user reports a bug in a shear capacity calculation.
 
-**CD (Continuous Deployment/Delivery):** When tests pass and code is merged, the library is automatically packaged and published to PyPI. No human has to remember to run `python -m build` and upload manually.
+**CD (Continuous Delivery):** An explicitly authorized version tag can invoke
+the validated package/publication workflow. A merge alone never publishes this
+library, and repository-owner release authority remains mandatory.
 
 > **Think of it like...** a structural inspection process. CI is the inspector who checks every weld on every beam the moment it's fabricated. CD is the logistics system that ships approved beams to the construction site. Without CI, you're hoping the welds are good. Without CD, approved beams sit in the factory.
 
-For a structural engineering library, CI is especially critical. A wrong sign in a moment equation, a missing safety factor, or a unit conversion error doesn't cause a UI glitch — it causes an *unsafe design*. The 28 checks exist because correctness isn't optional.
+For a structural engineering library, CI is especially critical. A wrong sign in a moment equation, a missing safety factor, or a unit conversion error doesn't cause a UI glitch — it causes an *unsafe design*. The 31 checks exist because correctness isn't optional.
 
 ---
 
-### 2. Our 28 Checks
+### 2. Our 31 Checks
 
 The `check_all.py` orchestrator organizes all validation into **8 categories**. Each category runs its checks in parallel for speed:
 
-#### Category 1: API (3 checks)
+#### Category 1: API (4 checks)
 
 Verifies public API signatures, response contracts, and OpenAPI manifest consistency.
 
@@ -56,7 +58,7 @@ Broken links (870+ internal links), stale version numbers, CLI reference, tasks 
 
 Enforces 4-layer boundaries (Core → IS 456 → Services → UI), detects circular imports, validates all `import` statements resolve.
 
-#### Category 4: Governance (4 checks)
+#### Category 4: Governance (5 checks)
 
 Governance rules, repo hygiene, Python version, Pydantic schema snapshots.
 
@@ -68,7 +70,7 @@ FastAPI issues, Docker config validity, OpenAPI snapshot drift.
 
 Clean git state, no unfinished merges, version consistency across 13+ files, script line budget.
 
-#### Category 7: Stale References (3 checks)
+#### Category 7: Stale References (4 checks)
 
 Script references still exist, agent instructions match codebase, bootstrap docs are fresh.
 
@@ -80,16 +82,16 @@ Type annotations present on functions.
 
 ### 3. Check Levels: Quick vs Full
 
-You don't always need all 28 checks. The `--quick` flag runs a curated **fast subset** for rapid feedback:
+You don't always need all 31 checks. The `--quick` flag runs a curated **fast subset** for rapid feedback:
 
 ```python
-# Quick checks — 8 checks from 5 categories, <30 seconds
+# Quick checks — 10 checks from 5 categories, <30 seconds
 QUICK_CHECKS = {
     "docs": ["Broken links", "Doc versions", "Brief length"],
     "arch": ["Import validation"],
-    "governance": ["Repo hygiene"],
-    "git": ["Git state", "Unfinished merge"],
-    "stale": ["Script references"],
+    "governance": ["Repo hygiene", "Token efficiency"],
+    "git": ["Git state", "Unfinished operation"],
+    "stale": ["Script references", "CLI smoke"],
 }
 ```
 
@@ -97,44 +99,51 @@ When to use which:
 
 | Situation | Command | Checks | Time |
 |-----------|---------|--------|------|
-| Quick sanity check | `./run.sh check --quick` | 8 | <30s |
-| Before a PR | `./run.sh check` | 28 | 2-5 min |
-| Single category | `./run.sh check --category api` | 3 | ~30s |
+| Quick sanity check | `./run.sh check --quick` | 10 | <30s |
+| Before a PR | `./run.sh check` | 31 | 2-5 min |
+| Single category | `./run.sh check --category api` | 4 | ~30s |
 | Only what changed | `./run.sh check --changed` | varies | varies |
-| Auto-fix issues | `./run.sh check --fix` | 28 | 2-5 min |
+| Auto-fix issues | `./run.sh check --fix` | 31 | 2-5 min |
 
-The `--changed` flag looks at `git diff` and only runs relevant categories (e.g., editing `Python/structural_lib/` triggers `arch` + `code`; editing `docs/` triggers `docs` + `stale`).
+The `--changed` flag compares the whole candidate with `origin/main`, includes
+working-tree changes, and uses the canonical verification-domain manifest.
+Unknown paths or Git failures select every domain rather than silently skipping.
 
 ---
 
 ### 4. GitHub Actions
 
-GitHub Actions are cloud-based CI runners. When you push code or open a PR, GitHub spins up a virtual machine and runs your checks automatically. This project has **17 workflow files**:
+GitHub Actions are cloud-based CI runners. When you push code or open a PR,
+GitHub spins up a virtual machine and runs checks. The maintained automation is
+consolidated into four workflow lanes.
 
 #### On every push and PR: Fast Checks
 
 ```yaml
 # .github/workflows/fast-checks.yml
-name: Fast PR Checks
+name: PR Validation
 on:
   pull_request:
   push:
     branches: [ main ]
 ```
 
-This workflow uses **path filtering** (`dorny/paths-filter`) to skip irrelevant jobs. Docs-only changes skip Python tests. This keeps PR feedback under **3-5 minutes**.
+This workflow calls `scripts/verification.py plan`; the same strict manifest
+drives local scheduling and hosted applicability. Unknown impact selects all
+seven domains, while known docs-only changes skip unrelated product jobs.
 
-#### On merge to main: Full Test Matrix
+#### Scheduled/manual: Full Test Matrix
 
 ```yaml
-# .github/workflows/python-tests.yml
-name: Python tests
+# .github/workflows/nightly.yml
+name: Weekly Full Verification
 on:
-  push:
-    branches: [ main ]
+  schedule:
+  workflow_dispatch:
 ```
 
-After code merges, the full test suite runs: Black formatting + Ruff linting + mypy types + full pytest + import validation.
+The weekly/manual lane runs the broad suites, clean-wheel/CLI checks, dependency
+audits, Docker health, and optional cross-platform smoke.
 
 #### On release tag: Publish to PyPI
 
@@ -151,7 +160,10 @@ When a version tag is pushed, it validates tests, checks tag matches `pyproject.
 
 #### Other workflows
 
-The project has 17 workflows total, including: `docker-build.yml` (PR Docker build), `security.yml` (dependency vulnerability scan), `codeql.yml` (static analysis), `link-check.yml` (doc links), `deploy-docs.yml` (MkDocs), `scorecard.yml` (OpenSSF), `nightly.yml` (extended daily suite), `performance.yml` (benchmark regression).
+The four maintained lanes are `fast-checks.yml`, `nightly.yml`, `publish.yml`,
+and `deploy-docs.yml`. Former standalone Docker, security, CodeQL, link,
+scorecard, and performance workflows were consolidated or explicitly parked by
+MAINT-008; see `.github/workflows/README.md` for the retained signal map.
 
 ---
 
@@ -165,7 +177,9 @@ Lint (Black, Ruff) + type check + import validation + commit message format + no
 
 #### Level 2: PR Gate (GitHub Actions)
 
-All Level 1 + full pytest suite + architecture boundaries + 85% branch coverage + React build + Docker build + OpenAPI drift. **Blocks the merge** — `--finish` polls and waits.
+Applicable manifest-planned Python, FastAPI, React, Excel, control,
+documentation, and repository jobs. The always-run required `PR Gate` rejects
+failed, cancelled, missing, or improperly skipped work and **blocks the merge**.
 
 #### Level 3: Release Gate (pre-release)
 
@@ -180,23 +194,23 @@ CI failures are normal — they're the system working as designed. Here's the wo
 #### Step 1: Diagnose
 
 ```bash
-.venv/bin/python scripts/diagnose_ci.py --pr 42   # Check what failed on a PR
-.venv/bin/python scripts/diagnose_ci.py --local    # Or check locally
+./scripts/python_runtime.sh scripts/diagnose_ci.py --pr 42   # Check a PR
+./scripts/python_runtime.sh scripts/diagnose_ci.py --local    # Check locally
 ```
 
 #### Step 2: Auto-fix if possible
 
 ```bash
-.venv/bin/python scripts/diagnose_ci.py --local --fix   # Black + Ruff auto-fix
+./scripts/python_runtime.sh scripts/diagnose_ci.py --local --fix
 ```
 
 #### Step 3: Manual fix, verify, recommit
 
 ```bash
-.venv/bin/pytest Python/tests/test_column.py -v -x   # Reproduce the failure
+./scripts/python_runtime.sh -m pytest Python/tests/test_column.py -v -x
 # Fix the code...
-./run.sh check --quick                                # Verify
-./scripts/ai_commit.sh "fix: resolve CI failure"       # Recommit
+./run.sh check --quick                              # Verify once
+# Codex stages only intended paths and creates the normal verified commit.
 ```
 
 #### Common failures
@@ -216,14 +230,12 @@ CI failures are normal — they're the system working as designed. Here's the wo
 
 ```bash
 # Preflight — validates EVERYTHING before release
-./run.sh release preflight 0.22.0
+./run.sh release preflight <version>
 # Checks: git state, tests, React build, docs, versions, CHANGELOG, security
 
-# Bump version + commit + tag
-.venv/bin/python scripts/release.py run 0.22.0
-./scripts/ai_commit.sh "chore: release v0.22.0"
-git tag v0.22.0 && git push origin v0.22.0
-# → publish.yml triggers automatically on the tag
+# Only after the repository owner explicitly authorizes that release:
+./run.sh release run <version>
+# Codex performs the normal commit/tag/push flow without bypassing gates.
 ```
 
 ---
@@ -231,8 +243,10 @@ git tag v0.22.0 && git push origin v0.22.0
 ### 8. The Feedback Loop
 
 ```
-Commit → Hooks check → Push → GitHub Actions → Pass? → Merge → Deploy
+Commit → Hooks check → Push → GitHub Actions → Pass? → Merge
                                               → Fail? → Fix → Recommit → ...
+
+Authorized release → Preflight → Tag checks → Package publication
 ```
 
 Each stage catches problems cheaper than the next: a hook catches formatting in 2 seconds. The same issue in a PR review costs 10 minutes. After release? Hours of emergency patching.
@@ -246,19 +260,21 @@ Each stage catches problems cheaper than the next: a hook catches formatting in 
 ```bash
 $ ./run.sh check --quick
 
-🔍 Running 8 quick checks (5 categories)...
+🔍 Running 10 quick checks (5 categories)...
 
   ✅ Broken links        (1.2s)
   ✅ Doc versions         (0.8s)
   ✅ Brief length         (0.3s)
   ✅ Import validation    (2.1s)
   ✅ Repo hygiene         (0.5s)
+  ✅ Token efficiency     (0.4s)
   ✅ Git state            (0.2s)
-  ✅ Unfinished merge     (0.1s)
+  ✅ Unfinished operation (0.1s)
   ✅ Script references    (1.8s)
+  ✅ CLI smoke            (0.8s)
 
 ━━━━━━━━━━━━━━━━━━━━━━
-✅ 8/8 checks passed (7.0s)
+✅ 10/10 checks passed (8.2s)
 ```
 
 ### Example 2: Full validation with a failure
@@ -266,22 +282,22 @@ $ ./run.sh check --quick
 ```bash
 $ ./run.sh check
 
-🔍 Running 28 checks (8 categories, 4 workers)...
+🔍 Running 31 checks (8 categories, 4 workers)...
 
-  API ━━━━━━ 3/3 ✅  |  Docs ━━━━━ 6/7 ⚠️  |  Arch ━━━━━ 3/3 ✅
-  Governance ━ 4/4 ✅  |  FastAPI ━━ 3/3 ✅  |  Git ━━━━━ 4/4 ✅
-  Stale ━━━━━ 3/3 ✅  |  Code ━━━━━ 1/1 ✅
+  API ━━━━━━ 4/4 ✅  |  Docs ━━━━━ 6/7 ⚠️  |  Arch ━━━━━ 3/3 ✅
+  Governance ━ 5/5 ✅  |  FastAPI ━━ 3/3 ✅  |  Git ━━━━━ 4/4 ✅
+  Stale ━━━━━ 4/4 ✅  |  Code ━━━━━ 1/1 ✅
 
   ❌ Broken links: 2 broken links found
      → docs/reference/api.md:42 → docs/old-file.md (not found)
 
-❌ 27/28 checks passed, 1 failed (127.3s)
+❌ 30/31 checks passed, 1 failed (127.3s)
 ```
 
 ### Example 3: Diagnosing a CI failure
 
 ```bash
-$ .venv/bin/python scripts/diagnose_ci.py --local
+$ ./scripts/python_runtime.sh scripts/diagnose_ci.py --local
 
 🔍 Local CI Diagnosis
 ━━━━━━━━━━━━━━━━━━━━
@@ -294,7 +310,7 @@ $ .venv/bin/python scripts/diagnose_ci.py --local
 
 Fix: run with --fix to auto-resolve lint issues
 
-$ .venv/bin/python scripts/diagnose_ci.py --local --fix
+$ ./scripts/python_runtime.sh scripts/diagnose_ci.py --local --fix
 
   ✅ Ruff: fixed 2 issues in column.py
   ✅ All checks now passing
@@ -303,12 +319,12 @@ $ .venv/bin/python scripts/diagnose_ci.py --local --fix
 ### Example 4: GitHub Actions output (PR view)
 
 ```
-Fast PR Checks
+PR Validation
 ├── Detect Changes       ✅ (5s)   │ python: true, docs: false
-├── Python Lint          ✅ (45s)  │ Black: ✅  Ruff: ✅
-├── Python Tests         ✅ (90s)  │ 247 passed
-├── Import Validation    ✅ (12s)
-└── Architecture Check   ✅ (18s)
+├── Python Validation    ✅ (45s)  │ lint, types, contracts, architecture
+├── FastAPI Validation   ✅ (75s)  │ tests and API/deployment contracts
+├── Documentation        — skipped │ canonical plan: docs=false
+└── PR Gate              ✅ (4s)   │ every applicable job succeeded
 All checks passed ✅ — ready to merge
 ```
 
@@ -334,7 +350,7 @@ Get into the habit of running this before every commit. It takes less than 30 se
 ### List all checks
 
 ```bash
-.venv/bin/python scripts/check_all.py --list
+./scripts/python_runtime.sh scripts/check_all.py --list
 ```
 
 ---
@@ -348,7 +364,7 @@ Get into the habit of running this before every commit. It takes less than 30 se
 ```
 
 **What to look for:**
-- How many checks ran? (Should be 8)
+- How many checks ran? (Should be 10)
 - How long did it take? (Should be <30s)
 - Did any fail? What was the error message?
 
@@ -360,14 +376,14 @@ Get into the habit of running this before every commit. It takes less than 30 se
 
 **What to look for:**
 - How many categories are there? (8)
-- How many total checks? (28)
+- How many total checks? (31)
 - Which category took the longest?
 - Did anything fail? Read the error messages carefully
 
 ### Exercise 3: Try the CI diagnostic tool
 
 ```bash
-.venv/bin/python scripts/diagnose_ci.py --local
+./scripts/python_runtime.sh scripts/diagnose_ci.py --local
 ```
 
 **What to look for:** Which local checks pass (Black, Ruff, imports, pytest)? Can failures be auto-fixed with `--fix`?
@@ -376,7 +392,7 @@ Get into the habit of running this before every commit. It takes less than 30 se
 
 Open `.github/workflows/fast-checks.yml` and identify:
 - What triggers the workflow? (`on:` section)
-- How does it decide which jobs to skip? (`dorny/paths-filter`)
+- How does it decide which jobs to skip? (`scripts/verification.py plan`)
 - What Python version does it use?
 
 ---
@@ -392,17 +408,17 @@ Test your understanding — try to answer these without looking back:
 5. **What are the 3 quality gate levels?** What does each one block?
 6. **When does the `publish.yml` workflow trigger?** What tag pattern activates it?
 7. **What is "Trusted Publishers" in PyPI?** Why is it better than storing API tokens?
-8. **Your `check --changed` only ran 2 categories after you edited a Python file. Which 2 categories?** How does the script know?
+8. **Why can one changed path select several domains?** How does the shared
+   manifest keep local and hosted scheduling consistent?
 
 ---
 
 ## 📎 References
 
-- [check_all.py](../../../scripts/check_all.py) — The 28-check orchestrator
+- [check_all.py](../../../scripts/check_all.py) — The 31-check orchestrator
 - [diagnose_ci.py](../../../scripts/diagnose_ci.py) — CI failure diagnosis + auto-fix
 - [fast-checks.yml](../../../.github/workflows/fast-checks.yml) — PR/push CI workflow
-- `python-tests.yml` — historical full-test workflow, consolidated into
-  [`nightly.yml`](../../../.github/workflows/nightly.yml) by MAINT-008
+- [nightly.yml](../../../.github/workflows/nightly.yml) — scheduled/manual broad verification
 - [publish.yml](../../../.github/workflows/publish.yml) — PyPI release workflow
 - [check_architecture_boundaries.py](../../../scripts/check_architecture_boundaries.py) — 4-layer enforcement
 - [validate_imports.py](../../../scripts/validate_imports.py) — Import resolution checker

--- a/docs/planning/maint-012-control-plane-modernization.md
+++ b/docs/planning/maint-012-control-plane-modernization.md
@@ -28,8 +28,8 @@ evidence a change invalidates.
 | Packet | Outcome | Boundary |
 |---|---|---|
 | `MAINT-012A` | Canonical control registry, schema, loader, CLI, complete permissions, structured commands, and deterministic legacy projection | Complete through PR #840 |
-| `MAINT-012B` | Replace broad generated folder-index dependence with small authoritative manifests and on-demand summaries; retain only indexes proven useful | Active isolated candidate after A |
-| `MAINT-012C` | Add content-addressed impact/evidence reuse and migrate quick/full/hosted validation scheduling to explicit change domains | Separate candidate; no safety gate may be skipped without a proved input identity |
+| `MAINT-012B` | Replace broad generated folder-index dependence with small authoritative manifests and on-demand summaries; retain only indexes proven useful | Complete through PR #841 |
+| `MAINT-012C` | Add content-addressed impact/evidence reuse and migrate quick/full/hosted validation scheduling to explicit change domains | Active isolated candidate; no safety gate may be skipped without a proved input identity |
 | `MAINT-012D` | Consolidate scanners and retire/move obsolete scripts using live callers, ownership, runtime, and replacement evidence | Separate candidate; every deletion/move requires preservation-aware proof |
 
 The order is deliberate: B-D consume the registry contract from A. They must not
@@ -156,6 +156,91 @@ normalization. Those are architecture costs, not isolated formatting defects.
    quick/full gates, normal hooks, and required hosted checks pass on one frozen
    candidate.
 
+## MAINT-012C frozen scope
+
+### Confirmed baseline
+
+- Local `./run.sh check --changed` inspected only `HEAD~1..HEAD`, used a private
+  prefix table, and treated an unmapped path or failed Git query as no work. A
+  real candidate spanning multiple commits could therefore omit earlier impact,
+  while a new root/path could produce a misleading green result.
+- Hosted PR scheduling repeated a separate hand-authored path map inside YAML.
+  Local and hosted ownership could drift without either validator knowing.
+- Quick/full gates had no reusable result identity. The normal commit hook then
+  invoked six controls through separate entry points; four duplicated the quick
+  gate while two were legitimate commit-only controls.
+- The parallel check runner's aggregate-timeout path could omit unfinished
+  futures from its result set instead of failing them explicitly.
+- PR #841's unchanged hosted candidate spent 35-86 seconds in each applicable
+  validation job after a 9-second classifier; retrying the same bytes could not
+  reuse the earlier PASS result.
+
+### Canonical contract
+
+- `scripts/verification-manifest.json` is the single seven-domain map for
+  `python`, `fastapi`, `react`, `excel`, `control_plane`, `docs`, and
+  `repository`. Each path rule is used for both scheduling and evidence inputs,
+  so there is no second fingerprint map to synchronize. Its strict schema and
+  semantic validator cover every current tracked/untracked non-ignored path. A
+  new/unmapped path, invalid base, or Git query failure selects every domain.
+  An unmapped live path is also rejected by strict registry validation, so the
+  all-domain run cannot turn missing ownership into a mergeable green result.
+- `./run.sh verification validate|plan|fingerprint|probe` exposes the read-only
+  schedule and evidence contract; `record` writes only to the Git-common or
+  hosted runner evidence directory after PASS. Local candidate discovery compares
+  the whole branch to `origin/main` plus staged, unstaged, and untracked work;
+  hosted discovery uses the exact event base/head.
+- A PASS identity binds the profile, normalized command, declared domain set,
+  current input-file bytes (including deletions), verification implementation,
+  platform/Python identity, installed distribution versions, and any supplied
+  Node/runner identity. Failed, missing, malformed, partial, or non-matching
+  receipts never skip execution.
+- Local receipts live outside tracked content in the shared Git common
+  directory. Quick and full profiles share receipts for the exact same check;
+  Git-state checks remain fresh. `--no-reuse` forces a new execution.
+- The normal pre-commit hook invokes the quick orchestrator once, so a prior
+  frozen-candidate quick PASS is reused instead of rerunning four overlapping
+  checks. Its two non-overlapping CLI/registry controls remain explicit, and
+  merge-completion commits retain their prior Git-operation exception.
+- Hosted jobs resolve their dependencies/runtime first, then use one exact
+  `actions/cache@v6` key with no prefix restore through one small composite
+  action. Only a separately verified PASS receipt skips the validation body; a
+  cache miss executes and records evidence only after every job step succeeds.
+- The previously unconditional repository bundle is split by ownership:
+  documentation owns versions/tasks/links, Python/FastAPI own architecture,
+  control owns registries/CLI policy, and repository owns YAML, hygiene, and
+  maintenance-script checks. No validation is discarded merely to gain a skip.
+- `test_changed.py` consumes the same whole-candidate plan, retains proved
+  Python/FastAPI focused mappings, runs React/Excel when their domains change,
+  and expands unclear ownership to the applicable full suite.
+
+### MAINT-012C exclusions
+
+- No scanner consolidation, compatibility-script deletion/move, or broad
+  physical script retirement; those remain MAINT-012D.
+- No dependency version, product calculation, public API, FastAPI behavior,
+  React UI, Excel workflow, ETABS, package, release, GitHub-setting, or
+  professional-approval change.
+- No reuse across a runtime/dependency identity that has not been observed, no
+  failed-result cache, no approximate/prefix cache key, and no calendar-only
+  claim that evidence remains valid.
+
+### MAINT-012C acceptance
+
+1. The live manifest is strict, covers every current repository path, and maps
+   unknown paths/query failures to all seven domains in local and hosted plans.
+2. Relevant bytes, commands, domain ownership, runtime/dependencies, and
+   verification-control changes alter the evidence fingerprint; irrelevant
+   domain bytes do not.
+3. Only an exact PASS receipt reuses a check/job. Malformed, failed, missing, or
+   mismatched evidence executes normally, and `--no-reuse` proves the fresh path.
+4. Local changed-test/check scheduling and hosted applicability use the same
+   manifest; `PR Gate` rejects missing flags, partial fail-closed routing, and
+   skipped applicable jobs.
+5. The frozen candidate passes focused scheduler/cache/workflow/control tests,
+   the quick and cumulative full gates, ordinary hooks, and every required
+   hosted check without changing product behavior.
+
 ## Efficient operating contract
 
 For an operation-metadata change, edit only `control-plane.json`, run
@@ -188,6 +273,14 @@ root, read-first authority, retained index-named surface, or canonical operation
 changes. It does not require a calendar refresh. A bounded quarterly review may
 measure whether routing is still useful, but unchanged live summaries never
 need regeneration.
+
+MAINT-012C's verification manifest is also event-driven: update its rules
+whenever a path owner, validation job, check command, dependency boundary, or
+verification implementation changes. The same rule changes scheduling and
+fingerprint inputs. Receipts need no manual refresh because their content
+address invalidates automatically; cache eviction only causes fresh execution.
+A quarterly review may compare observed job/check time and unknown-path events,
+but unchanged contracts need no rewrite.
 
 ## MAINT-012A acceptance
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,33 +4,39 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-23
-- Focus: Replace high-churn generic indexes with a small validated context
-- Git receipt: docs/verification/maint-012b-git-handoff-receipt.json | sha256:81293b2bfc69f568134ec2a311a352867649d56fed109228d0f446becc42ac3e | HOLD
-- Git identity: codex/maint-012b-index-architecture@efd219178c4293ab106f43e37b903c5c268283aa | upstream=origin/main@efd219178c4293ab106f43e37b903c5c268283aa | base=origin/main@efd219178c4293ab106f43e37b903c5c268283aa | tree=dirty | operation=none
+- Focus: Modernize validation scheduling and reuse only exact PASS evidence.
+- Git receipt: docs/verification/maint-012c-git-handoff-receipt.json | sha256:f4662fdc2b557aeb1c0011ce4f7aac795b09a4cb7cd704923e9dd4b0054da485 | HOLD
+- Git identity: codex/maint-012c-evidence-scheduling@646660e323b65118a805b554c6cf4dbef46ef479 | upstream=origin/main@646660e323b65118a805b554c6cf4dbef46ef479 | base=origin/main@646660e323b65118a805b554c6cf4dbef46ef479 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
 - Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `MAINT-012B` retires generic committed indexes and replaces them with one small validated routing manifest plus bounded read-only live summaries |
-| **Next** | Freeze the local candidate, run one quick and one full gate plus ordinary hooks, publish the unchanged PR, and require hosted checks before merge |
-| **Why** | The retired projections consumed 1.39 MB/43,141 lines, covered only part of their own topology, churned frequently, and made agents repeat refresh/check cycles instead of reading current files directly |
-| **Held** | MAINT-012C evidence reuse/change-domain scheduling; MAINT-012D scanner/script consolidation and physical compatibility deletion; product/structural/API/UI/Excel/ETABS behavior; dependencies; publication; settings; and professional approval |
+| **Current** | `MAINT-012C` owns one strict local/hosted validation-domain map and exact content-addressed PASS reuse |
+| **Next** | Complete the focused scheduler/cache/workflow contracts, freeze the candidate, run one quick and cumulative full gate plus ordinary hooks, then require every hosted check |
+| **Why** | Local changed-check scheduling could silently no-op on unknown paths, hosted YAML duplicated ownership, and unchanged checks/jobs had no reusable command/runtime/input identity |
+| **Held** | MAINT-012D scanner/script consolidation and physical compatibility deletion; product/structural/API/UI/Excel/ETABS behavior; dependencies; publication; settings; and professional approval |
 
-## Exact MAINT-012B state
+## Exact MAINT-012C state
 
-- Canonical routing: `scripts/context-manifest.json`; strict read-only command:
-  `./run.sh context validate|list|show|summary`.
-- Retired baseline: 140 files removed or replaced, including all generic folder
-  JSON indexes, 69 generic Markdown indexes, and `docs/docs-index.json`.
-- Retained index-named surfaces: authored `docs/index.md`, the required API
-  route page, and the specialized validated live-Git guidance manifest.
-- Compatibility generator entry points remain temporarily discoverable but
-  cannot write. Their physical disposition belongs to MAINT-012D.
-- The manifest is event-driven: update it only when an area root, read-first
-  authority, retained surface, or canonical operation changes. It needs no
-  periodic regeneration; a bounded quarterly usefulness review is sufficient.
+- Branch: `codex/maint-012c-evidence-scheduling`, created from exact merged
+  `origin/main` commit `646660e323b65118a805b554c6cf4dbef46ef479`.
+- Canonical scheduling: `scripts/verification-manifest.json`; read-only command:
+  `./run.sh verification validate|plan|fingerprint|probe`.
+- Seven domains: Python, FastAPI, React, Excel, control plane, docs, and
+  repository. Every current path is owned; unknown paths/query failures select
+  all seven. One rule set drives both job scheduling and fingerprint inputs.
+- Local PASS receipts live in the Git common directory and bind current bytes,
+  normalized command, declared domains, runtime/platform, and installed
+  distributions. Git-state checks always run fresh; `--no-reuse` forces all
+  selected checks fresh.
+- Hosted jobs resolve runtime/dependencies before exact-key receipt lookup.
+  There are no prefix restores, and the required PR Gate rejects missing or
+  partially fail-closed applicability. The old repository catch-all is split so
+  docs, architecture, and control checks run under their natural domains.
+- MAINT-012B remains merged through PR #841. Compatibility generator files and
+  scanner consolidation remain physically unchanged for MAINT-012D.
 
 ## Required Reading
 

--- a/docs/reference/automation-catalog.md
+++ b/docs/reference/automation-catalog.md
@@ -57,7 +57,7 @@ Standard pre-commit validation may run, but the repository must not install a
 custom `core.hooksPath` or reintroduce lifecycle wrappers. The read-only guard is:
 
 ```bash
-.venv/bin/python scripts/check_codex_git_workflow.py
+./scripts/python_runtime.sh scripts/check_codex_git_workflow.py
 ```
 
 ## Maintenance rule

--- a/docs/verification/maint-012c-git-handoff-receipt.json
+++ b/docs/verification/maint-012c-git-handoff-receipt.json
@@ -1,0 +1,161 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "f4662fdc2b557aeb1c0011ce4f7aac795b09a4cb7cd704923e9dd4b0054da485",
+    "state": {
+      "branch": "codex/maint-012c-evidence-scheduling",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "646660e323b65118a805b554c6cf4dbef46ef479",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 83.549,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib9",
+      "head_sha": "646660e323b65118a805b554c6cf4dbef46ef479",
+      "hold_reasons": [
+        "changed paths: 31"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-22T22:01:50.569614+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/maint-012c/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 31,
+        "modified_paths": [
+          ".github/workflows/README.md",
+          ".github/workflows/fast-checks.yml",
+          ".pre-commit-config.yaml",
+          "AGENTS.md",
+          "Python/tests/test_agent_governance_automation.py",
+          "Python/tests/test_ci_workflow_contract.py",
+          "Python/tests/test_control_plane.py",
+          "agents/agent-9/workflows/LINK_GOVERNANCE.md",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/_internal/git-governance.md",
+          "docs/contributing/testing-strategy.md",
+          "docs/guidelines/ai-token-efficiency.md",
+          "docs/migration/learning/day-23-ci-cd.md",
+          "docs/planning/maint-012-control-plane-modernization.md",
+          "docs/planning/next-session-brief.md",
+          "run.sh",
+          "scripts/README.md",
+          "scripts/automation-map.json",
+          "scripts/check_all.py",
+          "scripts/check_scripts_index.py",
+          "scripts/context-manifest.json",
+          "scripts/control-plane.json",
+          "scripts/control_plane/__init__.py",
+          "scripts/test_changed.py",
+          "scripts/test_cli_smoke.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          ".github/actions/verification-evidence/action.yml",
+          "Python/tests/test_verification_control.py",
+          "scripts/verification-manifest.json",
+          "scripts/verification-manifest.schema.json",
+          "scripts/verification.py"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "646660e323b65118a805b554c6cf4dbef46ef479",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/maint-012c/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:f4662fdc2b557aeb1c0011ce4f7aac795b09a4cb7cd704923e9dd4b0054da485",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-22T22:01:50.569785+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/**/*.py",
+      "fastapi_app/**/*.py",
+      "react_app/**/*.{ts,tsx}",
+      "excel_addin/**",
+      "Etabs_CSV/**",
+      "requirements*.txt"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "scripts/**",
+      ".github/**",
+      ".pre-commit-config.yaml",
+      "Python/tests/**",
+      "agents/**",
+      "docs/**",
+      "AGENTS.md",
+      "run.sh"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md",
+      "scripts/control-plane.json",
+      "scripts/automation-map.json",
+      "scripts/context-manifest.json"
+    ],
+    "task_id": "MAINT-012C"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -80,12 +80,13 @@ Run validation checks across the codebase.
 Options:
   (no args)            Run ALL checks (parallel by category)
   --quick              Fast subset: links, imports, hygiene (<30s)
-  --changed            Only run categories for recently changed files
+  --changed            Run categories for whole-candidate impact domains
   --pre-commit         Run pre-commit hooks (black, ruff, mypy, bandit)
   --category <name>    Run one category: api|docs|arch|governance|fastapi|git|stale|code
   --fix                Auto-fix what's fixable (sync numbers, etc.)
   --json               Machine-readable JSON output
   --list               Show available categories and their scripts
+  --no-reuse           Force fresh checks instead of exact PASS reuse
 
 Categories:
   api          API contracts, manifest, endpoint validation
@@ -810,6 +811,13 @@ _cmd_context() {
     "$VENV" "$SCRIPTS/repo_context.py" "$@"
 }
 
+# ── Command: verification ─────────────────────────────────────────────────
+
+_cmd_verification() {
+    _require_venv
+    "$VENV" "$SCRIPTS/verification.py" "$@"
+}
+
 # ── Command: pipeline ──────────────────────────────────────────────────────
 
 _cmd_pipeline() {
@@ -934,6 +942,7 @@ _print_usage() {
     echo -e "  ${GREEN}frontend${NC}    Run React checks with the pinned Node runtime"
     echo -e "  ${GREEN}generate${NC}    Generate SDKs, manifests, and scaffolds"
     echo -e "  ${GREEN}context${NC}     Validate/query live context without generated indexes"
+    echo -e "  ${GREEN}verification${NC} Plan change domains and inspect exact PASS evidence"
     echo -e "  ${GREEN}health${NC}      Project health scan (unified checker)"
     echo -e "  ${GREEN}feedback${NC}    Agent feedback collection & analysis"
     echo -e "  ${GREEN}dev${NC}         Launch full development stack (FastAPI + React)"
@@ -972,6 +981,7 @@ _dispatch_help() {
         frontend) _help_frontend ;;
         generate) _help_generate ;;
         context)  _cmd_context --help ;;
+        verification) _cmd_verification --help ;;
         health)   _help_health ;;
         feedback) _help_feedback ;;
         evolve)   _help_evolve ;;
@@ -1007,6 +1017,7 @@ _run_sh() {
         'frontend:Run React commands with pinned Node'
         'generate:Generate SDKs and manifests'
         'context:Query live repository context'
+        'verification:Plan change domains and exact PASS evidence'
         'health:Project health scan'
         'feedback:Agent feedback collection'
         'evolve:Self-evolution engine'
@@ -1019,7 +1030,7 @@ _run_sh() {
         'efficiency:Validate low-token controls'
         'model:Recommend model and reasoning profile'
     )
-    local -a check_opts=('--quick' '--changed' '--pre-commit' '--category' '--fix' '--json' '--list' '--serial')
+    local -a check_opts=('--quick' '--changed' '--pre-commit' '--category' '--fix' '--json' '--list' '--serial' '--no-reuse')
     local -a categories=('api' 'docs' 'arch' 'governance' 'fastapi' 'git' 'stale' 'code')
     local -a session_subs=('start' 'end' 'handoff' 'summary' 'sync' 'check' 'context' 'brief' 'usage' 'costs' 'compact' 'trust')
     local -a task_subs=('brief')
@@ -1034,6 +1045,7 @@ _run_sh() {
     local -a efficiency_subs=('check' 'prompt')
     local -a control_subs=('validate' 'find' 'list' 'stats' 'export-legacy')
     local -a context_subs=('validate' 'list' 'show' 'summary')
+    local -a verification_subs=('validate' 'plan' 'fingerprint' 'probe' 'record')
 
     if (( CURRENT == 2 )); then
         _describe 'command' commands
@@ -1053,6 +1065,7 @@ _run_sh() {
             efficiency) _values 'subcommand' $efficiency_subs ;;
             control) _values 'subcommand' $control_subs ;;
             context) _values 'subcommand' $context_subs ;;
+            verification) _values 'subcommand' $verification_subs ;;
         esac
     elif (( CURRENT == 4 )); then
         case "${words[2]}" in
@@ -1111,6 +1124,7 @@ main() {
         frontend) _cmd_frontend "$@" ;;
         generate) _cmd_generate "$@" ;;
         context)  _cmd_context "$@" ;;
+        verification) _cmd_verification "$@" ;;
         health)   _cmd_health "$@" ;;
         feedback) _cmd_feedback "$@" ;;
         evolve)   _cmd_evolve "$@" ;;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,6 +20,8 @@
 ./run.sh control validate
 ./run.sh context validate
 ./run.sh context summary automation
+./run.sh verification validate
+./run.sh verification plan
 ./run.sh audit
 ./run.sh health
 ./run.sh session usage --summary
@@ -57,6 +59,7 @@ hook enforcement and scripts that automate the Git lifecycle are prohibited.
 | Files | `safe_file_move.py` | Move files after a dry run and link scan |
 | Files | `safe_file_delete.py` | Delete files after a dry run and reference scan |
 | Live context | `run.sh context` | Validate canonical routing and summarize current files without generated folder indexes |
+| Verification impact | `run.sh verification` | Plan explicit change domains and inspect command/runtime/input-bound PASS evidence |
 | IS 456 quality | `check_function_quality.py --module <name>` | Source-relative static function-contract scan; not a numerical benchmark |
 | Sessions | `session.py` | Bounded session lifecycle and usage checkpoints |
 | CI | `diagnose_ci.py` | Diagnose CI failures without managing Git |
@@ -72,6 +75,10 @@ hook enforcement and scripts that automate the Git lifecycle are prohibited.
   `./run.sh context summary <area-or-folder>` for a bounded live inventory.
   Both are read-only.
 - Prefer targeted checks while editing and one full gate at closeout.
+- Quick/full checks reuse only an exact PASS receipt from the shared Git common
+  directory. `./run.sh check --no-reuse` forces fresh execution; failed,
+  malformed, runtime-different, command-different, or input-different evidence
+  never skips a check.
 - Preserve unrelated changes in a dirty worktree.
 - Stop on unclear Git state; do not automate recovery or rewrite history.
 - Release, merge, issue closure, and branch deletion require explicit user
@@ -83,3 +90,6 @@ refresh it only with `./run.sh control export-legacy --write`.
 [context-manifest.json](context-manifest.json) owns repository-area routing;
 validate it with `./run.sh context validate`. Top-level script coverage is
 derived directly from the live scripts directory and the control registry.
+[verification-manifest.json](verification-manifest.json) is the single local and
+hosted path-to-domain contract. The same rules select work and define the input
+bytes in its PASS fingerprint; new or unclassified paths select every domain.

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -2,7 +2,7 @@
   "_comment": "GENERATED compatibility projection from scripts/control-plane.json; do not edit directly",
   "_usage": "Use ./run.sh find <query> or ./run.sh control find <query>",
   "_source": "scripts/control-plane.json",
-  "_coverage": "114/114 top-level scripts registered",
+  "_coverage": "115/115 top-level scripts registered",
   "tasks": {
     "resolve python runtime": {
       "script": "./scripts/python_runtime.sh --version",
@@ -49,7 +49,7 @@
     "run all checks": {
       "script": "./scripts/python_runtime.sh scripts/check_all.py",
       "group": "Quality",
-      "description": "Run all 30 validation checks across 8 categories in parallel (also: ./run.sh check)",
+      "description": "Run all 31 validation checks across 8 categories in parallel with exact PASS reuse (also: ./run.sh check)",
       "permission": "ReadOnly",
       "permission_modes": {
         "--fix": "WorkspaceWrite"
@@ -57,13 +57,32 @@
       "options": {
         "--quick": "Run 10 quick checks only (<30s)",
         "--category X": "Run checks for specific category",
-        "--changed": "Auto-detect categories from git diff",
+        "--changed": "Plan explicit domains from the whole candidate diff; unknown impact runs all domains",
         "--fix": "Auto-fix where possible",
         "--json": "JSON output for CI",
+        "--no-reuse": "Force fresh execution instead of accepting exact PASS receipts",
         "--serial": "Run sequentially (debugging)"
       },
       "aliases": [
         "check"
+      ]
+    },
+    "verification impact": {
+      "script": "./scripts/python_runtime.sh scripts/verification.py validate",
+      "group": "Quality",
+      "description": "Validate the canonical change-domain map and content-addressed PASS evidence contract",
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "record": "WorkspaceWrite"
+      },
+      "options": {
+        "plan": "Classify a candidate or explicit paths into validation domains",
+        "fingerprint": "Compute exact command, runtime, and input-byte identity",
+        "probe": "Check whether an exact PASS receipt exists",
+        "record": "Write a PASS receipt outside tracked repository content"
+      },
+      "aliases": [
+        "verification"
       ]
     },
     "validate script references": {

--- a/scripts/check_all.py
+++ b/scripts/check_all.py
@@ -22,13 +22,24 @@ import os
 import subprocess
 import sys
 import time
-from concurrent.futures import as_completed
-from dataclasses import dataclass
+from concurrent.futures import Future, as_completed
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lib.utils import REPO_ROOT
 from _lib.output import StatusLine, print_json
+from verification import (
+    REQUIRED_DOMAINS,
+    EvidenceIdentity,
+    FingerprintContext,
+    VerificationError,
+    load_manifest,
+    local_evidence_path,
+    plan_changes,
+    probe_receipt,
+    write_receipt,
+)
 
 SCRIPTS_DIR = REPO_ROOT / "scripts"
 VENV_PYTHON = str(SCRIPTS_DIR / "python_runtime.sh")
@@ -47,6 +58,7 @@ class Check:
     cmd: list[str]
     timeout: int = 60
     fix_cmd: list[str] | None = None  # command to run with --fix
+    cacheable: bool = True
 
 
 @dataclass
@@ -56,6 +68,7 @@ class Category:
     name: str
     label: str
     checks: list[Check]
+    impact_domains: tuple[str, ...]
     description: str = ""
 
 
@@ -76,6 +89,7 @@ CATEGORIES: list[Category] = [
         name="api",
         label="API",
         description="API contracts, manifest, endpoint validation",
+        impact_domains=("python", "fastapi"),
         checks=[
             Check("API validation", _py("check_api.py", "--all")),
             Check("API contracts", _py("validate_api_contracts.py")),
@@ -93,6 +107,7 @@ CATEGORIES: list[Category] = [
         name="docs",
         label="Docs",
         description="Links, doc versions, metadata, tasks format",
+        impact_domains=("docs",),
         checks=[
             Check(
                 "Doc validation",
@@ -111,6 +126,7 @@ CATEGORIES: list[Category] = [
         name="arch",
         label="Architecture",
         description="Layer boundaries, circular imports, import validation",
+        impact_domains=("python", "fastapi"),
         checks=[
             Check(
                 "Architecture boundaries",
@@ -125,6 +141,7 @@ CATEGORIES: list[Category] = [
         name="governance",
         label="Governance",
         description="Governance rules, repo hygiene, Python version, schemas",
+        impact_domains=("control_plane", "repository"),
         checks=[
             Check("Governance rules", _py("check_governance.py", "--full")),
             Check("Repo hygiene", _py("check_repo_hygiene.py")),
@@ -137,6 +154,7 @@ CATEGORIES: list[Category] = [
         name="fastapi",
         label="FastAPI",
         description="FastAPI issues, Docker config, OpenAPI snapshot",
+        impact_domains=("fastapi",),
         checks=[
             Check("FastAPI issues", _py("check_fastapi_issues.py")),
             Check("Docker config", _py("check_docker_config.py")),
@@ -147,17 +165,35 @@ CATEGORIES: list[Category] = [
         name="git",
         label="Git",
         description="Read-only Git state, active operations, version consistency",
+        impact_domains=REQUIRED_DOMAINS,
         checks=[
-            Check("Git state", _py("git_state.py", "--guard", "validation")),
-            Check("Unfinished operation", _py("git_state.py", "--guard", "operation")),
-            Check("Version consistency", _sh("check_version_consistency.sh")),
-            Check("Codex-native Git workflow", _py("check_codex_git_workflow.py")),
+            Check(
+                "Git state",
+                _py("git_state.py", "--guard", "validation"),
+                cacheable=False,
+            ),
+            Check(
+                "Unfinished operation",
+                _py("git_state.py", "--guard", "operation"),
+                cacheable=False,
+            ),
+            Check(
+                "Version consistency",
+                _sh("check_version_consistency.sh"),
+                cacheable=False,
+            ),
+            Check(
+                "Codex-native Git workflow",
+                _py("check_codex_git_workflow.py"),
+                cacheable=False,
+            ),
         ],
     ),
     Category(
         name="stale",
         label="Stale Refs",
         description="Stale script references, instruction drift, bootstrap freshness",
+        impact_domains=("control_plane", "docs", "repository"),
         checks=[
             Check("Script references", _py("validate_script_refs.py")),
             Check("CLI smoke", _py("test_cli_smoke.py")),
@@ -169,6 +205,7 @@ CATEGORIES: list[Category] = [
         name="code",
         label="Code Quality",
         description="Type annotations",
+        impact_domains=("python", "fastapi"),
         checks=[
             Check("Type annotations", _py("check_type_annotations.py"), timeout=90),
         ],
@@ -184,64 +221,21 @@ QUICK_CHECKS: dict[str, list[str]] = {
     "stale": ["Script references", "CLI smoke"],
 }
 
-# File path patterns → categories for --changed mode
-_PATH_TO_CATEGORIES: list[tuple[str, list[str]]] = [
-    ("Python/structural_lib/services/api", ["api"]),
-    ("Python/structural_lib/", ["arch", "code"]),
-    ("fastapi_app/", ["api", "fastapi"]),
-    ("docs/", ["docs", "stale"]),
-    ("scripts/", ["docs", "stale", "governance"]),
-    (".codex/", ["governance"]),
-    ("react_app/", []),  # No script-based checks for React yet
-    (".pre-commit", ["governance"]),
-    ("docker-compose", ["fastapi"]),
-    ("Dockerfile", ["fastapi"]),
-    ("pyproject.toml", ["governance", "arch"]),
-]
 
-
-def _detect_changed_categories() -> set[str]:
-    """Detect which categories to run based on git diff."""
+def _detect_changed_domains() -> tuple[set[str], bool, tuple[str, ...]]:
+    """Use the canonical impact planner; invalid control state selects all."""
     try:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
-            cwd=str(REPO_ROOT),
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode != 0:
-            # Fallback: diff against working tree
-            result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
-                cwd=str(REPO_ROOT),
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-    except Exception:
-        return set()  # On error, return empty (caller falls back to all)
-
-    changed_files = result.stdout.strip().splitlines()
-    if not changed_files:
-        return set()
-
-    categories: set[str] = set()
-    # Always run git checks
-    categories.add("git")
-
-    for filepath in changed_files:
-        for pattern, cats in _PATH_TO_CATEGORIES:
-            if filepath.startswith(pattern):
-                categories.update(cats)
-                break
-
-    return categories
+        manifest = load_manifest(require_coverage=False)
+        plan = plan_changes(manifest)
+    except VerificationError as exc:
+        return set(REQUIRED_DOMAINS), True, (str(exc),)
+    reasons = (*plan.unknown_paths, *plan.failure_reasons)
+    return set(plan.domains), plan.fail_closed, reasons
 
 
 def _run_pre_commit(fix: bool = False) -> int:
     """Run pre-commit hooks and return exit code."""
-    cmd = ["pre-commit", "run", "--all-files"]
+    cmd = [VENV_PYTHON, "-m", "pre_commit", "run", "--all-files"]
     if fix:
         # pre-commit auto-fixes by default for formatters
         pass
@@ -278,12 +272,57 @@ class CheckResult:
     stderr: str = ""
     timed_out: bool = False
     error: str = ""
+    reused: bool = False
+    fingerprint: str = ""
 
 
-def _run_check(check: Check, category_name: str, use_fix: bool = False) -> CheckResult:
+def _append_missing_results(
+    results: list[CheckResult],
+    futures: dict[Future[CheckResult], tuple[Check, str]],
+) -> None:
+    """Turn an aggregate-runner omission into an explicit failed result."""
+    observed = {(result.category, result.name) for result in results}
+    for future, (check, cat_name) in futures.items():
+        if (cat_name, check.name) in observed:
+            continue
+        future.cancel()
+        results.append(
+            CheckResult(
+                name=check.name,
+                category=cat_name,
+                passed=False,
+                exit_code=-1,
+                duration=0.0,
+                timed_out=True,
+                error="aggregate runner did not return a result",
+            )
+        )
+
+
+def _run_check(
+    check: Check,
+    category_name: str,
+    use_fix: bool = False,
+    identity: EvidenceIdentity | None = None,
+    receipt_path: Path | None = None,
+    reuse: bool = True,
+) -> CheckResult:
     """Run a single check and return the result."""
     cmd = check.fix_cmd if (use_fix and check.fix_cmd) else check.cmd
     start = time.monotonic()
+
+    if reuse and identity is not None and receipt_path is not None:
+        valid, _reason = probe_receipt(receipt_path, identity)
+        if valid:
+            return CheckResult(
+                name=check.name,
+                category=category_name,
+                passed=True,
+                exit_code=0,
+                duration=time.monotonic() - start,
+                reused=True,
+                fingerprint=identity.fingerprint,
+            )
 
     try:
         result = subprocess.run(
@@ -304,6 +343,7 @@ def _run_check(check: Check, category_name: str, use_fix: bool = False) -> Check
             duration=elapsed,
             stdout=result.stdout,
             stderr=result.stderr,
+            fingerprint=identity.fingerprint if identity is not None else "",
         )
     except subprocess.TimeoutExpired:
         elapsed = time.monotonic() - start
@@ -315,6 +355,7 @@ def _run_check(check: Check, category_name: str, use_fix: bool = False) -> Check
             duration=elapsed,
             timed_out=True,
             error=f"Timed out after {check.timeout}s",
+            fingerprint=identity.fingerprint if identity is not None else "",
         )
     except FileNotFoundError as e:
         elapsed = time.monotonic() - start
@@ -325,6 +366,7 @@ def _run_check(check: Check, category_name: str, use_fix: bool = False) -> Check
             exit_code=-1,
             duration=elapsed,
             error=f"Script not found: {e}",
+            fingerprint=identity.fingerprint if identity is not None else "",
         )
     except Exception as e:
         elapsed = time.monotonic() - start
@@ -335,13 +377,14 @@ def _run_check(check: Check, category_name: str, use_fix: bool = False) -> Check
             exit_code=-1,
             duration=elapsed,
             error=str(e),
+            fingerprint=identity.fingerprint if identity is not None else "",
         )
 
 
 def _collect_checks(
     category_filter: str | None,
     quick: bool,
-    changed_categories: set[str] | None = None,
+    changed_domains: set[str] | None = None,
 ) -> list[tuple[Check, str]]:
     """Collect checks to run based on filters."""
     checks: list[tuple[Check, str]] = []
@@ -351,8 +394,10 @@ def _collect_checks(
         if category_filter and cat.name != category_filter:
             continue
 
-        # Changed-file filter
-        if changed_categories is not None and cat.name not in changed_categories:
+        # Canonical impact-domain filter
+        if changed_domains is not None and not (
+            set(cat.impact_domains) & changed_domains
+        ):
             continue
 
         if quick:
@@ -368,6 +413,23 @@ def _collect_checks(
                 checks.append((check, cat.name))
 
     return checks
+
+
+def _allow_operation_completion(
+    checks: list[tuple[Check, str]],
+) -> list[tuple[Check, str]]:
+    """Preserve the pre-commit merge-completion exception on the shared gate."""
+    return [
+        (
+            (
+                replace(check, cmd=[*check.cmd, "--allow-operation-completion"])
+                if check.name == "Unfinished operation"
+                else check
+            ),
+            category,
+        )
+        for check, category in checks
+    ]
 
 
 # ── Output ─────────────────────────────────────────────────────────────────
@@ -396,6 +458,7 @@ def _print_results_table(results: list[CheckResult]) -> None:
     total_passed = 0
     total_failed = 0
     total_timeout = 0
+    total_reused = 0
     fixable = 0
 
     for cat_name in [c.name for c in CATEGORIES]:
@@ -407,14 +470,17 @@ def _print_results_table(results: list[CheckResult]) -> None:
         passed = sum(1 for r in cat_results if r.passed)
         failed = len(cat_results) - passed
         timed_out = sum(1 for r in cat_results if r.timed_out)
+        reused = sum(1 for r in cat_results if r.reused)
 
         total_passed += passed
         total_failed += failed
         total_timeout += timed_out
+        total_reused += reused
 
         if failed == 0:
             icon = "✅"
-            detail = f"{passed}/{len(cat_results)} passed"
+            suffix = f", {reused} reused" if reused else ""
+            detail = f"{passed}/{len(cat_results)} passed{suffix}"
         elif timed_out > 0:
             icon = "⏱️ "
             detail = f"{passed}/{len(cat_results)} passed ({timed_out} timed out)"
@@ -435,7 +501,8 @@ def _print_results_table(results: list[CheckResult]) -> None:
 
     if total_failed == 0:
         print(
-            f"  ✅ Total: {total_passed}/{total} passed  ({_format_duration(total_time)})"
+            f"  ✅ Total: {total_passed}/{total} passed, {total_reused} reused  "
+            f"({_format_duration(total_time)})"
         )
     else:
         print(
@@ -487,6 +554,7 @@ def _print_json_results(results: list[CheckResult]) -> None:
         "passed": sum(1 for r in results if r.passed),
         "failed": sum(1 for r in results if not r.passed),
         "duration": round(sum(r.duration for r in results), 2),
+        "reused": sum(1 for r in results if r.reused),
         "categories": {},
         "checks": [],
     }
@@ -510,6 +578,8 @@ def _print_json_results(results: list[CheckResult]) -> None:
                 "exit_code": r.exit_code,
                 "duration": round(r.duration, 2),
                 "timed_out": r.timed_out,
+                "reused": r.reused,
+                "fingerprint": r.fingerprint or None,
                 "error": r.error or None,
             }
         )
@@ -555,6 +625,7 @@ def main() -> int:
             "  ./run.sh check --category api        # API checks only\n"
             "  ./run.sh check --changed             # Changed paths only\n"
             "  ./run.sh check --pre-commit          # Run pre-commit hooks\n"
+            "  ./run.sh check --no-reuse            # Force fresh execution\n"
             "  ./run.sh check --fix                 # Auto-fix issues\n"
             "  ./run.sh check --json                # CI output\n"
             "  ./run.sh check --list                # Show categories\n"
@@ -604,6 +675,16 @@ def main() -> int:
         help="Run checks serially instead of in parallel (for debugging)",
     )
     parser.add_argument(
+        "--no-reuse",
+        action="store_true",
+        help="Run checks even when an exact content/runtime PASS receipt exists",
+    )
+    parser.add_argument(
+        "--allow-operation-completion",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--workers",
         "-w",
         type=int,
@@ -621,17 +702,21 @@ def main() -> int:
     if args.pre_commit:
         return _run_pre_commit(fix=args.fix)
 
-    # Detect changed categories if --changed
-    changed_cats = None
+    # Detect canonical change domains if --changed
+    changed_domains = None
+    impact_fail_closed = False
+    impact_reasons: tuple[str, ...] = ()
     if args.changed:
-        changed_cats = _detect_changed_categories()
-        if not changed_cats:
+        changed_domains, impact_fail_closed, impact_reasons = _detect_changed_domains()
+        if not changed_domains:
             if not args.json:
                 print("✅ No changes detected — nothing to check")
             return 0
 
     # Collect checks to run
-    checks = _collect_checks(args.category, args.quick, changed_cats)
+    checks = _collect_checks(args.category, args.quick, changed_domains)
+    if args.allow_operation_completion:
+        checks = _allow_operation_completion(checks)
 
     if not checks:
         if args.category:
@@ -641,8 +726,8 @@ def main() -> int:
         return 1
 
     if not args.json:
-        if args.changed and changed_cats:
-            mode = f"changed: {', '.join(sorted(changed_cats))}"
+        if args.changed and changed_domains:
+            mode = f"changed domains: {', '.join(sorted(changed_domains))}"
         elif args.quick:
             mode = "quick"
         elif args.category:
@@ -651,6 +736,32 @@ def main() -> int:
             mode = "all"
         fix_tag = " (fix mode)" if args.fix else ""
         print(f"🔍 Running {len(checks)} check(s) [{mode}]{fix_tag}...")
+        if impact_fail_closed:
+            detail = "; ".join(impact_reasons) or "unknown impact"
+            print(f"  ⚠️  Impact is unknown; running every domain: {detail}")
+
+    evidence_context: FingerprintContext | None = None
+    evidence_manifest: dict[str, object] | None = None
+    prepared: dict[tuple[str, str], tuple[EvidenceIdentity, Path]] = {}
+    if not args.fix:
+        try:
+            evidence_manifest = load_manifest()
+            evidence_context = FingerprintContext(evidence_manifest)
+            category_domains = {cat.name: cat.impact_domains for cat in CATEGORIES}
+            for check, cat_name in checks:
+                if not check.cacheable:
+                    continue
+                identity = evidence_context.identity(
+                    profile=f"local-check:{cat_name}:{check.name}",
+                    domains=category_domains[cat_name],
+                    command=check.cmd,
+                )
+                receipt_path = local_evidence_path(REPO_ROOT, identity.fingerprint)
+                prepared[(cat_name, check.name)] = (identity, receipt_path)
+        except (OSError, VerificationError):
+            evidence_context = None
+            evidence_manifest = None
+            prepared = {}
 
     # Run checks
     results: list[CheckResult] = []
@@ -660,10 +771,24 @@ def main() -> int:
         for check, cat_name in checks:
             if not args.json:
                 print(f"  ▸ {check.name}...", end="", flush=True)
-            result = _run_check(check, cat_name, use_fix=args.fix)
+            identity, receipt_path = prepared.get((cat_name, check.name), (None, None))
+            result = _run_check(
+                check,
+                cat_name,
+                use_fix=args.fix,
+                identity=identity,
+                receipt_path=receipt_path,
+                reuse=not args.no_reuse,
+            )
             results.append(result)
             if not args.json:
-                icon = "✅" if result.passed else ("⏱️ " if result.timed_out else "❌")
+                icon = (
+                    "♻️ "
+                    if result.reused
+                    else (
+                        "✅" if result.passed else ("⏱️ " if result.timed_out else "❌")
+                    )
+                )
                 print(f" {icon} ({_format_duration(result.duration)})")
     else:
         # Parallel execution with ThreadPoolExecutor
@@ -672,7 +797,18 @@ def main() -> int:
         with ThreadPoolExecutor(max_workers=args.workers) as executor:
             futures = {}
             for check, cat_name in checks:
-                future = executor.submit(_run_check, check, cat_name, args.fix)
+                identity, receipt_path = prepared.get(
+                    (cat_name, check.name), (None, None)
+                )
+                future = executor.submit(
+                    _run_check,
+                    check,
+                    cat_name,
+                    args.fix,
+                    identity,
+                    receipt_path,
+                    not args.no_reuse,
+                )
                 futures[future] = (check, cat_name)
 
             aggregate_timeout = min(sum(c.timeout for c, _ in checks), 900)
@@ -682,9 +818,13 @@ def main() -> int:
                     results.append(result)
                     if not args.json:
                         icon = (
-                            "✅"
-                            if result.passed
-                            else ("⏱️ " if result.timed_out else "❌")
+                            "♻️ "
+                            if result.reused
+                            else (
+                                "✅"
+                                if result.passed
+                                else ("⏱️ " if result.timed_out else "❌")
+                            )
                         )
                         print(
                             f"  {icon} {result.name} ({_format_duration(result.duration)})"
@@ -696,10 +836,33 @@ def main() -> int:
                     )
                 for future in futures:
                     future.cancel()
+            _append_missing_results(results, futures)
 
     # Sort results by category order
     cat_order = {cat.name: i for i, cat in enumerate(CATEGORIES)}
     results.sort(key=lambda r: (cat_order.get(r.category, 99), r.name))
+
+    # Record only exact PASS identities that remained unchanged through the run.
+    if evidence_manifest is not None and prepared:
+        try:
+            post_context = FingerprintContext(evidence_manifest)
+            categories = {cat.name: cat.impact_domains for cat in CATEGORIES}
+            checks_by_key = {(cat, check.name): check for check, cat in checks}
+            for result in results:
+                key = (result.category, result.name)
+                if not result.passed or result.reused or key not in prepared:
+                    continue
+                check = checks_by_key[key]
+                before, receipt_path = prepared[key]
+                after = post_context.identity(
+                    profile=before.profile,
+                    domains=categories[result.category],
+                    command=check.cmd,
+                )
+                if after.fingerprint == before.fingerprint:
+                    write_receipt(receipt_path, after)
+        except (OSError, VerificationError):
+            pass
 
     # Output
     if args.json:

--- a/scripts/check_codex_git_workflow.py
+++ b/scripts/check_codex_git_workflow.py
@@ -13,7 +13,11 @@ import json
 import re
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+from verification import VerificationError, classify_paths, load_manifest  # noqa: E402
+
+REPO_ROOT = SCRIPT_DIR.parent
 CANONICAL = REPO_ROOT / "docs/git-automation/git-workflow-single-source.md"
 GIT_STATE_AUTHORITY = REPO_ROOT / "scripts/git_state.py"
 HANDOFF_RECEIPT = REPO_ROOT / "scripts/git_handoff_receipt.py"
@@ -553,7 +557,7 @@ def main() -> int:
     if pre_commit.exists():
         pre_commit_text = pre_commit.read_text(encoding="utf-8")
         expected_completion_guard = (
-            "bash scripts/check_unfinished_merge.sh --allow-operation-completion"
+            "scripts/check_all.py --quick --allow-operation-completion"
         )
         if expected_completion_guard not in pre_commit_text:
             errors.append(
@@ -567,8 +571,9 @@ def main() -> int:
         for token in (
             "control_plane:",
             "docs:",
-            "'scripts/**'",
-            "'docs/**'",
+            "python scripts/verification.py plan",
+            "steps.impact.outputs.control_plane",
+            "steps.impact.outputs.docs",
             "control-plane-validation:",
             "documentation-validation:",
             "needs.changes.outputs.control_plane == 'true'",
@@ -607,6 +612,22 @@ def main() -> int:
                 errors.append(
                     "control-plane CI tests do not bind the setup-python interpreter"
                 )
+
+        try:
+            verification_manifest = load_manifest()
+        except VerificationError as exc:
+            errors.append(f"canonical verification routing is invalid: {exc}")
+        else:
+            expected_routes = {
+                "scripts/check_codex_git_workflow.py": "control_plane",
+                "docs/contributing/testing-strategy.md": "docs",
+            }
+            for path, domain in expected_routes.items():
+                plan = classify_paths((path,), verification_manifest)
+                if domain not in plan.domains:
+                    errors.append(
+                        f"required PR Gate routing is missing: {path} -> {domain}"
+                    )
 
     if not DEPLOY_DOCS.exists():
         errors.append("post-merge documentation workflow is missing")

--- a/scripts/check_scripts_index.py
+++ b/scripts/check_scripts_index.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Ensure canonical control/context registries match the live repository.
+"""Ensure canonical control/context/verification registries match the repository.
 
 When to use: After adding or removing scripts from the scripts/ folder.
 Verifies every top-level script is registered, the legacy automation map is the
 exact deterministic compatibility projection, and generic folder indexes stay
-retired.
+retired. Also proves every current path has a fail-closed verification rule.
 """
 
 from __future__ import annotations
@@ -28,6 +28,10 @@ from control_plane import (  # noqa: E402
 from repo_context import (  # noqa: E402
     ContextManifestError,
     load_manifest as load_context_manifest,
+)
+from verification import (  # noqa: E402
+    VerificationError,
+    load_manifest as load_verification_manifest,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -108,6 +112,29 @@ def main() -> int:
             print(
                 "✓ context manifest: "
                 f"{len(context_manifest['areas'])} areas, 0 generated folder indexes"
+            )
+
+    try:
+        verification_manifest = load_verification_manifest()
+    except VerificationError as exc:
+        report["checks"]["verification_manifest"] = {
+            "status": "fail",
+            "reason": str(exc),
+        }
+        if not args.json:
+            print(f"ERROR: canonical verification manifest is invalid: {exc}")
+        errors += 1
+    else:
+        report["checks"]["verification_manifest"] = {
+            "status": "pass",
+            "domains": len(verification_manifest["domains"]),
+            "rules": len(verification_manifest["rules"]),
+        }
+        if not args.json:
+            print(
+                "✓ verification manifest: "
+                f"{len(verification_manifest['domains'])} domains, "
+                f"{len(verification_manifest['rules'])} rules"
             )
 
     # Check canonical control plane and exact compatibility projection.

--- a/scripts/context-manifest.json
+++ b/scripts/context-manifest.json
@@ -136,7 +136,12 @@
         "docs/contributing/testing-strategy.md",
         "docs/guidelines/ai-token-efficiency.md"
       ],
-      "operations": ["run tests", "parity dashboard", "run all checks"]
+      "operations": [
+        "run tests",
+        "parity dashboard",
+        "run all checks",
+        "verification impact"
+      ]
     }
   }
 }

--- a/scripts/control-plane.json
+++ b/scripts/control-plane.json
@@ -102,7 +102,7 @@
     },
     "run all checks": {
       "group": "Quality",
-      "description": "Run all 30 validation checks across 8 categories in parallel (also: ./run.sh check)",
+      "description": "Run all 31 validation checks across 8 categories in parallel with exact PASS reuse (also: ./run.sh check)",
       "status": "active",
       "command": {
         "display": "./scripts/python_runtime.sh scripts/check_all.py",
@@ -123,13 +123,45 @@
       "options": {
         "--quick": "Run 10 quick checks only (<30s)",
         "--category X": "Run checks for specific category",
-        "--changed": "Auto-detect categories from git diff",
+        "--changed": "Plan explicit domains from the whole candidate diff; unknown impact runs all domains",
         "--fix": "Auto-fix where possible",
         "--json": "JSON output for CI",
+        "--no-reuse": "Force fresh execution instead of accepting exact PASS receipts",
         "--serial": "Run sequentially (debugging)"
       },
       "aliases": [
         "check"
+      ]
+    },
+    "verification impact": {
+      "group": "Quality",
+      "description": "Validate the canonical change-domain map and content-addressed PASS evidence contract",
+      "status": "active",
+      "command": {
+        "display": "./scripts/python_runtime.sh scripts/verification.py validate",
+        "steps": [
+          {
+            "argv": [
+              "./scripts/python_runtime.sh",
+              "scripts/verification.py",
+              "validate"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "ReadOnly",
+      "permission_modes": {
+        "record": "WorkspaceWrite"
+      },
+      "options": {
+        "plan": "Classify a candidate or explicit paths into validation domains",
+        "fingerprint": "Compute exact command, runtime, and input-byte identity",
+        "probe": "Check whether an exact PASS receipt exists",
+        "record": "Write a PASS receipt outside tracked repository content"
+      },
+      "aliases": [
+        "verification"
       ]
     },
     "validate script references": {

--- a/scripts/control_plane/__init__.py
+++ b/scripts/control_plane/__init__.py
@@ -62,6 +62,16 @@ def _schema_errors(data: dict[str, Any], schema_path: Path) -> list[str]:
     return _validate_schema_value(data, schema, schema, ())
 
 
+def read_strict_json(path: Path) -> dict[str, Any]:
+    """Read a duplicate-key-safe JSON object for another control contract."""
+    return _read_json(path)
+
+
+def schema_errors(data: dict[str, Any], schema_path: Path) -> list[str]:
+    """Validate data with the repository's dependency-free JSON Schema subset."""
+    return _schema_errors(data, schema_path)
+
+
 def _schema_path(path: tuple[str | int, ...]) -> str:
     return "/".join(str(part) for part in path) or "<root>"
 

--- a/scripts/test_changed.py
+++ b/scripts/test_changed.py
@@ -23,6 +23,9 @@ import os
 import subprocess
 import sys
 import glob
+from pathlib import Path
+
+import verification as verification_control
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 VENV_PYTHON = os.path.join(REPO_ROOT, "scripts", "python_runtime.sh")
@@ -113,12 +116,13 @@ def get_changed_files(mode: str = "diff") -> list[str]:
     elif mode == "last-commit":
         cmd = ["git", "diff", "--name-only", "HEAD~1", "HEAD"]
     else:
-        # Changes vs current HEAD (uncommitted)
-        cmd = ["git", "diff", "--name-only", "HEAD"]
+        return list(verification_control.changed_paths(root=Path(REPO_ROOT)))
 
     result = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
     if result.returncode != 0:
-        return []
+        raise verification_control.VerificationError(
+            f"changed-file Git query failed: {' '.join(cmd)}"
+        )
 
     return [f for f in result.stdout.strip().split("\n") if f]
 
@@ -129,6 +133,13 @@ def map_to_tests(changed_files: list[str]) -> set[str]:
 
     for filepath in changed_files:
         mapped = False
+        if filepath.endswith(".py") and (
+            filepath.startswith("Python/tests/")
+            or filepath.startswith("fastapi_app/tests/")
+        ):
+            test_files.add(filepath)
+            _log(f"{filepath} → exact changed test")
+            continue
         for prefix, finder in SOURCE_TO_TEST_MAP:
             if filepath.startswith(prefix):
                 tests = finder(filepath)
@@ -149,6 +160,11 @@ def map_to_tests(changed_files: list[str]) -> set[str]:
     return test_files
 
 
+def _run(cmd: list[str]) -> int:
+    _log("running: " + " ".join(cmd))
+    return subprocess.run(cmd, cwd=REPO_ROOT).returncode
+
+
 def main() -> None:
     global VERBOSE
 
@@ -165,9 +181,26 @@ def main() -> None:
         else:
             extra_pytest_args.append(arg)
 
-    changed = get_changed_files(mode)
+    try:
+        manifest = verification_control.load_manifest(require_coverage=False)
+        if mode == "diff":
+            plan = verification_control.plan_changes(manifest)
+        else:
+            try:
+                discovered = get_changed_files(mode)
+            except verification_control.VerificationError as exc:
+                plan = verification_control.classify_paths(
+                    (), manifest, failure_reasons=(str(exc),)
+                )
+            else:
+                plan = verification_control.classify_paths(discovered, manifest)
+    except verification_control.VerificationError as exc:
+        print(f"ERROR: verification control is invalid: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
 
-    if not changed:
+    changed = list(plan.changed_paths)
+
+    if not changed and not plan.fail_closed:
         print("No changed files detected. Nothing to test.")
         return
 
@@ -177,41 +210,115 @@ def main() -> None:
     if len(changed) > 10:
         print(f"  ... and {len(changed) - 10} more")
 
-    # If too many files changed, just run everything
-    if len(changed) > 30:
-        print("\n\033[33m30+ files changed — running full test suite\033[0m")
-        os.chdir(os.path.join(REPO_ROOT, "Python"))
-        os.execv(
-            VENV_PYTHON,
-            [VENV_PYTHON, "-m", "pytest", "tests/", "-v"] + extra_pytest_args,
+    print(f"\n\033[1mImpacted domains:\033[0m {', '.join(plan.domains)}")
+    if plan.fail_closed:
+        reasons = [*plan.unknown_paths, *plan.failure_reasons]
+        print(
+            "\033[33mUnknown impact — every product test domain is required: "
+            + "; ".join(reasons)
+            + "\033[0m"
         )
-        return
 
     test_files = map_to_tests(changed)
-
-    if not test_files:
-        print("\nNo matching test files found for changes. Skipping.")
-        return
-
-    # Deduplicate and filter to existing files
     existing = sorted(
         t for t in test_files if os.path.exists(os.path.join(REPO_ROOT, t))
     )
+    domains = set(plan.domains)
+    full_python = "python" in domains and (
+        len(changed) > 30
+        or not existing
+        or any(
+            path.startswith("Python/")
+            and not path.startswith("Python/tests/")
+            and not any(
+                path.startswith(prefix) for prefix, _finder in SOURCE_TO_TEST_MAP
+            )
+            for path in changed
+        )
+    )
+    full_fastapi = "fastapi" in domains and (
+        len(changed) > 30
+        or not any(
+            path.startswith("fastapi_app/") or path.startswith("Python/structural_lib/")
+            for path in changed
+        )
+        or not any(path.startswith("fastapi_app/tests/") for path in existing)
+    )
 
-    if not existing:
-        print("\nMapped test files don't exist. Skipping.")
+    commands: list[list[str]] = []
+    if full_python:
+        commands.append(
+            [VENV_PYTHON, "-m", "pytest", "Python/tests/", "-v", *extra_pytest_args]
+        )
+    if full_fastapi:
+        commands.append(
+            [
+                VENV_PYTHON,
+                "-m",
+                "pytest",
+                "fastapi_app/tests/",
+                "-v",
+                *extra_pytest_args,
+            ]
+        )
+
+    focused = [
+        path
+        for path in existing
+        if not (full_python and path.startswith("Python/tests/"))
+        and not (full_fastapi and path.startswith("fastapi_app/tests/"))
+    ]
+    focused_python = [path for path in focused if path.startswith("Python/tests/")]
+    focused_fastapi = [
+        path for path in focused if path.startswith("fastapi_app/tests/")
+    ]
+    if focused_python:
+        commands.append(
+            [
+                VENV_PYTHON,
+                "-m",
+                "pytest",
+                "-v",
+                *extra_pytest_args,
+                *focused_python,
+            ]
+        )
+    if focused_fastapi:
+        commands.append(
+            [
+                VENV_PYTHON,
+                "-m",
+                "pytest",
+                "-v",
+                *extra_pytest_args,
+                *focused_fastapi,
+            ]
+        )
+    if "react" in domains:
+        commands.append([os.path.join(REPO_ROOT, "run.sh"), "test", "--react"])
+    if "excel" in domains:
+        commands.append(
+            [
+                VENV_PYTHON,
+                os.path.join(REPO_ROOT, "scripts", "node_runtime.py"),
+                "--",
+                "npm",
+                "--prefix",
+                "excel_addin",
+                "test",
+            ]
+        )
+
+    if not commands:
+        print("\nNo product test suite is owned by the impacted non-product domains.")
         return
 
-    print(f"\n\033[1mRunning {len(existing)} test file(s):\033[0m")
-    for t in existing:
-        print(f"  \033[32m→\033[0m {t}")
-
-    # Run pytest with the specific test files
-    cmd = [VENV_PYTHON, "-m", "pytest", "-v"] + extra_pytest_args + existing
-    print()
-    os.chdir(REPO_ROOT)
-    result = subprocess.run(cmd)
-    sys.exit(result.returncode)
+    failed = 0
+    for command in commands:
+        print("\n\033[1mRunning:\033[0m " + " ".join(command))
+        if _run(command) != 0:
+            failed += 1
+    raise SystemExit(1 if failed else 0)
 
 
 if __name__ == "__main__":

--- a/scripts/test_cli_smoke.py
+++ b/scripts/test_cli_smoke.py
@@ -93,6 +93,12 @@ SMOKE_TESTS: list[dict[str, Any]] = [
         "expect_rc": 0,
         "expect_output": "Context summary: automation",
     },
+    {
+        "name": "verification_manifest_validate",
+        "cmd": [VENV, "scripts/verification.py", "validate"],
+        "expect_rc": 0,
+        "expect_output": "Verification manifest: PASS",
+    },
     # Permission tools
     {
         "name": "permissions_check_read",

--- a/scripts/verification-manifest.json
+++ b/scripts/verification-manifest.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "./verification-manifest.schema.json",
+  "schema_version": 1,
+  "registry_kind": "structural-engineering-verification-impact",
+  "metadata": {
+    "owner": "MAINT-012 verification control plane",
+    "purpose": "Classify changed paths once and bind reusable PASS evidence to exact commands, runtimes, and input bytes.",
+    "unknown_impact": "all_domains",
+    "local_evidence_store": "git_common_dir"
+  },
+  "domains": {
+    "python": {
+      "description": "Python package, tests, examples, and public-client contracts",
+      "hosted_job": "python-validation"
+    },
+    "fastapi": {
+      "description": "FastAPI application, imported Python package, and deployment inputs",
+      "hosted_job": "fastapi-validation"
+    },
+    "react": {
+      "description": "React application source, dependencies, tests, and build configuration",
+      "hosted_job": "react-validation"
+    },
+    "excel": {
+      "description": "Excel add-in source and its dependency-free Node test surface",
+      "hosted_job": "excel-validation"
+    },
+    "control_plane": {
+      "description": "Agent, script, session, Git, registry, workflow, and permission controls",
+      "hosted_job": "control-plane-validation"
+    },
+    "docs": {
+      "description": "Maintained documentation, MkDocs configuration, and imported API documentation inputs",
+      "hosted_job": "documentation-validation"
+    },
+    "repository": {
+      "description": "Repository configuration, hygiene, YAML, and maintenance-script contracts",
+      "hosted_job": "repository-validation"
+    }
+  },
+  "rules": [
+    {
+      "paths": ["Python/structural_lib/**"],
+      "domains": ["python", "fastapi", "docs"]
+    },
+    {
+      "paths": ["Python/examples/**"],
+      "domains": ["python", "docs"]
+    },
+    {
+      "paths": ["Python/tests/**", "Python/scripts/**", "Python/.benchmarks/**", "Python/.coveragerc", "Python/pytest.ini", "Python/test_stats.json"],
+      "domains": ["python"]
+    },
+    {
+      "paths": ["Python/tests/test_agent_governance_automation.py", "Python/tests/test_audit_readiness_truth.py", "Python/tests/test_branch_disposition.py", "Python/tests/test_ci_workflow_contract.py", "Python/tests/test_control_plane.py", "Python/tests/test_git_*.py", "Python/tests/test_pipeline_state.py", "Python/tests/test_repo_context.py", "Python/tests/test_session_*.py", "Python/tests/test_verification_control.py"],
+      "domains": ["control_plane"]
+    },
+    {
+      "paths": ["Python/pyproject.toml", "Python/MANIFEST.in"],
+      "domains": ["python", "fastapi", "docs"]
+    },
+    {
+      "paths": ["Python/README.md", "Python/LICENSE"],
+      "domains": ["python", "docs"]
+    },
+    {
+      "paths": ["fastapi_app/**"],
+      "domains": ["fastapi"]
+    },
+    {
+      "paths": ["react_app/**", ".vite/**"],
+      "domains": ["react"]
+    },
+    {
+      "paths": ["excel_addin/**"],
+      "domains": ["excel"]
+    },
+    {
+      "paths": ["scripts/verification.py", "scripts/verification-manifest.json", "scripts/verification-manifest.schema.json", "scripts/check_all.py", "scripts/control_plane/**", "scripts/_lib/**", ".github/workflows/fast-checks.yml", ".github/actions/verification-evidence/**"],
+      "domains": ["python", "fastapi", "react", "excel", "control_plane", "docs", "repository"]
+    },
+    {
+      "paths": ["scripts/python_runtime.sh", "scripts/check_api.py", "scripts/validate_api_contracts.py", "scripts/generate_api_manifest.py", "scripts/generate_api_classification.py", "scripts/check_architecture_boundaries.py", "scripts/check_circular_imports.py", "scripts/validate_imports.py", "scripts/check_type_annotations.py", "scripts/check_governance.py"],
+      "domains": ["python", "fastapi", "docs"]
+    },
+    {
+      "paths": ["scripts/check_fastapi_issues.py", "scripts/check_docker_config.py", "scripts/check_openapi_snapshot.py"],
+      "domains": ["fastapi"]
+    },
+    {
+      "paths": ["scripts/check_docs.py", "scripts/check_links.py", "scripts/check_doc_versions.py", "scripts/check_cli_reference.py", "scripts/check_tasks_format.py", "scripts/check_next_session_brief_length.py", "scripts/check_scripts_index.py", "scripts/validate_script_refs.py", "scripts/test_cli_smoke.py", "scripts/check_instruction_drift.py", "scripts/check_bootstrap_freshness.py"],
+      "domains": ["docs"]
+    },
+    {
+      "paths": ["scripts/**", "run.sh", "agents/**", ".codex/**", ".claude/**", "AGENTS.md", "CLAUDE.md"],
+      "domains": ["control_plane"]
+    },
+    {
+      "paths": ["scripts/check_repo_hygiene.py", "scripts/validate_git_state.sh", "scripts/check_unfinished_merge.sh", "scripts/check_not_main.sh", "scripts/agent_start.sh", "scripts/git_state.py", "scripts/migrate_python_module.py", "scripts/migrate_react_component.py", "scripts/safe_file_move.py", "scripts/safe_file_delete.py", "scripts/batch_migrate_runner.py", ".github/**", ".pre-commit-config.yaml"],
+      "domains": ["control_plane", "repository"]
+    },
+    {
+      "paths": ["Python/structural_lib/_migration_fixtures/**", "react_app/src/__fixtures__/migration/**", "tests/fixtures/migration/**"],
+      "domains": ["repository"]
+    },
+    {
+      "paths": ["docs/git-automation/**", "docs/guidelines/ai-token-efficiency.md", "docs/research/git-governance/**"],
+      "domains": ["control_plane", "docs"]
+    },
+    {
+      "paths": ["docs/**", "README.md", "AUTHORS.md", "CHANGELOG.md", "CITATION.cff", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md", "LICENSE", "LICENSE_ENGINEERING.md", "llms.txt"],
+      "domains": ["docs"]
+    },
+    {
+      "paths": ["mkdocs.yml"],
+      "domains": ["docs", "repository"]
+    },
+    {
+      "paths": ["requirements*.txt", "Dockerfile.fastapi", "docker-compose*.yml", ".dockerignore", ".env.example"],
+      "domains": ["fastapi", "repository"]
+    },
+    {
+      "paths": [".nvmrc"],
+      "domains": ["react", "excel"]
+    },
+    {
+      "paths": ["clients/**"],
+      "domains": ["python", "react"]
+    },
+    {
+      "paths": ["Etabs_CSV/**"],
+      "domains": ["python"]
+    },
+    {
+      "paths": ["tests/**", "logs/**", "pyrightconfig.json", ".python-version", ".editorconfig", ".gitattributes", ".gitignore", ".lycheeexclude"],
+      "domains": ["repository"]
+    }
+  ]
+}

--- a/scripts/verification-manifest.schema.json
+++ b/scripts/verification-manifest.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://structural-engineering-lib.dev/schemas/verification-manifest-v1.json",
+  "title": "Structural Engineering Library Verification Impact Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "registry_kind",
+    "metadata",
+    "domains",
+    "rules"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "./verification-manifest.schema.json"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "registry_kind": {
+      "const": "structural-engineering-verification-impact"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "purpose", "unknown_impact", "local_evidence_store"],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        },
+        "unknown_impact": {
+          "const": "all_domains"
+        },
+        "local_evidence_store": {
+          "const": "git_common_dir"
+        }
+      }
+    },
+    "domains": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9_]*$"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/domain"
+      }
+    },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/rule"
+      }
+    }
+  },
+  "$defs": {
+    "stringList": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "domain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "hosted_job"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "hosted_job": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["paths", "domains"],
+      "properties": {
+        "paths": {
+          "$ref": "#/$defs/stringList"
+        },
+        "domains": {
+          "$ref": "#/$defs/stringList"
+        }
+      }
+    }
+  }
+}

--- a/scripts/verification.py
+++ b/scripts/verification.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""Plan validation work and reuse only content-bound PASS evidence.
+
+When to use: Classify a candidate into explicit verification domains, inspect
+an exact evidence identity, or validate the canonical verification manifest.
+Unknown paths and Git-query failures expand to every domain.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+MANIFEST_PATH = SCRIPT_DIR / "verification-manifest.json"
+SCHEMA_PATH = SCRIPT_DIR / "verification-manifest.schema.json"
+EVIDENCE_SCHEMA_VERSION = 1
+EVIDENCE_DIRECTORY = Path("structural-lib") / "verification-evidence" / "v1"
+REQUIRED_DOMAINS = (
+    "python",
+    "fastapi",
+    "react",
+    "excel",
+    "control_plane",
+    "docs",
+    "repository",
+)
+
+sys.path.insert(0, str(SCRIPT_DIR))
+from control_plane import (  # noqa: E402
+    ControlPlaneError,
+    read_strict_json,
+    schema_errors,
+)
+
+
+class VerificationError(ValueError):
+    """Raised when verification scheduling or evidence cannot be trusted."""
+
+
+def _git_bytes(root: Path, *args: str) -> bytes:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise VerificationError(f"Git query failed: git {' '.join(args)}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise VerificationError(
+            f"Git query failed: git {' '.join(args)}"
+            + (f": {detail}" if detail else "")
+        )
+    return result.stdout
+
+
+def _nul_paths(payload: bytes) -> list[str]:
+    return [os.fsdecode(item) for item in payload.split(b"\0") if item]
+
+
+def repository_paths(root: Path = REPO_ROOT) -> tuple[str, ...]:
+    """Return tracked and untracked non-ignored paths, including deletions."""
+    payload = _git_bytes(
+        root, "ls-files", "--cached", "--others", "--exclude-standard", "-z"
+    )
+    return tuple(sorted(set(_nul_paths(payload))))
+
+
+def _valid_pattern(value: str) -> bool:
+    path = Path(value)
+    return (
+        bool(value)
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and "\\" not in value
+    )
+
+
+def _matches(path: str, patterns: Iterable[str]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def validate_manifest(
+    manifest: dict[str, Any],
+    *,
+    root: Path = REPO_ROOT,
+    inventory: Sequence[str] | None = None,
+    require_coverage: bool = True,
+) -> None:
+    """Validate schema, domain ownership, patterns, and live path coverage."""
+    errors = schema_errors(manifest, SCHEMA_PATH)
+    if errors:
+        raise VerificationError("\n".join(errors))
+
+    domains = manifest["domains"]
+    domain_names = set(domains)
+    if tuple(domains) != REQUIRED_DOMAINS:
+        raise VerificationError(
+            "domains must use the canonical order: " + ", ".join(REQUIRED_DOMAINS)
+        )
+    hosted_jobs: set[str] = set()
+    for name, info in domains.items():
+        hosted_job = info["hosted_job"]
+        if hosted_job in hosted_jobs:
+            raise VerificationError(f"duplicate hosted job owner: {hosted_job}")
+        hosted_jobs.add(hosted_job)
+
+    rule_patterns: set[str] = set()
+    for index, rule in enumerate(manifest["rules"]):
+        unknown = sorted(set(rule["domains"]) - domain_names)
+        if unknown:
+            raise VerificationError(
+                f"rule:{index} references unknown domains: {', '.join(unknown)}"
+            )
+        for pattern in rule["paths"]:
+            if pattern in rule_patterns:
+                raise VerificationError(f"duplicate change-path pattern: {pattern}")
+            rule_patterns.add(pattern)
+
+    invalid = sorted(
+        pattern for pattern in rule_patterns if not _valid_pattern(pattern)
+    )
+    if invalid:
+        raise VerificationError(f"invalid repository patterns: {', '.join(invalid)}")
+
+    paths = tuple(inventory) if inventory is not None else repository_paths(root)
+    unmatched = sorted(
+        path
+        for path in paths
+        if not any(_matches(path, rule["paths"]) for rule in manifest["rules"])
+    )
+    if unmatched and require_coverage:
+        raise VerificationError(
+            "tracked/untracked paths lack an impact rule: " + ", ".join(unmatched)
+        )
+
+
+def load_manifest(
+    path: Path = MANIFEST_PATH,
+    *,
+    root: Path = REPO_ROOT,
+    inventory: Sequence[str] | None = None,
+    require_coverage: bool = True,
+) -> dict[str, Any]:
+    try:
+        manifest = read_strict_json(path)
+    except ControlPlaneError as exc:
+        raise VerificationError(str(exc)) from exc
+    validate_manifest(
+        manifest,
+        root=root,
+        inventory=inventory,
+        require_coverage=require_coverage,
+    )
+    return manifest
+
+
+@dataclass(frozen=True)
+class ImpactPlan:
+    """Deterministic validation schedule for a set of changed paths."""
+
+    domains: tuple[str, ...]
+    changed_paths: tuple[str, ...]
+    unknown_paths: tuple[str, ...]
+    failure_reasons: tuple[str, ...] = ()
+
+    @property
+    def fail_closed(self) -> bool:
+        return bool(self.unknown_paths or self.failure_reasons)
+
+    def as_dict(self, all_domains: Iterable[str]) -> dict[str, Any]:
+        selected = set(self.domains)
+        return {
+            "schema_version": 1,
+            "status": "all-domains" if self.fail_closed else "planned",
+            "fail_closed": self.fail_closed,
+            "domains": list(self.domains),
+            "domain_flags": {name: name in selected for name in all_domains},
+            "changed_paths": list(self.changed_paths),
+            "unknown_paths": list(self.unknown_paths),
+            "failure_reasons": list(self.failure_reasons),
+        }
+
+
+def classify_paths(
+    paths: Iterable[str],
+    manifest: dict[str, Any],
+    *,
+    failure_reasons: Iterable[str] = (),
+) -> ImpactPlan:
+    """Classify paths; any unknown path or upstream failure selects all domains."""
+    normalized = tuple(sorted(set(path for path in paths if path)))
+    selected: set[str] = set()
+    unknown: list[str] = []
+    for path in normalized:
+        if not _valid_pattern(path):
+            unknown.append(path)
+            continue
+        matched = False
+        for rule in manifest["rules"]:
+            if _matches(path, rule["paths"]):
+                selected.update(rule["domains"])
+                matched = True
+        if not matched:
+            unknown.append(path)
+
+    failures = tuple(str(reason) for reason in failure_reasons if str(reason))
+    if unknown or failures:
+        selected = set(manifest["domains"])
+    ordered = tuple(name for name in manifest["domains"] if name in selected)
+    return ImpactPlan(ordered, normalized, tuple(sorted(unknown)), failures)
+
+
+def changed_paths(
+    *,
+    root: Path = REPO_ROOT,
+    base: str | None = None,
+    head: str = "HEAD",
+    include_worktree: bool = True,
+) -> tuple[str, ...]:
+    """Return the whole candidate delta plus optional staged/unstaged files."""
+    resolved_base = base or os.environ.get("STRUCTURAL_LIB_BASE_REF", "origin/main")
+    if not resolved_base or set(resolved_base) == {"0"}:
+        raise VerificationError("base revision is missing or all-zero")
+    changed = set(
+        _nul_paths(
+            _git_bytes(
+                root,
+                "diff",
+                "--name-only",
+                "--no-renames",
+                "--diff-filter=ACDMRTUXB",
+                "-z",
+                f"{resolved_base}...{head}",
+            )
+        )
+    )
+    if include_worktree:
+        changed.update(
+            _nul_paths(
+                _git_bytes(
+                    root,
+                    "diff",
+                    "--name-only",
+                    "--no-renames",
+                    "--diff-filter=ACDMRTUXB",
+                    "-z",
+                    "HEAD",
+                )
+            )
+        )
+        changed.update(
+            _nul_paths(
+                _git_bytes(root, "ls-files", "--others", "--exclude-standard", "-z")
+            )
+        )
+    return tuple(sorted(changed))
+
+
+def plan_changes(
+    manifest: dict[str, Any],
+    *,
+    root: Path = REPO_ROOT,
+    base: str | None = None,
+    head: str = "HEAD",
+    include_worktree: bool = True,
+    paths: Iterable[str] | None = None,
+) -> ImpactPlan:
+    if paths is not None:
+        return classify_paths(paths, manifest)
+    try:
+        discovered = changed_paths(
+            root=root, base=base, head=head, include_worktree=include_worktree
+        )
+    except VerificationError as exc:
+        return classify_paths((), manifest, failure_reasons=(str(exc),))
+    return classify_paths(discovered, manifest)
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+
+
+def _runtime_identity(extra: bytes = b"") -> dict[str, Any]:
+    distributions = sorted(
+        {
+            (
+                (dist.metadata.get("Name") or "<unknown>").lower(),
+                dist.version or "<unknown>",
+            )
+            for dist in importlib.metadata.distributions()
+        }
+    )
+    return {
+        "python_implementation": platform.python_implementation(),
+        "python_version": platform.python_version(),
+        "platform_system": platform.system(),
+        "platform_release": platform.release(),
+        "platform_machine": platform.machine(),
+        "ci": os.environ.get("CI", ""),
+        "github_actions": os.environ.get("GITHUB_ACTIONS", ""),
+        "runner_os": os.environ.get("RUNNER_OS", ""),
+        "runner_arch": os.environ.get("RUNNER_ARCH", ""),
+        "runner_image_os": os.environ.get("ImageOS", ""),
+        "runner_image_version": os.environ.get("ImageVersion", ""),
+        "distributions": distributions,
+        "extra_sha256": hashlib.sha256(extra).hexdigest(),
+    }
+
+
+def _normalize_command(command: Sequence[str], root: Path) -> tuple[str, ...]:
+    normalized: list[str] = []
+    resolved_root = root.resolve()
+    for token in command:
+        candidate = Path(token)
+        if candidate.is_absolute():
+            try:
+                relative = candidate.resolve().relative_to(resolved_root)
+            except (OSError, ValueError):
+                normalized.append(token)
+            else:
+                normalized.append(f"./{relative.as_posix()}")
+        else:
+            normalized.append(token)
+    return tuple(normalized)
+
+
+@dataclass(frozen=True)
+class EvidenceIdentity:
+    fingerprint: str
+    profile: str
+    domains: tuple[str, ...]
+    command: tuple[str, ...]
+    runtime_digest: str
+    input_count: int
+
+
+class FingerprintContext:
+    """Hash repository inputs once and derive many exact evidence identities."""
+
+    def __init__(
+        self,
+        manifest: dict[str, Any],
+        *,
+        root: Path = REPO_ROOT,
+        runtime_extra: bytes = b"",
+        inventory: Sequence[str] | None = None,
+    ) -> None:
+        self.manifest = manifest
+        self.root = root.resolve()
+        self.inventory = (
+            tuple(inventory) if inventory is not None else repository_paths(root)
+        )
+        runtime = _runtime_identity(runtime_extra)
+        self.runtime_digest = hashlib.sha256(_canonical_bytes(runtime)).hexdigest()
+        self._path_digest_cache: dict[str, str] = {}
+        self._domain_paths_cache: dict[str, tuple[str, ...]] = {}
+        self._unknown_paths = {
+            path
+            for path in self.inventory
+            if not any(_matches(path, rule["paths"]) for rule in manifest["rules"])
+        }
+
+    def _path_digest(self, relative: str) -> str:
+        cached = self._path_digest_cache.get(relative)
+        if cached is not None:
+            return cached
+        path = self.root / relative
+        if path.is_symlink():
+            payload = b"symlink\0" + os.fsencode(os.readlink(path))
+        elif path.is_file():
+            payload = b"file\0" + path.read_bytes()
+        elif path.exists():
+            payload = b"non-file"
+        else:
+            payload = b"missing"
+        digest = hashlib.sha256(payload).hexdigest()
+        self._path_digest_cache[relative] = digest
+        return digest
+
+    def _paths_for_domain(self, domain: str) -> tuple[str, ...]:
+        cached = self._domain_paths_cache.get(domain)
+        if cached is not None:
+            return cached
+        patterns = [
+            pattern
+            for rule in self.manifest["rules"]
+            if domain in rule["domains"]
+            for pattern in rule["paths"]
+        ]
+        selected = tuple(
+            path
+            for path in self.inventory
+            if path in self._unknown_paths or _matches(path, patterns)
+        )
+        self._domain_paths_cache[domain] = selected
+        return selected
+
+    def identity(
+        self,
+        *,
+        profile: str,
+        domains: Iterable[str],
+        command: Sequence[str],
+    ) -> EvidenceIdentity:
+        domain_tuple = tuple(dict.fromkeys(domains))
+        unknown = sorted(set(domain_tuple) - set(self.manifest["domains"]))
+        if unknown:
+            raise VerificationError(f"unknown evidence domains: {', '.join(unknown)}")
+        selected_paths = sorted(
+            {path for domain in domain_tuple for path in self._paths_for_domain(domain)}
+        )
+        normalized_command = _normalize_command(command, self.root)
+        payload = {
+            "schema_version": EVIDENCE_SCHEMA_VERSION,
+            "profile": profile,
+            "domains": list(domain_tuple),
+            "command": list(normalized_command),
+            "runtime_digest": self.runtime_digest,
+            "inputs": [[path, self._path_digest(path)] for path in selected_paths],
+        }
+        fingerprint = hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+        return EvidenceIdentity(
+            fingerprint=fingerprint,
+            profile=profile,
+            domains=domain_tuple,
+            command=normalized_command,
+            runtime_digest=self.runtime_digest,
+            input_count=len(selected_paths),
+        )
+
+
+def local_evidence_path(root: Path, fingerprint: str) -> Path:
+    if len(fingerprint) != 64 or any(
+        char not in "0123456789abcdef" for char in fingerprint
+    ):
+        raise VerificationError("evidence fingerprint must be lowercase SHA-256")
+    common_text = (
+        _git_bytes(root, "rev-parse", "--git-common-dir")
+        .decode("utf-8", errors="strict")
+        .strip()
+    )
+    common = Path(common_text)
+    if not common.is_absolute():
+        common = root / common
+    return common.resolve() / EVIDENCE_DIRECTORY / f"{fingerprint}.json"
+
+
+def _receipt_payload(identity: EvidenceIdentity) -> dict[str, Any]:
+    return {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "status": "pass",
+        "fingerprint": identity.fingerprint,
+        "profile": identity.profile,
+        "domains": list(identity.domains),
+        "command": list(identity.command),
+        "runtime_digest": identity.runtime_digest,
+        "input_count": identity.input_count,
+        "observed_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def probe_receipt(path: Path, identity: EvidenceIdentity) -> tuple[bool, str]:
+    if not path.is_file() or path.is_symlink():
+        return False, "receipt-missing"
+    try:
+        receipt = read_strict_json(path)
+    except ControlPlaneError:
+        return False, "receipt-malformed"
+    expected_fields = set(_receipt_payload(identity))
+    if set(receipt) != expected_fields:
+        return False, "receipt-fields"
+    expected = _receipt_payload(identity)
+    expected.pop("observed_at_utc")
+    actual = dict(receipt)
+    observed = actual.pop("observed_at_utc", None)
+    if not isinstance(observed, str) or not observed:
+        return False, "receipt-time"
+    if actual != expected:
+        return False, "receipt-identity"
+    return True, "exact-pass"
+
+
+def write_receipt(path: Path, identity: EvidenceIdentity) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(_receipt_payload(identity), indent=2, sort_keys=True) + "\n"
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False
+    ) as handle:
+        handle.write(content)
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def _cli_receipt_is_allowed(path: Path, identity: EvidenceIdentity) -> bool:
+    resolved = path.resolve()
+    try:
+        if resolved == local_evidence_path(REPO_ROOT, identity.fingerprint):
+            return True
+    except VerificationError:
+        pass
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if runner_temp:
+        hosted_root = (Path(runner_temp) / "verification-evidence").resolve()
+        try:
+            resolved.relative_to(hosted_root)
+        except ValueError:
+            pass
+        else:
+            return True
+    return False
+
+
+def _write_github_output(path: Path, values: dict[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            if isinstance(value, bool):
+                rendered = "true" if value else "false"
+            elif isinstance(value, (dict, list, tuple)):
+                rendered = json.dumps(value, separators=(",", ":"), sort_keys=True)
+            else:
+                rendered = str(value).replace("\n", " ")
+            handle.write(f"{key}={rendered}\n")
+
+
+def _runtime_extra(path: Path | None) -> bytes:
+    if path is None:
+        return b""
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise VerificationError(f"cannot read runtime identity file: {path}") from exc
+
+
+def _identity_from_args(
+    args: argparse.Namespace, manifest: dict[str, Any]
+) -> EvidenceIdentity:
+    context = FingerprintContext(
+        manifest,
+        runtime_extra=_runtime_extra(args.runtime_file),
+    )
+    return context.identity(
+        profile=args.profile,
+        domains=args.domain,
+        command=args.identity_command or [args.profile],
+    )
+
+
+def _add_identity_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--domain", action="append", required=True)
+    parser.add_argument("--identity-command", action="append")
+    parser.add_argument("--runtime-file", type=Path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser(
+        "validate", help="Validate manifest and live path coverage"
+    )
+    validate.add_argument("--json", action="store_true")
+
+    plan = sub.add_parser("plan", help="Classify changed paths into validation domains")
+    plan.add_argument("--base")
+    plan.add_argument("--head", default="HEAD")
+    plan.add_argument("--no-worktree", action="store_true")
+    plan.add_argument("--path", action="append", dest="paths")
+    plan.add_argument("--json", action="store_true")
+    plan.add_argument("--github-output", type=Path)
+
+    fingerprint = sub.add_parser(
+        "fingerprint", help="Compute an exact evidence identity"
+    )
+    _add_identity_args(fingerprint)
+    fingerprint.add_argument("--json", action="store_true")
+    fingerprint.add_argument("--github-output", type=Path)
+
+    probe = sub.add_parser(
+        "probe", help="Probe an exact PASS receipt without failing on a miss"
+    )
+    _add_identity_args(probe)
+    probe.add_argument("--receipt", type=Path, required=True)
+    probe.add_argument("--github-output", type=Path)
+
+    record = sub.add_parser("record", help="Record PASS for the exact current identity")
+    _add_identity_args(record)
+    record.add_argument("--receipt", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        manifest = load_manifest(require_coverage=args.command == "validate")
+        if args.command == "validate":
+            result = {
+                "status": "pass",
+                "schema_version": manifest["schema_version"],
+                "domains": list(manifest["domains"]),
+                "rules": len(manifest["rules"]),
+                "unknown_impact": manifest["metadata"]["unknown_impact"],
+            }
+            if args.json:
+                print(json.dumps(result, indent=2))
+            else:
+                print(
+                    "Verification manifest: PASS "
+                    f"({len(manifest['domains'])} domains; {len(manifest['rules'])} rules; unknown -> all)"
+                )
+            return 0
+
+        if args.command == "plan":
+            plan = plan_changes(
+                manifest,
+                base=args.base,
+                head=args.head,
+                include_worktree=not args.no_worktree,
+                paths=args.paths,
+            )
+            result = plan.as_dict(manifest["domains"])
+            if args.github_output:
+                outputs = {**result["domain_flags"]}
+                outputs.update(
+                    {
+                        "fail_closed": plan.fail_closed,
+                        "changed_paths": list(plan.changed_paths),
+                        "unknown_paths": list(plan.unknown_paths),
+                        "failure_reasons": list(plan.failure_reasons),
+                    }
+                )
+                _write_github_output(args.github_output, outputs)
+            if args.json:
+                print(json.dumps(result, indent=2))
+            else:
+                label = ", ".join(plan.domains) or "none"
+                print(f"Verification domains: {label}")
+                if plan.fail_closed:
+                    print("Fail-closed reason: unknown impact selected every domain")
+            return 0
+
+        identity = _identity_from_args(args, manifest)
+        identity_result = {
+            "fingerprint": identity.fingerprint,
+            "profile": identity.profile,
+            "domains": list(identity.domains),
+            "runtime_digest": identity.runtime_digest,
+            "input_count": identity.input_count,
+        }
+        if args.command == "fingerprint":
+            if args.github_output:
+                _write_github_output(args.github_output, identity_result)
+            if args.json:
+                print(json.dumps(identity_result, indent=2))
+            else:
+                print(identity.fingerprint)
+            return 0
+        if args.command == "probe":
+            valid, reason = probe_receipt(args.receipt, identity)
+            result = {**identity_result, "valid": valid, "reason": reason}
+            if args.github_output:
+                _write_github_output(args.github_output, result)
+            print(json.dumps(result, indent=2))
+            return 0
+        if args.command == "record":
+            if not _cli_receipt_is_allowed(args.receipt, identity):
+                raise VerificationError(
+                    "receipt writes are limited to the Git-common evidence store "
+                    "or RUNNER_TEMP/verification-evidence"
+                )
+            write_receipt(args.receipt, identity)
+            print(f"Recorded exact PASS evidence: {args.receipt}")
+            return 0
+    except VerificationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- replace separate local and hosted change maps with one strict seven-domain verification manifest
- add exact content/runtime PASS receipts for local checks and GitHub Actions, with independent receipt validation
- consolidate overlapping pre-commit checks and assign hosted commands to their natural domains
- fail closed for unknown paths, Git discovery failures, invalid manifests, missing applicability, and incomplete PR gates
- keep product code, scanner redesign, release publication, and branch retirement outside MAINT-012C

## Validation

- focused verification/control/workflow regression suites passed
- changed Python formatting and lint checks passed
- fresh quick gate: 10/10 passed
- full gate: 31/31 passed
- normal commit hooks passed
- final read-only session validation passed on clean commit 56eff4d357ca62332fb0e50c6a55c2336af57c65

## Safety properties

- unknown or newly unmapped paths select all domains and strict validation prevents missing ownership from merging green
- Git-state checks remain fresh and are never reused
- hosted evidence uses exact cache keys without prefix restore
- a PASS receipt is accepted only when command, owned bytes, verifier implementation, platform, and installed runtime identity still match