### PR TITLE
chore(governance): measure session efficiency end to end

### DIFF
--- a/.github/skills/session-management/SKILL.md
+++ b/.github/skills/session-management/SKILL.md
@@ -15,14 +15,18 @@ Use the canonical `run.sh` entry points from the workspace root. Do not repeat t
 
 ## Session Start
 
-Run once, in this order:
+Run once for one exact task:
 
 ```bash
-./run.sh session brief --agent <role>
-./run.sh session start
+./run.sh session begin --task-id <task> --agent <role>
 ```
 
-The brief is the bounded orientation packet; session start verifies the environment and current project state. Use `./run.sh session context` only when the brief does not contain enough information for the task.
+`session begin` starts the shared task timer before printing the bounded brief,
+then verifies the environment and current project state. Use
+`./run.sh session context` only when the brief does not contain enough
+information for the task. `session brief` and `session start` remain read-only/
+compatibility entry points, but using them separately does not create complete
+end-to-end timing evidence.
 
 Before editing, confirm the branch and working tree shown by session start. Preserve unrelated user changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,10 @@ The canonical policy is [docs/guidelines/ai-token-efficiency.md](docs/guidelines
 - Never pass full parent history to a subagent. Send a concise packet with the objective, exact files, constraints, question, commands, and expected output.
 - The orchestrator must add non-goals, likely pitfalls, measurable acceptance criteria, narrow tests, and a return format to each packet, then independently inspect and verify the result before acceptance.
 - Named handoff chains below are quality roles, not mandatory agent processes. The parent normally performs implementation, testing, documentation, and operations passes itself.
-- Start with `./run.sh session brief --agent <role>`, `./run.sh context show <area>`, and targeted `rg`; do not load full agent files or large logs unless required.
+- Start one exact task with `./run.sh session begin --task-id <task> --agent <role>`;
+  it records timing before the compact brief and environment check. Then use
+  targeted `rg` and `./run.sh context show <area>` only when the brief cannot
+  answer a concrete question; do not load full agent files or large logs by default.
 - Use implementation-first, batched verification for each agreed bounded packet.
   Complete the scoped code, tests, documentation, and other intended writes
   before the routine verification sequence. While implementing, run only a
@@ -273,9 +276,8 @@ This feeds the improvement loop — recurring issues get fixed in agent instruct
 ## Session Workflow (MANDATORY)
 
 ```bash
-# START: bounded orientation + environment check
-./run.sh session brief --agent <role>
-./run.sh session start
+# START: task-bound timer + bounded orientation + environment check
+./run.sh session begin --task-id <task> --agent <role>
 
 # END: update task/handoff only when state changed, then use Codex Git/GitHub
 ./run.sh check --quick

--- a/Python/tests/test_control_plane.py
+++ b/Python/tests/test_control_plane.py
@@ -49,8 +49,8 @@ def test_current_registry_has_frozen_operation_and_script_parity():
     all_operations = control_plane.operation_map(registry)
     active_operations = control_plane.operation_map(registry, active_only=True)
 
-    assert len(all_operations) == 114
-    assert len(active_operations) == 114
+    assert len(all_operations) == 115
+    assert len(active_operations) == 115
     assert len(control_plane.top_level_scripts()) == 101
     assert control_plane.referenced_top_level_scripts(registry) == (
         control_plane.top_level_scripts()

--- a/Python/tests/test_session_automation.py
+++ b/Python/tests/test_session_automation.py
@@ -609,7 +609,9 @@ def test_task_brief_reports_lane_route_and_safe_workflow(
 
     assert brief["lane"] is lane
     assert brief["route"]["agent"]
-    assert brief["workflow"]["start"][0].startswith("./run.sh session brief")
+    assert brief["workflow"]["start"] == [
+        "./run.sh session begin --task-id <TASK-ID> --agent " + brief["route"]["agent"]
+    ]
     assert "inspection-only" in brief["workflow"]["git_rule"]
 
 
@@ -774,6 +776,30 @@ def test_active_task_reader_accepts_current_and_legacy_headings(
     monkeypatch.setattr(session, "TASKS_MD", tasks)
 
     assert session.get_active_tasks() == [("MAINT-005", "Finish maintenance", "")]
+
+
+def test_active_tasks_hide_exact_external_closeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    tasks = tmp_path / "TASKS.md"
+    tasks.write_text(
+        """# Tasks
+
+## Active
+
+| ID | Task | Owner | Status |
+|----|------|-------|--------|
+| MAINT-0131 | Already merged | Main Agent | CANDIDATE |
+| MAINT-0132 | Current work | Main Agent | ACTIVE |
+
+## Up Next
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(session, "TASKS_MD", tasks)
+    monkeypatch.setattr(session, "_externally_closed_task_ids", lambda: {"MAINT-0131"})
+
+    assert session.get_active_tasks() == [("MAINT-0132", "Current work", "")]
 
 
 def test_commit_summary_uses_exclusive_previous_day_boundary(
@@ -1003,15 +1029,38 @@ def test_usage_checkpoint_records_observable_fields_only(
     assert entry["verification"] == ["targeted tests pass"]
 
 
+USAGE_NOW = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+
+
+def _write_usage_start(
+    path: Path, *, task_id: str = "MAINT-0132", minutes_ago: float = 31
+) -> None:
+    started = USAGE_NOW - timedelta(minutes=minutes_ago)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "timestamp": started.isoformat(timespec="seconds"),
+                "checkpoint": "start",
+                "task_id": task_id,
+                "model": "unknown",
+                "reasoning": "unknown",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def _complete_efficiency_closeout_args() -> list[str]:
     arguments = [
         "usage",
         "--checkpoint",
         "closeout",
         "--task-id",
-        "MAINT-0131",
+        "MAINT-0132",
         "--candidate-head",
-        "abc1234",
+        "a" * 40,
         "--audit-rejections",
         "1",
         "--repair-batches",
@@ -1021,7 +1070,7 @@ def _complete_efficiency_closeout_args() -> list[str]:
         "--full-gate-runs",
         "1",
         "--hosted-validation-runs",
-        "1",
+        "0",
     ]
     minutes = (2, 10, 3, 4, 5, 6, 1)
     for label, value in zip(session.EFFICIENCY_PHASES, minutes, strict=True):
@@ -1034,12 +1083,22 @@ def test_closeout_usage_requires_complete_efficiency_evidence(
 ):
     usage_log = tmp_path / "model_usage.jsonl"
     monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    _write_usage_start(usage_log)
+    monkeypatch.setattr(session, "_usage_now", lambda: USAGE_NOW)
     args = session.build_parser().parse_args(
-        ["usage", "--checkpoint", "closeout", "--candidate-head", "abc1234"]
+        [
+            "usage",
+            "--checkpoint",
+            "closeout",
+            "--task-id",
+            "MAINT-0132",
+            "--candidate-head",
+            "a" * 40,
+        ]
     )
 
     assert session.cmd_usage(args) == 1
-    assert not usage_log.exists()
+    assert len(usage_log.read_text(encoding="utf-8").splitlines()) == 1
     assert "closeout efficiency evidence incomplete" in capsys.readouterr().err
 
 
@@ -1048,6 +1107,11 @@ def test_closeout_usage_records_non_overlapping_timing_and_retry_metrics(
 ):
     usage_log = tmp_path / "model_usage.jsonl"
     monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    _write_usage_start(usage_log)
+    monkeypatch.setattr(session, "_usage_now", lambda: USAGE_NOW)
+    monkeypatch.setattr(
+        session, "_resolve_commit_tree", lambda value, **_kwargs: (value, "b" * 40)
+    )
     monkeypatch.setattr(
         session,
         "_git_checkpoint_state",
@@ -1056,16 +1120,16 @@ def test_closeout_usage_records_non_overlapping_timing_and_retry_metrics(
     args = session.build_parser().parse_args(_complete_efficiency_closeout_args())
 
     assert session.cmd_usage(args) == 0
-    entry = json.loads(usage_log.read_text(encoding="utf-8"))
+    entry = json.loads(usage_log.read_text(encoding="utf-8").splitlines()[-1])
     efficiency = entry["efficiency"]
     assert entry["elapsed_min"] == 31
     assert efficiency["total_wall_time_min"] == 31
-    assert efficiency["candidate_heads"] == ["abc1234"]
+    assert efficiency["candidate_heads"] == ["a" * 40]
     assert efficiency["audit_rejections"] == 1
     assert efficiency["repair_batches"] == 1
     assert efficiency["focused_gate_retries"] == 2
     assert efficiency["full_gate_runs"] == 1
-    assert efficiency["hosted_validation_runs"] == 1
+    assert efficiency["hosted_validation_runs"] == 0
     assert efficiency["rework_minutes"] == 4
     assert efficiency["network_wait_minutes"] == 6
 
@@ -1075,11 +1139,185 @@ def test_closeout_usage_rejects_elapsed_total_mismatch(
 ):
     usage_log = tmp_path / "model_usage.jsonl"
     monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    _write_usage_start(usage_log)
+    monkeypatch.setattr(session, "_usage_now", lambda: USAGE_NOW)
     arguments = _complete_efficiency_closeout_args() + ["--elapsed-min", "99"]
 
     assert session.cmd_usage(session.build_parser().parse_args(arguments)) == 1
-    assert not usage_log.exists()
-    assert "do not equal phase total" in capsys.readouterr().err
+    assert len(usage_log.read_text(encoding="utf-8").splitlines()) == 1
+    assert "do not match derived elapsed" in capsys.readouterr().err
+
+
+def test_closeout_usage_rejects_unallocated_app_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    usage_log = tmp_path / "model_usage.jsonl"
+    monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    _write_usage_start(usage_log, minutes_ago=20.25)
+    monkeypatch.setattr(session, "_usage_now", lambda: USAGE_NOW)
+    arguments = _complete_efficiency_closeout_args()
+    values = (2, 7.5, 1.5, 0.5, 4, 1.3, 1.717)
+    arguments = [
+        item
+        for item in arguments
+        if not item.startswith(tuple(session.EFFICIENCY_PHASES))
+    ]
+    # Remove the value tokens paired with the original seven --phase flags.
+    rebuilt = arguments[: arguments.index("--phase")]
+    for label, value in zip(session.EFFICIENCY_PHASES, values, strict=True):
+        rebuilt.extend(["--phase", f"{label}={value}"])
+
+    assert session.cmd_usage(session.build_parser().parse_args(rebuilt)) == 1
+    assert "unallocated time 1.733m" in capsys.readouterr().err
+
+
+def test_usage_defaults_never_infer_model_or_reasoning() -> None:
+    args = session.build_parser().parse_args(
+        ["usage", "--checkpoint", "milestone", "--task-id", "MAINT-0132"]
+    )
+
+    assert args.model == "unknown"
+    assert args.reasoning == "unknown"
+    assert (
+        session._usage_profile(
+            {"schema_version": 1, "model": "gpt-5.6-sol", "reasoning": "high"}
+        )
+        == "legacy-unverified"
+    )
+
+
+def test_closeout_rejects_short_unresolved_candidate_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    usage_log = tmp_path / "model_usage.jsonl"
+    monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    _write_usage_start(usage_log)
+    monkeypatch.setattr(session, "_usage_now", lambda: USAGE_NOW)
+    arguments = _complete_efficiency_closeout_args()
+    arguments[arguments.index("a" * 40)] = "deadbee"
+
+    assert session.cmd_usage(session.build_parser().parse_args(arguments)) == 1
+    assert "exact 40-character lowercase commit SHA" in capsys.readouterr().err
+
+
+def test_usage_event_binds_to_latest_open_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    usage_log = tmp_path / "model_usage.jsonl"
+    monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    _write_usage_start(usage_log)
+    monkeypatch.setattr(session, "_usage_now", lambda: USAGE_NOW)
+    args = session.build_parser().parse_args(
+        [
+            "usage",
+            "--event",
+            "check quick",
+            "--duration-sec",
+            "12",
+            "--result-code",
+            "0",
+        ]
+    )
+
+    assert session.cmd_usage(args) == 0
+    event = json.loads(usage_log.read_text(encoding="utf-8").splitlines()[-1])
+    assert event["task_id"] == "MAINT-0132"
+    assert event["event"] == "check quick"
+    assert event["duration_sec"] == 12
+
+
+def test_active_usage_reports_derived_elapsed_and_recorded_steps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    usage_log = tmp_path / "model_usage.jsonl"
+    monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    _write_usage_start(usage_log, minutes_ago=20.25)
+    monkeypatch.setattr(session, "_usage_now", lambda: USAGE_NOW)
+    with usage_log.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "timestamp": USAGE_NOW.isoformat(timespec="seconds"),
+                    "checkpoint": "event",
+                    "task_id": "MAINT-0132",
+                    "event": "check quick",
+                    "duration_sec": 12,
+                    "result_code": 0,
+                }
+            )
+            + "\n"
+        )
+    args = session.build_parser().parse_args(["usage", "--active", "--json"])
+
+    assert session.cmd_usage(args) == 0
+    active = session._active_usage_payload(session._read_jsonl(usage_log), USAGE_NOW)
+    assert active is not None
+    assert active["derived_elapsed_min"] == 20.25
+    assert active["recorded_steps"][0]["event"] == "check quick"
+
+
+def test_closeout_integration_projects_externally_closed_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    usage_log = tmp_path / "model_usage.jsonl"
+    monkeypatch.setattr(session, "MODEL_USAGE_LOG", usage_log)
+    _write_usage_start(usage_log)
+    monkeypatch.setattr(session, "_usage_now", lambda: USAGE_NOW)
+
+    def resolve(value: str, *, label: str) -> tuple[str, str]:
+        assert label in {"candidate head", "merge commit"}
+        return value, "c" * 40
+
+    monkeypatch.setattr(session, "_resolve_commit_tree", resolve)
+    monkeypatch.setattr(
+        session, "_commit_reachable_from_origin_main", lambda _commit: True
+    )
+    arguments = _complete_efficiency_closeout_args()
+    arguments[arguments.index("0", arguments.index("--hosted-validation-runs"))] = "1"
+    arguments.extend(["--pr-number", "845", "--merge-commit", "d" * 40])
+
+    assert session.cmd_usage(session.build_parser().parse_args(arguments)) == 0
+    entries = session._read_jsonl(usage_log)
+    assert session._externally_closed_task_ids(entries) == {"MAINT-0132"}
+    integration = entries[-1]["efficiency"]["integration"]
+    assert integration["reviewed_tree_matches_merged_tree"] is True
+    assert integration["pr_number"] == 845
+
+
+def test_shared_usage_log_resolves_from_git_common_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        session.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            ["git", "rev-parse"], 0, ".git\n", ""
+        ),
+    )
+
+    assert (
+        session._resolve_shared_usage_log(tmp_path)
+        == (tmp_path / ".git" / "codex-runtime" / "model_usage.jsonl").resolve()
+    )
+
+
+def test_session_entry_and_check_orchestrator_record_timed_events() -> None:
+    run_sh = (REPO_ROOT / "run.sh").read_text(encoding="utf-8")
+    check_all = (REPO_ROOT / "scripts/check_all.py").read_text(encoding="utf-8")
+    brief = (REPO_ROOT / "scripts/agent_brief.sh").read_text(encoding="utf-8")
+
+    assert "_cmd_session_begin" in run_sh
+    assert 'usage --checkpoint start --task-id "$task_id"' in run_sh
+    assert '"$SCRIPTS/agent_start.sh" --quick --preflight-only' in run_sh
+    assert '_run_with_usage_event "session end"' in run_sh
+    assert "--preflight-only)" in (REPO_ROOT / "scripts/agent_start.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "_record_task_timing(" in check_all
+    assert 'return "check quick"' in check_all
+    assert "usage --closed-task-ids" in brief
+    assert "!closed[id]" in brief
 
 
 def test_tool_registry_discovers_all_copilot_skills():

--- a/Python/tests/test_token_efficiency.py
+++ b/Python/tests/test_token_efficiency.py
@@ -70,6 +70,18 @@ def test_quick_gate_enforces_token_policy() -> None:
     assert '"governance": ["Repo hygiene", "Token efficiency"]' in check_all
 
 
+def test_session_efficiency_guidance_uses_task_bound_observed_timing() -> None:
+    policy = (REPO_ROOT / "docs/guidelines/ai-token-efficiency.md").read_text(
+        encoding="utf-8"
+    )
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+    assert "session begin --task-id <task> --agent <role>" in policy
+    assert "derives actual elapsed time from the unmatched" in policy
+    assert "Git-common" in policy
+    assert "session begin --task-id <task> --agent <role>" in agents
+
+
 def test_verified_model_rates_are_checked_in() -> None:
     policy = json.loads(
         (REPO_ROOT / "agents" / "model_policy.json").read_text(encoding="utf-8")

--- a/Python/tests/test_verification_control.py
+++ b/Python/tests/test_verification_control.py
@@ -25,6 +25,48 @@ check_all = importlib.import_module("check_all")
 test_changed = importlib.import_module("test_changed")
 
 
+@pytest.mark.parametrize(
+    ("argv", "label"),
+    [
+        (
+            ["--quick", "--allow-operation-completion"],
+            "check commit hook",
+        ),
+        (["--quick"], "check quick"),
+        (["--pre-commit"], "check pre-commit"),
+        (["--changed"], "check changed"),
+        (["--category", "docs"], "check category"),
+        ([], "check full"),
+    ],
+)
+def test_check_orchestrator_timing_labels_are_stable(argv: list[str], label: str):
+    assert check_all._timing_label(argv) == label
+
+
+def test_check_timing_telemetry_never_changes_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[list[str]] = []
+
+    def record(args, **_kwargs):
+        calls.append([str(item) for item in args])
+        return subprocess.CompletedProcess(args, 1, "", "telemetry unavailable")
+
+    monkeypatch.setattr(check_all.subprocess, "run", record)
+
+    check_all._record_task_timing("check quick", 1.25, 0)
+
+    assert calls[0][-7:] == [
+        "usage",
+        "--event",
+        "check quick",
+        "--duration-sec",
+        "1.250",
+        "--result-code",
+        "0",
+    ]
+
+
 def test_live_verification_manifest_is_strict_and_covers_every_path():
     manifest = verification.load_manifest()
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,106 @@
 
 ---
 
+## 2026-08-23 — Session: MAINT-0132 automatic efficiency observability
+
+**Agent:** Codex (`governance`, sole writer)
+
+**Branch:** `codex/maint-0132-efficiency-observability`, from exact fetched
+`origin/main` commit `d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94`.
+
+**Git handoff receipt:**
+`docs/verification/maint-0132-git-handoff-receipt.json`
+
+**Focus:** Measure the whole task rather than a manually reconstructed subset,
+and prevent already-integrated work from consuming the next session's intake.
+
+### Summary
+
+- Added one `session begin` entry point that starts task-bound timing before the
+  compact brief and environment check; its composed compatibility helper stops
+  after preflight instead of printing a second copy of session context.
+- Moved new telemetry to the Git-common ignored ledger while retaining a
+  read-only projection of older worktree-local entries.
+- Made closeout derive elapsed time from its unmatched start and reject
+  unallocated/over-counted phase totals, invented short candidate IDs, inferred
+  model profiles, incomplete hosted integration, and unequal reviewed/merged
+  trees.
+- Added automatic quick/full/session-end step durations and an exact external
+  closeout projection so a frozen pre-push task row does not remain active after
+  proven integration.
+
+### Issues encountered
+
+- The MAINT-0131 app duration was 20m15s, while its manually entered phase sum
+  was 18m31s; 1m44s (8.6%) was absent from the ledger.
+- The compact start still reported merged MAINT-0130 and MAINT-0131 as active.
+- The prior ledger was rooted under each worktree, defaulted omitted identity to
+  `gpt-5.6-sol/high`, and accepted seven-character hexadecimal text as an exact
+  candidate without resolving a Git object.
+- The prior transcript contained 47 discovery markers before its first edit and
+  another seven edits after implementation was described as complete.
+- The first `session begin` composition still followed the compact brief with
+  the legacy helper's duplicate task, handoff, guidance, and Docker context.
+- Two diagnostic commands were started from the wrong directory: the first
+  memory lookup ran from the repository, and the first historical PR lookup ran
+  from the memory folder.
+- The first control-projection attempt used nonexistent `control project`, then
+  replacing the public start operation exposed `agent_start.sh` as unregistered.
+- The first consolidated focused batch found one Black delta and two stale
+  assertions: the old 114-operation count and one policy phrase spelling.
+- The first immutable-candidate commit attempt was stopped because the final
+  preflight-only assertion had not been included in the earlier Black target.
+
+### Root causes and resolutions
+
+- Confirmed root cause: closeout compared one manually supplied elapsed value
+  only with the manually supplied phase sum. Resolution: bind closeout to the
+  shared unmatched task-start timestamp and report the exact residual before
+  refusing a mismatched write.
+- Confirmed root cause: runtime telemetry used worktree-relative `logs/` paths.
+  Resolution: write through `git rev-parse --git-common-dir` and project retained
+  legacy worktree ledgers read-only for historical summaries.
+- Confirmed root cause: the immutable candidate cannot contain its future PR and
+  squash-merge identity, while the compact brief trusted only the frozen task
+  row. Resolution: require exact external PR/merge/tree closeout evidence and
+  use that successor observation only as a compact active-task overlay.
+- Confirmed root cause: model defaults and syntax-only short SHA validation
+  fabricated precision. Resolution: default model/reasoning to `unknown`,
+  require exact 40-character lowercase commits, resolve their trees, and prove
+  the final candidate tree equals the reachable merged tree.
+- Confirmed root cause: session orientation and routine gates had no automatic
+  step receipts. Resolution: make `session begin`, quick/full checks, and
+  `session end` append task-bound durations without changing command outcomes.
+- Confirmed root cause: `agent_start.sh --quick` combines environment preflight
+  with its own full onboarding output. Resolution: add a composable
+  `--preflight-only` mode and use it only after the canonical compact brief; the
+  compatibility start path remains unchanged.
+- Confirmed root cause: command working directories were not kept with their
+  evidence source. Resolution: rerun memory reads from the memory root and Git/
+  GitHub queries from the repository; neither failure changed repository state.
+- Confirmed root cause: the control CLI exposes `export-legacy`, not `project`,
+  and `session begin` composes rather than retires `agent_start.sh`. Resolution:
+  use the documented exporter and register the helper as an internal maintained
+  compatibility operation; control validation passes at 115 operations and
+  101/101 scripts.
+- Confirmed root cause: focused contracts still froze the pre-MAINT-0132 count
+  and an imprecise phrase. Resolution: update only those assertions and format
+  the affected test file; the failed/affected evidence then passes.
+- Confirmed root cause: the last focused edit occurred after the earlier
+  formatting check. Resolution: accept only Black's quote normalization, rerun
+  that focused module and the consolidated quick gate once, then retry normal
+  hooks without bypassing them.
+
+### Verification
+
+- Session automation, verification control, token efficiency, control plane,
+  Git guidance, and governance automation focused modules pass. Shell syntax,
+  Black, the live preflight-only path, instruction drift, task format, script
+  references, token policy, context, next-brief length, and the
+  115-operation/101-script registry pass.
+- The quick gate, commit hooks, full gate, clean session verdict, and hosted
+  evidence remain pending until immutable candidate freeze.
+
 ## 2026-08-23 — Session: MAINT-0131 measurable efficiency controls
 
 **Agent:** Codex (`governance`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-23 — MAINT-0131 efficiency controls active on merged MAINT-0130 baseline
+**Updated:** 2026-08-23 — MAINT-0132 automatic efficiency observability active
 
 ---
 
@@ -127,8 +127,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| MAINT-0131 | Repair closeout preparation semantics, helper-level verification routing, safe-file executable compatibility, and measurable efficiency closeout | Main Agent + governance | M | P0 | 🟡 CANDIDATE — focused 235-test/control proof and live preparation exit `2` pass; final local and hosted gates pending |
-| MAINT-0130 | Replace inconsistent move/delete/link/batch/migrator behavior with one fail-closed transactional safe-file system and retire age-only archival | Main Agent + governance | L | P0 | ✅ MERGED — PR #844 at `58ecc149`; bulk cleanup still needs a separately classified and authorized plan |
+| MAINT-0132 | Replace manually reconstructed per-worktree timing and stale task orientation with one task-bound shared observable session | Main Agent + governance | M | P0 | 🟡 CANDIDATE — focused session/control/instruction proof passes; quick/full/hooks/hosted closeout pending |
 
 No bulk cleanup or automatic archival is authorized by this packet. MAINT-0130
 is merged and green, but content movement remains held until a separate exact
@@ -205,6 +204,8 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| MAINT-0131 | Repaired preparation exit semantics, helper impact routing, safe-file executable compatibility, and mandatory closeout fields | Main Agent + governance | ✅ DONE — PR #845 merged at `d4e5b122`; candidate and merged trees equal `94bd3164`; focused 235, quick 10/10, full 31/31, and hosted 9/9 pass |
+| MAINT-0130 | Replaced split move/delete/migration safety with one fail-closed transactional safe-file system and retired age-only archival | Main Agent + governance | ✅ DONE — PR #844 merged at `58ecc149`; bulk cleanup remains separately classified and authorized |
 | MAINT-012D | Consolidated true duplicate scanners, archived obsolete compatibility paths, migrated live callers, and preserved distinct safety evidence | Main Agent + governance | ✅ COMPLETE ON MERGE — frozen candidate requires broad Python, quick/full, normal hooks, and all applicable hosted checks; PR facts remain external |
 | MAINT-012C | Unified local/hosted impact scheduling and exact content-addressed PASS reuse under one strict seven-domain verification manifest | Main Agent + governance | ✅ DONE — PR #842 merged at `84f3cbe6`; unknown paths fail closed and ordinary hooks reuse only exact matching evidence |
 | MAINT-012B | Replaced 141 generated index artifacts with a strict context manifest and bounded live summaries | Main Agent + governance | ✅ DONE — PR #841 merged at `646660e3`; generic index topology and regeneration were retired |

--- a/docs/contributing/handoff.md
+++ b/docs/contributing/handoff.md
@@ -9,9 +9,10 @@ tags: []
 
 # Handoff Quick Start
 
-> Current Git/session boundary: start with `./run.sh session brief --agent
-> <role>`, `./run.sh session start`, `scripts/python_runtime.sh --diagnose`, and
-> `scripts/git_state.py --json --worktrees`. The state authority is local-only;
+> Current Git/session boundary: start with `./run.sh session begin --task-id
+> <task> --agent <role>`, then use `scripts/python_runtime.sh --diagnose` or
+> `scripts/git_state.py --json --worktrees` only when the compact start reports
+> an unresolved lane question. The state authority is local-only;
 > remote freshness remains `NOT_CHECKED` unless separately established.
 
 Every durable task handoff uses a tracked machine-readable receipt built and

--- a/docs/git-automation/git-workflow-single-source.md
+++ b/docs/git-automation/git-workflow-single-source.md
@@ -87,8 +87,12 @@ The stage gates are:
 
 At closeout, record the seven non-overlapping wall-time phases, exact candidate
 heads, rejection/repair/retry counters, full-gate count, and hosted-run count in
-the ignored `session usage` ledger. This external measurement never changes the
-frozen candidate.
+the Git-common ignored `session usage` ledger. The total is derived from the
+task's unmatched `session begin` timestamp, not entered independently. Hosted
+closeout binds the PR and reachable merge commit and requires final
+candidate/merged-tree equality; this successor external observation can mask a
+frozen pre-push task row from later compact briefs without changing the
+candidate.
 
 The mutation cutoff is strict: finish versioned session/task/handoff records,
 local evidence, and the pre-commit receipt first; refresh only affected

--- a/docs/guidelines/ai-token-efficiency.md
+++ b/docs/guidelines/ai-token-efficiency.md
@@ -121,17 +121,18 @@ for the bounded exceptions above.
 
 ## Context Budget
 
-Start with the smallest orientation pack:
+Start one exact task with the smallest timed orientation pack:
 
 ```bash
-./run.sh session brief --agent <role>
-sed -n '1,80p' docs/TASKS.md
-git status --short --branch
+./run.sh session begin --task-id <task> --agent <role>
 ```
 
 Then:
 
-- Use `./run.sh context show <area>` for authoritative routing, then targeted
+- Treat the compact brief and environment result as the default orientation;
+  do not reopen files or rerun Git queries that they already answered.
+- Use `./run.sh context show <area>` only for a concrete unresolved routing
+  question, then targeted
   `rg`; request a bounded live inventory with
   `./run.sh context summary <area-or-folder>` only when useful.
 - Search with `rg` and read only the matching sections.
@@ -212,9 +213,15 @@ their sum as `total wall time`; do not count idle or network time in another
 interval. At closeout report `candidate_heads`, `audit_rejections`,
 `repair_batches`, `focused_gate_retries`, `full_gate_runs`,
 `hosted_validation_runs`, `rework_minutes`, and `network_wait_minutes`.
-The closeout `session usage` command validates all seven phase labels, computes
-their total, requires exact candidate heads and retry/run counters, and stores
-the result only in the ignored local runtime ledger.
+`session begin` records the start before orientation in the Git-common ignored
+ledger. Quick/full checks and `session end` add automatic step durations while
+that task remains open. Closeout derives actual elapsed time from the unmatched
+task start, rejects a phase sum with more than 0.1 minute unallocated or
+over-counted, requires resolvable 40-character candidate commits and retry/run
+counters, and never infers a model or reasoning profile. Hosted closeout also
+binds the PR and merge commit and proves equality between the final candidate
+and merged trees. That successor external observation prevents a merged task's
+frozen pre-push row from appearing active in later compact briefs.
 
 Safety-critical structural calculations still require independent reference
 validation. Token efficiency never replaces practicing-engineer review or the
@@ -231,18 +238,23 @@ IS 456 quality gate.
 - Run `./run.sh efficiency prompt` to print a reusable task preamble.
 - Run `./run.sh model --table` to compare profiles, or pass a task description
   to receive a deterministic recommendation and explicit escalation trigger.
-- Record start, milestone (roughly every 2–3 hours), and closeout checkpoints
-  with `./run.sh session usage`. The local JSONL ledger records model,
-  reasoning, elapsed time, parent/subagent counts, optional manually copied
-  dashboard values, verification, and Git state. It deliberately leaves token
-  and billing fields empty because the repository cannot measure them.
+- Start through `session begin`, optionally record milestones roughly every
+  2–3 hours, and record closeout after exact post-merge verification. The shared
+  Git-common JSONL ledger projects retained legacy per-worktree records for
+  history and records model, reasoning, derived elapsed time, automatic step
+  durations, parent/subagent counts, optional manually copied dashboard values,
+  verification, and Git state. It deliberately leaves token and billing fields
+  empty because the repository cannot measure them.
 
 ```bash
-./run.sh session usage --checkpoint start --task-id TASK-XXX --task "bounded scope"
+./run.sh session begin --task-id TASK-XXX --agent governance --task "bounded scope"
 ./run.sh session usage --checkpoint milestone --elapsed-min 120 \
   --verification "targeted tests pass" --notes "no subagents"
+./run.sh session usage --active --json
 ./run.sh session usage --checkpoint closeout --task-id TASK-XXX \
-  --candidate-head abc1234 --audit-rejections 0 --repair-batches 0 \
+  --candidate-head <40-character-candidate-sha> \
+  --pr-number <number> --merge-commit <40-character-merge-sha> \
+  --audit-rejections 0 --repair-batches 0 \
   --focused-gate-retries 0 --full-gate-runs 1 --hosted-validation-runs 1 \
   --phase "contract/intake=15" \
   --phase "writer implementation + focused verification=90" \

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,58 +4,39 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-23
-- Focus: Turn the reproduced MAINT-0130 efficiency defects into narrow,
-- Git receipt: docs/verification/maint-0131-git-handoff-receipt.json | sha256:034994ac2f36c9af805e711e421da103c38159524c4a12baa5192141dd537333 | HOLD
-- Git identity: codex/maint-0131-efficiency-controls@58ecc149bd4525ae92c4affb369851919fe1c402 | upstream=origin/main@58ecc149bd4525ae92c4affb369851919fe1c402 | base=origin/main@58ecc149bd4525ae92c4affb369851919fe1c402 | tree=dirty | operation=none
+- Focus: Measure the whole task rather than a manually reconstructed subset,
+- Git receipt: docs/verification/maint-0132-git-handoff-receipt.json | sha256:0de9060933fda48022cf81155235477c03bff8a8d71d85e3fba967a771871674 | HOLD
+- Git identity: codex/maint-0132-efficiency-observability@d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94 | upstream=origin/main@d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94 | base=origin/main@d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
 - Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `MAINT-0131` repairs deterministic efficiency-control defects observed during the merged MAINT-0130 workflow |
-| **Next** | Prove closeout status, helper-level impact routing, executable compatibility, and complete timing evidence on one frozen candidate |
-| **Why** | Broad helper routing selected unrelated product jobs, dirty preparation contradicted its documented exit, and timing requirements were not executable |
+| **Current** | `MAINT-0132` makes the whole task observable from pre-orientation start through exact post-merge closeout |
+| **Next** | Freeze and prove the shared ledger, derived elapsed-time, automatic step timing, exact identities, and stale-task projection |
+| **Why** | MAINT-0131 took 20m15s while its manual ledger recorded 18m31s; the compact brief also presented already-merged work as active |
 | **Held** | Bulk cleanup, automatic archival, unclassified file movement, branch/worktree deletion, product behavior, release, and professional approval |
 
-## Exact MAINT-0131 state
+## Exact MAINT-0132 state
 
-- Branch: `codex/maint-0131-efficiency-controls`, created from merged MAINT-0130
-  baseline `58ecc149bd4525ae92c4affb369851919fe1c402`.
-- Dirty preparation is status `2` only when every non-cleanliness check passes;
-  unknown Git state, operations/conflicts, missing receipts, and final dirty
-  validation remain status `1`.
-- `scripts/_lib/safe_file_ops.py` selects control-plane, docs, and repository
-  validation rather than unrelated Python/FastAPI/React/Excel product jobs.
-  Unknown paths still select all domains.
-- Closeout usage evidence requires all seven phase timings, exact candidate
-  heads, and rejection/repair/retry/full/hosted counters before it writes the
-  ignored local ledger.
-- Focused control, instruction, and migration evidence is green; candidate
-  closeout still requires the quick/full gates, hooks, and hosted checks.
+- Branch: `codex/maint-0132-efficiency-observability`, created from exact merged
+  MAINT-0131 baseline `d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94`.
+- `session begin` starts one task timer before the compact brief and environment
+  check. Quick/full gates and `session end` record automatic step durations.
+- New entries use the Git-common ignored ledger; summaries retain a read-only
+  projection of older worktree-local records.
+- Closeout requires an unmatched task start, derived elapsed/phase agreement,
+  resolvable 40-character candidates, complete counters, and exact hosted
+  PR/merge/tree evidence when hosted validation ran.
+- Exact external closeout IDs mask frozen pre-push task rows from later compact
+  starts without rewriting the candidate.
 
-## Exact MAINT-0130 state
+## Preserved boundary
 
-- Branch: `codex/maint-0130-safe-file-foundation`, created from freshly fetched
-  `origin/main` commit `242ba386925d29766b1467810044e276ebbceb64`.
-- `scripts/_lib/safe_file_ops.py` owns regular-file/repository path checks,
-  reference classification, exact snapshots, link-validator protocol, hashes,
-  and content-addressed delete backups.
-- Move/delete commands default to explicit dry-run registry entries; directories,
-  symlinks, outside paths, existing destinations, missing validators,
-  unresolved maintained references, force overwrite, and no-backup deletion fail.
-- Link checks cover maintained Markdown and local images, including `.github`
-  and current research. Historical surfaces are supplemental; ambiguous repair
-  requires an explicit mapping.
-- Python/React previews include generated `__init__.py`/barrel paths and live
-  validation failures restore exact bytes.
-- Batch migration preflights every operation, rejects collisions/cycles/bypass
-  flags, protects arbitrary rollback roots from child rewriting, compares exact
-  preview/live paths and hashes, and restores the whole batch.
-- Age-only `archive_old_files.sh` is inactive under `scripts/_archive/`;
-  `evolve.py` reports candidates without moving them.
-- The registry now has 114 active operations and 101/101 active top-level
-  scripts. Historical references remain preserved.
+- MAINT-0130/0131 are merged and remain unchanged. Bulk cleanup, automatic
+  archival, product behavior, release, branch/worktree deletion, and
+  professional approval are not authorized by MAINT-0132.
 
 ## Required Reading
 

--- a/docs/verification/maint-0132-git-handoff-receipt.json
+++ b/docs/verification/maint-0132-git-handoff-receipt.json
@@ -1,0 +1,147 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "0de9060933fda48022cf81155235477c03bff8a8d71d85e3fba967a771871674",
+    "state": {
+      "branch": "codex/maint-0132-efficiency-observability",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 98.866,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-maint-0132-efficiency-observability",
+      "head_sha": "d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94",
+      "hold_reasons": [
+        "changed paths: 22"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-23T07:09:42.603572+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0132-efficiency-observability",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 22,
+        "modified_paths": [
+          ".github/skills/session-management/SKILL.md",
+          "AGENTS.md",
+          "Python/tests/test_control_plane.py",
+          "Python/tests/test_session_automation.py",
+          "Python/tests/test_token_efficiency.py",
+          "Python/tests/test_verification_control.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/contributing/handoff.md",
+          "docs/git-automation/git-workflow-single-source.md",
+          "docs/guidelines/ai-token-efficiency.md",
+          "docs/planning/next-session-brief.md",
+          "run.sh",
+          "scripts/README.md",
+          "scripts/agent_brief.sh",
+          "scripts/agent_start.sh",
+          "scripts/automation-map.json",
+          "scripts/check_all.py",
+          "scripts/control-plane.json",
+          "scripts/prompt_router.py",
+          "scripts/session.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/maint-0132-git-handoff-receipt.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0132-efficiency-observability"
+    }
+  },
+  "local_state_receipt_hash": "sha256:0de9060933fda48022cf81155235477c03bff8a8d71d85e3fba967a771871674",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-23T07:09:42.603705+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/**/*.py",
+      "fastapi_app/**/*.py",
+      "react_app/**/*.{ts,tsx}",
+      "excel_addin/**",
+      "Etabs_CSV/**",
+      "requirements*.txt"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "AGENTS.md",
+      ".github/skills/session-management/SKILL.md",
+      "run.sh",
+      "scripts/**",
+      "Python/tests/**",
+      "docs/**"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "MAINT-0132"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -64,6 +64,23 @@ _require_venv() {
     fi
 }
 
+_run_with_usage_event() {
+    local label="$1"
+    shift
+    local started_epoch finished_epoch duration_sec status
+    started_epoch=$(date +%s)
+    set +e
+    "$@"
+    status=$?
+    set -e
+    finished_epoch=$(date +%s)
+    duration_sec=$((finished_epoch - started_epoch))
+    "$VENV" "$SCRIPTS/session.py" usage \
+        --event "$label" --duration-sec "$duration_sec" --result-code "$status" \
+        >/dev/null 2>&1 || true
+    return "$status"
+}
+
 # ── Command: check ─────────────────────────────────────────────────────────
 
 _cmd_check() {
@@ -109,17 +126,67 @@ EOF
 
 # ── Command: session ───────────────────────────────────────────────────────
 
+_cmd_session_begin() {
+    _require_venv
+    local agent="" task_id="" task="" model="unknown" reasoning="unknown"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --agent) agent="${2:-}"; shift 2 ;;
+            --task-id) task_id="${2:-}"; shift 2 ;;
+            --task) task="${2:-}"; shift 2 ;;
+            --model) model="${2:-}"; shift 2 ;;
+            --reasoning) reasoning="${2:-}"; shift 2 ;;
+            --help|-h)
+                echo "Usage: ./run.sh session begin --task-id TASK --agent ROLE [--task TEXT] [--model NAME] [--reasoning LEVEL]"
+                return 0
+                ;;
+            *) _error "Unknown session begin option: $1"; return 1 ;;
+        esac
+    done
+    if [[ -z "$task_id" ]]; then
+        _error "session begin requires --task-id"
+        return 1
+    fi
+
+    local -a usage_args=(usage --checkpoint start --task-id "$task_id")
+    [[ -n "$task" ]] && usage_args+=(--task "$task")
+    usage_args+=(--model "$model" --reasoning "$reasoning")
+    "$VENV" "$SCRIPTS/session.py" "${usage_args[@]}"
+
+    local -a brief_args=()
+    [[ -n "$agent" ]] && brief_args+=(--agent "$agent")
+    local started_epoch finished_epoch duration_sec status
+    started_epoch=$(date +%s)
+    set +e
+    bash "$SCRIPTS/agent_brief.sh" "${brief_args[@]}"
+    status=$?
+    if [[ "$status" -eq 0 ]]; then
+        "$SCRIPTS/agent_start.sh" --quick --preflight-only
+        status=$?
+    fi
+    set -e
+    finished_epoch=$(date +%s)
+    duration_sec=$((finished_epoch - started_epoch))
+    "$VENV" "$SCRIPTS/session.py" usage \
+        --event "orientation/session start" \
+        --duration-sec "$duration_sec" --result-code "$status" >/dev/null
+    return "$status"
+}
+
 _cmd_session() {
     local subcmd="${1:-}"
     shift 2>/dev/null || true
 
     case "$subcmd" in
+        begin)
+            _cmd_session_begin "$@"
+            ;;
         start)
             "$SCRIPTS/agent_start.sh" --quick "$@"
             ;;
         end)
             _require_venv
-            "$VENV" "$SCRIPTS/session.py" end "$@"
+            _run_with_usage_event "session end" "$VENV" "$SCRIPTS/session.py" end "$@"
             ;;
         handoff)
             _require_venv
@@ -163,6 +230,7 @@ Usage: ./run.sh session <subcommand>
 Manage agent work sessions.
 
 Subcommands:
+  begin      Timed compact brief + environment start for one exact task
   start      Begin session (verify env, read priorities)
   end        Validate closeout; --fix updates handoff, --log-cost records a proxy
   handoff    Write a receipt-bound durable task handoff
@@ -177,7 +245,8 @@ Subcommands:
   trust      Show or reset session trust state
 
 Examples:
-  ./run.sh session start      # First thing every session
+  ./run.sh session begin --task-id TASK-XXX --agent governance
+  ./run.sh session start      # Compatibility entry without automatic timing
   ./run.sh session context    # Quick orientation mid-session
   ./run.sh session usage --help
   ./run.sh session end        # Validate closeout without hidden writes

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@
 ## Preferred entry points
 
 ```bash
-./run.sh session start
+./run.sh session begin --task-id TASK-XXX --agent governance
 ./run.sh task brief "describe the task"
 ./run.sh check --quick
 ./run.sh check
@@ -28,9 +28,14 @@
 ./run.sh session end
 ```
 
-A `session usage --checkpoint closeout` record is fail-closed unless it includes
-all canonical phase timings, exact candidate heads, and the required retry/run
-counters documented in `docs/guidelines/ai-token-efficiency.md`.
+A `session usage --checkpoint closeout` record is fail-closed unless it matches
+an unmatched task start, all canonical phases equal derived elapsed time, each
+candidate is a resolvable 40-character commit, and the required retry/run
+counters are complete. Hosted closeout additionally binds the PR, merge commit,
+and equal reviewed/merged tree. New records live in the Git-common ignored
+ledger, so every linked worktree sees the same task history.
+Use `./run.sh session usage --active --json` to inspect derived elapsed time and
+automatically recorded steps before allocating the seven closeout phases.
 
 `run.sh` is a thin dispatcher for project validation and discovery. It does not
 stage, commit, push, create PRs, merge, or recover Git state.

--- a/scripts/agent_brief.sh
+++ b/scripts/agent_brief.sh
@@ -49,8 +49,14 @@ _priorities() {
 # ── Active tasks ───────────────────────────────────────────────────────
 _active_tasks() {
     if [[ -f "$TASKS" ]]; then
-        local active_items
-        active_items=$(awk '
+        local active_items closed_tasks
+        closed_tasks=$(cd "$REPO_ROOT" && ./scripts/python_runtime.sh \
+            scripts/session.py usage --closed-task-ids 2>/dev/null) || true
+        active_items=$(awk -v closed_source="$closed_tasks" '
+            BEGIN {
+                count=split(closed_source, closed_ids, "\n")
+                for (i=1; i<=count; i++) closed[closed_ids[i]]=1
+            }
             /^## Active$/ { in_active=1; next }
             /^## / && in_active { exit }
             in_active && /^\|/ && $0 !~ /^\|[- ]+\|/ && $0 !~ /\| ID \|/ {
@@ -59,7 +65,7 @@ _active_tasks() {
                 gsub(/^[[:space:]]+|[[:space:]]+$/, "", id)
                 gsub(/^[[:space:]]+|[[:space:]]+$/, "", task)
                 gsub(/^[[:space:]]+|[[:space:]]+$/, "", status)
-                if (id != "") print "  " id ": " task " [" status "]"
+                if (id != "" && !closed[id]) print "  " id ": " task " [" status "]"
             }
         ' "$TASKS" | head -3) || true
         [[ -n "$active_items" ]] && echo "$active_items"

--- a/scripts/agent_start.sh
+++ b/scripts/agent_start.sh
@@ -9,6 +9,7 @@
 #   ./scripts/agent_start.sh --agent frontend        # Agent-specific context
 #   ./scripts/agent_start.sh --worktree AGENT_5      # Worktree-specific guidance
 #   ./scripts/agent_start.sh --skip-preflight        # Skip preflight (for recovery)
+#   ./scripts/agent_start.sh --preflight-only        # Environment proof without context
 #
 # Available agents come from agents/agent_registry.json.
 #
@@ -42,6 +43,7 @@ AGENT=""
 QUICK=""
 WORKTREE=""
 SKIP_PREFLIGHT=""
+PREFLIGHT_ONLY=""
 while [[ $# -gt 0 ]]; do
     case $1 in
         --agent)
@@ -60,6 +62,10 @@ while [[ $# -gt 0 ]]; do
             SKIP_PREFLIGHT="true"
             shift
             ;;
+        --preflight-only)
+            PREFLIGHT_ONLY="true"
+            shift
+            ;;
         --help|-h)
             echo "Usage: ./scripts/agent_start.sh [OPTIONS]"
             echo ""
@@ -68,6 +74,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --quick           Skip detailed checks, faster startup"
             echo "  --worktree NAME   Display worktree-specific guidance"
             echo "  --skip-preflight  Skip pre-flight checks (for recovery)"
+            echo "  --preflight-only  Stop after environment preflight; no session/context output"
             echo ""
             echo "Agents: ./scripts/python_runtime.sh scripts/agent_context.py --list"
             echo ""
@@ -189,6 +196,11 @@ else
     else
         echo -e "  ${GREEN}✓${NC} Pre-flight checks passed"
     fi
+fi
+
+if [ -n "$PREFLIGHT_ONLY" ]; then
+    echo -e "  ${GREEN}✓${NC} Environment preflight complete"
+    exit 0
 fi
 
 # Step 4: Start Session

--- a/scripts/automation-map.json
+++ b/scripts/automation-map.json
@@ -260,13 +260,19 @@
       "permission": "ReadOnly"
     },
     "start session": {
-      "script": "./scripts/agent_start.sh --quick",
+      "script": "./run.sh session begin --task-id <task> --agent <role>",
       "group": "Session",
-      "description": "Resolve the approved runtime, run preflight, and start a session without Git/GitHub lifecycle actions",
+      "description": "Start one shared task timer before the compact brief and environment preflight without Git/GitHub lifecycle actions",
       "permission": "WorkspaceWrite",
       "aliases": [
         "session"
       ]
+    },
+    "session environment start compatibility": {
+      "script": "./scripts/agent_start.sh --quick",
+      "group": "Session",
+      "description": "Maintained environment-preflight helper composed by session begin in preflight-only mode and by the compatibility session start command",
+      "permission": "WorkspaceWrite"
     },
     "end session": {
       "script": "./scripts/python_runtime.sh scripts/session.py end",
@@ -873,13 +879,17 @@
     "model usage checkpoint": {
       "script": "./run.sh session usage",
       "group": "Session",
-      "description": "Record or summarize model, reasoning, elapsed time, agents, manual dashboard usage, verification, and Git state without estimating billing tokens",
+      "description": "Record or summarize shared task-bound model identity, derived elapsed time, step durations, verification, and Git state without estimating billing tokens",
       "permission": "ReadOnly",
       "permission_modes": {
-        "--checkpoint start|milestone|closeout": "WorkspaceWrite"
+        "--checkpoint start|milestone|closeout": "WorkspaceWrite",
+        "--event <label>": "WorkspaceWrite"
       },
       "options": {
         "--checkpoint start|milestone|closeout": "Append a local checkpoint",
+        "--event <label>": "Append one automatically timed task step",
+        "--active": "Show the unmatched task timer and recorded steps",
+        "--closed-task-ids": "Print exact externally closed task IDs",
         "--summary": "Aggregate checkpoints by model/reasoning profile",
         "--hours N": "Limit display or summary to a recent time window",
         "--json": "Machine-readable output"

--- a/scripts/check_all.py
+++ b/scripts/check_all.py
@@ -613,7 +613,7 @@ def _print_list() -> None:
 # ── Main ───────────────────────────────────────────────────────────────────
 
 
-def main() -> int:
+def _main() -> int:
     parser = argparse.ArgumentParser(
         prog="check_all.py",
         description="Run all validation checks in parallel, grouped by category.",
@@ -873,6 +873,57 @@ def main() -> int:
     # Exit code
     failed = sum(1 for r in results if not r.passed)
     return 1 if failed > 0 else 0
+
+
+def _timing_label(argv: list[str]) -> str:
+    if "--allow-operation-completion" in argv:
+        return "check commit hook"
+    if "--pre-commit" in argv:
+        return "check pre-commit"
+    if "--quick" in argv:
+        return "check quick"
+    if "--changed" in argv:
+        return "check changed"
+    if "--category" in argv or "-c" in argv:
+        return "check category"
+    return "check full"
+
+
+def _record_task_timing(label: str, duration_sec: float, result_code: int) -> None:
+    """Best-effort external telemetry; never changes a validation verdict."""
+    try:
+        subprocess.run(
+            [
+                VENV_PYTHON,
+                str(SCRIPTS_DIR / "session.py"),
+                "usage",
+                "--event",
+                label,
+                "--duration-sec",
+                f"{duration_sec:.3f}",
+                "--result-code",
+                str(result_code),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+def main() -> int:
+    started = time.monotonic()
+    result_code = 1
+    try:
+        result_code = _main()
+        return result_code
+    finally:
+        _record_task_timing(
+            _timing_label(sys.argv[1:]), time.monotonic() - started, result_code
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/control-plane.json
+++ b/scripts/control-plane.json
@@ -553,7 +553,33 @@
     },
     "start session": {
       "group": "Session",
-      "description": "Resolve the approved runtime, run preflight, and start a session without Git/GitHub lifecycle actions",
+      "description": "Start one shared task timer before the compact brief and environment preflight without Git/GitHub lifecycle actions",
+      "status": "active",
+      "command": {
+        "display": "./run.sh session begin --task-id <task> --agent <role>",
+        "steps": [
+          {
+            "argv": [
+              "./run.sh",
+              "session",
+              "begin",
+              "--task-id",
+              "<task>",
+              "--agent",
+              "<role>"
+            ],
+            "cwd": "."
+          }
+        ]
+      },
+      "permission": "WorkspaceWrite",
+      "aliases": [
+        "session"
+      ]
+    },
+    "session environment start compatibility": {
+      "group": "Session",
+      "description": "Maintained environment-preflight helper composed by session begin in preflight-only mode and by the compatibility session start command",
       "status": "active",
       "command": {
         "display": "./scripts/agent_start.sh --quick",
@@ -567,10 +593,7 @@
           }
         ]
       },
-      "permission": "WorkspaceWrite",
-      "aliases": [
-        "session"
-      ]
+      "permission": "WorkspaceWrite"
     },
     "end session": {
       "group": "Session",
@@ -2014,7 +2037,7 @@
     },
     "model usage checkpoint": {
       "group": "Session",
-      "description": "Record or summarize model, reasoning, elapsed time, agents, manual dashboard usage, verification, and Git state without estimating billing tokens",
+      "description": "Record or summarize shared task-bound model identity, derived elapsed time, step durations, verification, and Git state without estimating billing tokens",
       "status": "active",
       "command": {
         "display": "./run.sh session usage",
@@ -2031,10 +2054,14 @@
       },
       "permission": "ReadOnly",
       "permission_modes": {
-        "--checkpoint start|milestone|closeout": "WorkspaceWrite"
+        "--checkpoint start|milestone|closeout": "WorkspaceWrite",
+        "--event <label>": "WorkspaceWrite"
       },
       "options": {
         "--checkpoint start|milestone|closeout": "Append a local checkpoint",
+        "--event <label>": "Append one automatically timed task step",
+        "--active": "Show the unmatched task timer and recorded steps",
+        "--closed-task-ids": "Print exact externally closed task IDs",
         "--summary": "Aggregate checkpoints by model/reasoning profile",
         "--hours N": "Limit display or summary to a recent time window",
         "--json": "Machine-readable output"

--- a/scripts/prompt_router.py
+++ b/scripts/prompt_router.py
@@ -565,8 +565,8 @@ def build_task_brief(query: str) -> dict[str, Any]:
         "initial_context": _initial_context(routing.skills, tools),
         "workflow": {
             "start": [
-                f"./run.sh session brief --agent {routing.agent}",
-                "./run.sh session start",
+                "./run.sh session begin --task-id <TASK-ID> "
+                f"--agent {routing.agent}",
             ],
             "close": [
                 "./run.sh check --quick",

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -15,6 +15,7 @@ USAGE:
     ./scripts/python_runtime.sh scripts/session.py summary [--write]
     ./scripts/python_runtime.sh scripts/session.py sync [--fix] [--json]
     ./scripts/python_runtime.sh scripts/session.py usage [--checkpoint start|milestone|closeout] [...]
+    # Prefer ./run.sh session begin --task-id TASK --agent ROLE for a complete start.
     ./scripts/python_runtime.sh scripts/session.py compact [--keep-last N] [--dry-run]
 """
 
@@ -226,6 +227,7 @@ def add_session_log_entry() -> bool:
 def get_active_tasks() -> list[tuple[str, str, str]]:
     try:
         content = TASKS_MD.read_text()
+        externally_closed = _externally_closed_task_ids()
         active_match = re.search(
             r"^##\s+(?:🔴\s+)?Active\s*$\n(.*?)(?=^##\s|\Z)",
             content,
@@ -243,6 +245,8 @@ def get_active_tasks() -> list[tuple[str, str, str]]:
                 continue
             task_id = cells[0].strip("*").strip()
             if task_id.lower() == "id" or not task_id or set(task_id) <= {"-", ":"}:
+                continue
+            if task_id in externally_closed:
                 continue
             task_desc = cells[1].strip()
             status = cells[3].strip()
@@ -345,8 +349,10 @@ def archive_completed_tasks(fix: bool = False) -> tuple[int, int]:
     return len(rows), archived_count
 
 
-def get_key_blocker() -> Optional[str]:
-    for task_id, desc, hint in get_active_tasks():
+def get_key_blocker(
+    tasks: list[tuple[str, str, str]] | None = None,
+) -> Optional[str]:
+    for task_id, desc, hint in tasks if tasks is not None else get_active_tasks():
         if "BLOCKER" in hint:
             return f"{task_id}: {desc}"
     return None
@@ -452,7 +458,7 @@ def cmd_start(args: argparse.Namespace) -> int:
         else:
             print(f"  • {desc}")
 
-    blocker = get_key_blocker()
+    blocker = get_key_blocker(tasks)
     if blocker:
         print()
         print(f"  ⚠️  Key Blocker: {blocker}")
@@ -490,7 +496,29 @@ def cmd_start(args: argparse.Namespace) -> int:
 # ─── Cost / Token Logging ────────────────────────────────────────────────────
 
 COST_LOG = REPO_ROOT / "logs" / "agent_costs.jsonl"
-MODEL_USAGE_LOG = REPO_ROOT / "logs" / "model_usage.jsonl"
+LEGACY_MODEL_USAGE_LOG = REPO_ROOT / "logs" / "model_usage.jsonl"
+
+
+def _resolve_shared_usage_log(repo_root: Path = REPO_ROOT) -> Path:
+    """Resolve one ignored telemetry ledger shared by all linked worktrees."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    raw_path = result.stdout.strip()
+    if result.returncode != 0 or not raw_path:
+        return repo_root / "logs" / "model_usage.jsonl"
+    common_dir = Path(raw_path)
+    if not common_dir.is_absolute():
+        common_dir = (repo_root / common_dir).resolve()
+    return common_dir / "codex-runtime" / "model_usage.jsonl"
+
+
+MODEL_USAGE_LOG = _resolve_shared_usage_log()
+TIMING_TOLERANCE_MIN = 0.1
 
 EFFICIENCY_PHASES = (
     "contract/intake",
@@ -673,6 +701,108 @@ def _read_jsonl(path: Path) -> list[dict]:
     return entries
 
 
+def _legacy_usage_log_paths() -> list[Path]:
+    """Return retained per-worktree ledgers for read-only historical projection."""
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return [LEGACY_MODEL_USAGE_LOG]
+    paths = [
+        Path(line.removeprefix("worktree ")) / "logs" / "model_usage.jsonl"
+        for line in result.stdout.splitlines()
+        if line.startswith("worktree ")
+    ]
+    return list(dict.fromkeys([LEGACY_MODEL_USAGE_LOG, *paths]))
+
+
+def _all_usage_entries() -> list[dict]:
+    """Read the shared ledger plus retained legacy ledgers without duplicating rows."""
+    entries: list[dict] = []
+    seen: set[str] = set()
+    for path in [MODEL_USAGE_LOG, *_legacy_usage_log_paths()]:
+        for entry in _read_jsonl(path):
+            identity = json.dumps(entry, sort_keys=True, separators=(",", ":"))
+            if identity in seen:
+                continue
+            seen.add(identity)
+            entries.append(entry)
+    return sorted(entries, key=lambda item: str(item.get("timestamp", "")))
+
+
+def _usage_now() -> datetime:
+    return datetime.now().astimezone()
+
+
+def _latest_open_start(task_id: str, entries: list[dict]) -> dict | None:
+    for entry in reversed(entries):
+        if entry.get("task_id") != task_id:
+            continue
+        checkpoint = entry.get("checkpoint")
+        if checkpoint == "closeout":
+            return None
+        if checkpoint == "start":
+            return entry
+    return None
+
+
+def _active_usage_start(entries: list[dict]) -> dict | None:
+    open_starts: dict[str, dict] = {}
+    for entry in entries:
+        task_id = entry.get("task_id")
+        if not isinstance(task_id, str) or not task_id:
+            continue
+        if entry.get("checkpoint") == "start":
+            open_starts[task_id] = entry
+        elif entry.get("checkpoint") == "closeout":
+            open_starts.pop(task_id, None)
+    if not open_starts:
+        return None
+    return max(open_starts.values(), key=lambda item: str(item.get("timestamp", "")))
+
+
+def _resolve_commit_tree(value: str, *, label: str) -> tuple[str, str]:
+    if re.fullmatch(r"[0-9a-f]{40}", value) is None:
+        raise ValueError(f"{label} must be one exact 40-character lowercase commit SHA")
+    commit = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{value}^{{commit}}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if commit.returncode != 0 or commit.stdout.strip() != value:
+        raise ValueError(f"{label} is not a resolvable commit: {value}")
+    tree = subprocess.run(
+        ["git", "rev-parse", f"{value}^{{tree}}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    tree_sha = tree.stdout.strip()
+    if tree.returncode != 0 or re.fullmatch(r"[0-9a-f]{40}", tree_sha) is None:
+        raise ValueError(f"{label} tree could not be resolved: {value}")
+    return value, tree_sha
+
+
+def _commit_reachable_from_origin_main(commit: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "merge-base", "--is-ancestor", commit, "origin/main"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
 def _git_checkpoint_state() -> dict[str, object]:
     """Return cheap, observable repository state for a usage checkpoint."""
     state = collect_repository_state(REPO_ROOT)
@@ -692,21 +822,30 @@ def _git_checkpoint_state() -> dict[str, object]:
 
 
 def _usage_profile(entry: dict) -> str:
+    if entry.get("schema_version", 0) < 2:
+        return "legacy-unverified"
     model = entry.get("model", "unknown")
     reasoning = entry.get("reasoning", "unknown")
     return f"{model}/{reasoning}"
 
 
-def _efficiency_payload(args: argparse.Namespace) -> dict[str, object] | None:
-    """Validate and normalize optional non-overlapping wall-time evidence."""
+def _efficiency_payload(
+    args: argparse.Namespace,
+    *,
+    entries: list[dict],
+    observed_at: datetime,
+) -> dict[str, object] | None:
+    """Validate closeout phases against a task-bound observed start timestamp."""
     raw_phases = getattr(args, "phase", None) or []
     candidate_heads = getattr(args, "candidate_head", None) or []
     counter_values = {
         name: getattr(args, name, None)
         for name, _option in EFFICIENCY_COUNTER_ARGUMENTS
     }
-    supplied = bool(raw_phases or candidate_heads) or any(
-        value is not None for value in counter_values.values()
+    supplied = (
+        bool(raw_phases or candidate_heads or args.merge_commit)
+        or args.pr_number is not None
+        or any(value is not None for value in counter_values.values())
     )
     if args.checkpoint != "closeout" and supplied:
         raise ValueError("phase and candidate/retry evidence is closeout-only")
@@ -754,31 +893,105 @@ def _efficiency_payload(args: argparse.Namespace) -> dict[str, object] | None:
     for name, value in counter_values.items():
         if value is not None and value < 0:
             raise ValueError(f"{name} must be non-negative")
-    invalid_heads = [
-        head
-        for head in candidate_heads
-        if re.fullmatch(r"[0-9a-fA-F]{7,40}", head) is None
-    ]
-    if invalid_heads:
+    if not args.task_id:
+        raise ValueError("closeout requires one non-empty --task-id")
+    started = _latest_open_start(args.task_id, entries)
+    if started is None:
         raise ValueError(
-            "candidate heads must be 7-40 hexadecimal characters: "
-            + ", ".join(invalid_heads)
+            f"closeout requires an unmatched start checkpoint for task {args.task_id}"
         )
+    try:
+        started_at = datetime.fromisoformat(str(started["timestamp"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("task start timestamp is missing or malformed") from exc
+    if started_at.tzinfo is None:
+        raise ValueError("task start timestamp must include a timezone")
+    actual_elapsed = round((observed_at - started_at).total_seconds() / 60, 3)
+    if actual_elapsed < 0:
+        raise ValueError("task start timestamp is later than closeout")
 
-    total_wall_time = round(sum(phases.values()), 3)
-    if args.elapsed_min and not math.isclose(
-        args.elapsed_min, total_wall_time, rel_tol=0, abs_tol=0.05
+    phase_total = round(sum(phases.values()), 3)
+    unallocated = round(actual_elapsed - phase_total, 3)
+    if not math.isclose(
+        actual_elapsed,
+        phase_total,
+        rel_tol=0,
+        abs_tol=TIMING_TOLERANCE_MIN,
     ):
         raise ValueError(
-            f"elapsed minutes {args.elapsed_min} do not equal phase total {total_wall_time}"
+            f"phase total {phase_total}m does not match derived elapsed "
+            f"{actual_elapsed}m; unallocated time {unallocated}m"
+        )
+    if args.elapsed_min is not None and not math.isclose(
+        args.elapsed_min,
+        actual_elapsed,
+        rel_tol=0,
+        abs_tol=TIMING_TOLERANCE_MIN,
+    ):
+        raise ValueError(
+            f"supplied elapsed minutes {args.elapsed_min} do not match derived "
+            f"elapsed {actual_elapsed}"
         )
 
-    return {
+    resolved_candidates = [
+        _resolve_commit_tree(head, label="candidate head") for head in candidate_heads
+    ]
+    canonical_heads = list(dict.fromkeys(head for head, _tree in resolved_candidates))
+    candidate_trees = dict(resolved_candidates)
+
+    integration: dict[str, object] | None = None
+    if args.pr_number is not None or args.merge_commit:
+        if args.pr_number is None or args.pr_number <= 0 or not args.merge_commit:
+            raise ValueError(
+                "integration evidence requires --pr-number and --merge-commit"
+            )
+        merge_commit, merged_tree = _resolve_commit_tree(
+            args.merge_commit, label="merge commit"
+        )
+        if not _commit_reachable_from_origin_main(merge_commit):
+            raise ValueError("merge commit is not reachable from observed origin/main")
+        final_candidate_tree = candidate_trees[canonical_heads[-1]]
+        if final_candidate_tree != merged_tree:
+            raise ValueError(
+                "final candidate tree does not equal the merged tree: "
+                f"{final_candidate_tree} != {merged_tree}"
+            )
+        integration = {
+            "pr_number": args.pr_number,
+            "merge_commit": merge_commit,
+            "merged_tree": merged_tree,
+            "final_candidate_tree": final_candidate_tree,
+            "reviewed_tree_matches_merged_tree": True,
+            "authority": "caller-supplied PR identity plus locally resolved Git objects",
+        }
+    elif counter_values["hosted_validation_runs"]:
+        raise ValueError(
+            "a hosted closeout requires --pr-number and exact --merge-commit evidence"
+        )
+
+    task_events = [
+        {
+            "event": entry.get("event"),
+            "duration_sec": entry.get("duration_sec"),
+            "result_code": entry.get("result_code"),
+        }
+        for entry in entries
+        if entry.get("checkpoint") == "event"
+        and entry.get("task_id") == args.task_id
+        and str(entry.get("timestamp", "")) >= str(started.get("timestamp", ""))
+    ]
+
+    payload: dict[str, object] = {
         "phase_timings_min": {
             label: phases[label] for label in EFFICIENCY_PHASES if label in phases
         },
-        "total_wall_time_min": total_wall_time,
-        "candidate_heads": list(dict.fromkeys(candidate_heads)),
+        "phase_total_min": phase_total,
+        "total_wall_time_min": actual_elapsed,
+        "unallocated_time_min": unallocated,
+        "measurement_source": "derived from unmatched task start and closeout timestamps",
+        "started_at": started_at.isoformat(timespec="seconds"),
+        "candidate_heads": canonical_heads,
+        "candidate_trees": candidate_trees,
         "audit_rejections": counter_values["audit_rejections"],
         "repair_batches": counter_values["repair_batches"],
         "focused_gate_retries": counter_values["focused_gate_retries"],
@@ -786,21 +999,33 @@ def _efficiency_payload(args: argparse.Namespace) -> dict[str, object] | None:
         "hosted_validation_runs": counter_values["hosted_validation_runs"],
         "rework_minutes": phases.get("writer rework", 0.0),
         "network_wait_minutes": phases.get("hosted/network wait", 0.0),
+        "recorded_steps": task_events,
     }
+    if integration is not None:
+        payload["integration"] = integration
+    return payload
 
 
 def _record_usage_checkpoint(
-    args: argparse.Namespace, efficiency: dict[str, object] | None = None
+    args: argparse.Namespace,
+    efficiency: dict[str, object] | None = None,
+    *,
+    observed_at: datetime | None = None,
 ) -> dict:
     """Append an observable model/agent checkpoint without estimating billing."""
     entry = {
-        "schema_version": 1,
-        "timestamp": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "schema_version": 2,
+        "timestamp": (observed_at or _usage_now()).isoformat(timespec="seconds"),
         "checkpoint": args.checkpoint,
         "task_id": args.task_id or "",
         "task": args.task or "",
         "model": args.model,
         "reasoning": args.reasoning,
+        "profile_source": (
+            "caller-supplied"
+            if args.model != "unknown" or args.reasoning != "unknown"
+            else "not-observed"
+        ),
         "parent_agents": args.parent_agents,
         "subagents": args.subagents,
         "worker_models": args.worker_model or [],
@@ -829,15 +1054,134 @@ def _record_usage_checkpoint(
     return entry
 
 
+def _record_usage_event(args: argparse.Namespace, entries: list[dict]) -> dict | None:
+    if not args.event:
+        return None
+    if args.duration_sec is None or not math.isfinite(args.duration_sec):
+        raise ValueError("event duration must be a finite --duration-sec value")
+    if args.duration_sec < 0:
+        raise ValueError("event duration must be non-negative")
+    active = _active_usage_start(entries)
+    if active is None:
+        return None
+    entry = {
+        "schema_version": 2,
+        "timestamp": _usage_now().isoformat(timespec="seconds"),
+        "checkpoint": "event",
+        "task_id": active["task_id"],
+        "event": args.event,
+        "duration_sec": round(args.duration_sec, 3),
+        "result_code": args.result_code,
+        "billing_tokens": None,
+        "billing_cost": None,
+    }
+    MODEL_USAGE_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with MODEL_USAGE_LOG.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+    return entry
+
+
+def _externally_closed_task_ids(entries: list[dict] | None = None) -> set[str]:
+    closed: set[str] = set()
+    for entry in entries if entries is not None else _all_usage_entries():
+        efficiency = entry.get("efficiency")
+        integration = (
+            efficiency.get("integration") if isinstance(efficiency, dict) else None
+        )
+        if (
+            entry.get("checkpoint") == "closeout"
+            and isinstance(integration, dict)
+            and integration.get("reviewed_tree_matches_merged_tree") is True
+            and isinstance(entry.get("task_id"), str)
+        ):
+            closed.add(entry["task_id"])
+    return closed
+
+
+def _active_usage_payload(entries: list[dict], observed_at: datetime) -> dict | None:
+    active = _active_usage_start(entries)
+    if active is None:
+        return None
+    started_at = datetime.fromisoformat(str(active["timestamp"]))
+    elapsed = round((observed_at - started_at).total_seconds() / 60, 3)
+    steps = [
+        {
+            "event": entry.get("event"),
+            "duration_sec": entry.get("duration_sec"),
+            "result_code": entry.get("result_code"),
+        }
+        for entry in entries
+        if entry.get("checkpoint") == "event"
+        and entry.get("task_id") == active.get("task_id")
+        and str(entry.get("timestamp", "")) >= str(active.get("timestamp", ""))
+    ]
+    return {
+        "task_id": active["task_id"],
+        "started_at": started_at.isoformat(timespec="seconds"),
+        "derived_elapsed_min": elapsed,
+        "recorded_steps": steps,
+    }
+
+
 def cmd_usage(args: argparse.Namespace) -> int:
     """Record or summarize model, agent, elapsed-time, and usage checkpoints."""
-    if args.checkpoint:
+    if args.closed_task_ids:
+        for task_id in sorted(_externally_closed_task_ids()):
+            print(task_id)
+        return 0
+
+    entries = _read_jsonl(MODEL_USAGE_LOG)
+    if args.active:
+        active = _active_usage_payload(entries, _usage_now())
+        if args.json_output:
+            print(json.dumps(active, indent=2))
+        elif active is None:
+            print("No unmatched shared task start checkpoint.")
+        else:
+            print(
+                f"Active task {active['task_id']}: "
+                f"{active['derived_elapsed_min']}m since {active['started_at']}"
+            )
+            for step in active["recorded_steps"]:
+                print(
+                    f"  {step['event']}: {step['duration_sec']}s "
+                    f"(exit {step['result_code']})"
+                )
+        return 0
+    if args.event:
         try:
-            efficiency = _efficiency_payload(args)
+            event = _record_usage_event(args, entries)
         except ValueError as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 1
-        entry = _record_usage_checkpoint(args, efficiency)
+        if event is not None and args.json_output:
+            print(json.dumps(event, indent=2))
+        return 0
+
+    if args.checkpoint:
+        if args.checkpoint in {"start", "closeout"} and not args.task_id:
+            print(
+                "ERROR: start and closeout checkpoints require --task-id",
+                file=sys.stderr,
+            )
+            return 1
+        active_start = _active_usage_start(entries)
+        if args.checkpoint == "start" and active_start is not None:
+            print(
+                "ERROR: an unmatched start checkpoint already exists for task "
+                f"{active_start['task_id']}",
+                file=sys.stderr,
+            )
+            return 1
+        observed_at = _usage_now()
+        try:
+            efficiency = _efficiency_payload(
+                args, entries=entries, observed_at=observed_at
+            )
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+        entry = _record_usage_checkpoint(args, efficiency, observed_at=observed_at)
         if args.json_output:
             print(json.dumps(entry, indent=2))
         else:
@@ -858,7 +1202,7 @@ def cmd_usage(args: argparse.Namespace) -> int:
                 )
         return 0
 
-    entries = _read_jsonl(MODEL_USAGE_LOG)
+    entries = _all_usage_entries()
     if args.hours is not None:
         cutoff = datetime.now().astimezone() - timedelta(hours=args.hours)
         entries = [
@@ -2634,14 +2978,22 @@ def build_parser() -> argparse.ArgumentParser:
     p_usage.add_argument("--checkpoint", choices=("start", "milestone", "closeout"))
     p_usage.add_argument("--task-id", default="", help="Task identifier")
     p_usage.add_argument("--task", default="", help="Short task description")
-    p_usage.add_argument("--model", default="gpt-5.6-sol", help="Parent model")
-    p_usage.add_argument("--reasoning", default="high", help="Reasoning effort")
+    p_usage.add_argument(
+        "--model", default="unknown", help="Observed parent model; never inferred"
+    )
+    p_usage.add_argument(
+        "--reasoning", default="unknown", help="Observed reasoning; never inferred"
+    )
     p_usage.add_argument("--parent-agents", type=int, default=1)
     p_usage.add_argument("--subagents", type=int, default=0)
     p_usage.add_argument(
         "--worker-model", action="append", help="Worker model/profile; repeatable"
     )
-    p_usage.add_argument("--elapsed-min", type=float, default=0)
+    p_usage.add_argument(
+        "--elapsed-min",
+        type=float,
+        help="Optional cross-check; closeout elapsed is derived from its task start",
+    )
     p_usage.add_argument(
         "--weekly-remaining", type=float, help="Manual dashboard percentage"
     )
@@ -2664,10 +3016,23 @@ def build_parser() -> argparse.ArgumentParser:
     p_usage.add_argument("--focused-gate-retries", type=int)
     p_usage.add_argument("--full-gate-runs", type=int)
     p_usage.add_argument("--hosted-validation-runs", type=int)
+    p_usage.add_argument("--pr-number", type=int)
+    p_usage.add_argument("--merge-commit")
+    p_usage.add_argument("--event", help="Record one automatically timed run.sh step")
+    p_usage.add_argument("--duration-sec", type=float)
+    p_usage.add_argument("--result-code", type=int)
+    p_usage.add_argument(
+        "--closed-task-ids",
+        action="store_true",
+        help="Print task IDs with exact successor merge/tree closeout evidence",
+    )
     p_usage.add_argument("--notes", default="")
     p_usage.add_argument("--last", type=int, default=10)
     p_usage.add_argument("--hours", type=float, help="Limit display/summary window")
     p_usage.add_argument("--summary", action="store_true")
+    p_usage.add_argument(
+        "--active", action="store_true", help="Show the unmatched task timer and steps"
+    )
     p_usage.add_argument("--json", dest="json_output", action="store_true")
 
     # context


### PR DESCRIPTION
## Summary

- start one shared task timer before compact orientation and use preflight-only environment proof
- derive closeout wall time and residuals from exact task timestamps, candidates, and merged-tree evidence
- time quick, commit-hook, full, and session-end steps automatically and hide exactly integrated stale task rows

## Verification

- focused session, control-plane, verification, policy, and Git-governance tests pass
- `./run.sh check --quick`: 10/10
- normal commit hooks: pass
- clean `./run.sh session end`: pass
- `./run.sh check`: 31/31

## Scope

Control-plane and session observability only. No product math, API, UI, cleanup, release, file movement, branch deletion, or worktree deletion.