### PR TITLE
docs(governance): freeze cleanup authorization inventory

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,78 @@
 
 ---
 
+## 2026-08-23 — Session: MAINT-0133 cleanup inventory and authorization
+
+**Agent:** Codex (`governance`, sole writer)
+
+**Branch:** `codex/maint-0133-cleanup-inventory`, from exact fetched
+`origin/main` commit `60e95bbe52575d3335e7195db944b2c82630ed2e`.
+
+**Git handoff receipt:**
+`docs/verification/maint-0133-git-handoff-receipt.json`
+
+**Focus:** Freeze an exact read-only repository file-cleanup inventory and
+future transactional batch without moving or deleting content.
+
+### Summary
+
+- Bound the discovery contract to tracked hygiene artifacts, exact Git blobs,
+  explicit inactive metadata outside archive roots, active control coverage,
+  and exact safe-file previews; age-only and unreferenced-name guesses are
+  excluded.
+- Classified six explicit inactive-location files: two are
+  `MOVE_READY_NOT_AUTHORIZED`, four are `HOLD_UNRESOLVED`, and none has enough
+  evidence for deletion.
+- Froze exact source blobs, destinations, reference counts, retained surfaces,
+  and the two-operation future `MAINT-0133B-PACKET-A` batch.
+- Preserved 507 archived documents, 119 archived scripts, 1,760 vendor
+  references, four distinct empty Python test-package markers, and all 48
+  observed worktrees. No live move, delete, branch, or worktree action ran.
+
+### Issues encountered
+
+- The first worktree-creation call used the not-yet-created worktree as its
+  process directory, so the process could not start.
+- The exact-byte duplicate probe assumed `shasum` existed and repeated the
+  command-not-found error for each tracked file.
+- A zsh loop variable named `path` overwrote zsh's tied command-search path, so
+  subsequent `sed` calls in that shell were not found.
+- The deprecated agent-guide `README.md` preview matched 1,107 basename
+  occurrences and blocked on 279 unresolved maintained references.
+- Three other inactive documents remain blocked by two, two, and three
+  unresolved references respectively.
+
+### Root causes and resolutions
+
+- Confirmed root cause: a command cannot start in a directory that will only be
+  created by that same command. Resolution: create the worktree from the
+  existing repository, then run `session begin` inside the new lane; exact Git
+  state reports `READY_LOCAL` and the runtime reports `source_bound=true`.
+- Confirmed root cause: `shasum` is unavailable in this environment.
+  Resolution: use tracked Git blob identities, which directly prove exact byte
+  equality without an external hash executable; the only duplicate group is
+  four empty `__init__.py` package markers and is kept.
+- Confirmed root cause: `path` is a special zsh array tied to `PATH`.
+  Resolution: use task-specific variable names such as `candidate_file`; the
+  corrected header/reference inspection completed without state changes.
+- Confirmed root cause: the transactional scanner conservatively treats the
+  generic `README.md` basename as ambiguous across maintained surfaces.
+  Resolution: record the 279-reference hold and require a separately reviewed
+  path-qualified mapping or scanner repair; no force or manual move was used.
+- Confirmed root cause: active governance/planning content still owns the other
+  unresolved names. Resolution: keep those four sources in place and reserve
+  their exact repairs for separate packets. The two completed INDIA-2 plans
+  independently pass single and complete-batch previews with zero unresolved
+  references.
+
+### Verification
+
+- Repository hygiene, maintained links/images, the 115-operation/101-script
+  control registry, JSON syntax, source-blob identity, and the complete
+  two-operation batch dry run pass. The batch preview performs zero writes.
+- Focused migration tests, context, quick/full gates, normal hooks, clean
+  session closeout, and hosted evidence remain pending until candidate freeze.
+
 ## 2026-08-23 — Session: MAINT-0132 automatic efficiency observability
 
 **Agent:** Codex (`governance`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-23 — MAINT-0132 automatic efficiency observability active
+**Updated:** 2026-08-23 — MAINT-0133 cleanup inventory candidate active
 
 ---
 
@@ -127,11 +127,12 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| MAINT-0132 | Replace manually reconstructed per-worktree timing and stale task orientation with one task-bound shared observable session | Main Agent + governance | M | P0 | 🟡 CANDIDATE — focused session/control/instruction proof passes; quick/full/hooks/hosted closeout pending |
+| MAINT-0133 | Freeze an exact read-only cleanup inventory and future authorization batch without moving or deleting content | Main Agent + governance | M | P0 | 🟡 CANDIDATE — six exact candidates: two move-ready for later authorization, four held, zero deletes; local/hosted closeout pending |
 
-No bulk cleanup or automatic archival is authorized by this packet. MAINT-0130
-is merged and green, but content movement remains held until a separate exact
-cleanup plan is classified, reviewed, and authorized.
+No live move, delete, automatic archival, branch cleanup, or worktree cleanup is
+authorized by this packet. The two clean previews are frozen only as a future
+`MAINT-0133B-PACKET-A` batch and require separate explicit live-execution
+authorization.
 
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. The reproduced public-route safety packet is integrated. INDIA-3,
@@ -204,6 +205,7 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| MAINT-0132 | Added shared task-bound elapsed time, compact preflight-only orientation, automatic verification-step timing, and exact external integration closeout | Main Agent + governance | ✅ DONE — PR #846 merged at `60e95bbe`; candidate and merged trees equal `292c562d`; focused, quick 10/10, full 31/31, and hosted 9/9 pass |
 | MAINT-0131 | Repaired preparation exit semantics, helper impact routing, safe-file executable compatibility, and mandatory closeout fields | Main Agent + governance | ✅ DONE — PR #845 merged at `d4e5b122`; candidate and merged trees equal `94bd3164`; focused 235, quick 10/10, full 31/31, and hosted 9/9 pass |
 | MAINT-0130 | Replaced split move/delete/migration safety with one fail-closed transactional safe-file system and retired age-only archival | Main Agent + governance | ✅ DONE — PR #844 merged at `58ecc149`; bulk cleanup remains separately classified and authorized |
 | MAINT-012D | Consolidated true duplicate scanners, archived obsolete compatibility paths, migrated live callers, and preserved distinct safety evidence | Main Agent + governance | ✅ COMPLETE ON MERGE — frozen candidate requires broad Python, quick/full, normal hooks, and all applicable hosted checks; PR facts remain external |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -19,6 +19,7 @@ Internal planning documents and research notes.
 |----------|---------|
 | [Next Session Brief](next-session-brief.md) | What to work on next |
 | [TASKS.md](../TASKS.md) | Canonical task backlog |
+| [MAINT-0133 Cleanup Inventory](maint-0133-cleanup-inventory-and-authorization.md) | Exact read-only cleanup classification, holds, and future transactional batch |
 | [Pre-Release Input Safety and Professional Readiness Plan](pre-release-input-safety-and-professional-readiness-plan.md) | Active contract-first remediation and release holds from the one-storey usability pilot |
 | [Public Route Safety Closure Plan](public-route-safety-closure-plan.md) | Current exact-tree remediation sequence for reproduced lower-level public-route safety defects |
 | [IS 456 Solid Slabs Master Plan](is456-solid-slabs-master-plan.md) | Source-gated, implementation-ready program for simply supported/continuous one-way and common two-way solid slabs; flat slabs held separately |
@@ -34,6 +35,7 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
+| `maint-0133-cleanup-inventory-and-authorization.md` | 2026-08-23 | 🚧 Immutable inventory candidate; two moves ready for later authorization, four held, zero deletes |
 | `public-route-safety-closure-plan.md` | 2026-08-22 | ✅ LIB-PRO-003-D local candidate accepted; hosted/exact-tree closure pending; release and professional claims held by PARTIAL readiness |
 | `next-session-brief.md` | 2026-08-22 | 🚧 Publish/validate the immutable Packet D candidate, then resume read-only INDIA-3-G0 |
 | `pre-release-input-safety-and-professional-readiness-plan.md` | 2026-08-17 | 🚧 A-G merged; CLI, hosted-interpreter, preflight-verdict, and authorization holds remain through I-J |

--- a/docs/planning/maint-0133-cleanup-inventory-and-authorization.md
+++ b/docs/planning/maint-0133-cleanup-inventory-and-authorization.md
@@ -1,0 +1,104 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-23
+doc_type: spec
+complexity: intermediate
+tags: [maintenance, cleanup, safe-file-ops, authorization]
+---
+
+# MAINT-0133 Cleanup Inventory and Authorization Plan
+
+## Decision
+
+MAINT-0133 completes the read-only classification prerequisite for repository
+file cleanup. It does not move, delete, archive, clean, reset, or retire any
+file, branch, or worktree.
+
+The exact baseline is merged `origin/main` commit
+`60e95bbe52575d3335e7195db944b2c82630ed2e`. The machine-readable inventory is
+[`maint-0133-cleanup-inventory.json`](../verification/maint-0133-cleanup-inventory.json),
+and the two-operation future batch is
+[`maint-0133-cleanup-batch.json`](../verification/maint-0133-cleanup-batch.json).
+
+## Discovery contract
+
+The inventory includes only evidence-bearing classes:
+
+1. tracked artifacts rejected by repository hygiene;
+2. exact duplicate Git blobs;
+3. documents explicitly marked `deprecated` or `archived` outside archive
+   roots;
+4. active top-level scripts not covered by the canonical control registry; and
+5. exact safe-file reference previews.
+
+File age, a suggestive filename, or an unreferenced-name scan is insufficient.
+Historical archives, vendor references, and branch/worktree cleanup remain
+preserved or separately held.
+
+## Result
+
+| Disposition | Count | Meaning |
+|---|---:|---|
+| `MOVE_READY_NOT_AUTHORIZED` | 2 | Exact dry-run succeeds with zero unresolved references |
+| `HOLD_UNRESOLVED` | 4 | The transactional mover correctly blocks the operation |
+| `DELETE_READY` | 0 | No deletion has replacement, reference, and retention proof |
+| `KEEP` duplicate group | 1 | Four empty Python test-package markers have distinct ownership |
+
+The maintained baseline is clean: 4,106 tracked files, 478 maintained Markdown
+files, 1,013 local links, six local images, zero broken links, 115 active
+operations, and 101/101 active top-level scripts covered. Repository hygiene
+passes.
+
+### Future Packet A — two clean planning moves
+
+These exact sources are eligible for later live authorization:
+
+| Source | Destination | Updateable | Preserved | Unresolved |
+|---|---|---:|---:|---:|
+| `docs/planning/india-2-remaining-is456-elements-plan.md` | `docs/_archive/planning/india-2-remaining-is456-elements-plan.md` | 3 | 46 | 0 |
+| `docs/planning/india-2-next-session-publication-and-closeout-plan.md` | `docs/_archive/planning/india-2-next-session-publication-and-closeout-plan.md` | 2 | 25 | 0 |
+
+The reviewed batch file is executable by the transactional runner, but its
+embedded status is `NOT_AUTHORIZED_FOR_LIVE_EXECUTION`. MAINT-0133B must first
+receive explicit live-execution authorization, rebind to then-current
+`origin/main`, repeat the complete batch dry-run, compare the path set with this
+record, and execute exactly once only if it remains equal.
+
+### Held candidates
+
+| Source | Unresolved | Hold reason |
+|---|---:|---|
+| `docs/agents/guides/README.md` | 279 | Generic `README.md` basename matches are ambiguous; no force or manual move is allowed |
+| `docs/agents/guides/agent-quick-reference.md` | 2 | Maintained governance checks still name the file |
+| `docs/agents/guides/agent-workflow-master-guide.md` | 2 | Maintained governance checks still name the file |
+| `docs/planning/is456-library-first-master-plan.md` | 3 | Current planning documents still require successor-aware reference repairs |
+
+These holds are not failures to clean. They are the intended fail-closed result
+of the safe-file contract. Each requires a separately reviewed reference repair
+before another preview.
+
+## Preserved surfaces
+
+- 507 files under `docs/_archive/**` remain historical evidence.
+- 119 files under `scripts/_archive/**` remain inactive audit/recovery content.
+- 1,760 files under `docs/reference/vendor/**` remain protected reference
+  material.
+- All 48 observed worktrees remain outside this file-cleanup authority,
+  including dirty, detached, foreign, and uncertain lanes.
+
+## Acceptance and stop conditions
+
+MAINT-0133 is complete when:
+
+- every candidate is bound to an exact source blob and destination;
+- the future two-operation batch passes a complete dry-run;
+- every unresolved reference remains held;
+- zero live moves and zero deletes occurred;
+- maintained links, control coverage, context, focused migration tests, quick,
+  full, normal hooks, and hosted checks pass on the immutable candidate; and
+- post-merge external closeout removes the frozen task row from future session
+  orientation.
+
+Stop MAINT-0133B if a destination appears, a source blob changes, the predicted
+path set changes, any unresolved reference appears, or any validator fails.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,43 +4,41 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-23
-- Focus: Measure the whole task rather than a manually reconstructed subset,
-- Git receipt: docs/verification/maint-0132-git-handoff-receipt.json | sha256:0de9060933fda48022cf81155235477c03bff8a8d71d85e3fba967a771871674 | HOLD
-- Git identity: codex/maint-0132-efficiency-observability@d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94 | upstream=origin/main@d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94 | base=origin/main@d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94 | tree=dirty | operation=none
+- Focus: Freeze an exact read-only repository file-cleanup inventory and
+- Git receipt: docs/verification/maint-0133-git-handoff-receipt.json | sha256:c93a2c5b4e0cbd0189bc088f64e0bbdf9f2842011bdca924cc805db1dcf93cf8 | HOLD
+- Git identity: codex/maint-0133-cleanup-inventory@60e95bbe52575d3335e7195db944b2c82630ed2e | upstream=origin/main@60e95bbe52575d3335e7195db944b2c82630ed2e | base=origin/main@60e95bbe52575d3335e7195db944b2c82630ed2e | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
 - Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `MAINT-0132` makes the whole task observable from pre-orientation start through exact post-merge closeout |
-| **Next** | Freeze and prove the shared ledger, derived elapsed-time, automatic step timing, exact identities, and stale-task projection |
-| **Why** | MAINT-0131 took 20m15s while its manual ledger recorded 18m31s; the compact brief also presented already-merged work as active |
-| **Held** | Bulk cleanup, automatic archival, unclassified file movement, branch/worktree deletion, product behavior, release, and professional approval |
+| **Current** | `MAINT-0133` freezes the first exact read-only file-cleanup inventory on merged MAINT-0130/0131/0132 controls |
+| **Next** | Validate and integrate the inventory; live execution remains a separately authorized `MAINT-0133B` packet |
+| **Why** | Six files are explicitly inactive outside archive roots, but only two pass the transactional move preview and none pass a deletion case |
+| **Held** | Every live move/delete, four unresolved candidates, automatic archival, branch/worktree deletion, product behavior, release, and professional approval |
 
-## Exact MAINT-0132 state
+## Exact MAINT-0133 state
 
-- Branch: `codex/maint-0132-efficiency-observability`, created from exact merged
-  MAINT-0131 baseline `d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94`.
-- `session begin` starts one task timer before the compact brief and environment
-  check. Quick/full gates and `session end` record automatic step durations.
-- New entries use the Git-common ignored ledger; summaries retain a read-only
-  projection of older worktree-local records.
-- Closeout requires an unmatched task start, derived elapsed/phase agreement,
-  resolvable 40-character candidates, complete counters, and exact hosted
-  PR/merge/tree evidence when hosted validation ran.
-- Exact external closeout IDs mask frozen pre-push task rows from later compact
-  starts without rewriting the candidate.
+- Branch: `codex/maint-0133-cleanup-inventory`, created from exact merged
+  MAINT-0132 baseline `60e95bbe52575d3335e7195db944b2c82630ed2e`.
+- Inventory: six exact inactive-location candidates; two
+  `MOVE_READY_NOT_AUTHORIZED`, four `HOLD_UNRESOLVED`, zero delete candidates.
+- The future batch contains only the two completed INDIA-2 planning moves and
+  passes a complete transactional dry run with zero unresolved references.
+- Exact duplicate blobs, archives, vendor references, and all observed
+  worktrees are explicitly kept or held rather than inferred obsolete.
+- No live safe-file operation has run in MAINT-0133.
 
 ## Preserved boundary
 
-- MAINT-0130/0131 are merged and remain unchanged. Bulk cleanup, automatic
-  archival, product behavior, release, branch/worktree deletion, and
-  professional approval are not authorized by MAINT-0132.
+- MAINT-0130/0131/0132 are merged and remain unchanged. MAINT-0133 does not
+  authorize its future batch, repair unresolved references, or mutate product,
+  release, branch, worktree, historical, or professional-approval state.
 
 ## Required Reading
 
 1. [Safe file operations guide](../guidelines/file-operations-safety-guide.md)
 2. [Folder cleanup workflow](../guidelines/folder-cleanup-workflow.md)
-3. [Current task board](../TASKS.md)
-4. [Git workflow single source](../git-automation/git-workflow-single-source.md)
+3. [MAINT-0133 plan](maint-0133-cleanup-inventory-and-authorization.md)
+4. [Current task board](../TASKS.md)

--- a/docs/verification/maint-0133-cleanup-batch.json
+++ b/docs/verification/maint-0133-cleanup-batch.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "task_id": "MAINT-0133B-PACKET-A",
+  "baseline_commit": "60e95bbe52575d3335e7195db944b2c82630ed2e",
+  "authorization_status": "NOT_AUTHORIZED_FOR_LIVE_EXECUTION",
+  "purpose": "Reviewed future batch containing only MAINT-0133 move-ready files",
+  "operations": [
+    {
+      "tool": "safe_move",
+      "source": "docs/planning/india-2-remaining-is456-elements-plan.md",
+      "destination": "docs/_archive/planning/india-2-remaining-is456-elements-plan.md"
+    },
+    {
+      "tool": "safe_move",
+      "source": "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
+      "destination": "docs/_archive/planning/india-2-next-session-publication-and-closeout-plan.md"
+    }
+  ]
+}

--- a/docs/verification/maint-0133-cleanup-inventory.json
+++ b/docs/verification/maint-0133-cleanup-inventory.json
@@ -1,0 +1,213 @@
+{
+  "schema_version": 1,
+  "task_id": "MAINT-0133",
+  "baseline_commit": "60e95bbe52575d3335e7195db944b2c82630ed2e",
+  "observed_date": "2026-08-23",
+  "mode": "READ_ONLY_CLASSIFICATION",
+  "live_file_operations_authorized": false,
+  "discovery_contract": {
+    "included": [
+      "tracked hygiene artifacts",
+      "exact Git-blob duplicates",
+      "explicit deprecated or archived metadata outside archive roots",
+      "active top-level control scripts",
+      "maintained Markdown and local-image references"
+    ],
+    "excluded": [
+      "age-only candidates",
+      "unreferenced-name guesses",
+      "branches and worktrees",
+      "historical archive content",
+      "vendor/reference content",
+      "untracked content from foreign worktrees"
+    ]
+  },
+  "baseline": {
+    "tracked_files": 4106,
+    "maintained_markdown_files": 478,
+    "maintained_local_links": 1013,
+    "maintained_local_images": 6,
+    "broken_links": 0,
+    "active_control_operations": 115,
+    "registered_top_level_scripts": 101,
+    "top_level_scripts_total": 101,
+    "repository_hygiene": "PASS"
+  },
+  "summary": {
+    "explicit_inactive_candidates": 6,
+    "move_ready": 2,
+    "hold_unresolved": 4,
+    "delete_ready": 0,
+    "exact_duplicate_groups": 1,
+    "live_operations_performed": 0
+  },
+  "candidates": [
+    {
+      "source": "docs/agents/guides/README.md",
+      "source_blob": "fa1fb6ee28673a898e3ea93870117791b3d1f0e5",
+      "size_bytes": 2612,
+      "declared_status": "deprecated",
+      "owner": "agent documentation",
+      "disposition": "HOLD_UNRESOLVED",
+      "destination": "docs/_archive/agents/guides/README.md",
+      "reason": "Historical navigation is explicitly deprecated, but the generic basename produces ambiguous maintained matches.",
+      "preview": {
+        "success": false,
+        "updateable_references": 0,
+        "preserved_references": 828,
+        "unresolved_references": 279,
+        "baseline_broken_links": 0
+      },
+      "next_action": "Improve or explicitly map path-qualified README references in a separately reviewed repair; do not bypass the hold."
+    },
+    {
+      "source": "docs/agents/guides/agent-quick-reference.md",
+      "source_blob": "55f9c5d3533387c2d83497abc02bc64db5ded2cc",
+      "size_bytes": 10256,
+      "declared_status": "deprecated",
+      "owner": "agent documentation",
+      "disposition": "HOLD_UNRESOLVED",
+      "destination": "docs/_archive/agents/guides/agent-quick-reference.md",
+      "reason": "The historical guide is deprecated, but active and archived governance checks still contain unresolved filename contracts.",
+      "preview": {
+        "success": false,
+        "updateable_references": 7,
+        "preserved_references": 37,
+        "unresolved_references": 2,
+        "unresolved": [
+          "scripts/_archive/check_governance_compliance.py:194",
+          "scripts/check_governance.py:805"
+        ],
+        "baseline_broken_links": 0
+      },
+      "next_action": "Decide and update the maintained governance contract before repeating the move preview."
+    },
+    {
+      "source": "docs/agents/guides/agent-workflow-master-guide.md",
+      "source_blob": "63cd5c737c39b55465d56f7c241a295daf476023",
+      "size_bytes": 19829,
+      "declared_status": "deprecated",
+      "owner": "agent documentation",
+      "disposition": "HOLD_UNRESOLVED",
+      "destination": "docs/_archive/agents/guides/agent-workflow-master-guide.md",
+      "reason": "The historical guide is deprecated, but active and archived governance checks still contain unresolved filename contracts.",
+      "preview": {
+        "success": false,
+        "updateable_references": 5,
+        "preserved_references": 51,
+        "unresolved_references": 2,
+        "unresolved": [
+          "scripts/_archive/check_governance_compliance.py:195",
+          "scripts/check_governance.py:806"
+        ],
+        "baseline_broken_links": 0
+      },
+      "next_action": "Decide and update the maintained governance contract before repeating the move preview."
+    },
+    {
+      "source": "docs/planning/is456-library-first-master-plan.md",
+      "source_blob": "e33f1bd7fcad2e5ce8b548af1d2e83acf9db6c4e",
+      "size_bytes": 73605,
+      "declared_status": "archived",
+      "owner": "library planning",
+      "disposition": "HOLD_UNRESOLVED",
+      "destination": "docs/_archive/planning/is456-library-first-master-plan.md",
+      "reason": "The completed plan is marked archived, but three maintained planning references require an explicit successor-aware repair.",
+      "preview": {
+        "success": false,
+        "updateable_references": 3,
+        "preserved_references": 4,
+        "unresolved_references": 3,
+        "unresolved": [
+          "docs/planning/README.md:43",
+          "docs/planning/india-2-next-session-publication-and-closeout-plan.md:221",
+          "docs/planning/professional-library-remediation-plan.md:141"
+        ],
+        "baseline_broken_links": 0
+      },
+      "next_action": "Repair the three maintained planning references in one reviewed content packet before repeating the move preview."
+    },
+    {
+      "source": "docs/planning/india-2-remaining-is456-elements-plan.md",
+      "source_blob": "3c3d2a3e62bf6f22d4746da241ad0a6cd66e3a9c",
+      "size_bytes": 22535,
+      "declared_status": "archived",
+      "owner": "Indian-code planning",
+      "disposition": "MOVE_READY_NOT_AUTHORIZED",
+      "destination": "docs/_archive/planning/india-2-remaining-is456-elements-plan.md",
+      "reason": "INDIA-2 is administratively complete and the exact move preview updates both maintained references while preserving 43 historical references.",
+      "preview": {
+        "success": true,
+        "updateable_references": 3,
+        "preserved_references": 46,
+        "unresolved_references": 0,
+        "predicted_changed_files": [
+          "docs/TASKS.md",
+          "docs/_archive/planning/india-2-remaining-is456-elements-plan.md",
+          "docs/planning/india-2-remaining-is456-elements-plan.md",
+          "docs/planning/indian-code-completion-plan.md",
+          "docs/planning/maint-0133-cleanup-inventory-and-authorization.md"
+        ],
+        "baseline_broken_links": 0
+      },
+      "future_batch": "MAINT-0133B-PACKET-A"
+    },
+    {
+      "source": "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
+      "source_blob": "2e576e90256d72ca5cdd886ca67ee881d4227087",
+      "size_bytes": 29082,
+      "declared_status": "archived",
+      "owner": "Indian-code planning",
+      "disposition": "MOVE_READY_NOT_AUTHORIZED",
+      "destination": "docs/_archive/planning/india-2-next-session-publication-and-closeout-plan.md",
+      "reason": "The sequence is complete and the exact move preview updates its maintained parent reference while preserving 21 historical references.",
+      "preview": {
+        "success": true,
+        "updateable_references": 2,
+        "preserved_references": 25,
+        "unresolved_references": 0,
+        "predicted_changed_files": [
+          "docs/_archive/planning/india-2-next-session-publication-and-closeout-plan.md",
+          "docs/planning/india-2-next-session-publication-and-closeout-plan.md",
+          "docs/planning/indian-code-completion-plan.md",
+          "docs/planning/maint-0133-cleanup-inventory-and-authorization.md"
+        ],
+        "baseline_broken_links": 0
+      },
+      "future_batch": "MAINT-0133B-PACKET-A"
+    }
+  ],
+  "kept_surfaces": [
+    {
+      "class": "exact-byte duplicate Python package markers",
+      "count": 4,
+      "blob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "disposition": "KEEP",
+      "reason": "Empty __init__.py files establish distinct test-package boundaries; byte equality is not duplicate ownership."
+    },
+    {
+      "class": "docs archive",
+      "count": 507,
+      "disposition": "KEEP",
+      "reason": "Historical evidence and retained recovery records are preservation surfaces, not cleanup candidates."
+    },
+    {
+      "class": "scripts archive",
+      "count": 119,
+      "disposition": "KEEP",
+      "reason": "Inactive scripts are already outside the active 101-script control plane and retained for audit/recovery."
+    },
+    {
+      "class": "vendor reference",
+      "count": 1760,
+      "disposition": "KEEP",
+      "reason": "Protected reference content is outside cleanup authority."
+    }
+  ],
+  "held_out_of_scope": {
+    "worktrees_observed": 48,
+    "reason": "Branch/worktree cleanup has separate evidence and deletion authority; dirty, detached, foreign, and uncertain lanes remain untouched."
+  },
+  "future_batch_plan": "docs/verification/maint-0133-cleanup-batch.json",
+  "decision": "MAINT-0133 completes classification only. No move or delete is authorized or performed."
+}

--- a/docs/verification/maint-0133-git-handoff-receipt.json
+++ b/docs/verification/maint-0133-git-handoff-receipt.json
@@ -1,0 +1,136 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "c93a2c5b4e0cbd0189bc088f64e0bbdf9f2842011bdca924cc805db1dcf93cf8",
+    "state": {
+      "branch": "codex/maint-0133-cleanup-inventory",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "60e95bbe52575d3335e7195db944b2c82630ed2e",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 112.125,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-maint-0133-cleanup-inventory",
+      "head_sha": "60e95bbe52575d3335e7195db944b2c82630ed2e",
+      "hold_reasons": [
+        "changed paths: 7"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-23T07:33:57.166580+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0133-cleanup-inventory",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 7,
+        "modified_paths": [
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/README.md",
+          "docs/planning/next-session-brief.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/planning/maint-0133-cleanup-inventory-and-authorization.md",
+          "docs/verification/maint-0133-cleanup-batch.json",
+          "docs/verification/maint-0133-cleanup-inventory.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "60e95bbe52575d3335e7195db944b2c82630ed2e",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0133-cleanup-inventory"
+    }
+  },
+  "local_state_receipt_hash": "sha256:c93a2c5b4e0cbd0189bc088f64e0bbdf9f2842011bdca924cc805db1dcf93cf8",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-23T07:33:57.166748+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python/structural_lib/**/*.py",
+      "fastapi_app/**/*.py",
+      "react_app/**/*.{ts,tsx}",
+      "excel_addin/**",
+      "Etabs_CSV/**",
+      "scripts/safe_file_move.py",
+      "scripts/safe_file_delete.py",
+      "scripts/batch_migrate_runner.py"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "docs/planning/maint-0133-cleanup-inventory-and-authorization.md",
+      "docs/verification/maint-0133-cleanup-batch.json",
+      "docs/verification/maint-0133-cleanup-inventory.json",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/README.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/README.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "MAINT-0133"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}


### PR DESCRIPTION
## Summary

- freeze the MAINT-0133 evidence-bearing cleanup inventory at candidate f8c8d2642fa1f61f78366b3a05ff8dded692b75d
- classify six explicit inactive-location candidates: two future move-ready items, four held for unresolved references, and zero delete candidates
- publish a machine-readable future batch for MAINT-0133B-PACKET-A without performing any live file move or delete
- record root causes, verification evidence, and the source-bound Git handoff receipt

## Authorization boundary

This PR is read-only cleanup planning and authorization evidence. It does not authorize or execute the two proposed safe moves. A separate explicitly approved MAINT-0133B packet is required for live execution.

## Verification

- safe-file batch dry-run: 2/2 passed, zero failures, seven predicted changed paths
- migration integration tests: 10 passed
- maintained links: 479 documents, 1,016 links, 6 images, 0 broken
- quick gate: 10/10 passed once after content freeze
- normal commit hooks: passed on first attempt
- final session validation: passed on clean immutable commit
- full gate: 31/31 passed once

## Cleanup outcome

- 2 MOVE_READY_NOT_AUTHORIZED
- 4 HOLD_UNRESOLVED
- 0 delete candidates
- 0 live file operations performed