### PR TITLE
fix(parity): preserve canonical cross-surface identity

### DIFF
--- a/Python/structural_lib/services/batch.py
+++ b/Python/structural_lib/services/batch.py
@@ -237,16 +237,18 @@ def _calculation_payload(
     units: str,
 ) -> dict[str, Any]:
     d_mm = beam.resolved_d_mm
+    d_dash_mm = beam.D_mm - d_mm if beam.effective_depth_basis is not None else 50.0
     result = api.design_beam_is456(
         units=units,
         case_id=beam.member_id,
         b_mm=beam.b_mm,
         D_mm=beam.D_mm,
-        d_mm=d_mm,
+        d_mm=beam.d_mm,
         mu_knm=beam.mu_knm,
         vu_kn=beam.vu_kn,
         fck_nmm2=beam.fck_nmm2,
         fy_nmm2=beam.fy_nmm2,
+        effective_depth_basis=beam.effective_depth_basis,
     )
     evidence = build_beam_evidence_envelope(
         inputs={
@@ -259,7 +261,7 @@ def _calculation_payload(
             "d_mm": d_mm,
             "fck_nmm2": beam.fck_nmm2,
             "fy_nmm2": beam.fy_nmm2,
-            "d_dash_mm": 50.0,
+            "d_dash_mm": d_dash_mm,
             "asv_mm2": 100.0,
         },
         is_ok=result.is_ok,

--- a/Python/tests/unit/test_batch.py
+++ b/Python/tests/unit/test_batch.py
@@ -276,6 +276,52 @@ def test_explicit_and_derived_effective_depth_produce_same_numeric_result() -> N
         assert explicit_calculation[key] == derived_calculation[key]
 
 
+def test_derived_depth_basis_reaches_the_canonical_calculation_unchanged() -> None:
+    payload = _canonical_beam(
+        member_id="etabs:P5-TRIAL-HALL:101",
+        mu_knm=150.0,
+        vu_kn=75.0,
+        source_metadata={"snapshot_sha256": "a" * 64},
+    )
+    payload.pop("d_mm")
+    payload["effective_depth_basis"] = {
+        "clear_cover_mm": 40.0,
+        "stirrup_diameter_mm": 8.0,
+        "tension_bar_diameter_mm": 20.0,
+    }
+
+    validation = validate_project_beam_design_input_v1(payload)
+    assert validation.value is not None
+    member = design_project_beams_v1([payload]).to_dict()["members"][0]
+    direct = batch.api.design_beam_is456(
+        units="IS456",
+        case_id=payload["member_id"],
+        b_mm=payload["b_mm"],
+        D_mm=payload["D_mm"],
+        d_mm=None,
+        mu_knm=payload["mu_knm"],
+        vu_kn=payload["vu_kn"],
+        fck_nmm2=payload["fck_nmm2"],
+        fy_nmm2=payload["fy_nmm2"],
+        effective_depth_basis=validation.value.effective_depth_basis,
+    )
+
+    assert direct.effective_depth_resolution == {
+        "contract_version": "effective-depth-basis/v1",
+        "source": "DERIVED",
+        "D_mm": 500.0,
+        "d_mm": 442.0,
+        "effective_depth_basis": payload["effective_depth_basis"],
+    }
+    assert member["calculation"]["flexure"]["ast_required"] == pytest.approx(
+        direct.flexure.Ast_required
+    )
+    assert (
+        member["result_envelope"]["result_identity"]
+        == direct.result_envelope["result_identity"]
+    )
+
+
 @pytest.mark.parametrize(
     ("basis", "expected_code", "expected_path"),
     [

--- a/Python/tests/unit/test_excel_workbench_v1.py
+++ b/Python/tests/unit/test_excel_workbench_v1.py
@@ -14,6 +14,7 @@ from structural_lib.core.excel_workbook import (
     ExcelWorkbookRunRequestV1,
     ExcelWorkbookSelectionV1,
 )
+from structural_lib.services.batch import design_project_beams_v1
 from structural_lib.services.beam_api import design_beam_is456
 from structural_lib.services.excel_workbench import (
     ExcelReviewBundleConflictError,
@@ -26,7 +27,10 @@ from structural_lib.services.excel_workbench import (
     run_excel_workbook_v1,
     serialize_excel_review_bundle_v1,
 )
-from structural_lib.services.project_beam import EffectiveDepthBasisV1
+from structural_lib.services.project_beam import (
+    EffectiveDepthBasisV1,
+    ProjectBeamDesignInputV1,
+)
 from structural_lib.services.serialization import to_transport_value
 
 HEADERS = (
@@ -255,6 +259,143 @@ def test_excel_result_matches_direct_canonical_beam_pass_and_fail() -> None:
     assert result.row_ledger[1].result == direct_fail
     assert result.row_ledger[0].result_envelope["overall_status"] == "PASS"
     assert result.row_ledger[1].result_envelope["overall_status"] == "FAIL"
+
+
+def test_p5_snapshot_request_has_identical_excel_identity_and_snapshot_freshness() -> (
+    None
+):
+    snapshot_sha256 = "a82d927d347108f56aa3fcdd559c1aa45ba8d87673cb3feec61a03d5eadbf4f8"
+    member_id = "etabs:P5-TRIAL-HALL:101"
+    basis = EffectiveDepthBasisV1(
+        clear_cover_mm=40.0,
+        stirrup_diameter_mm=8.0,
+        tension_bar_diameter_mm=20.0,
+    )
+    requests = (
+        ProjectBeamDesignInputV1(
+            schema_version="project-beam-design/v1",
+            member_id=member_id,
+            b_mm=300.0,
+            D_mm=500.0,
+            mu_knm=150.0,
+            vu_kn=75.0,
+            fck_nmm2=25.0,
+            fy_nmm2=500.0,
+            effective_depth_basis=basis,
+            source_metadata={"snapshot_sha256": snapshot_sha256},
+        ),
+        ProjectBeamDesignInputV1(
+            schema_version="project-beam-design/v1",
+            member_id="etabs:P5-TRIAL-HALL:102",
+            b_mm=300.0,
+            D_mm=550.0,
+            mu_knm=130.0,
+            vu_kn=65.0,
+            fck_nmm2=25.0,
+            fy_nmm2=500.0,
+            effective_depth_basis=basis,
+            source_metadata={"snapshot_sha256": snapshot_sha256},
+        ),
+    )
+    project_members = tuple(
+        member.to_dict() for member in design_project_beams_v1(requests).members
+    )
+    parity_headers = HEADERS + ("Source Snapshot SHA-256",)
+    parity_rows = (
+        (
+            "P5-R1",
+            member_id,
+            member_id,
+            150.0,
+            75.0,
+            300.0,
+            500.0,
+            "DERIVED_FROM_BARS",
+            None,
+            40.0,
+            8.0,
+            20.0,
+            None,
+            100.0,
+            25.0,
+            500.0,
+            "AUTO_FROM_FLEXURE",
+            snapshot_sha256,
+        ),
+        (
+            "P5-R2",
+            "etabs:P5-TRIAL-HALL:102",
+            "etabs:P5-TRIAL-HALL:102",
+            130.0,
+            65.0,
+            300.0,
+            550.0,
+            "DERIVED_FROM_BARS",
+            None,
+            40.0,
+            8.0,
+            20.0,
+            None,
+            100.0,
+            25.0,
+            500.0,
+            "AUTO_FROM_FLEXURE",
+            snapshot_sha256,
+        ),
+    )
+    preview_request = _preview_request(parity_rows, parity_headers)
+    preview = build_excel_mapping_preview_v1(preview_request)
+    excel_result = run_excel_workbook_v1(
+        ExcelWorkbookRunRequestV1(
+            selection=preview_request.selection,
+            headers=parity_headers,
+            rows=parity_rows,
+            confirmed_mapping_hash=preview.mapping_hash,
+        )
+    )
+
+    assert preview.excluded_headers == ("Source Snapshot SHA-256",)
+    assert excel_result.counts.accepted_rows == 2
+    for project_member, excel_member in zip(
+        project_members, excel_result.row_ledger, strict=True
+    ):
+        assert excel_member.normalized_input is not None
+        assert excel_member.passport is not None
+        assert (
+            project_member["overall_status"]
+            == excel_member.result_envelope["overall_status"]
+        )
+        assert project_member["issues"] == [
+            item.model_dump() for item in excel_member.issues
+        ]
+        assert (
+            project_member["result_envelope"]["result_identity"]
+            == excel_member.result_envelope["result_identity"]
+        )
+        assert (
+            project_member["result_envelope"]["result_identity"]["input_hash"]
+            == excel_member.passport.normalized_input_hash
+        )
+
+    retained = retain_excel_workbook_evidence_v1(excel_result)
+    edited_rows = (parity_rows[0][:-1] + ("b" * 64,), parity_rows[1])
+    edited_preview = _preview_request(edited_rows, parity_headers)
+    stale = check_excel_workbook_freshness_v1(
+        ExcelFreshnessRequestV1(
+            previous_evidence=retained,
+            current_request=edited_preview,
+        )
+    )
+    assert stale.freshness_status == "STALE"
+    assert stale.reasons == ("SOURCE_TABLE_CHANGED",)
+    with pytest.raises(ExcelReviewBundleConflictError, match="stale"):
+        build_excel_review_bundle_v1(
+            ExcelReviewBundleExportRequestV1(
+                current_request=edited_preview,
+                previous_evidence=retained,
+                confirmed_mapping_hash=preview.mapping_hash,
+            )
+        )
 
 
 def test_mapping_must_be_reviewed_again_after_header_change() -> None:

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,126 @@
 
 ---
 
+## 2026-08-24 — Session: LIB-PRO-007-P6 cross-surface parity
+
+**Agent:** Codex (`orchestrator`, sole writer; no subagents)
+
+**Branch:** `codex/lib-pro-007-p6-cross-surface-parity`, from exact merged P5
+hosted-main commit `6d533b6f3754e4fe41522e042f17192d550a1d1b`, tree
+`d3bbaeb239726733412af7072a651a718d893d18`.
+
+**Git handoff receipt:**
+`docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-receipt.json`
+
+**Focus:** Prove one canonical calculation identity, governing status, issues,
+and source freshness through maintained Python, REST, React, and Excel product
+surfaces. P7, broad cumulative M0 suites, live ETABS, EDB parsing, analysis
+control, model modification/save/write-back, installed Excel rerun, INDIA-3
+engineering, release, and professional approval remain excluded.
+
+### Summary
+
+- Preserved the original effective-depth basis through strict project-batch
+  design instead of converting it to an explicit numeric depth before the
+  canonical calculation.
+- Proved both accepted P5 synthetic snapshot members carry the same normalized
+  input hash, canonical result identity, governing status, and issues through
+  Python, REST, and Routine Workbench V1.
+- Factored the React request transport into a pure formula-free mapper and made
+  retained batch results fail closed unless the canonical result envelope and
+  evidence agree on contract, input, calculation, library, and status identity.
+- Included complete imported source metadata in React member revisions. A
+  snapshot-only source change now stales retained results and blocks export.
+  Excel applies the equivalent block through its selected-table hash while the
+  evidence-only snapshot column remains outside calculation mapping.
+- Added a gravity-client contract check that preserves the maintained example's
+  workflow-result hash, calculation-book binding, governing `HOLD`, and issues
+  from Python through REST and React. Excel remains a canonical beam review
+  surface; no second gravity calculator or transport-side formula was added.
+- Kept the open Windows ETABS trial model untouched. The public P6 vector is the
+  deterministic synthetic P5 export; optional real-model evidence remains a
+  private, read-only exported-file supplement under the P5 acquisition matrix.
+
+### Issues encountered
+
+- The first P6 session start found an unmatched P5 usage checkpoint even though
+  the P5 read-only session end had passed.
+- The pre-repair parity reproducer found different Python and Excel normalized
+  input/result identities for P5 member `101`.
+- The first gravity REST parity test returned HTTP 422 while direct Python
+  execution passed.
+- A broad shell path probe used an unmatched `Excel*` zsh glob.
+- The first React focused command could not find Vitest in this linked worktree.
+- The first frozen React production build rejected an under-typed test fetch
+  mock, and the first changed-file Ruff check required canonical import order.
+- The first test-inclusive targeted mypy command selected existing test-module
+  annotations outside P6's source-check contract.
+- Two manual P5 usage phase-closeout attempts drifted while elapsed time
+  advanced before the dynamic closeout succeeded.
+
+### Root causes and resolutions
+
+- P5 had passed its repository session closeout, but the separate shared usage
+  ledger lacked an exact merge closeout. Resolution: bind the retained P5
+  candidate `783cc15e`, PR #857, hosted merge `6d533b6f`, and exact merged tree,
+  then record a dynamically measured phase total. P6 session begin passed.
+- The project batch resolved a complete cover/stirrup/bar basis to `d=442 mm`
+  and then called `design_beam_is456` as though that depth had been supplied
+  explicitly. That selected the historical `d'=50 mm` default instead of the
+  basis-derived `D-d=58 mm`; Excel preserved the basis. Resolution: pass the
+  original `EffectiveDepthBasisV1` to the canonical service and use the same
+  resolved compression depth in evidence. Both P5 members now have identical
+  Python/Excel input and result identities, and REST delegates the same result.
+- Serializing the internal gravity request model included computed
+  `accepted_model_hash` and `load_model_hash` fields that the public request
+  contract rejects. Resolution: send
+  `get_gravity_workflow_example_document_v1()`, the maintained public REST
+  example document. The affected parity test passes.
+- zsh rejects an unmatched glob before the command can inspect paths.
+  Resolution: rerun the read-only inventory with explicit maintained paths.
+  ⚠️ TERMINAL ISSUE: unmatched `Excel*` glob -> used exact repository paths.
+- Linked worktrees do not share `react_app/node_modules`. Resolution: install
+  the exact lockfile with the maintained pinned Node launcher, then run focused
+  tests through `./run.sh frontend test`; 25 React tests pass.
+  ⚠️ TERMINAL ISSUE: Vitest missing in linked worktree -> initialized exact
+  worktree-local dependencies with the supported launcher.
+- Vitest inferred the zero-argument mock implementation rather than the fetch
+  call signature used by the assertion; the Python import additions were not in
+  Ruff order. Resolution: type the fetch mock as `(RequestInfo | URL,
+  RequestInit?) -> Promise<Response>` and order the two service imports. The
+  affected two React and 15 Excel tests pass, Ruff passes, and the production
+  TypeScript/Vite build passes.
+- The chosen mypy command included entire established test modules, exposing 11
+  existing optional-typing findings rather than source defects. Resolution:
+  run configured mypy on the changed calculation source, matching the normal
+  source-hook boundary; `batch.py` passes. No unrelated test annotations were
+  changed. ⚠️ TERMINAL ISSUE: test-inclusive mypy exceeded the maintained
+  source boundary -> used the changed-source configured check.
+- Manually copied elapsed totals were stale by command completion. Resolution:
+  read the live checkpoint and close the predecessor with a command-derived
+  current phase total; no verification or task claim was changed.
+
+### Validation through content freeze
+
+- Exact source binding is hosted `6d533b6f` / tree `d3bbaeb2`; preserved
+  INDIA-3 candidate `9c976b1f` and every unrelated dirty, detached, behind, or
+  diverged lane remain unchanged.
+- The P5 snapshot remains
+  `a82d927d347108f56aa3fcdd559c1aa45ba8d87673cb3feec61a03d5eadbf4f8`.
+  Member `101` resolves input hash `b7f22f6e`, calculation identity
+  `2c15be7a`, `PASS`, and no issues; member `102` resolves input hash
+  `e7a4d93d`, calculation identity `0d9677e6`, `PASS`, and no issues.
+- The maintained gravity example resolves workflow-result and calculation-book
+  hash `95487e89`, governing `HOLD`, and sole issue
+  `BEAM_SUPPLIED_REINFORCEMENT_NOT_SUPPLIED`.
+- The frozen affected selection passes 147 Python/FastAPI/Excel tests and 35
+  React tests. React lint and production build pass; changed-source Ruff/mypy
+  pass. Architecture checks 222 files with zero violations, imports check 694
+  files with zero broken imports, and circular-import validation checks 202
+  files with no cycle. The one consolidated quick gate passes 10/10 with two
+  unchanged reused checks. Normal staged hooks and hosted checks follow on the
+  immutable candidate; broad cumulative suites remain reserved for M0.
+
 ## 2026-08-23 — Session: LIB-PRO-007-P5 ETABS exported snapshot
 
 **Agent:** Codex (`orchestrator`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-23 — LIB-PRO-007-P5 ETABS exported-snapshot candidate
+**Updated:** 2026-08-24 — LIB-PRO-007-P6 cross-surface parity candidate
 
 ---
 
@@ -127,7 +127,7 @@
 
 | ID | Task | Agent | Est | Priority | Status |
 |----|------|-------|-----|----------|--------|
-| LIB-PRO-007-P5 | Converge ETABS exported files into one hash-bound snapshot and canonical beam requests | Main Agent | M | P0 | 🟡 ACTIVE — canonical service, deterministic fixture, row dispositions, acquisition matrix, and focused tests implemented; candidate verification pending |
+| LIB-PRO-007-P6 | Prove canonical beam and gravity identity/status/issues across maintained product surfaces | Main Agent | M | P0 | 🟡 ACTIVE — parity repair and focused Python/REST/React/Excel tests implemented; candidate verification pending |
 | INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent + structural engineer | S | P0 | ⏸ PAUSED — private source library preserved; resume after LIB-PRO-007 cumulative acceptance |
 
 `LIB-PRO-006` merged through PR #851 at `2d6df18e`. It confirms the practical
@@ -178,8 +178,8 @@ basis. Each action receives source/destination ledger entries and exact
 reconciliation; no IS 875 generation, lateral action, or destination inference
 is added.
 
-`LIB-PRO-007-P5` starts from exact merged P4 base `426d401b` / tree
-`a5b01272`. It converges separate lossless ETABS geometry/force CSVs, EDB/E2K
+`LIB-PRO-007-P5` merged through PR #857 at hosted commit `6d533b6f` with exact
+merged tree `d3bbaeb2`. It converges separate lossless ETABS geometry/force CSVs, EDB/E2K
 identity, selected-table archive hashes, units, local axes, one exact result
 selection, stable ETABS `UniqueName` member IDs, and exhaustive `ACCEPTED` /
 `APPROVED_EXCLUSION` / `BLOCKED` source-row dispositions into one deterministic
@@ -187,6 +187,16 @@ snapshot. Only an accepted snapshot emits existing canonical beam requests.
 Manual table export remains valid when the trial API is unavailable. Live
 ETABS control, EDB parsing, analysis changes, save/write-back, P6/P7, INDIA-3
 engineering, release, and professional approval remain held.
+
+`LIB-PRO-007-P6` starts from exact merged P5 base `6d533b6f` / tree
+`d3bbaeb2`. It repairs the project-batch loss of a derived effective-depth
+basis, then proves both P5 fixture beams preserve normalized input identity,
+canonical result identity, governing status, and issues across Python, REST,
+React, and Excel. React now rejects envelope/evidence identity disagreement and
+stales retained results when imported source metadata changes. The maintained
+gravity example preserves its workflow-result hash, governing `HOLD`, and issue
+identity through Python, REST, and React. No transport receives a structural
+formula; Excel is not expanded into a gravity calculator.
 
 `MAINT-0134` assigns cross-agent policy to `AGENTS.md`, composes Claude
 through `@AGENTS.md`, keeps a concise standalone Copilot baseline, retires

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,6 +7,7 @@ End-user and developer guides for specific workflows.
 | Guide | Description |
 |-------|-------------|
 | `ai-agent-coding-guide.md` | AI agent coding practices |
+| `cross-surface-parity-v1.md` | Canonical Python, REST, React, and Excel identity/freshness contract |
 | `etabs-exported-snapshot-v1.md` | Read-only, trial-compatible ETABS exported-file snapshot workflow |
 | `code-reuse-and-library-structure.md` | Library structure and reuse patterns |
 

--- a/docs/guides/cross-surface-parity-v1.md
+++ b/docs/guides/cross-surface-parity-v1.md
@@ -1,0 +1,91 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-24
+doc_type: guide
+complexity: intermediate
+tags: [parity, etabs, react, excel, gravity]
+---
+
+# Cross-Surface Parity V1
+
+## Boundary
+
+LIB-PRO-007-P6 proves that maintained transports carry the same canonical
+calculation request and result; it does not give any transport calculation
+authority. Python remains the calculation authority. FastAPI delegates, React
+retains revision-bound evidence, and Excel transports reviewed selected-table
+rows through the local REST service.
+
+P6 performs no live ETABS operation. It does not open or parse EDB files,
+unlock a model, run or change analysis, modify model data, save, or write back.
+The trial-compatible exported-file boundary from P5 remains unchanged.
+
+## Frozen datasets
+
+| Dataset | Identity | P6 use | Disclosure boundary |
+|---|---|---|---|
+| P5 synthetic ETABS exported-file fixture | Snapshot `a82d927d347108f56aa3fcdd559c1aa45ba8d87673cb3feec61a03d5eadbf4f8`; members `101` and `102` | Deterministic Python, REST, React, and Excel beam parity | Public synthetic data; no real model or protected source content |
+| Maintained open-hall gravity example | `get_gravity_workflow_example_request_v1()` | Python/REST/React workflow-result hash, governing `HOLD`, and issue parity | Maintained demonstration; not a real project design basis |
+| Optional real trial export | One P5-accepted private snapshot | Additional read-only acquisition evidence only | Review project/confidential identifiers before any Git inclusion; retain hashes privately when disclosure is not approved |
+
+The synthetic fixture is the repeatable software acceptance dataset. A real
+trial export can supplement it, but P6 does not wait for trial API access and
+does not publish project data by default. Manual E2K and selected-table export
+from a locked model remains valid.
+
+## Parity matrix
+
+| Surface | Frozen entry | Required equality | Freshness owner |
+|---|---|---|---|
+| Python | `build_etabs_canonical_snapshot_v1` then `design_project_beams_v1` | Canonical member ID, normalized input hash, result identity, status, and issues | Caller supplies the current accepted snapshot |
+| REST | `POST /api/v1/import/project-beams` | Exact canonical request payload and the Python result identity/status/issues | Stateless; clients must retain source identity |
+| React | `buildProjectBeamBatchRequest`, canonical batch stream, and `WorkspaceSnapshotV1` | No transport-side depth arithmetic; result envelope must match evidence identity before becoming current | Project/member/input revision plus complete imported source metadata |
+| Excel | Routine Workbench V1 selected table | Calculation-bearing cells produce the same input hash and result identity; an evidence-only `Source Snapshot SHA-256` column is excluded from calculation but retained in source-table freshness | Source-table, mapping, and engine hashes |
+| Gravity review | Maintained example through Python, REST, and React | Workflow-result hash, governing status, and canonical issues | Request/result hash; Excel is not a full gravity-workflow surface |
+
+Excel participates in the canonical rectangular-beam slice. It does not become
+a Building Gravity V1 calculator, and no structural formula is added to
+Office.js. The full gravity review dossier remains a Python/REST/React surface.
+
+## Root parity repair
+
+P5 requests use either an explicit effective depth or a complete
+cover/stirrup/tension-bar basis. Before P6, the strict project batch resolved a
+derived depth to a number and then called the canonical beam service as though
+that number had been supplied explicitly. For the P5 fixture this changed the
+compression-steel depth basis from `D - d = 58 mm` to the historical explicit
+depth default of `50 mm`. Excel preserved the original basis, so its normalized
+input and result identity differed.
+
+P6 passes the original basis to `design_beam_is456` and uses the same resolved
+compression-depth value in the project evidence identity. This repairs the
+calculation path, rather than normalizing two different outcomes after the
+fact.
+
+## Freshness and export rules
+
+- React hashes the complete imported source metadata, including the P5
+  snapshot hash. A source-only identity change advances the revision, marks
+  retained results stale, and makes current export ineligible.
+- React accepts a current result only when the canonical result envelope and
+  evidence agree on contract version, normalized input hash, calculation
+  identity, library version, and governing status.
+- Excel may carry `Source Snapshot SHA-256` as an evidence-only selected-table
+  column. It is not a calculation input, but it is covered by the source-table
+  hash. Changing only that value returns `STALE` and blocks the current review
+  bundle until recalculation.
+- REST is stateless. It preserves source metadata in the evidence response but
+  cannot declare a retained client result current.
+- `PASS`, `FAIL`, `HOLD`, and source freshness remain separate from qualified
+  review, release approval, and professional approval.
+
+## P6 non-goals
+
+- live ETABS API or UI automation;
+- EDB parsing, analysis control, unlock, save, or write-back;
+- structural formulas in React, Office.js, or FastAPI;
+- a new Excel gravity-workflow implementation;
+- P7 compatibility migration or deletion;
+- INDIA-3 formulas or source promotion;
+- release, package publication, or professional approval.

--- a/docs/planning/lib-pro-007-product-foundation-convergence.md
+++ b/docs/planning/lib-pro-007-product-foundation-convergence.md
@@ -1,7 +1,7 @@
 ---
 owner: Main Agent
 status: active
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 doc_type: spec
 complexity: advanced
 tags: [product-foundation, optimization, detailing, etabs, excel, react, compatibility]
@@ -37,8 +37,10 @@ unchanged.
   `d3e3e9a3`. It makes unrounded development length, normalized bend/U-hook
   anchorage, explicit geometry, constructability, and `PASS`/`FAIL`/`HOLD`
   outcomes decisive.
-- P4 is in implementation on a source-bound lane from exact `0ea3e2d4`.
-- P5-P7 and cumulative M0 remain held in the frozen sequence below.
+- P4 merged through PR #856 at `426d401b` with exact merged tree `a5b01272`.
+- P5 merged through PR #857 at `6d533b6f` with exact merged tree `d3bbaeb2`.
+- P6 is active on a source-bound lane from exact `6d533b6f`; P7 and cumulative
+  M0 remain held in the frozen sequence below.
 
 ## Why this precedes INDIA-3
 
@@ -198,6 +200,10 @@ identity, complete row dispositions, or the canonical snapshot hash. The
 trial-compatible acquisition matrix is maintained in
 [ETABS Exported Snapshot V1](../guides/etabs-exported-snapshot-v1.md).
 
+P5 merged through PR #857 at hosted commit `6d533b6f` with exact merged tree
+`d3bbaeb2`. The public acceptance fixture is synthetic; it does not claim that
+a real ETABS model or analysis was validated.
+
 ### P6 - Cross-surface parity
 
 For one frozen ETABS-exported beam dataset and the maintained gravity example,
@@ -205,6 +211,22 @@ prove identical normalized request identity, result identity, governing status,
 and issues through Python, REST, React, and Excel. Source changes must mark
 retained results stale and block current export until recalculation. Excel and
 React contain no structural formulas.
+
+P6 uses both members from the accepted P5 synthetic snapshot. Python is the
+canonical calculator; REST delegates the same strict project-batch request;
+React maps without depth arithmetic and accepts a retained result only when its
+canonical envelope and evidence identities agree; Excel transports the same
+beam inputs through Routine Workbench V1. Complete imported source metadata,
+including the P5 snapshot SHA-256, participates in React freshness. An
+evidence-only Excel snapshot column participates in the selected-table hash but
+not calculation inputs, so changing only the source identity blocks export on
+both client surfaces.
+
+The maintained gravity example proves workflow-result hash, governing `HOLD`,
+and canonical issue parity through Python, REST, and React. Excel remains the
+canonical beam slice and does not become a second gravity implementation. The
+detailed acceptance matrix is maintained in
+[Cross-Surface Parity V1](../guides/cross-surface-parity-v1.md).
 
 ### P7 - Compatibility convergence
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -3,55 +3,61 @@
 ## Latest Handoff (auto)
 
 <!-- HANDOFF:START -->
-- Date: 2026-08-23
-- Focus: Converge ETABS exported files into one deterministic snapshot and canonical beam requests
-- Git receipt: docs/verification/lib-pro-007-p5-etabs-snapshot-git-handoff-receipt.json | sha256:aae36c259380c3aa2ed3a94c4af038bfbd87bbf5634b89ee3476d6178f899457 | HOLD
-- Git identity: codex/lib-pro-007-p5-etabs-snapshot@426d401bb2afde417ff989bd7349c99b8f7cb438 | upstream=NONE | base=origin/main@426d401bb2afde417ff989bd7349c99b8f7cb438 | tree=dirty | operation=none
+- Date: 2026-08-24
+- Focus: Prove one canonical calculation identity, governing status, issues,
+- Git receipt: docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-receipt.json | sha256:cdc6c7220a1b705d2b38ae5d95e8c299570ff383c9dad98c65d5d7a000d71d18 | HOLD
+- Git identity: codex/lib-pro-007-p6-cross-surface-parity@6d533b6f3754e4fe41522e042f17192d550a1d1b | upstream=NONE@UNKNOWN | base=origin/main@6d533b6f3754e4fe41522e042f17192d550a1d1b | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: COMMIT_INTENDED_PATHS
 <!-- HANDOFF:END -->
 
 | State | Boundary |
 |---|---|
-| **Current** | `LIB-PRO-007-P5` has one deterministic ETABS exported-file snapshot implementation from exact merged P4 base `426d401b` / tree `a5b01272` |
-| **Next** | Freeze P5 content, run its focused batch, quick gate, normal staged hooks, hosted checks, and exact-tree merge |
-| **Why** | P5 makes project/export/source identity, units, local axes, result selection, stable member IDs, exclusions, ambiguities, and every source row explicit before a canonical beam request exists |
-| **Held** | P6-P7, M0 broad suites, live ETABS automation, EDB parsing, analysis control, model save/write-back, INDIA-3 engineering, release, branch/worktree deletion, and professional approval |
+| **Current** | `LIB-PRO-007-P6` has a bounded parity repair and focused cross-surface tests from exact merged P5 base `6d533b6f` / tree `d3bbaeb2` |
+| **Next** | Freeze P6 content, run the focused batch, quick gate, normal staged hooks, hosted checks, and exact-tree merge |
+| **Why** | P6 prevents transport drift by binding canonical request/result identity, governing status, issues, and source freshness to one Python calculation authority |
+| **Held** | P7, M0 broad suites, installed Windows Excel rerun, live ETABS automation, EDB parsing, analysis control, model save/write-back, INDIA-3 engineering, release, branch/worktree deletion, and professional approval |
 
-## P5 candidate outcome
+## P6 candidate outcome
 
-- P4 merged through PR #856 at hosted `426d401b` / tree `a5b01272`; P5 starts
-  from that exact tree and preserves the held INDIA-3 lane plus unrelated work.
-- `build_etabs_canonical_snapshot_v1` reads only exported artifacts and delegates
-  separate geometry and force CSVs to `parse_dual_csv_lossless`.
-- EDB identity is recorded by name/hash without EDB intake. E2K and selected
-  CSV/XML/Excel table archives are hash-bound; direct EDB parsing is rejected.
-- Exact units, `M3 -> mu_knm` / `V2 -> vu_kn` mapping, and one case,
-  combination, or source-envelope identity are required without implicit
-  conversion or selection.
-- ETABS `UniqueName` creates stable canonical member IDs. Every physical source
-  row is `ACCEPTED`, `APPROVED_EXCLUSION`, or `BLOCKED`; any blocked row or
-  ambiguity exposes no snapshot or request.
-- The accepted synthetic fixture accounts 7 rows as 6 accepted, 1 approved
-  non-beam exclusion, and 0 blocked, then emits two existing
-  `ProjectBeamDesignInputV1` requests.
-- Trial API access is optional. Manual ETABS table export remains the valid
-  fallback and converges on the identical exported-file contract.
+- P5 merged through PR #857 at hosted `6d533b6f` / tree `d3bbaeb2`; P6
+  starts from that exact tree and preserves the held INDIA-3 lane plus unrelated
+  work.
+- The strict project batch preserves an original derived effective-depth basis
+  through the canonical service. The P5 member no longer changes compression
+  depth from the basis-derived `58 mm` to the explicit-depth default `50 mm`.
+- Both accepted P5 fixture members prove equal normalized input hash, result
+  identity, governing status, and issues across Python, REST, and Excel. React
+  maps the identical project request without structural arithmetic and retains
+  only identity-consistent envelopes.
+- Complete ETABS source metadata participates in React input revision hashing.
+  A snapshot-only change stales retained results and blocks current export.
+  Excel covers an evidence-only snapshot column with its selected-table hash,
+  producing the same stale/export block without treating it as a calculation
+  input.
+- The maintained open-hall gravity example preserves workflow-result hash,
+  governing `HOLD`, and canonical issues through Python, REST, and React. Excel
+  remains a canonical beam review surface, not a gravity implementation.
+- No live ETABS action is needed or performed. The open Windows trial model is
+  untouched; P5 manual/API exported-file acquisition remains the optional
+  read-only real-model supplement.
 
-## P5 verification boundary
+## P6 verification boundary
 
-- Run snapshot/import/capability/project-beam/packaging focused tests together,
-  then the consolidated quick gate once and normal staged hooks once.
-- Verify the deterministic fixture and machine evidence, architecture/imports,
-  docs, and unchanged REST/OpenAPI surface.
+- Run the affected project-beam, Excel-workbench, REST, React workspace, and
+  gravity-client checks together, then the consolidated quick gate once and
+  normal staged hooks once.
+- Verify the frozen P5 snapshot and member identities, maintained gravity hash,
+  architecture/import boundaries, React lint/build, docs, and evidence.
 - Broad Python/FastAPI/React and full repository gates remain reserved for
-  cumulative M0. P5 does not own P6, P7, live ETABS operation, release,
+  cumulative M0. P6 does not own P7, live ETABS operation, release,
   professional approval, or INDIA-3 engineering.
 
 ## Required Reading
 
 1. [Product-foundation convergence plan](lib-pro-007-product-foundation-convergence.md)
-2. [P5 acquisition and snapshot guide](../guides/etabs-exported-snapshot-v1.md)
-3. [P5 machine evidence](../verification/lib-pro-007-p5-etabs-snapshot-evidence.json)
-4. [Current task board](../TASKS.md)
-5. [Git workflow single source](../git-automation/git-workflow-single-source.md)
+2. [P6 cross-surface parity guide](../guides/cross-surface-parity-v1.md)
+3. [P6 machine evidence](../verification/lib-pro-007-p6-cross-surface-parity-evidence.json)
+4. [P5 exported-snapshot guide](../guides/etabs-exported-snapshot-v1.md)
+5. [Current task board](../TASKS.md)
+6. [Git workflow single source](../git-automation/git-workflow-single-source.md)

--- a/docs/verification/lib-pro-007-p6-cross-surface-parity-evidence.json
+++ b/docs/verification/lib-pro-007-p6-cross-surface-parity-evidence.json
@@ -1,0 +1,138 @@
+{
+  "schema_version": "lib-pro-007-p6-evidence/v1",
+  "task_id": "LIB-PRO-007-P6",
+  "status": "LOCAL_FOCUSED_STATIC_FRONTEND_PASS_QUICK_HOOKS_HOSTED_PENDING",
+  "base": {
+    "hosted_main_commit": "6d533b6f3754e4fe41522e042f17192d550a1d1b",
+    "exact_tree": "d3bbaeb239726733412af7072a651a718d893d18",
+    "predecessor_pr": 857
+  },
+  "scope": {
+    "canonical_calculation_authority": "structural_lib",
+    "beam_entrypoint": "structural_lib.services.batch.design_project_beams_v1",
+    "gravity_entrypoint": "structural_lib.run_gravity_workflow_with_book_v1",
+    "frozen_datasets": [
+      "P5 synthetic ETABS exported-file snapshot",
+      "maintained open-hall gravity example"
+    ],
+    "out_of_scope": [
+      "live ETABS API or UI automation",
+      "direct EDB binary parsing",
+      "unlock or analysis control",
+      "model modification",
+      "model save or write-back",
+      "structural formulas in FastAPI, React, or Office.js",
+      "Excel gravity-workflow implementation",
+      "installed Windows Excel rerun",
+      "P7 compatibility convergence",
+      "INDIA-3 formulas",
+      "release or professional approval"
+    ]
+  },
+  "confirmed_root_repair": {
+    "surface": "strict project-beam batch",
+    "before": "a derived effective depth was resolved to d_mm before the canonical call, which selected the explicit-depth d_dash default",
+    "p5_member_101_before_d_dash_mm": 50.0,
+    "canonical_basis_d_dash_mm": 58.0,
+    "resolution": "preserve EffectiveDepthBasisV1 through design_beam_is456 and use the same resolved d_dash_mm in evidence",
+    "outcome_significance": "compression reinforcement depth participates in doubly reinforced beam calculation and result identity"
+  },
+  "beam_fixture": {
+    "project_id": "P5-TRIAL-HALL",
+    "export_id": "P5-EXPORT-001",
+    "snapshot_sha256": "a82d927d347108f56aa3fcdd559c1aa45ba8d87673cb3feec61a03d5eadbf4f8",
+    "members": [
+      {
+        "member_id": "etabs:P5-TRIAL-HALL:101",
+        "normalized_input_hash": "b7f22f6effcf20fd508bdec0c4cf1f260318be0798a39d336eb76acebbd13783",
+        "calculation_identity": "2c15be7ad0ad410f6af92a9c64e884e5d299ac69ffcd06d03e4a57260edc166b",
+        "provenance_hash": "5b80acfa17c6eff7d894b14c74e78fc054839f32cfc03c9c8bc45e4bfb749656",
+        "governing_status": "PASS",
+        "issue_codes": []
+      },
+      {
+        "member_id": "etabs:P5-TRIAL-HALL:102",
+        "normalized_input_hash": "e7a4d93dc74e068bdaccd4ed6cffc9573c342a9316c803a42e494236ee5306be",
+        "calculation_identity": "0d9677e6c2db06b412284dfd5281929c94421d40c2bf9624e12dce65c6566d09",
+        "provenance_hash": "2d2bdc3c1a822737ecda4ed459e3f2f041ec2d477730f37c3b358ae887b12c25",
+        "governing_status": "PASS",
+        "issue_codes": []
+      }
+    ]
+  },
+  "gravity_fixture": {
+    "builder": "get_gravity_workflow_example_request_v1",
+    "workflow_result_hash": "95487e890c74a245360a1855e8cd07f323446da7ed4f2f2a56e4822cbb55751e",
+    "calculation_book_workflow_result_hash": "95487e890c74a245360a1855e8cd07f323446da7ed4f2f2a56e4822cbb55751e",
+    "governing_status": "HOLD",
+    "issue_codes": [
+      "BEAM_SUPPLIED_REINFORCEMENT_NOT_SUPPLIED"
+    ]
+  },
+  "parity_matrix": [
+    {
+      "surface": "PYTHON_BEAM",
+      "entrypoint": "design_project_beams_v1",
+      "asserted_identity": "normalized input hash plus canonical result identity",
+      "status": "FOCUSED_PASS"
+    },
+    {
+      "surface": "REST_BEAM",
+      "entrypoint": "POST /api/v1/import/project-beams",
+      "asserted_identity": "exact Python input, result identity, governing status, issues, and snapshot metadata",
+      "status": "FOCUSED_PASS"
+    },
+    {
+      "surface": "REACT_BEAM",
+      "entrypoint": "buildProjectBeamBatchRequest plus WorkspaceSnapshotV1",
+      "asserted_identity": "formula-free request mapping and envelope/evidence identity agreement",
+      "status": "FOCUSED_PASS"
+    },
+    {
+      "surface": "EXCEL_BEAM",
+      "entrypoint": "Routine Workbench V1 selected table",
+      "asserted_identity": "same normalized input hash, result identity, governing status, and issues",
+      "status": "FOCUSED_PASS"
+    },
+    {
+      "surface": "PYTHON_REST_REACT_GRAVITY",
+      "entrypoint": "maintained example run bundle",
+      "asserted_identity": "workflow-result hash, governing status, issues, and calculation-book hash",
+      "status": "FOCUSED_PASS"
+    }
+  ],
+  "freshness": {
+    "react": "complete imported source metadata participates in member input identity; snapshot-only changes stale retained results and block export",
+    "excel": "evidence-only Source Snapshot SHA-256 is excluded from calculation mapping but covered by source-table hash; changes stale evidence and block review export",
+    "rest": "stateless transport preserves source metadata; retained-result freshness remains a client responsibility"
+  },
+  "verification": {
+    "implementation_debug_checks": {
+      "python_excel_fastapi": "PASS_61",
+      "react": "PASS_25"
+    },
+    "frozen_focused_tests": {
+      "python_fastapi_excel": "PASS_147",
+      "react": "PASS_35",
+      "affected_repair_reruns": "PASS_EXCEL_15_AND_REACT_2"
+    },
+    "react_lint_and_build": "PASS",
+    "changed_source_ruff_and_mypy": "PASS",
+    "architecture_and_import_checks": {
+      "architecture": "PASS_222_FILES_ZERO_VIOLATIONS",
+      "imports": "PASS_694_FILES_ZERO_BROKEN_IMPORTS",
+      "circular_imports": "PASS_202_FILES_ZERO_CYCLES"
+    },
+    "quick_gate": "PASS_10_OF_10_WITH_2_REUSED",
+    "normal_staged_hooks": "PENDING_SINGLE_RUN",
+    "broad_cumulative_suites": "RESERVED_FOR_LIB_PRO_007_M0",
+    "hosted_checks": "PENDING_IMMUTABLE_CANDIDATE"
+  },
+  "claims": {
+    "software_scope": "BOUNDED_P6_CROSS_SURFACE_PARITY_ONLY",
+    "real_etabs_model_or_analysis_validated": false,
+    "installed_excel_revalidated": false,
+    "engineering_approval": false,
+    "release_authorized": false
+  }
+}

--- a/docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-receipt.json
@@ -1,0 +1,198 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_INSTRUCTION",
+      "observed_at_utc": "2026-08-23T18:57:36Z",
+      "query_status": "OK",
+      "reference": "okay please plan well and start next work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "IMPLEMENT_LIB_PRO_007_P6_BOUNDED_PACKET",
+      "ADD_FOCUSED_TESTS_DOCUMENTATION_AND_EVIDENCE",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-23T18:57:36Z",
+    "prohibited_actions": [
+      "DELETE_BRANCH_OR_WORKTREE",
+      "RESET_STASH_CLEAN_OR_REWRITE",
+      "BYPASS_CHECKS_OR_FORCE_PUSH",
+      "PUBLISH_RELEASE",
+      "ACTIVATE_PROFESSIONAL_APPROVAL",
+      "CHANGE_INDIA_3_ENGINEERING",
+      "DIRECT_EDB_BINARY_PARSING",
+      "LIVE_ETABS_AUTOMATION",
+      "UNLOCK_RUN_OR_CHANGE_ANALYSIS",
+      "MODIFY_SAVE_OR_WRITE_BACK_ETABS_MODEL",
+      "RERUN_INSTALLED_WINDOWS_EXCEL",
+      "START_LIB_PRO_007_P7_OR_M0"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "IMPLEMENT_LIB_PRO_007_P6_BOUNDED_PACKET",
+        "ADD_FOCUSED_TESTS_DOCUMENTATION_AND_EVIDENCE",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/lib-pro-007-p6-cross-surface-parity",
+      "head_sha": "6d533b6f3754e4fe41522e042f17192d550a1d1b",
+      "task_id": "LIB-PRO-007-P6"
+    }
+  },
+  "holds": [
+    "AUTHORIZATION_SOURCE_KIND_INVALID",
+    "LOCAL_HOLD_DIRTY",
+    "PRESERVE_EVERY_UNRELATED_DIRTY_DETACHED_BEHIND_OR_DIVERGED_LANE",
+    "PRESERVE_INDIA_3_SOURCE_LIBRARY_CANDIDATE_UNTIL_LIB_PRO_007_M0",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "cdc6c7220a1b705d2b38ae5d95e8c299570ff383c9dad98c65d5d7a000d71d18",
+    "state": {
+      "branch": "codex/lib-pro-007-p6-cross-surface-parity",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "6d533b6f3754e4fe41522e042f17192d550a1d1b",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 84.751,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib13",
+      "head_sha": "6d533b6f3754e4fe41522e042f17192d550a1d1b",
+      "hold_reasons": [
+        "changed paths: 19"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-23T18:58:08.036108+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 19,
+        "modified_paths": [
+          "Python/structural_lib/services/batch.py",
+          "Python/tests/unit/test_batch.py",
+          "Python/tests/unit/test_excel_workbench_v1.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/guides/README.md",
+          "docs/planning/lib-pro-007-product-foundation-convergence.md",
+          "docs/planning/next-session-brief.md",
+          "react_app/src/features/building-gravity/client.ts",
+          "react_app/src/hooks/__tests__/useBatchDesign.test.ts",
+          "react_app/src/hooks/useBatchDesign.ts",
+          "react_app/src/workspace/__tests__/importAdapter.test.ts",
+          "react_app/src/workspace/importAdapter.ts",
+          "react_app/src/workspace/resultRecords.ts"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/guides/cross-surface-parity-v1.md",
+          "docs/verification/lib-pro-007-p6-cross-surface-parity-evidence.json",
+          "docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-source-evidence.json",
+          "fastapi_app/tests/test_lib_pro_007_p6_parity.py",
+          "react_app/src/features/building-gravity/client.test.ts"
+        ]
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:cdc6c7220a1b705d2b38ae5d95e8c299570ff383c9dad98c65d5d7a000d71d18",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-23T18:58:08.036250+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [
+      "PRESERVE_INDIA_3_SOURCE_LIBRARY_CANDIDATE_UNTIL_LIB_PRO_007_M0",
+      "PRESERVE_EVERY_UNRELATED_DIRTY_DETACHED_BEHIND_OR_DIVERGED_LANE"
+    ],
+    "observed_at_utc": "2026-08-23T18:57:36Z",
+    "owner": "Main Agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources"
+    ],
+    "integration_owner": "orchestrator",
+    "owned_paths": [
+      "Python/structural_lib/services/batch.py",
+      "Python/tests/unit/test_batch.py",
+      "Python/tests/unit/test_excel_workbench_v1.py",
+      "fastapi_app/tests/test_lib_pro_007_p6_parity.py",
+      "react_app/src/features/building-gravity/client.ts",
+      "react_app/src/features/building-gravity/client.test.ts",
+      "react_app/src/hooks/useBatchDesign.ts",
+      "react_app/src/hooks/__tests__/useBatchDesign.test.ts",
+      "react_app/src/workspace/importAdapter.ts",
+      "react_app/src/workspace/resultRecords.ts",
+      "react_app/src/workspace/__tests__/importAdapter.test.ts",
+      "docs/guides/README.md",
+      "docs/guides/cross-surface-parity-v1.md",
+      "docs/planning/lib-pro-007-product-foundation-convergence.md",
+      "docs/verification/lib-pro-007-p6-cross-surface-parity-evidence.json",
+      "docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-source-evidence.json",
+      "docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "LIB-PRO-007-P6"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-source-evidence.json
+++ b/docs/verification/lib-pro-007-p6-cross-surface-parity-git-handoff-source-evidence.json
@@ -1,0 +1,69 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_INSTRUCTION",
+      "observed_at_utc": "2026-08-23T18:57:36Z",
+      "query_status": "OK",
+      "reference": "okay please plan well and start next work",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "IMPLEMENT_LIB_PRO_007_P6_BOUNDED_PACKET",
+      "ADD_FOCUSED_TESTS_DOCUMENTATION_AND_EVIDENCE",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-23T18:57:36Z",
+    "prohibited_actions": [
+      "DELETE_BRANCH_OR_WORKTREE",
+      "RESET_STASH_CLEAN_OR_REWRITE",
+      "BYPASS_CHECKS_OR_FORCE_PUSH",
+      "PUBLISH_RELEASE",
+      "ACTIVATE_PROFESSIONAL_APPROVAL",
+      "CHANGE_INDIA_3_ENGINEERING",
+      "DIRECT_EDB_BINARY_PARSING",
+      "LIVE_ETABS_AUTOMATION",
+      "UNLOCK_RUN_OR_CHANGE_ANALYSIS",
+      "MODIFY_SAVE_OR_WRITE_BACK_ETABS_MODEL",
+      "RERUN_INSTALLED_WINDOWS_EXCEL",
+      "START_LIB_PRO_007_P7_OR_M0"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "IMPLEMENT_LIB_PRO_007_P6_BOUNDED_PACKET",
+        "ADD_FOCUSED_TESTS_DOCUMENTATION_AND_EVIDENCE",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/lib-pro-007-p6-cross-surface-parity",
+      "head_sha": "6d533b6f3754e4fe41522e042f17192d550a1d1b",
+      "task_id": "LIB-PRO-007-P6"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [
+      "PRESERVE_INDIA_3_SOURCE_LIBRARY_CANDIDATE_UNTIL_LIB_PRO_007_M0",
+      "PRESERVE_EVERY_UNRELATED_DIRTY_DETACHED_BEHIND_OR_DIVERGED_LANE"
+    ],
+    "observed_at_utc": "2026-08-23T18:57:36Z",
+    "owner": "Main Agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/fastapi_app/tests/test_lib_pro_007_p6_parity.py
+++ b/fastapi_app/tests/test_lib_pro_007_p6_parity.py
@@ -1,0 +1,124 @@
+"""LIB-PRO-007-P6 REST parity for the frozen ETABS and gravity vectors."""
+
+from __future__ import annotations
+
+from fastapi_app.tests.conftest import unwrap
+from structural_lib import (
+    get_gravity_workflow_example_document_v1,
+    get_gravity_workflow_example_request_v1,
+    run_gravity_workflow_with_book_v1,
+)
+from structural_lib.services.batch import design_project_beams_v1
+
+SNAPSHOT_SHA256 = "a82d927d347108f56aa3fcdd559c1aa45ba8d87673cb3feec61a03d5eadbf4f8"
+
+
+def _p5_request(
+    *,
+    unique_name: str,
+    source_member_id: str,
+    D_mm: float,
+    mu_knm: float,
+    vu_kn: float,
+) -> dict[str, object]:
+    return {
+        "schema_version": "project-beam-design/v1",
+        "member_id": f"etabs:P5-TRIAL-HALL:{unique_name}",
+        "b_mm": 300.0,
+        "D_mm": D_mm,
+        "mu_knm": mu_knm,
+        "vu_kn": vu_kn,
+        "fck_nmm2": 25.0,
+        "fy_nmm2": 500.0,
+        "effective_depth_basis": {
+            "clear_cover_mm": 40.0,
+            "stirrup_diameter_mm": 8.0,
+            "tension_bar_diameter_mm": 20.0,
+        },
+        "source_metadata": {
+            "source_system": "ETABS_EXPORTED_FILES",
+            "project_id": "P5-TRIAL-HALL",
+            "export_id": "P5-EXPORT-001",
+            "snapshot_sha256": SNAPSHOT_SHA256,
+            "source_unique_name": unique_name,
+            "source_member_id": source_member_id,
+        },
+    }
+
+
+def _p5_requests() -> list[dict[str, object]]:
+    return [
+        _p5_request(
+            unique_name="101",
+            source_member_id="B1_L1",
+            D_mm=500.0,
+            mu_knm=150.0,
+            vu_kn=75.0,
+        ),
+        _p5_request(
+            unique_name="102",
+            source_member_id="B2_L1",
+            D_mm=550.0,
+            mu_knm=130.0,
+            vu_kn=65.0,
+        ),
+    ]
+
+
+def test_p5_canonical_request_has_identical_python_and_rest_result_identity(
+    client,
+) -> None:
+    requests = _p5_requests()
+    python_members = [
+        member.to_dict() for member in design_project_beams_v1(requests).members
+    ]
+
+    response = client.post("/api/v1/import/project-beams", json=requests)
+
+    assert response.status_code == 200
+    rest_members = unwrap(response)["members"]
+    assert len(rest_members) == len(python_members) == 2
+    for rest_member, python_member in zip(rest_members, python_members, strict=True):
+        assert rest_member["input"] == python_member["input"]
+        assert rest_member["overall_status"] == python_member["overall_status"]
+        assert rest_member["issues"] == python_member["issues"]
+        assert (
+            rest_member["result_envelope"]["result_identity"]
+            == python_member["result_envelope"]["result_identity"]
+        )
+        assert (
+            rest_member["calculation"]["evidence"]["source_metadata"]["snapshot_sha256"]
+            == SNAPSHOT_SHA256
+        )
+
+
+def test_maintained_gravity_example_has_identical_python_and_rest_identity(
+    client,
+) -> None:
+    request = get_gravity_workflow_example_request_v1()
+    python_bundle = run_gravity_workflow_with_book_v1(request).model_dump(mode="json")
+
+    response = client.post(
+        "/api/v1/building-gravity/v1/run",
+        json=get_gravity_workflow_example_document_v1(),
+    )
+
+    assert response.status_code == 200
+    rest_bundle = unwrap(response)
+    python_workflow = python_bundle["workflow_result"]
+    rest_workflow = rest_bundle["workflow_result"]
+    assert (
+        rest_workflow["workflow_result_hash"] == python_workflow["workflow_result_hash"]
+    )
+    assert (
+        rest_workflow["result_envelope"]["overall_status"]
+        == python_workflow["result_envelope"]["overall_status"]
+    )
+    assert (
+        rest_workflow["result_envelope"]["issues"]
+        == python_workflow["result_envelope"]["issues"]
+    )
+    assert (
+        rest_bundle["calculation_book"]["workflow_result_hash"]
+        == rest_workflow["workflow_result_hash"]
+    )

--- a/react_app/src/features/building-gravity/client.test.ts
+++ b/react_app/src/features/building-gravity/client.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  parseGravityWorkflowRunBundle,
+  runGravityWorkflow,
+} from './client';
+
+const WORKFLOW_HASH = 'a'.repeat(64);
+
+function bundle() {
+  const envelope = {
+    overall_status: 'HOLD',
+    qualified_review_required: true,
+    review_status: 'QUALIFIED_REVIEW_REQUIRED',
+    issues: [{
+      code: 'BEAM_SUPPLIED_REINFORCEMENT_NOT_SUPPLIED',
+      path: '$.components.B1',
+      message: 'A supplied bar schedule is required.',
+    }],
+  };
+  return {
+    schema_version: 'gravity-workflow-run-bundle/v1',
+    workflow_result: {
+      schema_version: 'gravity-workflow-result/v1',
+      model_hash: 'b'.repeat(64),
+      load_model_hash: 'c'.repeat(64),
+      ledger_hash: 'd'.repeat(64),
+      workflow_result_hash: WORKFLOW_HASH,
+      practical_action_reconciliation: [],
+      actions: [],
+      components: [{
+        component_id: 'B1',
+        kind: 'BEAM',
+        canonical_function: 'design_beam_is456',
+        result_envelope: envelope,
+        result: null,
+      }],
+      result_envelope: envelope,
+      limitations: [],
+    },
+    calculation_book: {
+      schema_version: 'gravity-calculation-book/v1',
+      workflow_result_hash: WORKFLOW_HASH,
+      practical_action_reconciliation: [],
+      reconciliation: {
+        all_balanced: true,
+        boundary_count: 1,
+        maximum_absolute_residual_kn: 0,
+        balance_tolerance_kn: 0.001,
+        accepted_entry_count: 1,
+        blocked_entry_count: 0,
+      },
+      approved_exclusions: [],
+      limitations: [],
+      issues: envelope.issues,
+      review_disposition: 'QUALIFIED_REVIEW_REQUIRED',
+    },
+  };
+}
+
+describe('building gravity parity client', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('preserves the REST workflow identity, governing status, and issues', async () => {
+    const payload = bundle();
+    const fetchMock = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(async () => new Response(JSON.stringify({
+      success: true,
+      data: payload,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await runGravityWorkflow({ schema_version: 'gravity-workflow-request/v1' });
+
+    expect(result.workflow_result.workflow_result_hash).toBe(WORKFLOW_HASH);
+    expect(result.workflow_result.result_envelope.overall_status).toBe('HOLD');
+    expect(result.workflow_result.result_envelope.issues).toEqual(
+      payload.workflow_result.result_envelope.issues,
+    );
+    const [, request] = fetchMock.mock.calls[0];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      schema_version: 'gravity-workflow-request/v1',
+    });
+  });
+
+  it('blocks a mismatched calculation-book identity', () => {
+    const payload = bundle();
+    payload.calculation_book.workflow_result_hash = 'f'.repeat(64);
+
+    expect(() => parseGravityWorkflowRunBundle(payload)).toThrow(
+      /inconsistent identity/i,
+    );
+  });
+});

--- a/react_app/src/features/building-gravity/client.ts
+++ b/react_app/src/features/building-gravity/client.ts
@@ -13,6 +13,64 @@ async function readResponse<T>(response: Response, fallback: string): Promise<T>
   return unwrapResponse<T>(body);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+const GRAVITY_STATUSES = new Set([
+  'BLOCKED',
+  'ERROR',
+  'NOT_EVALUATED',
+  'STALE',
+  'PASS',
+  'FAIL',
+  'HOLD',
+]);
+
+function hasCanonicalIssues(value: unknown): boolean {
+  return Array.isArray(value) && value.every((issue) => (
+    isRecord(issue)
+    && typeof issue.code === 'string'
+    && typeof issue.path === 'string'
+    && typeof issue.message === 'string'
+  ));
+}
+
+function hasGravityEnvelope(value: unknown): boolean {
+  return isRecord(value)
+    && GRAVITY_STATUSES.has(String(value.overall_status))
+    && typeof value.qualified_review_required === 'boolean'
+    && typeof value.review_status === 'string'
+    && hasCanonicalIssues(value.issues);
+}
+
+/** Fail closed before React accepts a gravity result identity or issue list. */
+export function parseGravityWorkflowRunBundle(value: unknown): GravityWorkflowRunBundle {
+  if (!isRecord(value) || value.schema_version !== 'gravity-workflow-run-bundle/v1') {
+    throw new Error('Gravity workflow bundle is missing or unsupported.');
+  }
+  const workflow = value.workflow_result;
+  const book = value.calculation_book;
+  if (
+    !isRecord(workflow)
+    || workflow.schema_version !== 'gravity-workflow-result/v1'
+    || typeof workflow.workflow_result_hash !== 'string'
+    || !/^[0-9a-f]{64}$/.test(workflow.workflow_result_hash)
+    || !hasGravityEnvelope(workflow.result_envelope)
+    || !Array.isArray(workflow.components)
+    || workflow.components.some(
+      (component) => !isRecord(component) || !hasGravityEnvelope(component.result_envelope),
+    )
+    || !isRecord(book)
+    || book.schema_version !== 'gravity-calculation-book/v1'
+    || book.workflow_result_hash !== workflow.workflow_result_hash
+    || !hasCanonicalIssues(book.issues)
+  ) {
+    throw new Error('Gravity workflow bundle has inconsistent identity, status, or issues.');
+  }
+  return value as unknown as GravityWorkflowRunBundle;
+}
+
 export async function getGravityWorkflowDefinition(
   signal?: AbortSignal,
 ): Promise<GravityWorkflowDefinition> {
@@ -32,5 +90,7 @@ export async function runGravityWorkflow(
     body: JSON.stringify(request),
     ...(signal ? { signal } : {}),
   });
-  return readResponse(response, 'Gravity workflow failed');
+  return parseGravityWorkflowRunBundle(
+    await readResponse<unknown>(response, 'Gravity workflow failed'),
+  );
 }

--- a/react_app/src/hooks/__tests__/useBatchDesign.test.ts
+++ b/react_app/src/hooks/__tests__/useBatchDesign.test.ts
@@ -5,7 +5,10 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useBatchDesign } from '../../hooks/useBatchDesign';
+import {
+  buildProjectBeamBatchRequest,
+  useBatchDesign,
+} from '../../hooks/useBatchDesign';
 import type { BeamCSVRow } from '../../types/csv';
 import { useImportedBeamsStore } from '../../store/importedBeamsStore';
 import { projectExportReadiness } from '../../workspace/resultRecords';
@@ -94,6 +97,26 @@ const evidence = {
   qualified_review_requirement: 'Qualified review required.',
 };
 
+const canonicalEnvelope = {
+  schema_version: 'structural-result-envelope/v2' as const,
+  intake_status: 'VALID' as const,
+  calculation_status: 'COMPLETED' as const,
+  engineering_status: 'PASS' as const,
+  review_status: 'QUALIFIED_REVIEW_REQUIRED' as const,
+  qualified_review_required: true,
+  freshness_status: 'CURRENT' as const,
+  serviceability_escalation: null,
+  overall_status: 'PASS' as const,
+  issues: [],
+  result_identity: {
+    contract_version: 'canonical-beam-result/v1',
+    library_version: evidence.library_version,
+    input_hash: evidence.normalized_input_hash,
+    calculation_identity: evidence.calculation_identity,
+    artifact_sha256: null,
+  },
+};
+
 describe('useBatchDesign', () => {
   beforeEach(() => {
     MockEventSource.instances = [];
@@ -156,6 +179,60 @@ describe('useBatchDesign', () => {
     expect(payload[0]).not.toHaveProperty('fck_nmm2');
     expect(payload[0]).not.toHaveProperty('d_mm');
     expect(payload[0]).not.toHaveProperty('effective_depth_basis');
+  });
+
+  it('maps the frozen P5 request without transport-side structural arithmetic', () => {
+    const snapshotSha256 = 'a82d927d347108f56aa3fcdd559c1aa45ba8d87673cb3feec61a03d5eadbf4f8';
+    const request = buildProjectBeamBatchRequest(
+      {
+        id: 'B1',
+        source_id: 'etabs:P5-TRIAL-HALL:101',
+        story: 'L1',
+        b: 300,
+        D: 500,
+        span: 5000,
+        fck: 25,
+        fy: 500,
+        cover: 40,
+        stirrup_diameter_mm: 8,
+        tension_bar_diameter_mm: 20,
+        mu_envelope: 150,
+        vu_envelope: 75,
+        source_metadata: {
+          source_system: 'ETABS_EXPORTED_FILES',
+          snapshot_sha256: snapshotSha256,
+          source_unique_name: '101',
+        },
+      },
+      {
+        requestId: 'P6-REQUEST-001',
+        projectId: 'P5-TRIAL-HALL',
+        projectRevision: 1,
+        inputRevision: 1,
+      },
+    );
+
+    expect(request).toMatchObject({
+      schema_version: 'project-beam-design/v1',
+      member_id: 'etabs:P5-TRIAL-HALL:101',
+      b_mm: 300,
+      D_mm: 500,
+      mu_knm: 150,
+      vu_kn: 75,
+      fck_nmm2: 25,
+      fy_nmm2: 500,
+      effective_depth_basis: {
+        clear_cover_mm: 40,
+        stirrup_diameter_mm: 8,
+        tension_bar_diameter_mm: 20,
+      },
+      source_metadata: {
+        snapshot_sha256: snapshotSha256,
+        source_unique_name: '101',
+        request_id: 'P6-REQUEST-001',
+      },
+    });
+    expect(request).not.toHaveProperty('d_mm');
   });
 
   it('posts a maintained-size batch instead of placing it in the request URL', () => {
@@ -407,6 +484,7 @@ describe('useBatchDesign', () => {
         shear: { tau_v: 0.65, tau_c: 0.48, tau_c_max: 3.1, vus: 42, stirrup_spacing: 150, is_safe: true },
         utilization_ratio: 0.78,
         evidence,
+        result_envelope: canonicalEnvelope,
       });
     });
 
@@ -425,6 +503,40 @@ describe('useBatchDesign', () => {
       ast_required: 850,
       status: 'pass',
     });
+  });
+
+  it('holds a result when its envelope and evidence identities disagree', () => {
+    const beam = { ...mockBeam('Label B1'), source_id: 'ETABS-101' };
+    useImportedBeamsStore.getState().setBeams([beam]);
+    const { result } = renderHook(() => useBatchDesign());
+
+    act(() => result.current.startBatchDesign([beam]));
+    act(() => {
+      MockEventSource.instances[0].emit('design_result', {
+        beam_id: 'ETABS-101',
+        design_succeeded: true,
+        is_safe: true,
+        status: 'PASS',
+        utilization_ratio: 0.78,
+        evidence,
+        result_envelope: {
+          ...canonicalEnvelope,
+          result_identity: {
+            ...canonicalEnvelope.result_identity,
+            input_hash: 'different-input-sha256',
+          },
+        },
+      });
+    });
+
+    const snapshot = useWorkspaceStore.getState().snapshot!;
+    expect(snapshot.members[0].result).toMatchObject({
+      lifecycle: 'unsupported',
+      decision: 'HOLD',
+      error: { code: 'RESULT_IDENTITY_MISMATCH' },
+    });
+    expect(projectExportReadiness(snapshot).eligible).toBe(false);
+    expect(result.current.results[0]).toMatchObject({ status: 'HOLD' });
   });
 
   it('rejects a late result after the member input revision changes', () => {
@@ -449,6 +561,7 @@ describe('useBatchDesign', () => {
         status: 'PASS',
         utilization_ratio: 0.78,
         evidence,
+        result_envelope: canonicalEnvelope,
       });
     });
 

--- a/react_app/src/hooks/useBatchDesign.ts
+++ b/react_app/src/hooks/useBatchDesign.ts
@@ -1,6 +1,10 @@
 /** Revision-bound SSE batch design with explicit evidence lifecycles. */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { EvidenceEnvelope } from '../api/client';
+import {
+  parseStructuralResultEnvelope,
+  type EvidenceEnvelope,
+  type StructuralResultEnvelope,
+} from '../api/client';
 import { toast } from '../components/ui/Toast';
 import { API_BASE_URL } from '../config';
 import { useImportedBeamsStore } from '../store/importedBeamsStore';
@@ -25,6 +29,7 @@ export interface BatchResult {
   design_succeeded: boolean;
   is_safe: boolean;
   status: BatchOverallStatus;
+  result_envelope?: StructuralResultEnvelope;
   flexure?: {
     ast_required: number;
     asc_required: number;
@@ -193,6 +198,52 @@ function uniqueId(prefix: string): string {
   return `${prefix}-${crypto.randomUUID()}`;
 }
 
+export interface ProjectBeamRequestContext {
+  requestId: string;
+  projectId?: string;
+  projectRevision?: number;
+  inputRevision?: number;
+}
+
+/** Map one imported beam to the strict project-beam transport without calculations. */
+export function buildProjectBeamBatchRequest(
+  beam: BeamCSVRow,
+  context: ProjectBeamRequestContext,
+): Record<string, unknown> {
+  const depth = beam.d_mm !== undefined
+    ? { d_mm: beam.d_mm }
+    : beam.cover !== undefined
+      && beam.stirrup_diameter_mm !== undefined
+      && beam.tension_bar_diameter_mm !== undefined
+      ? {
+          effective_depth_basis: {
+            clear_cover_mm: beam.cover,
+            stirrup_diameter_mm: beam.stirrup_diameter_mm,
+            tension_bar_diameter_mm: beam.tension_bar_diameter_mm,
+          },
+        }
+      : {};
+  return {
+    schema_version: 'project-beam-design/v1',
+    member_id: beam.source_id ?? beam.id,
+    b_mm: beam.b,
+    D_mm: beam.D,
+    mu_knm: beam.mu_envelope ?? beam.Mu_mid,
+    vu_kn: beam.vu_envelope ?? beam.Vu_start,
+    fck_nmm2: beam.fck,
+    fy_nmm2: beam.fy,
+    ...depth,
+    source_metadata: {
+      ...beam.source_metadata,
+      request_id: context.requestId,
+      project_id: context.projectId,
+      project_revision: context.projectRevision,
+      input_revision: context.inputRevision,
+      span_mm: beam.span,
+    },
+  };
+}
+
 function runId(run: ActiveBatchRun): string {
   return run.serverJobId ?? run.localRunId;
 }
@@ -241,6 +292,14 @@ function settleUnreceived(
 function normalizedResult(data: ServerBatchResult): BatchResult | null {
   const beamId = data.beam_id ?? data.input?.member_id;
   if (!beamId) return null;
+  let resultEnvelope: StructuralResultEnvelope | undefined;
+  if (data.result_envelope !== undefined) {
+    try {
+      resultEnvelope = parseStructuralResultEnvelope(data.result_envelope);
+    } catch {
+      resultEnvelope = undefined;
+    }
+  }
   const status = BATCH_OVERALL_STATUSES.has(data.status as BatchOverallStatus)
     ? data.status as BatchOverallStatus
     : 'HOLD';
@@ -249,6 +308,7 @@ function normalizedResult(data: ServerBatchResult): BatchResult | null {
     design_succeeded: data.design_succeeded === true,
     is_safe: data.is_safe === true,
     status,
+    result_envelope: resultEnvelope,
     flexure: data.flexure,
     shear: data.shear,
     utilization_ratio: data.utilization_ratio,
@@ -326,38 +386,12 @@ export function useBatchDesign() {
           is_valid: false,
         }));
       }
-      const depth = beam.d_mm !== undefined
-        ? { d_mm: beam.d_mm }
-        : beam.cover !== undefined
-          && beam.stirrup_diameter_mm !== undefined
-          && beam.tension_bar_diameter_mm !== undefined
-          ? {
-              effective_depth_basis: {
-                clear_cover_mm: beam.cover,
-                stirrup_diameter_mm: beam.stirrup_diameter_mm,
-                tension_bar_diameter_mm: beam.tension_bar_diameter_mm,
-              },
-            }
-          : {};
-      return {
-        schema_version: 'project-beam-design/v1',
-        member_id: responseId,
-        b_mm: beam.b,
-        D_mm: beam.D,
-        mu_knm: beam.mu_envelope ?? beam.Mu_mid,
-        vu_kn: beam.vu_envelope ?? beam.Vu_start,
-        fck_nmm2: beam.fck,
-        fy_nmm2: beam.fy,
-        ...depth,
-        source_metadata: {
-          ...beam.source_metadata,
-          request_id: requestId,
-          project_id: snapshot?.projectId,
-          project_revision: snapshot?.projectRevision,
-          input_revision: member?.inputRevision,
-          span_mm: beam.span,
-        },
-      };
+      return buildProjectBeamBatchRequest(beam, {
+        requestId,
+        projectId: snapshot?.projectId,
+        projectRevision: snapshot?.projectRevision,
+        inputRevision: member?.inputRevision,
+      });
     });
 
     const run: ActiveBatchRun = {

--- a/react_app/src/workspace/__tests__/importAdapter.test.ts
+++ b/react_app/src/workspace/__tests__/importAdapter.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import type { BeamCSVRow } from '../../types/csv';
 import { useWorkspaceStore } from '../workspaceStore';
+import { projectExportReadiness } from '../resultRecords';
 import {
   beamRowsToWorkspaceMembers,
   synchronizeImportedBeams,
@@ -72,5 +73,49 @@ describe('import workspace adapter', () => {
       { id: 'B1', source_id: 'ETABS-101', b: 300, D: 500, Mu_mid: 120 },
       { id: 'B2', source_id: 'ETABS-102', b: 300, D: 450, Mu_mid: 100 },
     ]);
+  });
+
+  it('makes retained results stale when only the ETABS snapshot identity changes', () => {
+    const snapshotA = 'a'.repeat(64);
+    const sourceBeams = beams.map((beam) => ({
+      ...beam,
+      source_metadata: {
+        source_system: 'ETABS_EXPORTED_FILES',
+        snapshot_sha256: snapshotA,
+      },
+    }));
+    synchronizeImportedBeams(sourceBeams);
+    const pending = useWorkspaceStore.getState().beginMemberRequest(
+      'ETABS-101',
+      'result',
+      'P6-RESULT-001',
+    )!;
+    useWorkspaceStore.getState().applyMemberRecord('ETABS-101', 'result', {
+      ...pending,
+      lifecycle: 'current',
+      calculationIdentity: 'calculation-identity',
+      libraryVersion: '0.23.1a2',
+      decision: 'PASS',
+      supportStatus: 'SUPPORTED',
+      data: { result_identity: 'p6' },
+      settledAt: '2026-08-24T00:00:00.000Z',
+    });
+
+    synchronizeImportedBeams(sourceBeams.map((beam) => ({
+      ...beam,
+      source_metadata: {
+        ...beam.source_metadata,
+        snapshot_sha256: 'b'.repeat(64),
+      },
+    })));
+
+    const changed = useWorkspaceStore.getState().snapshot!;
+    expect(changed.members[0].inputs.sourceSnapshotSha256).toBe('b'.repeat(64));
+    expect(changed.members[0].result?.lifecycle).toBe('stale');
+    expect(projectExportReadiness(changed).eligible).toBe(false);
+    expect(workspaceSnapshotToBeamRows(changed)[0].source_metadata).toMatchObject({
+      source_system: 'ETABS_EXPORTED_FILES',
+      snapshot_sha256: 'b'.repeat(64),
+    });
   });
 });

--- a/react_app/src/workspace/importAdapter.ts
+++ b/react_app/src/workspace/importAdapter.ts
@@ -16,6 +16,29 @@ function stableJsonValue(value: JsonValue): JsonValue {
   return value;
 }
 
+function importedJsonValue(value: unknown, path = 'source_metadata'): JsonValue {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'boolean'
+    || (typeof value === 'number' && Number.isFinite(value))
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item, index) => importedJsonValue(item, `${path}[${index}]`));
+  }
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        importedJsonValue(item, `${path}.${key}`),
+      ]),
+    );
+  }
+  throw new Error(`${path} must contain only finite JSON values.`);
+}
+
 export function hashWorkspaceInputs(inputs: { [key: string]: JsonValue }): string {
   const canonical = JSON.stringify(stableJsonValue(inputs));
   let hash = 2166136261;
@@ -28,6 +51,11 @@ export function hashWorkspaceInputs(inputs: { [key: string]: JsonValue }): strin
 
 function pointInput(point: Point3D | undefined): JsonValue {
   return point ? { x: point.x, y: point.y, z: point.z } : null;
+}
+
+function sourceSnapshotSha256(beam: BeamCSVRow): JsonValue {
+  const value = beam.source_metadata?.snapshot_sha256;
+  return typeof value === 'string' ? value : null;
 }
 
 export function beamRowInputs(beam: BeamCSVRow): { [key: string]: JsonValue } {
@@ -50,6 +78,8 @@ export function beamRowInputs(beam: BeamCSVRow): { [key: string]: JsonValue } {
     datasetId: beam.dataset_id ?? null,
     datasetVersion: beam.dataset_version ?? null,
     datasetSha256: beam.dataset_sha256 ?? null,
+    sourceSnapshotSha256: sourceSnapshotSha256(beam),
+    sourceMetadata: importedJsonValue(beam.source_metadata ?? null),
   };
 }
 
@@ -142,6 +172,13 @@ function pointFromInput(value: JsonValue | undefined): Point3D | undefined {
     : undefined;
 }
 
+function sourceMetadataFromInput(
+  value: JsonValue | undefined,
+): Record<string, unknown> | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value;
+}
+
 /** Restore the imported-beam compatibility view from durable canonical inputs. */
 export function workspaceSnapshotToBeamRows(snapshot: WorkspaceSnapshotV1): BeamCSVRow[] {
   return snapshot.members.map((member) => {
@@ -167,6 +204,7 @@ export function workspaceSnapshotToBeamRows(snapshot: WorkspaceSnapshotV1): Beam
       dataset_id: typeof member.inputs.datasetId === 'string' ? member.inputs.datasetId : undefined,
       dataset_version: typeof member.inputs.datasetVersion === 'string' ? member.inputs.datasetVersion : undefined,
       dataset_sha256: typeof member.inputs.datasetSha256 === 'string' ? member.inputs.datasetSha256 : undefined,
+      source_metadata: sourceMetadataFromInput(member.inputs.sourceMetadata),
       status: member.result?.lifecycle === 'current'
         ? member.result.decision === 'PASS' ? 'pass' : 'fail'
         : 'pending',

--- a/react_app/src/workspace/resultRecords.ts
+++ b/react_app/src/workspace/resultRecords.ts
@@ -29,6 +29,29 @@ function settledRecord(
   return { ...pending, ...values, settledAt };
 }
 
+function unsupportedIdentityRecord(
+  pending: EvidenceRecord,
+  runId: string,
+  code: string,
+  message: string,
+  settledAt?: string,
+): EvidenceRecord {
+  return settledRecord(
+    pending,
+    {
+      lifecycle: 'unsupported',
+      runId,
+      calculationIdentity: null,
+      libraryVersion: null,
+      decision: 'HOLD',
+      supportStatus: 'HELD',
+      data: null,
+      error: { code, message },
+    },
+    settledAt,
+  );
+}
+
 export function completedBatchRecord(
   pending: EvidenceRecord,
   result: BatchResult,
@@ -37,21 +60,48 @@ export function completedBatchRecord(
 ): EvidenceRecord {
   const evidence = result.evidence;
   if (!evidence) {
-    return settledRecord(
+    return unsupportedIdentityRecord(
       pending,
-      {
-        lifecycle: 'unsupported',
-        runId,
-        calculationIdentity: null,
-        libraryVersion: null,
-        decision: 'HOLD',
-        supportStatus: 'HELD',
-        data: null,
-        error: {
-          code: 'EVIDENCE_MISSING',
-          message: 'The batch result did not include a traceable evidence identity.',
-        },
-      },
+      runId,
+      'EVIDENCE_MISSING',
+      'The batch result did not include a traceable evidence identity.',
+      settledAt,
+    );
+  }
+  const envelope = result.result_envelope;
+  const identity = envelope?.result_identity;
+  if (!envelope || !identity) {
+    return unsupportedIdentityRecord(
+      pending,
+      runId,
+      'RESULT_ENVELOPE_MISSING',
+      'The batch result did not include its canonical result identity.',
+      settledAt,
+    );
+  }
+  if (
+    envelope.overall_status !== result.status
+    || envelope.overall_status !== evidence.status
+  ) {
+    return unsupportedIdentityRecord(
+      pending,
+      runId,
+      'RESULT_STATUS_MISMATCH',
+      'The batch status and canonical result envelope do not agree.',
+      settledAt,
+    );
+  }
+  if (
+    identity.contract_version !== 'canonical-beam-result/v1'
+    || identity.input_hash !== evidence.normalized_input_hash
+    || identity.calculation_identity !== evidence.calculation_identity
+    || identity.library_version !== evidence.library_version
+  ) {
+    return unsupportedIdentityRecord(
+      pending,
+      runId,
+      'RESULT_IDENTITY_MISMATCH',
+      'The result envelope and evidence identity do not agree.',
       settledAt,
     );
   }
@@ -61,8 +111,8 @@ export function completedBatchRecord(
     {
       lifecycle: evidence.support_status === 'SUPPORTED' ? 'current' : 'unsupported',
       runId,
-      calculationIdentity: evidence.calculation_identity,
-      libraryVersion: evidence.library_version,
+      calculationIdentity: identity.calculation_identity,
+      libraryVersion: identity.library_version,
       decision: evidence.status,
       supportStatus: evidence.support_status,
       data: jsonClone(result),


### PR DESCRIPTION
## Summary
- preserve the original effective-depth basis through project batch design so Python and Excel use the same canonical calculation
- validate beam result-envelope identity and source freshness across REST, React, and Routine Workbench V1
- bind the maintained gravity workflow hash, governing status, issues, and calculation-book identity through Python, REST, and React
- keep live ETABS, EDB parsing, analysis/model mutation, installed Excel rerun, P7, INDIA-3, release, and professional approval out of scope

## Verification
- 147 focused Python/FastAPI/Excel tests passed
- 35 focused React tests passed; affected repair reruns passed
- React lint and production build passed
- changed-source Ruff/mypy passed
- architecture/import/circular checks passed
- `./run.sh check --quick`: 10/10 passed
- normal staged hooks passed

## Boundary
The public parity vector is the deterministic synthetic P5 exported-file snapshot. The open Windows ETABS trial model was not touched.