### PR TITLE
docs(india-3): establish private source library boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ logs/*
 # -----------------------------------------------------------------------------
 docs/_references/downloads_snapshot/
 
-# Protected engineering sources and extracted standard data (local only)
+# Protected engineering PDFs, extracted page cache, and source database (local only)
 /private_sources/
 
 # -----------------------------------------------------------------------------

--- a/Python/tests/test_private_source_boundary.py
+++ b/Python/tests/test_private_source_boundary.py
@@ -21,17 +21,18 @@ def test_private_sources_directory_is_ignored_and_untracked() -> None:
     )
     assert tracked.stdout == ""
 
-    ignored = subprocess.run(
-        [
-            "git",
-            "check-ignore",
-            "-q",
-            "private_sources/is456_library_first/manifest.json",
-        ],
-        cwd=ROOT,
-        check=False,
+    ignored_paths = (
+        "private_sources/is456_library_first/manifest.json",
+        "private_sources/is_code_library/library.sqlite3",
+        "private_sources/is_code_library/source_pdfs/is13920/example.pdf",
     )
-    assert ignored.returncode == 0
+    for ignored_path in ignored_paths:
+        ignored = subprocess.run(
+            ["git", "check-ignore", "-q", ignored_path],
+            cwd=ROOT,
+            check=False,
+        )
+        assert ignored.returncode == 0, ignored_path
 
 
 def test_package_configuration_has_no_private_source_data() -> None:

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,111 @@
 
 ---
 
+## 2026-08-23 — Session: INDIA-3-G0 private multi-code source library
+
+**Agent:** Codex (`library-expert`, sole writer)
+
+**Branch:** `codex/india-3-g0-source-library`, from exact remote `main`
+commit `f24c3904b4af7d768f71342f11ac70f21e7b1dfa`.
+
+**Git handoff receipt:**
+`docs/verification/india-3-g0-private-source-library-git-handoff-receipt.json`
+
+**Focus:** Inspect additional IS-code PDFs in Downloads, preserve useful code
+sources in the existing Git-ignored private-source boundary, and create a
+searchable, hash-bound database that avoids repeated discovery/screenshots
+without reproducing protected source content in tracked or packaged outputs.
+
+### Summary
+
+- Created a private SQLite source library in the retained primary checkout,
+  referenced the two existing IS 456 PDFs, and copied 23 distinct IS 875,
+  IS 1893, IS 13920, and IS 2950 PDFs without moving or deleting Downloads.
+- Bound 25 distinct PDF identities to 27 original aliases and 732 cached pages;
+  exact duplicate downloads deduplicate by SHA-256.
+- Added separate identity, edition/amendment, review, applicability, and
+  distribution states; page FTS; visual/OCR-required flags; and normalized
+  reference contracts with no protected-excerpt field.
+- Added three `UNREVIEWED_IMPLEMENTATION_CLAIM` navigation records for the
+  current IS 13920 beam, column, and strong-column/weak-beam symbols. No
+  source-derived engineering value or accepted page pointer was recorded.
+- Reconciled the merged MAINT-0133B predecessor and activated INDIA-3-G0 as an
+  audit/decision packet only. No formula, support, release, or professional-use
+  claim changed.
+
+### Issues encountered
+
+- `session brief` emitted a macOS `awk` newline error while formatting the
+  multi-line closed-task ID list.
+- A SQLite CLI `-readonly` query returned `unable to open database file` once
+  immediately after parallel verification, although the database file and
+  integrity state were present.
+- The first page-cache classifier treated any non-empty extracted text as a
+  successful page. The consolidated IS 13920 PDF has scanned pages whose only
+  extractable content is a short watermark layer.
+- The available PDF runtime has no OCR engine. Several scanned/low-text pages
+  cannot truthfully become searchable source content in this packet.
+- The first Git handoff-receipt invocation passed a Markdown file to the
+  structured `--evidence` option, so receipt creation stopped without output.
+- The first normal hook run rejected the Latest Handoff receipt hash even
+  though the receipt itself validated.
+
+### Root causes and resolutions
+
+- Confirmed inherited root cause: `scripts/agent_brief.sh` passes multi-line
+  closed task IDs through one `awk -v` value, which macOS awk rejects.
+  Resolution: use `session start`'s independent Python task parser, which
+  returned `READY_LOCAL`; retain the formatter repair for automation scope.
+  ⚠️ TERMINAL ISSUE: the shell brief could not format closed tasks → the
+  maintained Python session parser completed startup and task state was read
+  directly from `docs/TASKS.md`.
+- SQLite CLI root cause remains **unconfirmed**; file presence, permissions,
+  page rows, and `PRAGMA integrity_check` were healthy immediately afterward.
+  Resolution: reopen the same database normally with `PRAGMA query_only=ON`;
+  the failed query and all later read-only SQL completed without recreation or
+  data loss. ⚠️ TERMINAL ISSUE: one `sqlite3 -readonly` open failed → a normal
+  connection with query-only enforcement worked and integrity stayed `ok`.
+- Confirmed root cause: a watermark text layer made scanned pages non-empty but
+  did not contain their engineering content. Resolution: classify empty pages
+  as `NO_EXTRACTABLE_TEXT`, normalized text below 250 characters as
+  `LOW_TEXT_VISUAL_OR_OCR_REQUIRED`, reclassify all 732 cached pages, and save
+  no incomplete clause pointer as accepted normalization.
+- Confirmed limitation: neither `tesseract` nor another OCR executable is
+  provisioned. Resolution: preserve the exact PDF/page identities and mark 142
+  pages for future visual/OCR review; do not infer missing content or block the
+  590 genuinely searchable pages.
+- Confirmed root cause: `git_handoff_receipt.py --evidence` parses a JSON
+  mapping, while the reviewed evidence artifact was Markdown. Resolution: keep
+  the Markdown as an owned path, add a minimal structured authorization and
+  retention evidence record, and regenerate the receipt from that JSON.
+  ⚠️ TERMINAL ISSUE: Markdown evidence failed JSON parsing → structured source
+  evidence plus the owned Markdown path produced the fail-closed receipt.
+- Confirmed root cause: the handoff contract requires the receipt's embedded
+  `local_state_receipt_hash`, while the briefing contained the SHA-256 of the
+  JSON file bytes. Resolution: replace that one field with the embedded
+  `sha256:c81907...84484cf` identity and rerun only `check-session-docs`.
+
+### Validation through content freeze
+
+- Git/source binding: clean linked worktree from exact `origin/main` at
+  `f24c3904`; `git_state.py` returned `READY_LOCAL` and runtime diagnosis
+  returned `source_bound=true` before edits.
+- Private verifier: `documents=25`, `aliases=27`, `pages=732`,
+  `normalized_references=3`, `visual_review_pages=142`; SQLite integrity,
+  every stored/reference PDF hash, page ownership, and Git-ignore guard pass.
+- Private seed idempotence: a second 27-entry run created aliases only; document
+  and page counts stayed unchanged.
+- Focused repository boundary: `2 passed` in
+  `Python/tests/test_private_source_boundary.py`; `git ls-files private_sources`
+  is empty and representative database/PDF paths are ignored.
+- Documentation: front matter reports zero invalid files; 478 maintained
+  Markdown files, 992 local links, and six local images have zero broken links.
+- Consolidated quick gate passed `10/10` with zero reused results. Every
+  ordinary staged hook also passes after the one targeted session-document
+  receipt-hash repair. The fail-closed Git handoff receipt validates as `HOLD`
+  only for the expected dirty/remote/PR/review facts. Final read-only session
+  closeout, commit, push, and hosted evidence remain.
+
 ## 2026-08-23 — Session: MAINT-0133B exact cleanup execution
 
 **Agent:** Codex (`governance`, sole writer)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -127,18 +127,19 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| MAINT-0133B | Execute only the two owner-authorized moves frozen by MAINT-0133 and preserve every unresolved candidate | Main Agent + governance | S | P0 | 🟡 CANDIDATE — 2/2 transactional moves succeeded with zero unresolved or broken references; integration pending |
+| INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | 🟡 IN PROGRESS — private multi-code source library established; IS 13920 truth/benchmark/contract decision remains |
 
-The owner explicitly authorized completion of the frozen
-`MAINT-0133B-PACKET-A` batch. Exactly two completed INDIA-2 plans moved through
-the transactional safe-file tool; four unresolved candidates, every delete,
-automatic archival, branch cleanup, and worktree cleanup remain held.
+`MAINT-0133B-PACKET-A` merged through PR #848 at `f24c3904`. The owner then
+selected `INDIA-3-G0` and authorized use of additional local IS-code PDFs under
+the existing non-distribution boundary. The private library now binds exact
+PDF hashes, editions/amendments, page-search state, and normalized-reference
+records without tracking or packaging protected source content.
 
 INDIA-2 remains administratively complete within its recorded accepted/held
-boundary. The reproduced public-route safety packet is integrated. INDIA-3,
-dependency work, the next package version, further cleanup, and professional
-approval remain separately held until a successor is explicitly selected and
-scoped.
+boundary. The reproduced public-route safety packet is integrated. INDIA-3-G0
+remains an audit/decision packet only: no new formula, support claim, IS 875 or
+IS 1893 implementation, next package version, release, or professional
+approval is activated.
 
 `LIB-PRO-003-A` was accepted and exact-tree merged through PR #832 at
 `e7698a63b86d2db6db2f3970871122af1ce562f6`; Packet B was accepted and
@@ -169,7 +170,6 @@ write-back/nightly work remain outside E1.
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | ⏸ AFTER LIB-PRO-003 — truth/benchmark/contract audit only; no new formulas or support claims |
 | SPARK-001-G0 | Reassess the stale Spark work-program proposal before any implementation | repository owner | review gate | P2 | ⏸ OWNER REVIEW — the 2026-08-11 model/preview assumptions and bulk wave require refresh or rejection |
 
 ## Backlog

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,42 +4,50 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-23
-- Focus: Execute only the two owner-authorized planning moves frozen by
-- Git receipt: docs/verification/maint-0133b-git-handoff-receipt.json | sha256:886caa2e404083b871df33dd570a4d9ea60c2d8ab5e8437bc236ca5413bcc36f | HOLD
-- Git identity: codex/maint-0133b-packet-a@417a16590892d176ea288bbda93ad4d48b4603c4 | upstream=origin/main@417a16590892d176ea288bbda93ad4d48b4603c4 | base=origin/main@417a16590892d176ea288bbda93ad4d48b4603c4 | tree=dirty | operation=none
+- Focus: Establish the private multi-code source library for INDIA-3-G0
+- Git receipt: docs/verification/india-3-g0-private-source-library-git-handoff-receipt.json | sha256:c81907a196e335aa8fa815159906263f7c4d5abbc5905f07aaf57934f84484cf | HOLD
+- Git identity: codex/india-3-g0-source-library@f24c3904b4af7d768f71342f11ac70f21e7b1dfa | upstream=origin/main@f24c3904b4af7d768f71342f11ac70f21e7b1dfa | base=origin/main@f24c3904b4af7d768f71342f11ac70f21e7b1dfa | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
-- Next action: COMMIT_INTENDED_PATHS
+- Next action: FREEZE_IS13920_G0_TRUTH_BENCHMARK_CONTRACT_DECISION
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `MAINT-0133B-PACKET-A` executed the two exact owner-authorized planning moves on merged MAINT-0133 controls |
-| **Next** | Integrate the unchanged candidate, then start the separately scoped actual product packet `INDIA-3-G0` when selected |
-| **Why** | Both frozen moves still had identical source blobs, absent destinations, zero unresolved references, and the exact predicted path set |
-| **Held** | Four unresolved cleanup candidates, every delete, automatic archival, branch/worktree deletion, release, and professional approval |
+| **Current** | `INDIA-3-G0` has one private hash-bound library covering the retained IS 456 sources plus discovered IS 875, IS 1893, IS 13920, and IS 2950 PDFs |
+| **Next** | Audit the complete relevant IS 13920 beam, column, and joint pages plus amendment chain; freeze one bounded acceptance sequence or `HOLD` |
+| **Why** | Exact PDFs, page search, duplicates, editions, amendments, and implementation navigation are now reusable without repeated discovery or uncontrolled screenshots |
+| **Held** | Source-page reproduction; unreviewed normalization; new formulas; IS 13920 wall/foundation work; IS 875/1893 implementation; ETABS; release; and professional approval |
 
-## Exact MAINT-0133 completion state
+## Exact private-library state
 
-- MAINT-0133 inventory PR #847 is merged at
-  `417a16590892d176ea288bbda93ad4d48b4603c4`.
-- Inventory: six exact inactive-location candidates; two
-  owner-authorized moves, four `HOLD_UNRESOLVED`, zero delete candidates.
-- MAINT-0133B executed only the two completed INDIA-2 planning moves through
-  `safe_file_move.py`; both live operations succeeded without rollback.
-- The destination blobs equal the original source blobs, the original sources
-  are absent, and maintained references now point to the archive destinations.
-- Exact duplicate blobs, archives, vendor references, and all observed
-  worktrees are explicitly kept or held rather than inferred obsolete.
+- The primary checkout's ignored `private_sources/is_code_library/` contains the
+  SQLite catalog and 23 archived Downloads PDFs. Two retained IS 456 PDFs are
+  referenced from the earlier private corpus without copying their bytes.
+- Verified inventory: 25 distinct documents, 27 source aliases, 732 pages, and
+  three unreviewed current-implementation navigation records.
+- Search state: 590 pages have usable extracted text; 113 low-text pages and 29
+  no-text pages are explicitly marked visual/OCR-required.
+- Every newly discovered non-IS-456 source remains
+  `UNKNOWN_PENDING_ENGINEERING_REVIEW`. Parallel IS 13920 amendment copies and
+  IS 2950 Part 1 copies are preserved without silently selecting one.
+- The private verifier passed SQLite integrity, all PDF hashes, page counts,
+  FTS ownership, and Git-ignore protection. Downloads originals were not moved
+  or deleted.
+- Focused boundary/document/context checks and the consolidated quick gate pass;
+  quick reports `10/10` with zero reused results.
 
 ## Preserved boundary
 
-- MAINT-0130/0131/0132/0133 remain unchanged. Packet A does not repair the four
-  unresolved candidates or mutate product, release, branch, worktree,
-  historical, or professional-approval state.
+- The private page cache is navigation evidence, not source interpretation or
+  benchmark truth. Tracked files contain no PDF, extracted prose, page image,
+  database bytes, or normalized engineering value.
+- INDIA-3-G0 remains a truth/benchmark/contract audit. This source foundation
+  does not activate the existing beam/column/joint claims or any later
+  companion-code packet.
 
 ## Required Reading
 
-1. [Safe file operations guide](../guidelines/file-operations-safety-guide.md)
-2. [Folder cleanup workflow](../guidelines/folder-cleanup-workflow.md)
-3. [MAINT-0133 plan](maint-0133-cleanup-inventory-and-authorization.md)
-4. [Current task board](../TASKS.md)
+1. [Private source-library evidence](../verification/india-3-g0-private-source-library-evidence.md)
+2. [Indian-code completion plan](indian-code-completion-plan.md)
+3. [Current task board](../TASKS.md)
+4. [Git workflow single source](../git-automation/git-workflow-single-source.md)

--- a/docs/verification/india-3-g0-private-source-library-evidence.md
+++ b/docs/verification/india-3-g0-private-source-library-evidence.md
@@ -1,0 +1,112 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-23
+doc_type: reference
+task: INDIA-3-G0
+---
+
+# INDIA-3 G0 Private Source-Library Evidence
+
+## Decision
+
+**SOURCE FOUNDATION READY; ENGINEERING DECISION PENDING.** The primary checkout
+now retains one Git-ignored, hash-bound, searchable private source library for
+the existing IS 456 corpus and the newly discovered IS 875, IS 1893, IS 13920,
+and IS 2950 PDFs. This clears repeated source discovery and navigation work. It
+does not accept an edition, amendment effect, formula, benchmark, capability,
+release, or professional-use claim.
+
+Protected PDFs, extracted page text, database bytes, private helper code, and
+source-expression search results remain under `private_sources/` in the primary
+checkout. They are untracked, excluded from packaging, and not materialized in
+linked worktrees. Public repository content records only this boundary and
+aggregate verification facts.
+
+## Exact local inventory
+
+The private SQLite library contains:
+
+| Standard family | Distinct PDF identities | Cached pages |
+|---|---:|---:|
+| IS 456 | 2 | 130 |
+| IS 875 | 7 | 181 |
+| IS 1893 | 8 | 280 |
+| IS 13920 | 6 | 84 |
+| IS 2950 | 2 | 57 |
+| **Total** | **25** | **732** |
+
+Twenty-seven original paths resolve to those 25 identities; two exact repeated
+downloads are aliases rather than duplicate stored files. Twenty-three PDFs
+were copied from Downloads into the private archive. The two existing
+controlled IS 456 PDFs remain in the earlier private corpus and are referenced
+without duplicate bytes.
+
+The database and its private importer record:
+
+- SHA-256, logical and hash-bound source IDs, original filename aliases, title,
+  standard, part, edition, revision, amendment, reaffirmation metadata, byte
+  size, PDF page count, and archive path;
+- separate identity, review, applicability, and distribution states;
+- page-numbered extracted text plus text hashes and FTS5 private search;
+- explicit visual/OCR-required flags; and
+- project-authored normalized references with units, conditions, page range,
+  review state, and no source-excerpt field.
+
+## Extraction and review boundary
+
+Private verification reports 590 text-searchable pages and 142 pages requiring
+visual or OCR review: 113 pages have only a low-volume text layer and 29 have no
+extractable text. The low-text rule was added after the consolidated IS 13920
+PDF revealed scanned pages containing only a short watermark text layer.
+
+No incomplete clause pointer was saved as accepted source normalization. Three
+`UNREVIEWED_IMPLEMENTATION_CLAIM` navigation records bind the current beam,
+column, and strong-column/weak-beam symbols to their existing decorator and
+capability-manifest clause claims. They contain no source-derived values and no
+page acceptance. The accepted source-normalized engineering-value count is
+zero. INDIA-3-G0 must inspect the complete relevant pages and amendment chain
+before promoting any beam, column, or joint reference record.
+
+All newly imported non-IS-456 documents remain
+`UNKNOWN_PENDING_ENGINEERING_REVIEW`. Parallel byte-distinct copies exist for
+IS 13920 Amendments 1 and 2 and IS 2950 Part 1; none is silently preferred.
+The older monolithic IS 1893:1984 source is explicitly historical pending
+review.
+
+## Reuse contract
+
+Future source work starts by listing or searching the private database, then
+visually reviews only the complete pages that govern the bounded packet. A
+downloaded filename, search hit, OCR result, decorator registration, or
+existing implementation is navigation evidence only.
+
+Normalized data may be added only when one bounded packet records the exact
+source identity, edition/amendment applicability, clause/table/figure/formula
+reference, units, limits, conditions, page location, independent benchmark,
+unsafe and out-of-domain behavior, and review state. Protected prose, page
+images, or publication-ready reproductions must not enter tracked files or
+package artifacts.
+
+## Verification
+
+- Git ignore: database and representative archived-PDF paths resolve through
+  the root `/private_sources/` rule; `git ls-files private_sources` is empty.
+- SQLite integrity, foreign keys, all 25 PDF hashes, 732 cached page rows, and
+  FTS ownership pass the private verifier.
+- The exact-download seed is idempotent by SHA-256; duplicate paths become
+  aliases and originals in Downloads are not moved or deleted.
+- Repository boundary regression covers the prior IS 456 manifest, the new
+  SQLite database, and an archived IS 13920 PDF path.
+- The affected focused checks, documentation front matter, maintained links,
+  context manifest, and consolidated quick gate pass; quick reports `10/10`
+  with zero reused results.
+
+## Next INDIA-3-G0 boundary
+
+Use the controlled IS 13920 consolidated/base copies and separate amendment
+copies to audit the current beam, column, and strong-column/weak-beam joint
+surface. Freeze one truthful acceptance sequence or return `HOLD` where the
+source, amendment applicability, benchmark, or public contract is incomplete.
+Do not implement IS 875, IS 1893, new IS 13920 formulas, wall/foundation
+provisions, release, ETABS, or professional approval in this G0 packet.

--- a/docs/verification/india-3-g0-private-source-library-git-handoff-receipt.json
+++ b/docs/verification/india-3-g0-private-source-library-git-handoff-receipt.json
@@ -1,0 +1,177 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-23T08:34:18Z",
+      "query_status": "OK",
+      "reference": "Active Codex task: inspect Downloads for usable IS codes, preserve PDFs in a Git-ignored private database, and do not reproduce or reprint source content",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "INVENTORY_DOWNLOADS_IS_CODE_PDFS",
+      "COPY_PDFS_TO_PRIVATE_IGNORED_LIBRARY",
+      "CREATE_PRIVATE_SEARCH_DATABASE",
+      "RECORD_PUBLIC_BOUNDARY_EVIDENCE",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-23T08:34:18Z",
+    "prohibited_actions": [
+      "TRACK_PRIVATE_SOURCE_CONTENT",
+      "PACKAGE_PRIVATE_SOURCE_CONTENT",
+      "REPRODUCE_OR_REPRINT_SOURCE_PROSE_OR_PAGE_IMAGES",
+      "DELETE_DOWNLOADS_ORIGINALS",
+      "IMPLEMENT_NEW_ENGINEERING_FORMULAS",
+      "ACTIVATE_NEW_SUPPORT_CLAIMS",
+      "PUBLISH_RELEASE",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "INVENTORY_DOWNLOADS_IS_CODE_PDFS",
+        "COPY_PDFS_TO_PRIVATE_IGNORED_LIBRARY",
+        "CREATE_PRIVATE_SEARCH_DATABASE",
+        "RECORD_PUBLIC_BOUNDARY_EVIDENCE",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/india-3-g0-source-library",
+      "head_sha": "f24c3904b4af7d768f71342f11ac70f21e7b1dfa",
+      "task_id": "INDIA-3-G0-SOURCE-LIBRARY"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "observed_at_utc": "2026-08-23T08:34:18Z",
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "c81907a196e335aa8fa815159906263f7c4d5abbc5905f07aaf57934f84484cf",
+    "state": {
+      "branch": "codex/india-3-g0-source-library",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "f24c3904b4af7d768f71342f11ac70f21e7b1dfa",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 95.423,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib12",
+      "head_sha": "f24c3904b4af7d768f71342f11ac70f21e7b1dfa",
+      "hold_reasons": [
+        "changed paths: 8"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-23T08:34:55.751941+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/india-3-g0-source-library/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 8,
+        "modified_paths": [
+          ".gitignore",
+          "Python/tests/test_private_source_boundary.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/next-session-brief.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/india-3-g0-private-source-library-evidence.md",
+          "docs/verification/india-3-g0-private-source-library-git-handoff-receipt.json",
+          "docs/verification/india-3-g0-private-source-library-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/india-3-g0-source-library/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:c81907a196e335aa8fa815159906263f7c4d5abbc5905f07aaf57934f84484cf",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-23T08:34:55.752106+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [],
+    "observed_at_utc": "2026-08-23T08:34:18Z",
+    "owner": "Main Agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources/**",
+      "Python/structural_lib/**",
+      "fastapi_app/**",
+      "react_app/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      ".gitignore",
+      "Python/tests/test_private_source_boundary.py",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md",
+      "docs/verification/india-3-g0-private-source-library-evidence.md",
+      "docs/verification/india-3-g0-private-source-library-source-evidence.json"
+    ],
+    "shared_paths": [
+      ".gitignore",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "INDIA-3-G0-SOURCE-LIBRARY"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-3-g0-private-source-library-source-evidence.json
+++ b/docs/verification/india-3-g0-private-source-library-source-evidence.json
@@ -1,0 +1,65 @@
+{
+  "authorization": {
+    "status": "OBSERVED",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-23T08:34:18Z",
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "reference": "Active Codex task: inspect Downloads for usable IS codes, preserve PDFs in a Git-ignored private database, and do not reproduce or reprint source content",
+      "status": "OBSERVED",
+      "query_status": "OK",
+      "observed_at_utc": "2026-08-23T08:34:18Z"
+    },
+    "authorized_actions": [
+      "INVENTORY_DOWNLOADS_IS_CODE_PDFS",
+      "COPY_PDFS_TO_PRIVATE_IGNORED_LIBRARY",
+      "CREATE_PRIVATE_SEARCH_DATABASE",
+      "RECORD_PUBLIC_BOUNDARY_EVIDENCE",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "prohibited_actions": [
+      "TRACK_PRIVATE_SOURCE_CONTENT",
+      "PACKAGE_PRIVATE_SOURCE_CONTENT",
+      "REPRODUCE_OR_REPRINT_SOURCE_PROSE_OR_PAGE_IMAGES",
+      "DELETE_DOWNLOADS_ORIGINALS",
+      "IMPLEMENT_NEW_ENGINEERING_FORMULAS",
+      "ACTIVATE_NEW_SUPPORT_CLAIMS",
+      "PUBLISH_RELEASE",
+      "DELETE_BRANCH",
+      "DELETE_WORKTREE"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "target_binding": {
+      "task_id": "INDIA-3-G0-SOURCE-LIBRARY",
+      "branch": "codex/india-3-g0-source-library",
+      "head_sha": "f24c3904b4af7d768f71342f11ac70f21e7b1dfa",
+      "actions": [
+        "INVENTORY_DOWNLOADS_IS_CODE_PDFS",
+        "COPY_PDFS_TO_PRIVATE_IGNORED_LIBRARY",
+        "CREATE_PRIVATE_SEARCH_DATABASE",
+        "RECORD_PUBLIC_BOUNDARY_EVIDENCE",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ]
+    }
+  },
+  "integration": {
+    "status": "NOT_APPLICABLE",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-23T08:34:18Z",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR"
+  },
+  "retention": {
+    "status": "OBSERVED",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-23T08:34:18Z",
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "owner": "Main Agent under repository preservation policy",
+    "holds": []
+  }
+}


### PR DESCRIPTION
## Summary

- activate the bounded INDIA-3-G0 source-foundation packet after merged PR #848
- record the verified private multi-code catalog boundary: 25 PDF identities, 27 aliases, and 732 cached pages across IS 456, IS 875, IS 1893, IS 13920, and IS 2950
- strengthen the Git-ignore/package regression for the private SQLite database and archived PDF paths
- retain three current IS 13920 implementation links as unreviewed navigation only

The PDFs, extracted page text, SQLite database, and private helper remain only in the primary checkout's ignored `private_sources/` directory. No protected source content or database bytes are included in this PR.

## Verification

- private verifier: 25 documents, 27 aliases, 732 pages, 3 unreviewed navigation records, all PDF hashes and SQLite integrity pass
- focused boundary: 2 passed
- documentation front matter: zero invalid
- maintained links: 478 Markdown files, 992 local links, zero broken
- context manifest: pass
- quick gate: 10/10
- ordinary commit hooks: pass after the targeted handoff-hash repair
- final read-only session closeout: pass

## Held

No source-page reproduction, accepted normalization, new formula, IS 13920 capability activation, IS 875/1893 implementation, ETABS work, release, or professional approval is included.
