### PR TITLE
fix(governance): make efficiency controls executable

### DIFF
--- a/.github/skills/agent-evolution/SKILL.md
+++ b/.github/skills/agent-evolution/SKILL.md
@@ -48,6 +48,12 @@ managed trend artifact.
 
 Review each proposal against the underlying sessions. Correlation or a single bad run is not a root cause.
 
+This threshold governs behavior- or performance-based instruction evolution.
+It does not delay a deterministic executable contract repair when source and a
+focused regression prove the contradiction and the user explicitly authorizes
+the bounded repair. Record that path as a normal control-plane task rather than
+fabricating an evolution proposal or ID.
+
 ## Apply or Roll Back
 
 Preview one exact proposal ID:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,13 @@ The canonical policy is [docs/guidelines/ai-token-efficiency.md](docs/guidelines
   packets are integrated. Run either broad gate earlier only when an
   outcome-changing failure or repository-wide surface makes it necessary;
   never bypass required hosted checks.
-- Use `/status` and Settings → Usage for Codex usage. Run `./run.sh efficiency check` for repository-side policy validation.
+- Route changed paths by their maintained callers and outcome owners. A shared
+  folder name alone must not select unrelated product domains; unknown or
+  unclassified impact still fails closed to every domain.
+- Use `/status` and Settings → Usage for Codex usage. Run `./run.sh efficiency
+  check` for repository-side policy validation, and record the required
+  non-overlapping timing/candidate/retry counters with a closeout
+  `./run.sh session usage` checkpoint.
 - Run `./run.sh model "task"` only when the user asks for a recommendation,
   has not selected a model, or has delegated model choice. The picker is
   advisory: Luna-first for clear repeatable work, Terra for normal or high-risk
@@ -291,7 +297,9 @@ repair candidate, not a routine status/documentation commit.
 before candidate freeze when explicitly needed. Review all resulting writes,
 create the candidate commit, and rerun `session end` without `--fix`. A
 preparation run that otherwise passes exits `2`, never `0`, so automation
-cannot mistake it for the final verdict.
+cannot mistake it for the final verdict. Expected dirty preparation content
+does not by itself change that `2`; unknown Git state, an operation/conflict,
+missing receipt, or another failed preparation check still exits `1`.
 
 Log feedback only when a concrete stale instruction or missing control was found. `session summary`, `session sync`, and `session end` are read-only by default; `--write` or `--fix` must be intentional. Agent evolution is scheduled governance work, not a mandatory session-end mutation.
 

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -392,11 +392,13 @@ def test_session_end_fix_never_writes_indexes_or_claims_final_closeout(
     args.fix = True
     monkeypatch.setattr(session, "_do_handoff", lambda **_kwargs: (True, "prepared"))
 
-    assert session.cmd_end(args) == 1
+    assert session.cmd_end(args) == 2
     output = capsys.readouterr().out
     assert authority_calls == [["collect_repository_state"]]
     assert "Repository Context" in output
     assert "Preparation mode completed; this is not a final closeout verdict" in output
+    assert "Dirty content is allowed only for preparation" in output
+    assert "Exit status 2: final read-only validation is still required" in output
     assert "Safe to end session" not in output
     assert all(
         "generate_enhanced_index.py" not in command
@@ -420,6 +422,26 @@ def test_session_end_fix_clean_preparation_cannot_exit_as_final_success(
     assert "Preparation mode completed; this is not a final closeout verdict" in output
     assert "Exit status 2: final read-only validation is still required" in output
     assert "Safe to end session" not in output
+
+
+def test_session_end_fix_missing_receipt_remains_a_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _authority_calls, args = _patch_cmd_end_dependencies(
+        monkeypatch, _closeout_state(clean=False, paths=["docs/SESSION_LOG.md"])
+    )
+    args.fix = True
+    monkeypatch.setattr(session, "_do_handoff", lambda **_kwargs: (True, "prepared"))
+    monkeypatch.setattr(
+        session,
+        "_resolve_git_receipt",
+        lambda _block, _path: (None, None, ["missing task-to-Git receipt"]),
+    )
+
+    assert session.cmd_end(args) == 1
+    output = capsys.readouterr().out
+    assert "missing task-to-Git receipt" in output
+    assert "Exit status 2" not in output
 
 
 def test_session_end_query_failure_cannot_pass_or_print_clean(
@@ -979,6 +1001,85 @@ def test_usage_checkpoint_records_observable_fields_only(
     assert entry["billing_tokens"] is None
     assert entry["billing_cost"] is None
     assert entry["verification"] == ["targeted tests pass"]
+
+
+def _complete_efficiency_closeout_args() -> list[str]:
+    arguments = [
+        "usage",
+        "--checkpoint",
+        "closeout",
+        "--task-id",
+        "MAINT-0131",
+        "--candidate-head",
+        "abc1234",
+        "--audit-rejections",
+        "1",
+        "--repair-batches",
+        "1",
+        "--focused-gate-retries",
+        "2",
+        "--full-gate-runs",
+        "1",
+        "--hosted-validation-runs",
+        "1",
+    ]
+    minutes = (2, 10, 3, 4, 5, 6, 1)
+    for label, value in zip(session.EFFICIENCY_PHASES, minutes, strict=True):
+        arguments.extend(["--phase", f"{label}={value}"])
+    return arguments
+
+
+def test_closeout_usage_requires_complete_efficiency_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    usage_log = tmp_path / "model_usage.jsonl"
+    monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    args = session.build_parser().parse_args(
+        ["usage", "--checkpoint", "closeout", "--candidate-head", "abc1234"]
+    )
+
+    assert session.cmd_usage(args) == 1
+    assert not usage_log.exists()
+    assert "closeout efficiency evidence incomplete" in capsys.readouterr().err
+
+
+def test_closeout_usage_records_non_overlapping_timing_and_retry_metrics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    usage_log = tmp_path / "model_usage.jsonl"
+    monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    monkeypatch.setattr(
+        session,
+        "_git_checkpoint_state",
+        lambda: {"branch": "task/TEST", "head": "abc1234", "working_tree_files": 0},
+    )
+    args = session.build_parser().parse_args(_complete_efficiency_closeout_args())
+
+    assert session.cmd_usage(args) == 0
+    entry = json.loads(usage_log.read_text(encoding="utf-8"))
+    efficiency = entry["efficiency"]
+    assert entry["elapsed_min"] == 31
+    assert efficiency["total_wall_time_min"] == 31
+    assert efficiency["candidate_heads"] == ["abc1234"]
+    assert efficiency["audit_rejections"] == 1
+    assert efficiency["repair_batches"] == 1
+    assert efficiency["focused_gate_retries"] == 2
+    assert efficiency["full_gate_runs"] == 1
+    assert efficiency["hosted_validation_runs"] == 1
+    assert efficiency["rework_minutes"] == 4
+    assert efficiency["network_wait_minutes"] == 6
+
+
+def test_closeout_usage_rejects_elapsed_total_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    usage_log = tmp_path / "model_usage.jsonl"
+    monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    arguments = _complete_efficiency_closeout_args() + ["--elapsed-min", "99"]
+
+    assert session.cmd_usage(session.build_parser().parse_args(arguments)) == 1
+    assert not usage_log.exists()
+    assert "do not equal phase total" in capsys.readouterr().err
 
 
 def test_tool_registry_discovers_all_copilot_skills():

--- a/Python/tests/test_verification_control.py
+++ b/Python/tests/test_verification_control.py
@@ -73,6 +73,19 @@ def test_manifest_rejects_duplicate_keys_and_unknown_fields(tmp_path):
             {"fastapi", "control_plane"},
         ),
         ("scripts/safe_file_move.py", {"control_plane", "repository"}),
+        (
+            "scripts/_lib/safe_file_ops.py",
+            {"control_plane", "docs", "repository"},
+        ),
+        (
+            "scripts/_lib/indian_code_manifest.py",
+            {"python", "control_plane", "docs"},
+        ),
+        (
+            "scripts/_lib/utils.py",
+            {"python", "fastapi", "control_plane", "docs", "repository"},
+        ),
+        ("scripts/_lib/agent_data.py", {"control_plane"}),
         ("scripts/check_links.py", {"control_plane", "docs"}),
         (
             ".github/actions/verification-evidence/action.yml",

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,104 @@
 
 ---
 
+## 2026-08-23 — Session: MAINT-0131 measurable efficiency controls
+
+**Agent:** Codex (`governance`, sole writer)
+
+**Branch:** `codex/maint-0131-efficiency-controls`, from exact fetched
+`origin/main` commit `58ecc149bd4525ae92c4affb369851919fe1c402`.
+
+**Git handoff receipt:**
+`docs/verification/maint-0131-git-handoff-receipt.json`
+
+**Focus:** Turn the reproduced MAINT-0130 efficiency defects into narrow,
+executable controls without changing product or safe-file behavior.
+
+### Summary
+
+- Made dirty content an expected preparation-only state for `session end --fix`
+  while preserving fail-closed handling for unknown Git state, operations,
+  missing receipts, and every other failed preparation check.
+- Replaced the blanket `scripts/_lib/**` all-domain rule with explicit
+  maintained-caller mappings for shared utilities, AST helpers, Indian-code
+  manifests, and safe-file primitives; control-only agent helpers retain the
+  generic control owner, and unknown impact still selects all domains.
+- Added a direct executable-mode regression for the two public safe-file
+  compatibility entrypoints.
+- Made closeout timing evidence executable in the ignored local usage ledger:
+  all seven non-overlapping phases, exact candidate heads, and rejection,
+  repair, retry, full-gate, and hosted-run counters are required and validated.
+
+### Instruction decision record
+
+- Evidence session: Codex task `01a02ce0-3608-7a32-afae-e69019d14822`
+  and its merged MAINT-0130 record below.
+- Repeated behavior: broad domain scheduling, preparation exit contradiction,
+  late repair candidates, and omitted closeout timing metrics.
+- Confirmed root cause: deterministic source/contract mismatches, not a model
+  preference or a correlation inferred from one score.
+- Exact instructions changed: the mandatory efficiency summary, canonical
+  efficiency policy, end-of-session workflow, Git workflow, and the
+  agent-evolution deterministic-repair boundary.
+- Expected measurable effect: safe-file helper changes select only maintained
+  control/docs/repository owners; otherwise passing dirty preparation exits `2`;
+  incomplete timing closeout fails before writing; candidate and hosted reruns
+  are visible in one local report.
+- Approval: the user explicitly authorized the bounded implementation with
+  “okay do it” on 2026-08-23.
+- Evolution/rollback identity: no automatic evolution proposal or ID was
+  fabricated; this is normal regression-backed control work. Rollback remains
+  the exact MAINT-0131 candidate commit through an ordinary reviewed revert.
+
+### Issues encountered
+
+- The protected primary `main` was clean but one commit behind merged
+  `origin/main`; editing there would have omitted MAINT-0130.
+- The verification manifest assigned every product domain to every helper in
+  `scripts/_lib`, even though those helpers have different maintained callers.
+- `session end --fix` reused the final clean-tree verdict for a phase that is
+  required to run before the candidate is committed.
+- The canonical policy required closeout timing/candidate/retry fields, but the
+  usage command accepted and stored an incomplete closeout checkpoint.
+- The prior safe-file rewrite lost two executable bits without an invariant
+  that protected those public compatibility entrypoints.
+
+### Root causes and resolutions
+
+- Confirmed root cause: the primary checkout had not been fast-forwarded after
+  PR #844. Resolution: create one clean source-bound worktree directly from
+  exact `origin/main` and preserve every existing lane.
+- Confirmed root cause: `classify_paths` unions every matching rule, so a later
+  specific rule could not override the blanket `scripts/_lib/**` all-domain
+  owner. Resolution: remove that blanket and explicitly map outcome-changing
+  helper families while retaining generic control-plane coverage and unknown
+  fail-closed behavior.
+- Confirmed root cause: `cmd_end` marked dirty evidence failed before applying
+  its preparation-only return contract. Resolution: allow only `DIRTY` in
+  preparation mode; `UNKNOWN`, operation/conflict, receipt, and other failures
+  remain status `1`, while plain final validation still requires `CLEAN`.
+- Confirmed root cause: timing labels lived only in prose and the ledger schema
+  had no completeness or sum checks. Resolution: validate canonical labels,
+  non-negative finite minutes, exact total, candidate heads, and every required
+  counter before appending a closeout checkpoint.
+- Confirmed root cause: executable compatibility was accidental file metadata.
+  Resolution: add one focused regression for the two public entrypoints rather
+  than create a second executable registry.
+
+### Verification
+
+- The complete affected selection passes: 235 tests across session automation,
+  verification routing/evidence, migration entrypoints, Git guidance,
+  token-efficiency semantics, and control-plane contracts.
+- Verification-manifest validation passes with seven domains, 28 rules, and
+  unknown impact selecting all domains. Instruction drift, task format, active
+  script references, token-efficiency controls, and canonical context pass.
+- Live preparation on the 15-path dirty candidate validates the exact HOLD
+  receipt and exits `2`; it updates only the maintained handoff block and never
+  prints the final safe-closeout verdict.
+- The immutable candidate still requires one quick gate, one cumulative full
+  gate, ordinary commit hooks, and all applicable hosted checks.
+
 ## 2026-08-23 — Session: MAINT-0130 transactional safe-file foundation
 
 **Agent:** Codex (`governance`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-23 — MAINT-0130 safe-file prerequisite implemented for candidate closeout
+**Updated:** 2026-08-23 — MAINT-0131 efficiency controls active on merged MAINT-0130 baseline
 
 ---
 
@@ -127,11 +127,12 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| MAINT-0130 | Replace inconsistent move/delete/link/batch/migrator behavior with one fail-closed transactional safe-file system and retire age-only archival | Main Agent + governance | L | P0 | ✅ COMPLETE ON MERGE — source-bound candidate requires focused, quick/full, ordinary-hook, and hosted proof before bulk cleanup is unblocked |
+| MAINT-0131 | Repair closeout preparation semantics, helper-level verification routing, safe-file executable compatibility, and measurable efficiency closeout | Main Agent + governance | M | P0 | 🟡 CANDIDATE — focused 235-test/control proof and live preparation exit `2` pass; final local and hosted gates pending |
+| MAINT-0130 | Replace inconsistent move/delete/link/batch/migrator behavior with one fail-closed transactional safe-file system and retire age-only archival | Main Agent + governance | L | P0 | ✅ MERGED — PR #844 at `58ecc149`; bulk cleanup still needs a separately classified and authorized plan |
 
-No bulk cleanup or automatic archival is authorized by this packet. Content
-movement remains held until the exact MAINT-0130 candidate is merged and its
-required evidence is green.
+No bulk cleanup or automatic archival is authorized by this packet. MAINT-0130
+is merged and green, but content movement remains held until a separate exact
+cleanup plan is classified, reviewed, and authorized.
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. The reproduced public-route safety packet is integrated. INDIA-3,

--- a/docs/contributing/end-of-session-workflow.md
+++ b/docs/contributing/end-of-session-workflow.md
@@ -54,7 +54,9 @@ tags: []
 
 This is preparation mode, not a final closeout verdict. It may update handoff
 or task files, but it never generates indexes. Review its writes before the
-candidate freeze.
+candidate freeze. A dirty candidate is expected here and is reported as
+preparation evidence; unknown/contradictory Git state, an active operation,
+missing receipt, or another failed check remains a real failure.
 
 **What it checks:**
 - ✅ Uncommitted changes (reminds you to commit)
@@ -70,14 +72,15 @@ candidate freeze.
 
 Preparation returns exit status `2` when its checks otherwise pass. That
 non-zero status is intentional: callers must not treat a potentially mutating
-preparation run as the final closeout success.
+preparation run as the final closeout success. It exits `1` for a failed
+preparation check, and only a later clean read-only run can exit `0`.
 
 **Expected output:**
 ```
 ============================================================
 🏁 END OF SESSION CHECKS
 ============================================================
-[✓] Git working tree clean
+[i] Dirty candidate recorded for preparation; final closeout still requires clean
 [✓] Session log entry exists for 2026-01-06
 [✓] Next session brief is fresh (updated today)
 [✓] No active tasks need attention

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -85,6 +85,11 @@ The stage gates are:
    integrated checks, and task/handoff/receipt truth. Retain branches and
    worktrees unless deletion is separately authorized.
 
+At closeout, record the seven non-overlapping wall-time phases, exact candidate
+heads, rejection/repair/retry counters, full-gate count, and hosted-run count in
+the ignored `session usage` ledger. This external measurement never changes the
+frozen candidate.
+
 The mutation cutoff is strict: finish versioned session/task/handoff records,
 local evidence, and the pre-commit receipt first; refresh only affected
 maintained indexes once as the final repository write; then commit the immutable

--- a/docs/guidelines/ai-token-efficiency.md
+++ b/docs/guidelines/ai-token-efficiency.md
@@ -184,6 +184,11 @@ malformed evidence is never stored or reused. Use `./run.sh check --no-reuse`
 when a genuinely fresh execution is required; changing the input invalidates the
 receipt automatically, so calendar-based cache resets are unnecessary.
 
+Changed-path routing follows maintained callers and outcome owners, not a
+headline folder category. Shared helper directories must be decomposed into
+explicit helper-level impact rules when their callers differ. A genuinely
+unknown or unclassified path remains fail-closed and selects every domain.
+
 For work requiring independent acceptance, use these stricter efficiency
 controls:
 
@@ -207,6 +212,9 @@ their sum as `total wall time`; do not count idle or network time in another
 interval. At closeout report `candidate_heads`, `audit_rejections`,
 `repair_batches`, `focused_gate_retries`, `full_gate_runs`,
 `hosted_validation_runs`, `rework_minutes`, and `network_wait_minutes`.
+The closeout `session usage` command validates all seven phase labels, computes
+their total, requires exact candidate heads and retry/run counters, and stores
+the result only in the ignored local runtime ledger.
 
 Safety-critical structural calculations still require independent reference
 validation. Token efficiency never replaces practicing-engineer review or the
@@ -233,8 +241,15 @@ IS 456 quality gate.
 ./run.sh session usage --checkpoint start --task-id TASK-XXX --task "bounded scope"
 ./run.sh session usage --checkpoint milestone --elapsed-min 120 \
   --verification "targeted tests pass" --notes "no subagents"
-./run.sh session usage --checkpoint closeout --elapsed-min 210 \
-  --verification "quick gate 9/9"
+./run.sh session usage --checkpoint closeout --task-id TASK-XXX \
+  --candidate-head abc1234 --audit-rejections 0 --repair-batches 0 \
+  --focused-gate-retries 0 --full-gate-runs 1 --hosted-validation-runs 1 \
+  --phase "contract/intake=15" \
+  --phase "writer implementation + focused verification=90" \
+  --phase "independent local audit=20" --phase "writer rework=0" \
+  --phase "final local closeout=35" --phase "hosted/network wait=40" \
+  --phase "merge + post-merge verification=10" \
+  --verification "quick and full gates pass"
 ./run.sh session usage --summary --hours 24
 ```
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,19 +4,35 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-23
-- Focus: Replace split file-operation safety with one fail-closed transactional system.
-- Git receipt: docs/verification/maint-0130-git-handoff-receipt.json | sha256:4ba9dd73d694e8b3606336222de5eb06116b73051873180da23627161dc5fa47 | HOLD
-- Git identity: codex/maint-0130-safe-file-foundation@242ba386925d29766b1467810044e276ebbceb64 | upstream=origin/main@242ba386925d29766b1467810044e276ebbceb64 | base=origin/main@242ba386925d29766b1467810044e276ebbceb64 | tree=dirty | operation=none
+- Focus: Turn the reproduced MAINT-0130 efficiency defects into narrow,
+- Git receipt: docs/verification/maint-0131-git-handoff-receipt.json | sha256:034994ac2f36c9af805e711e421da103c38159524c4a12baa5192141dd537333 | HOLD
+- Git identity: codex/maint-0131-efficiency-controls@58ecc149bd4525ae92c4affb369851919fe1c402 | upstream=origin/main@58ecc149bd4525ae92c4affb369851919fe1c402 | base=origin/main@58ecc149bd4525ae92c4affb369851919fe1c402 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
 - Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `MAINT-0130` replaces the unsafe file-operation split with one classified, fail-closed, transactional system |
-| **Next** | Freeze and prove the exact candidate locally and in hosted checks; only after merge may the separately classified cleanup plan begin |
-| **Why** | Move/delete discovery, mutation, validation, backup, and batch rollback previously disagreed, allowing false success and incomplete recovery |
+| **Current** | `MAINT-0131` repairs deterministic efficiency-control defects observed during the merged MAINT-0130 workflow |
+| **Next** | Prove closeout status, helper-level impact routing, executable compatibility, and complete timing evidence on one frozen candidate |
+| **Why** | Broad helper routing selected unrelated product jobs, dirty preparation contradicted its documented exit, and timing requirements were not executable |
 | **Held** | Bulk cleanup, automatic archival, unclassified file movement, branch/worktree deletion, product behavior, release, and professional approval |
+
+## Exact MAINT-0131 state
+
+- Branch: `codex/maint-0131-efficiency-controls`, created from merged MAINT-0130
+  baseline `58ecc149bd4525ae92c4affb369851919fe1c402`.
+- Dirty preparation is status `2` only when every non-cleanliness check passes;
+  unknown Git state, operations/conflicts, missing receipts, and final dirty
+  validation remain status `1`.
+- `scripts/_lib/safe_file_ops.py` selects control-plane, docs, and repository
+  validation rather than unrelated Python/FastAPI/React/Excel product jobs.
+  Unknown paths still select all domains.
+- Closeout usage evidence requires all seven phase timings, exact candidate
+  heads, and rejection/repair/retry/full/hosted counters before it writes the
+  ignored local ledger.
+- Focused control, instruction, and migration evidence is green; candidate
+  closeout still requires the quick/full gates, hooks, and hosted checks.
 
 ## Exact MAINT-0130 state
 

--- a/docs/verification/maint-0131-git-handoff-receipt.json
+++ b/docs/verification/maint-0131-git-handoff-receipt.json
@@ -1,0 +1,138 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "034994ac2f36c9af805e711e421da103c38159524c4a12baa5192141dd537333",
+    "state": {
+      "branch": "codex/maint-0131-efficiency-controls",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "58ecc149bd4525ae92c4affb369851919fe1c402",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 112.885,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-maint-0131-efficiency-controls",
+      "head_sha": "58ecc149bd4525ae92c4affb369851919fe1c402",
+      "hold_reasons": [
+        "changed paths: 14"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-23T05:48:25.858454+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0131-efficiency-controls",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 14,
+        "modified_paths": [
+          ".github/skills/agent-evolution/SKILL.md",
+          "AGENTS.md",
+          "Python/tests/test_session_automation.py",
+          "Python/tests/test_verification_control.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/contributing/end-of-session-workflow.md",
+          "docs/git-automation/git-workflow-single-source.md",
+          "docs/guidelines/ai-token-efficiency.md",
+          "docs/planning/next-session-brief.md",
+          "scripts/README.md",
+          "scripts/session.py",
+          "scripts/verification-manifest.json",
+          "tests/integration/test_migration_scripts.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "58ecc149bd4525ae92c4affb369851919fe1c402",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0131-efficiency-controls"
+    }
+  },
+  "local_state_receipt_hash": "sha256:034994ac2f36c9af805e711e421da103c38159524c4a12baa5192141dd537333",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-23T05:48:25.858642+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/**/*.py",
+      "fastapi_app/**/*.py",
+      "react_app/**/*.{ts,tsx}",
+      "excel_addin/**",
+      "Etabs_CSV/**",
+      "requirements*.txt"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "AGENTS.md",
+      ".github/skills/agent-evolution/SKILL.md",
+      "scripts/**",
+      "Python/tests/**",
+      "tests/**",
+      "docs/**"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "MAINT-0131"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,10 @@
 ./run.sh session end
 ```
 
+A `session usage --checkpoint closeout` record is fail-closed unless it includes
+all canonical phase timings, exact candidate heads, and the required retry/run
+counters documented in `docs/guidelines/ai-token-efficiency.md`.
+
 `run.sh` is a thin dispatcher for project validation and discovery. It does not
 stage, commit, push, create PRs, merge, or recover Git state.
 

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import subprocess
 import sys
@@ -491,6 +492,23 @@ def cmd_start(args: argparse.Namespace) -> int:
 COST_LOG = REPO_ROOT / "logs" / "agent_costs.jsonl"
 MODEL_USAGE_LOG = REPO_ROOT / "logs" / "model_usage.jsonl"
 
+EFFICIENCY_PHASES = (
+    "contract/intake",
+    "writer implementation + focused verification",
+    "independent local audit",
+    "writer rework",
+    "final local closeout",
+    "hosted/network wait",
+    "merge + post-merge verification",
+)
+EFFICIENCY_COUNTER_ARGUMENTS = (
+    ("audit_rejections", "--audit-rejections"),
+    ("repair_batches", "--repair-batches"),
+    ("focused_gate_retries", "--focused-gate-retries"),
+    ("full_gate_runs", "--full-gate-runs"),
+    ("hosted_validation_runs", "--hosted-validation-runs"),
+)
+
 
 def _log_session_cost(agent: str = "unknown") -> None:
     """Append session cost entry to logs/agent_costs.jsonl."""
@@ -679,7 +697,101 @@ def _usage_profile(entry: dict) -> str:
     return f"{model}/{reasoning}"
 
 
-def _record_usage_checkpoint(args: argparse.Namespace) -> dict:
+def _efficiency_payload(args: argparse.Namespace) -> dict[str, object] | None:
+    """Validate and normalize optional non-overlapping wall-time evidence."""
+    raw_phases = getattr(args, "phase", None) or []
+    candidate_heads = getattr(args, "candidate_head", None) or []
+    counter_values = {
+        name: getattr(args, name, None)
+        for name, _option in EFFICIENCY_COUNTER_ARGUMENTS
+    }
+    supplied = bool(raw_phases or candidate_heads) or any(
+        value is not None for value in counter_values.values()
+    )
+    if args.checkpoint != "closeout" and supplied:
+        raise ValueError("phase and candidate/retry evidence is closeout-only")
+    if args.checkpoint != "closeout":
+        return None
+
+    phases: dict[str, float] = {}
+    for raw in raw_phases:
+        label, separator, value_text = raw.partition("=")
+        label = label.strip()
+        if not separator or label not in EFFICIENCY_PHASES:
+            raise ValueError(
+                "phase must use '<canonical label>=<minutes>'; canonical labels: "
+                + ", ".join(EFFICIENCY_PHASES)
+            )
+        if label in phases:
+            raise ValueError(f"duplicate phase timing: {label}")
+        try:
+            minutes = float(value_text)
+        except ValueError as exc:
+            raise ValueError(f"phase minutes must be numeric: {raw}") from exc
+        if not math.isfinite(minutes) or minutes < 0:
+            raise ValueError(f"phase minutes must be finite and non-negative: {raw}")
+        phases[label] = minutes
+
+    if args.checkpoint == "closeout":
+        missing_phases = [label for label in EFFICIENCY_PHASES if label not in phases]
+        missing_counters = [
+            option
+            for name, option in EFFICIENCY_COUNTER_ARGUMENTS
+            if counter_values[name] is None
+        ]
+        if missing_phases or not candidate_heads or missing_counters:
+            details: list[str] = []
+            if missing_phases:
+                details.append("missing phases: " + ", ".join(missing_phases))
+            if not candidate_heads:
+                details.append("at least one --candidate-head is required")
+            if missing_counters:
+                details.append("missing counters: " + ", ".join(missing_counters))
+            raise ValueError(
+                "closeout efficiency evidence incomplete; " + "; ".join(details)
+            )
+
+    for name, value in counter_values.items():
+        if value is not None and value < 0:
+            raise ValueError(f"{name} must be non-negative")
+    invalid_heads = [
+        head
+        for head in candidate_heads
+        if re.fullmatch(r"[0-9a-fA-F]{7,40}", head) is None
+    ]
+    if invalid_heads:
+        raise ValueError(
+            "candidate heads must be 7-40 hexadecimal characters: "
+            + ", ".join(invalid_heads)
+        )
+
+    total_wall_time = round(sum(phases.values()), 3)
+    if args.elapsed_min and not math.isclose(
+        args.elapsed_min, total_wall_time, rel_tol=0, abs_tol=0.05
+    ):
+        raise ValueError(
+            f"elapsed minutes {args.elapsed_min} do not equal phase total {total_wall_time}"
+        )
+
+    return {
+        "phase_timings_min": {
+            label: phases[label] for label in EFFICIENCY_PHASES if label in phases
+        },
+        "total_wall_time_min": total_wall_time,
+        "candidate_heads": list(dict.fromkeys(candidate_heads)),
+        "audit_rejections": counter_values["audit_rejections"],
+        "repair_batches": counter_values["repair_batches"],
+        "focused_gate_retries": counter_values["focused_gate_retries"],
+        "full_gate_runs": counter_values["full_gate_runs"],
+        "hosted_validation_runs": counter_values["hosted_validation_runs"],
+        "rework_minutes": phases.get("writer rework", 0.0),
+        "network_wait_minutes": phases.get("hosted/network wait", 0.0),
+    }
+
+
+def _record_usage_checkpoint(
+    args: argparse.Namespace, efficiency: dict[str, object] | None = None
+) -> dict:
     """Append an observable model/agent checkpoint without estimating billing."""
     entry = {
         "schema_version": 1,
@@ -692,7 +804,9 @@ def _record_usage_checkpoint(args: argparse.Namespace) -> dict:
         "parent_agents": args.parent_agents,
         "subagents": args.subagents,
         "worker_models": args.worker_model or [],
-        "elapsed_min": args.elapsed_min,
+        "elapsed_min": (
+            efficiency["total_wall_time_min"] if efficiency else args.elapsed_min
+        ),
         "dashboard": {
             "weekly_remaining_pct": args.weekly_remaining,
             "turns": args.turns,
@@ -707,6 +821,8 @@ def _record_usage_checkpoint(args: argparse.Namespace) -> dict:
             "No token or billing estimate is inferred."
         ),
     }
+    if efficiency is not None:
+        entry["efficiency"] = efficiency
     MODEL_USAGE_LOG.parent.mkdir(parents=True, exist_ok=True)
     with MODEL_USAGE_LOG.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(entry, sort_keys=True) + "\n")
@@ -716,7 +832,12 @@ def _record_usage_checkpoint(args: argparse.Namespace) -> dict:
 def cmd_usage(args: argparse.Namespace) -> int:
     """Record or summarize model, agent, elapsed-time, and usage checkpoints."""
     if args.checkpoint:
-        entry = _record_usage_checkpoint(args)
+        try:
+            efficiency = _efficiency_payload(args)
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+        entry = _record_usage_checkpoint(args, efficiency)
         if args.json_output:
             print(json.dumps(entry, indent=2))
         else:
@@ -728,6 +849,13 @@ def cmd_usage(args: argparse.Namespace) -> int:
             print(
                 "Token/cost fields remain empty unless an authoritative source is added."
             )
+            if efficiency is not None:
+                print(
+                    "Efficiency closeout: "
+                    f"{efficiency['total_wall_time_min']}m | "
+                    f"candidate heads {len(efficiency['candidate_heads'])} | "
+                    f"hosted runs {efficiency['hosted_validation_runs']}"
+                )
         return 0
 
     entries = _read_jsonl(MODEL_USAGE_LOG)
@@ -761,6 +889,15 @@ def cmd_usage(args: argparse.Namespace) -> int:
             ),
             "billing_tokens": None,
             "billing_cost": None,
+            "latest_efficiency_closeout": next(
+                (
+                    entry.get("efficiency")
+                    for entry in reversed(entries)
+                    if entry.get("checkpoint") == "closeout"
+                    and entry.get("efficiency") is not None
+                ),
+                None,
+            ),
         }
         if args.json_output:
             print(json.dumps(summary, indent=2))
@@ -776,6 +913,12 @@ def cmd_usage(args: argparse.Namespace) -> int:
                     f"{summary['latest_weekly_remaining_pct']}%"
                 )
             print("  Billing tokens/cost: unavailable (not estimated)")
+            if summary["latest_efficiency_closeout"] is not None:
+                efficiency = summary["latest_efficiency_closeout"]
+                print(
+                    "  Latest closeout wall time: "
+                    f"{efficiency['total_wall_time_min']}m"
+                )
         return 0
 
     selected = entries[-args.last :]
@@ -847,19 +990,28 @@ def get_closeout_git_evidence() -> tuple[str, list[str], str]:
 
 def report_closeout_git_evidence(
     evidence: tuple[str, list[str], str] | None = None,
+    *,
+    allow_dirty_preparation: bool = False,
 ) -> bool:
-    """Print fail-closed closeout evidence; return true only for CLEAN."""
+    """Print fail-closed evidence; optionally accept DIRTY for preparation only."""
     print("📁 Uncommitted Changes:")
     status, paths, reason = evidence or get_closeout_git_evidence()
     if status == "UNKNOWN":
         print(f"  ⚠️  Git state UNKNOWN/hold: {reason}")
         return False
     if status == "DIRTY":
-        print(f"  ⚠️  {len(paths)} uncommitted file(s):")
+        marker = "ℹ️ " if allow_dirty_preparation else "⚠️ "
+        print(f"  {marker} {len(paths)} uncommitted file(s):")
         for path in paths[:5]:
             print(f"     {path}")
         if len(paths) > 5:
             print(f"     ... and {len(paths) - 5} more")
+        if allow_dirty_preparation:
+            print(
+                "  ℹ️  Dirty content is allowed only for preparation; "
+                "final closeout still requires CLEAN."
+            )
+            return True
         return False
     print("  ✅ Working tree clean (scripts/git_state.py)")
     return True
@@ -974,7 +1126,9 @@ def cmd_end(args: argparse.Namespace) -> int:
 
     # 1. Uncommitted changes
     closeout_evidence = get_closeout_git_evidence()
-    if not report_closeout_git_evidence(closeout_evidence):
+    if not report_closeout_git_evidence(
+        closeout_evidence, allow_dirty_preparation=args.fix
+    ):
         all_passed = False
     print()
 
@@ -2495,6 +2649,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_usage.add_argument(
         "--verification", action="append", help="Check/test evidence; repeatable"
     )
+    p_usage.add_argument(
+        "--phase",
+        action="append",
+        help="Closeout phase as '<canonical label>=<minutes>'; repeat all seven",
+    )
+    p_usage.add_argument(
+        "--candidate-head",
+        action="append",
+        help="Exact candidate head identifier; repeat for every candidate",
+    )
+    p_usage.add_argument("--audit-rejections", type=int)
+    p_usage.add_argument("--repair-batches", type=int)
+    p_usage.add_argument("--focused-gate-retries", type=int)
+    p_usage.add_argument("--full-gate-runs", type=int)
+    p_usage.add_argument("--hosted-validation-runs", type=int)
     p_usage.add_argument("--notes", default="")
     p_usage.add_argument("--last", type=int, default=10)
     p_usage.add_argument("--hours", type=float, help="Limit display/summary window")

--- a/scripts/verification-manifest.json
+++ b/scripts/verification-manifest.json
@@ -76,8 +76,24 @@
       "domains": ["excel"]
     },
     {
-      "paths": ["scripts/verification.py", "scripts/verification-manifest.json", "scripts/verification-manifest.schema.json", "scripts/check_all.py", "scripts/control_plane/**", "scripts/_lib/**", ".github/workflows/fast-checks.yml", ".github/actions/verification-evidence/**"],
+      "paths": ["scripts/verification.py", "scripts/verification-manifest.json", "scripts/verification-manifest.schema.json", "scripts/check_all.py", "scripts/control_plane/**", ".github/workflows/fast-checks.yml", ".github/actions/verification-evidence/**"],
       "domains": ["python", "fastapi", "react", "excel", "control_plane", "docs", "repository"]
+    },
+    {
+      "paths": ["scripts/_lib/utils.py"],
+      "domains": ["python", "fastapi", "control_plane", "docs", "repository"]
+    },
+    {
+      "paths": ["scripts/_lib/ast_helpers.py"],
+      "domains": ["python", "fastapi", "control_plane"]
+    },
+    {
+      "paths": ["scripts/_lib/indian_code_manifest.py"],
+      "domains": ["python", "control_plane", "docs"]
+    },
+    {
+      "paths": ["scripts/_lib/safe_file_ops.py"],
+      "domains": ["control_plane", "docs", "repository"]
     },
     {
       "paths": ["scripts/python_runtime.sh", "scripts/check_api.py", "scripts/validate_api_contracts.py", "scripts/generate_api_manifest.py", "scripts/generate_api_classification.py", "scripts/check_architecture_boundaries.py", "scripts/check_circular_imports.py", "scripts/validate_imports.py", "scripts/check_type_annotations.py", "scripts/check_governance.py"],

--- a/tests/integration/test_migration_scripts.py
+++ b/tests/integration/test_migration_scripts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -14,6 +15,12 @@ SCRIPTS_DIR = REPO_ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 safe_file_move = importlib.import_module("safe_file_move")
+
+
+def test_public_safe_file_entrypoints_keep_executable_compatibility() -> None:
+    for name in ("safe_file_move.py", "safe_file_delete.py"):
+        mode = (SCRIPTS_DIR / name).stat().st_mode
+        assert mode & stat.S_IXUSR, f"scripts/{name} lost its executable file mode"
 
 
 def _load_golden(name: str) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- repair `session end --fix` so otherwise-passing dirty preparation exits 2 while final dirty/unknown/missing-receipt states still fail
- replace blanket `scripts/_lib/**` all-domain impact with maintained-caller helper mappings while preserving unknown -> all
- require complete non-overlapping closeout timing, exact candidate heads, and retry/run counters in the ignored usage ledger
- protect safe-file executable compatibility and align the bounded canonical instructions

## Verification

- affected control/instruction/migration selection: 235 tests passed
- verification manifest: 7 domains, 28 rules, unknown -> all
- live dirty preparation: valid HOLD receipt, exit 2
- quick gate: 10/10, 0 reused
- full gate: 31/31, 8 exact quick receipts reused
- normal commit hooks: passed
- clean read-only session closeout: exit 0

## Boundaries

No product code, bulk cleanup, release, branch deletion, or worktree deletion is included.