### PR TITLE
fix(is13920): repair joint scwb contract

### DIFF
--- a/Python/structural_lib/codes/is13920/joint.py
+++ b/Python/structural_lib/codes/is13920/joint.py
@@ -1,190 +1,297 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2024-2026 Pravin Surawase
-"""
-Module:       codes.is13920.joint
-Description:  IS 13920:2016 Beam-Column Joint checks.
-Traceability: Functions are decorated with @clause for IS 13920 clause references.
-
-Implements:
-- Strong Column Weak Beam (SCWB) check (Cl 7.2.1)
-
-The SCWB requirement ensures that plastic hinges form in beams rather than
-columns during seismic events, preventing a storey-level collapse mechanism.
-
-References:
-    IS 13920:2016, Cl. 7.2.1
-    Pillai & Menon, "Reinforced Concrete Design", 3rd Ed.
-"""
+"""Bounded IS 13920:2016 strong-column/weak-beam joint check."""
 
 from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from enum import StrEnum
 
 from structural_lib.codes.is456.traceability import clause
-from structural_lib.core.errors import (
-    E_SCWB_002,
-    DesignError,
-)
+from structural_lib.core.errors import E_SCWB_002, DesignError
 
 __all__ = [
+    "ColumnCapacityBasis",
+    "JointTopology",
+    "PrincipalPlane",
     "SCWBResult",
+    "ShakingDirection",
     "check_scwb",
 ]
 
-# IS 13920:2016 Cl 7.2.1: Default SCWB factor
-_SCWB_FACTOR: float = 1.1
+_SCWB_FACTOR_IS13920: float = 1.4
+_SCWB_REFERENCE = (
+    "IS 13920:2016 Cl. 7.2.1-7.2.1.3 with Amendment 1 column-capacity basis"
+)
+_SCWB_CASE_SCOPE = "ONE_PRINCIPAL_PLANE_ONE_SHAKING_DIRECTION"
+_SCWB_APPLICABILITY = "APPLICABLE_NON_ROOF_BEAM_COLUMN_JOINT"
+
+
+class JointTopology(StrEnum):
+    """Supported beam framing topology in the checked principal plane."""
+
+    INTERIOR = "INTERIOR"
+    EXTERIOR_LEFT = "EXTERIOR_LEFT"
+    EXTERIOR_RIGHT = "EXTERIOR_RIGHT"
+
+
+class PrincipalPlane(StrEnum):
+    """Principal plane for the directional capacity check."""
+
+    X = "X"
+    Y = "Y"
+
+
+class ShakingDirection(StrEnum):
+    """Direction of the beam actions used in one SCWB case."""
+
+    POSITIVE = "POSITIVE"
+    NEGATIVE = "NEGATIVE"
+
+    def opposite(self) -> ShakingDirection:
+        """Return the direction required for the column capacities."""
+        if self is ShakingDirection.POSITIVE:
+            return ShakingDirection.NEGATIVE
+        return ShakingDirection.POSITIVE
+
+
+class ColumnCapacityBasis(StrEnum):
+    """Supported basis for column moment capacities."""
+
+    FACTORED_AXIAL_LOAD = "FACTORED_AXIAL_LOAD"
 
 
 @dataclass(frozen=True)
 class SCWBResult:
-    """Result of IS 13920:2016 Cl 7.2.1 Strong Column Weak Beam check.
+    """Result for one applicable principal-plane and shaking-direction case.
 
-    Attributes:
-        sum_column_capacity_knm: ΣMc — sum of column moment capacities at joint (kNm).
-        sum_beam_capacity_knm: ΣMb — sum of beam moment capacities at joint (kNm).
-        required_column_capacity_knm: factor × ΣMb — minimum required ΣMc (kNm).
-        ratio: ΣMc / (factor × ΣMb) — values ≥ 1.0 satisfy the check.
-        factor: SCWB factor used (default 1.1 per IS 13920).
-        is_satisfied: True if ΣMc ≥ factor × ΣMb.
-        clause: IS 13920 clause reference.
-        errors: Accumulated design errors (empty tuple if check passes).
-        warnings: Any warnings generated.
+    A passing instance is not a complete whole-joint assessment. The caller
+    must evaluate both shaking directions in every applicable principal plane.
     """
 
+    topology: JointTopology
+    principal_plane: PrincipalPlane
+    shaking_direction: ShakingDirection
+    beam_capacity_direction: ShakingDirection
+    column_capacity_direction: ShakingDirection
+    column_capacity_basis: ColumnCapacityBasis
+    column_top_factored_axial_load_kn: float
+    column_bottom_factored_axial_load_kn: float
     sum_column_capacity_knm: float
     sum_beam_capacity_knm: float
     required_column_capacity_knm: float
     ratio: float
     factor: float
     is_satisfied: bool
-    clause: str
+    standard: str
+    source_reference: str
+    applicability: str
+    assessment_scope: str
     errors: tuple[DesignError, ...] = ()
     warnings: tuple[str, ...] = ()
 
+    @property
+    def clause(self) -> str:
+        """Backward-readable source reference for this bounded result."""
+        return self.source_reference
+
     def is_safe(self) -> bool:
-        """Return True if the SCWB check is satisfied."""
+        """Return whether this directional case satisfies the SCWB ratio."""
         return self.is_satisfied
 
     def to_dict(self) -> dict:
-        """Return a dict representation of the result."""
+        """Return a JSON-compatible representation of the result."""
         return {
+            "topology": self.topology.value,
+            "principal_plane": self.principal_plane.value,
+            "shaking_direction": self.shaking_direction.value,
+            "beam_capacity_direction": self.beam_capacity_direction.value,
+            "column_capacity_direction": self.column_capacity_direction.value,
+            "column_capacity_basis": self.column_capacity_basis.value,
+            "column_top_factored_axial_load_kn": (
+                self.column_top_factored_axial_load_kn
+            ),
+            "column_bottom_factored_axial_load_kn": (
+                self.column_bottom_factored_axial_load_kn
+            ),
             "sum_column_capacity_knm": self.sum_column_capacity_knm,
             "sum_beam_capacity_knm": self.sum_beam_capacity_knm,
             "required_column_capacity_knm": self.required_column_capacity_knm,
             "ratio": self.ratio,
             "factor": self.factor,
             "is_satisfied": self.is_satisfied,
+            "standard": self.standard,
+            "source_reference": self.source_reference,
             "clause": self.clause,
-            "errors": [e.to_dict() for e in self.errors],
+            "applicability": self.applicability,
+            "assessment_scope": self.assessment_scope,
+            "errors": [error.to_dict() for error in self.errors],
             "warnings": list(self.warnings),
         }
 
     def summary(self) -> str:
-        """Return a human-readable summary."""
+        """Return a human-readable directional-case summary."""
         status = "PASS" if self.is_satisfied else "FAIL"
         return (
-            f"SCWB Check ({self.clause}): {status} — "
+            f"SCWB directional case ({self.principal_plane.value}, "
+            f"{self.shaking_direction.value}, {self.topology.value}): {status} — "
             f"ΣMc={self.sum_column_capacity_knm:.1f} kNm, "
             f"required={self.required_column_capacity_knm:.1f} kNm, "
             f"ratio={self.ratio:.3f}"
         )
 
 
+def _require_enum(value: object, enum_type: type[StrEnum], field: str) -> None:
+    if not isinstance(value, enum_type):
+        raise TypeError(f"{field} must be a {enum_type.__name__}")
+
+
+def _require_bool(value: object, field: str) -> None:
+    if not isinstance(value, bool):
+        raise TypeError(f"{field} must be a bool")
+
+
+def _require_positive_finite(value: float, field: str) -> None:
+    if isinstance(value, bool) or not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{field} must be a finite value > 0, got {value}")
+
+
+def _require_finite(value: float, field: str) -> None:
+    if isinstance(value, bool) or not math.isfinite(value):
+        raise ValueError(f"{field} must be finite, got {value}")
+
+
+def _validate_topology(
+    topology: JointTopology,
+    beam_left_capacity_knm: float | None,
+    beam_right_capacity_knm: float | None,
+) -> tuple[float, ...]:
+    capacities: tuple[float, ...]
+    if topology is JointTopology.INTERIOR:
+        if beam_left_capacity_knm is None or beam_right_capacity_knm is None:
+            raise ValueError(
+                "INTERIOR topology requires left and right beam capacities"
+            )
+        capacities = (beam_left_capacity_knm, beam_right_capacity_knm)
+    elif topology is JointTopology.EXTERIOR_LEFT:
+        if beam_left_capacity_knm is None or beam_right_capacity_knm is not None:
+            raise ValueError(
+                "EXTERIOR_LEFT topology requires only the left beam capacity"
+            )
+        capacities = (beam_left_capacity_knm,)
+    else:
+        if beam_left_capacity_knm is not None or beam_right_capacity_knm is None:
+            raise ValueError(
+                "EXTERIOR_RIGHT topology requires only the right beam capacity"
+            )
+        capacities = (beam_right_capacity_knm,)
+
+    for index, capacity in enumerate(capacities):
+        _require_positive_finite(capacity, f"beam_capacity_knm[{index}]")
+    return capacities
+
+
 @clause("7.2.1", standard="IS 13920")
 def check_scwb(
-    column_moments_top_knm: float,
-    column_moments_bottom_knm: float,
-    beam_moments_left_knm: float,
-    beam_moments_right_knm: float,
-    factor: float = _SCWB_FACTOR,
+    *,
+    column_top_capacity_knm: float,
+    column_bottom_capacity_knm: float,
+    beam_left_capacity_knm: float | None,
+    beam_right_capacity_knm: float | None,
+    topology: JointTopology,
+    principal_plane: PrincipalPlane,
+    shaking_direction: ShakingDirection,
+    column_capacity_direction: ShakingDirection,
+    column_top_factored_axial_load_kn: float,
+    column_bottom_factored_axial_load_kn: float,
+    column_capacity_basis: ColumnCapacityBasis,
+    is_roof_joint: bool,
+    is_flat_slab_system: bool,
 ) -> SCWBResult:
-    """IS 13920:2016 Cl 7.2.1 — Strong Column Weak Beam (SCWB) check.
+    """Check one bounded IS 13920 SCWB directional case.
 
-    At every beam-column joint, the sum of the moment capacities of the
-    columns framing into the joint must be at least ``factor`` times the
-    sum of the moment capacities of the beams framing into the joint:
+    Beam capacities must act in ``shaking_direction``. Column capacities must
+    act in the opposite direction and be evaluated at the provided factored
+    axial loads. The fixed IS 13920 requirement is ``ΣMc >= 1.4ΣMb``.
 
-        ΣMc ≥ factor × ΣMb
-
-    This ensures that plastic hinges develop in beams (ductile) rather
-    than columns (brittle storey mechanism).
-
-    Args:
-        column_moments_top_knm: Moment capacity of column above joint (kNm).
-        column_moments_bottom_knm: Moment capacity of column below joint (kNm).
-        beam_moments_left_knm: Moment capacity of beam to left of joint (kNm).
-        beam_moments_right_knm: Moment capacity of beam to right of joint (kNm).
-        factor: SCWB factor (default 1.1 per IS 13920:2016 Cl 7.2.1).
-
-    Returns:
-        SCWBResult with check outcome, ratio, and any errors.
-
-    Raises:
-        ValueError: If any moment capacity is negative or zero, or factor ≤ 0.
-
-    References:
-        IS 13920:2016, Cl. 7.2.1
+    Roof joints and flat-slab systems do not produce a passing or failing SCWB
+    result from this function. Both shaking directions must be checked in every
+    applicable principal plane before making a whole-joint assessment.
     """
-    # ------------------------------------------------------------------
-    # Input validation — all moment capacities must be positive
-    # ------------------------------------------------------------------
-    errors: list[DesignError] = []
+    _require_enum(topology, JointTopology, "topology")
+    _require_enum(principal_plane, PrincipalPlane, "principal_plane")
+    _require_enum(shaking_direction, ShakingDirection, "shaking_direction")
+    _require_enum(
+        column_capacity_direction,
+        ShakingDirection,
+        "column_capacity_direction",
+    )
+    _require_enum(
+        column_capacity_basis,
+        ColumnCapacityBasis,
+        "column_capacity_basis",
+    )
+    _require_bool(is_roof_joint, "is_roof_joint")
+    _require_bool(is_flat_slab_system, "is_flat_slab_system")
 
-    if column_moments_top_knm <= 0:
+    if is_flat_slab_system:
+        raise ValueError("SCWB check is not supported for flat-slab systems")
+    if is_roof_joint:
+        raise ValueError("SCWB requirement is waived at roof joints")
+    if column_capacity_basis is not ColumnCapacityBasis.FACTORED_AXIAL_LOAD:
+        raise ValueError("column capacities must use the factored axial-load basis")
+
+    required_column_direction = shaking_direction.opposite()
+    if column_capacity_direction is not required_column_direction:
         raise ValueError(
-            f"column_moments_top_knm must be > 0, got {column_moments_top_knm}"
-        )
-    if column_moments_bottom_knm <= 0:
-        raise ValueError(
-            f"column_moments_bottom_knm must be > 0, got {column_moments_bottom_knm}"
-        )
-    if beam_moments_left_knm <= 0:
-        raise ValueError(
-            f"beam_moments_left_knm must be > 0, got {beam_moments_left_knm}"
-        )
-    if beam_moments_right_knm <= 0:
-        raise ValueError(
-            f"beam_moments_right_knm must be > 0, got {beam_moments_right_knm}"
-        )
-    if factor <= 0:
-        raise ValueError(f"factor must be > 0, got {factor}")
-
-    # ------------------------------------------------------------------
-    # IS 13920:2016 Cl 7.2.1: ΣMc ≥ factor × ΣMb
-    # ------------------------------------------------------------------
-    # IS 13920 Cl 7.2.1: ΣMc = Mc_top + Mc_bottom
-    sum_mc = column_moments_top_knm + column_moments_bottom_knm
-
-    # IS 13920 Cl 7.2.1: ΣMb = Mb_left + Mb_right
-    sum_mb = beam_moments_left_knm + beam_moments_right_knm
-
-    # IS 13920 Cl 7.2.1: required = factor × ΣMb
-    required = factor * sum_mb
-
-    # IS 13920 Cl 7.2.1: ratio = ΣMc / (factor × ΣMb)
-    # required > 0 is guaranteed since all inputs are > 0 and factor > 0
-    ratio = sum_mc / required
-
-    # IS 13920 Cl 7.2.1: ΣMc ≥ factor × ΣMb
-    is_satisfied = sum_mc >= required - 1e-9  # tolerance for floating point
-
-    # Guard against NaN/Inf
-    if math.isnan(ratio) or math.isinf(ratio):
-        raise ValueError(
-            f"Numerical error: ratio={ratio} (ΣMc={sum_mc}, required={required})"
+            "column_capacity_direction must oppose the declared shaking_direction"
         )
 
-    if not is_satisfied:
-        errors.append(E_SCWB_002)
+    _require_positive_finite(column_top_capacity_knm, "column_top_capacity_knm")
+    _require_positive_finite(
+        column_bottom_capacity_knm,
+        "column_bottom_capacity_knm",
+    )
+    _require_finite(
+        column_top_factored_axial_load_kn,
+        "column_top_factored_axial_load_kn",
+    )
+    _require_finite(
+        column_bottom_factored_axial_load_kn,
+        "column_bottom_factored_axial_load_kn",
+    )
+    beam_capacities = _validate_topology(
+        topology,
+        beam_left_capacity_knm,
+        beam_right_capacity_knm,
+    )
+
+    sum_column_capacity = column_top_capacity_knm + column_bottom_capacity_knm
+    sum_beam_capacity = sum(beam_capacities)
+    required_column_capacity = _SCWB_FACTOR_IS13920 * sum_beam_capacity
+    ratio = sum_column_capacity / required_column_capacity
+    is_satisfied = sum_column_capacity >= required_column_capacity - 1e-9
+    errors = () if is_satisfied else (E_SCWB_002,)
 
     return SCWBResult(
-        sum_column_capacity_knm=sum_mc,
-        sum_beam_capacity_knm=sum_mb,
-        required_column_capacity_knm=required,
+        topology=topology,
+        principal_plane=principal_plane,
+        shaking_direction=shaking_direction,
+        beam_capacity_direction=shaking_direction,
+        column_capacity_direction=column_capacity_direction,
+        column_capacity_basis=column_capacity_basis,
+        column_top_factored_axial_load_kn=column_top_factored_axial_load_kn,
+        column_bottom_factored_axial_load_kn=column_bottom_factored_axial_load_kn,
+        sum_column_capacity_knm=sum_column_capacity,
+        sum_beam_capacity_knm=sum_beam_capacity,
+        required_column_capacity_knm=required_column_capacity,
         ratio=ratio,
-        factor=factor,
+        factor=_SCWB_FACTOR_IS13920,
         is_satisfied=is_satisfied,
-        clause="IS 13920:2016 Cl 7.2.1",
-        errors=tuple(errors),
+        standard="IS 13920:2016",
+        source_reference=_SCWB_REFERENCE,
+        applicability=_SCWB_APPLICABILITY,
+        assessment_scope=_SCWB_CASE_SCOPE,
+        errors=errors,
     )

--- a/Python/structural_lib/core/errors.py
+++ b/Python/structural_lib/core/errors.py
@@ -888,11 +888,11 @@ E_SCWB_001 = DesignError(
 E_SCWB_002 = DesignError(
     code="E_SCWB_002",
     severity=Severity.ERROR,
-    message="Strong Column Weak Beam check failed: ΣMc < 1.1 × ΣMb",
+    message="Strong Column Weak Beam check failed: ΣMc < 1.4 × ΣMb",
     field="sum_column_capacity_knm",
     hint="Increase column moment capacity or reduce beam moment capacity at joint.",
     clause="IS 13920 Cl. 7.2.1",
-    recovery="Increase column sections or reinforcement so that ΣMc ≥ 1.1 × ΣMb at every joint.",
+    recovery="Increase column sections or reinforcement so that ΣMc ≥ 1.4 × ΣMb at every applicable joint case.",
 )
 
 

--- a/Python/tests/codes/is13920/test_joint.py
+++ b/Python/tests/codes/is13920/test_joint.py
@@ -1,266 +1,245 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2024-2026 Pravin Surawase
-"""
-Tests for IS 13920:2016 Cl 7.2.1 — Strong Column Weak Beam (SCWB) check.
-
-Functions under test:
-    - check_scwb (Cl 7.2.1)
-
-Test types:
-    1. Unit tests — passing case (columns stronger)
-    2. Unit tests — failing case (beams stronger)
-    3. Boundary test — exactly at 1.1 ratio
-    4. Input validation — zero/negative inputs
-    5. Custom factor test
-    6. Result methods — is_safe(), to_dict(), summary()
-"""
+"""Tests for the bounded IS 13920 SCWB directional-case contract."""
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
-from structural_lib.codes.is13920.joint import check_scwb
+from structural_lib.codes.is13920.joint import (
+    ColumnCapacityBasis,
+    JointTopology,
+    PrincipalPlane,
+    ShakingDirection,
+    check_scwb,
+)
 
-# =============================================================================
-# 1. Passing Case — Columns stronger than beams
-# =============================================================================
+
+def _check(**overrides: Any):
+    inputs: dict[str, Any] = {
+        "column_top_capacity_knm": 200.0,
+        "column_bottom_capacity_knm": 200.0,
+        "beam_left_capacity_knm": 100.0,
+        "beam_right_capacity_knm": 100.0,
+        "topology": JointTopology.INTERIOR,
+        "principal_plane": PrincipalPlane.X,
+        "shaking_direction": ShakingDirection.POSITIVE,
+        "column_capacity_direction": ShakingDirection.NEGATIVE,
+        "column_top_factored_axial_load_kn": 850.0,
+        "column_bottom_factored_axial_load_kn": 900.0,
+        "column_capacity_basis": ColumnCapacityBasis.FACTORED_AXIAL_LOAD,
+        "is_roof_joint": False,
+        "is_flat_slab_system": False,
+    }
+    inputs.update(overrides)
+    return check_scwb(**inputs)
 
 
-class TestSCWBPass:
-    """ΣMc ≥ 1.1 × ΣMb — check should pass."""
-
-    def test_columns_clearly_stronger(self) -> None:
-        """Columns well above the 1.1× threshold."""
-        result = check_scwb(
-            column_moments_top_knm=200.0,
-            column_moments_bottom_knm=200.0,
-            beam_moments_left_knm=150.0,
-            beam_moments_right_knm=150.0,
+class TestFixedIS13920Requirement:
+    def test_g0_false_pass_benchmark_now_fails_at_1_4(self) -> None:
+        result = _check(
+            column_top_capacity_knm=125.0,
+            column_bottom_capacity_knm=125.0,
         )
-        # ΣMc = 400, ΣMb = 300, required = 330, ratio = 400/330 ≈ 1.212
-        assert result.is_satisfied is True
-        assert result.is_safe() is True
-        assert result.sum_column_capacity_knm == pytest.approx(400.0)
-        assert result.sum_beam_capacity_knm == pytest.approx(300.0)
-        assert result.required_column_capacity_knm == pytest.approx(330.0)
-        assert result.ratio == pytest.approx(400.0 / 330.0, rel=1e-6)
-        assert len(result.errors) == 0
 
-    def test_asymmetric_beams(self) -> None:
-        """Different beam capacities on left and right."""
-        result = check_scwb(
-            column_moments_top_knm=250.0,
-            column_moments_bottom_knm=250.0,
-            beam_moments_left_knm=100.0,
-            beam_moments_right_knm=200.0,
-        )
-        # ΣMc = 500, ΣMb = 300, required = 330
-        assert result.is_satisfied is True
-        assert result.ratio == pytest.approx(500.0 / 330.0, rel=1e-6)
-
-    def test_asymmetric_columns(self) -> None:
-        """Different column capacities top and bottom."""
-        result = check_scwb(
-            column_moments_top_knm=300.0,
-            column_moments_bottom_knm=100.0,
-            beam_moments_left_knm=150.0,
-            beam_moments_right_knm=150.0,
-        )
-        # ΣMc = 400, ΣMb = 300, required = 330
-        assert result.is_satisfied is True
-
-
-# =============================================================================
-# 2. Failing Case — Beams stronger than columns
-# =============================================================================
-
-
-class TestSCWBFail:
-    """ΣMc < 1.1 × ΣMb — check should fail."""
-
-    def test_beams_clearly_stronger(self) -> None:
-        """Beams much stronger — obvious SCWB violation."""
-        result = check_scwb(
-            column_moments_top_knm=100.0,
-            column_moments_bottom_knm=100.0,
-            beam_moments_left_knm=200.0,
-            beam_moments_right_knm=200.0,
-        )
-        # ΣMc = 200, ΣMb = 400, required = 440, ratio = 200/440 ≈ 0.455
+        assert result.factor == 1.4
+        assert result.sum_column_capacity_knm == 250.0
+        assert result.sum_beam_capacity_knm == 200.0
+        assert result.required_column_capacity_knm == pytest.approx(280.0)
+        assert result.ratio == pytest.approx(0.8928571428571429)
         assert result.is_satisfied is False
-        assert result.is_safe() is False
-        assert result.ratio == pytest.approx(200.0 / 440.0, rel=1e-6)
-        assert len(result.errors) == 1
         assert result.errors[0].code == "E_SCWB_002"
+        assert "1.4" in result.errors[0].message
 
-    def test_marginally_below_threshold(self) -> None:
-        """Just barely below the 1.1× threshold."""
-        # ΣMb = 200, required = 220, ΣMc = 219 < 220
-        result = check_scwb(
-            column_moments_top_knm=109.0,
-            column_moments_bottom_knm=110.0,
-            beam_moments_left_knm=100.0,
-            beam_moments_right_knm=100.0,
+    def test_exact_1_4_boundary_passes(self) -> None:
+        result = _check(
+            column_top_capacity_knm=140.0,
+            column_bottom_capacity_knm=140.0,
         )
-        # ΣMc = 219, required = 220
-        assert result.is_satisfied is False
 
-
-# =============================================================================
-# 3. Boundary Case — Exactly at 1.1 ratio
-# =============================================================================
-
-
-class TestSCWBBoundary:
-    """ΣMc = 1.1 × ΣMb exactly — should pass (≥ not >)."""
-
-    def test_exactly_at_threshold(self) -> None:
-        """Exactly at the 1.1 boundary — should satisfy the check."""
-        # ΣMb = 200, required = 220, ΣMc = 220
-        result = check_scwb(
-            column_moments_top_knm=110.0,
-            column_moments_bottom_knm=110.0,
-            beam_moments_left_knm=100.0,
-            beam_moments_right_knm=100.0,
-        )
         assert result.is_satisfied is True
-        assert result.ratio == pytest.approx(1.0, rel=1e-6)
-        assert len(result.errors) == 0
+        assert result.ratio == pytest.approx(1.0)
+        assert result.errors == ()
 
-    def test_marginally_above_threshold(self) -> None:
-        """Just barely above the 1.1× threshold."""
-        result = check_scwb(
-            column_moments_top_knm=110.5,
-            column_moments_bottom_knm=110.0,
-            beam_moments_left_knm=100.0,
-            beam_moments_right_knm=100.0,
+    def test_nonstandard_factor_override_is_not_part_of_contract(self) -> None:
+        with pytest.raises(TypeError, match="unexpected keyword argument 'factor'"):
+            _check(factor=1.0)
+
+    def test_result_is_labeled_only_with_fixed_is13920_basis(self) -> None:
+        result = _check()
+
+        assert result.standard == "IS 13920:2016"
+        assert "7.2.1-7.2.1.3" in result.source_reference
+        assert result.factor == 1.4
+
+
+class TestDirectionalAndAxialCapacityProvenance:
+    @pytest.mark.parametrize(
+        ("plane", "shaking", "column_direction"),
+        [
+            (PrincipalPlane.X, ShakingDirection.POSITIVE, ShakingDirection.NEGATIVE),
+            (PrincipalPlane.X, ShakingDirection.NEGATIVE, ShakingDirection.POSITIVE),
+            (PrincipalPlane.Y, ShakingDirection.POSITIVE, ShakingDirection.NEGATIVE),
+            (PrincipalPlane.Y, ShakingDirection.NEGATIVE, ShakingDirection.POSITIVE),
+        ],
+    )
+    def test_every_plane_direction_case_is_explicit(
+        self,
+        plane: PrincipalPlane,
+        shaking: ShakingDirection,
+        column_direction: ShakingDirection,
+    ) -> None:
+        result = _check(
+            principal_plane=plane,
+            shaking_direction=shaking,
+            column_capacity_direction=column_direction,
         )
-        # ΣMc = 220.5, required = 220
-        assert result.is_satisfied is True
 
+        assert result.principal_plane is plane
+        assert result.shaking_direction is shaking
+        assert result.beam_capacity_direction is shaking
+        assert result.column_capacity_direction is column_direction
+        assert result.assessment_scope == "ONE_PRINCIPAL_PLANE_ONE_SHAKING_DIRECTION"
 
-# =============================================================================
-# 4. Input Validation — Zero/negative inputs
-# =============================================================================
+    def test_column_capacity_direction_must_oppose_shaking(self) -> None:
+        with pytest.raises(ValueError, match="must oppose"):
+            _check(column_capacity_direction=ShakingDirection.POSITIVE)
 
-
-class TestSCWBValidation:
-    """Zero and negative inputs should raise ValueError."""
-
-    def test_zero_column_top(self) -> None:
-        with pytest.raises(ValueError, match="column_moments_top_knm"):
-            check_scwb(0.0, 100.0, 100.0, 100.0)
-
-    def test_negative_column_bottom(self) -> None:
-        with pytest.raises(ValueError, match="column_moments_bottom_knm"):
-            check_scwb(100.0, -50.0, 100.0, 100.0)
-
-    def test_zero_beam_left(self) -> None:
-        with pytest.raises(ValueError, match="beam_moments_left_knm"):
-            check_scwb(100.0, 100.0, 0.0, 100.0)
-
-    def test_negative_beam_right(self) -> None:
-        with pytest.raises(ValueError, match="beam_moments_right_knm"):
-            check_scwb(100.0, 100.0, 100.0, -10.0)
-
-    def test_zero_factor(self) -> None:
-        with pytest.raises(ValueError, match="factor"):
-            check_scwb(100.0, 100.0, 100.0, 100.0, factor=0.0)
-
-    def test_negative_factor(self) -> None:
-        with pytest.raises(ValueError, match="factor"):
-            check_scwb(100.0, 100.0, 100.0, 100.0, factor=-1.0)
-
-
-# =============================================================================
-# 5. Custom Factor
-# =============================================================================
-
-
-class TestSCWBCustomFactor:
-    """Use a non-default SCWB factor."""
-
-    def test_factor_1_2(self) -> None:
-        """Use factor=1.2 — stricter requirement."""
-        # ΣMb = 200, required = 240, ΣMc = 250
-        result = check_scwb(
-            column_moments_top_knm=125.0,
-            column_moments_bottom_knm=125.0,
-            beam_moments_left_knm=100.0,
-            beam_moments_right_knm=100.0,
-            factor=1.2,
+    def test_factored_axial_load_basis_and_values_are_retained(self) -> None:
+        result = _check(
+            column_top_factored_axial_load_kn=812.5,
+            column_bottom_factored_axial_load_kn=-125.0,
         )
-        assert result.is_satisfied is True
-        assert result.factor == 1.2
-        assert result.required_column_capacity_knm == pytest.approx(240.0)
 
-    def test_factor_1_0(self) -> None:
-        """Use factor=1.0 — equal capacity check (non-standard)."""
-        # ΣMb = 200, required = 200, ΣMc = 200
-        result = check_scwb(
-            column_moments_top_knm=100.0,
-            column_moments_bottom_knm=100.0,
-            beam_moments_left_knm=100.0,
-            beam_moments_right_knm=100.0,
-            factor=1.0,
+        assert result.column_capacity_basis is ColumnCapacityBasis.FACTORED_AXIAL_LOAD
+        assert result.column_top_factored_axial_load_kn == 812.5
+        assert result.column_bottom_factored_axial_load_kn == -125.0
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "column_top_factored_axial_load_kn",
+            "column_bottom_factored_axial_load_kn",
+        ],
+    )
+    def test_axial_load_basis_rejects_nonfinite_values(self, field: str) -> None:
+        with pytest.raises(ValueError, match=field):
+            _check(**{field: float("nan")})
+
+
+class TestApplicability:
+    def test_non_roof_beam_column_joint_is_explicitly_applicable(self) -> None:
+        result = _check()
+        assert result.applicability == "APPLICABLE_NON_ROOF_BEAM_COLUMN_JOINT"
+
+    def test_roof_joint_waiver_cannot_be_reported_as_pass(self) -> None:
+        with pytest.raises(ValueError, match="waived at roof joints"):
+            _check(is_roof_joint=True)
+
+    def test_flat_slab_exclusion_cannot_be_reported_as_pass(self) -> None:
+        with pytest.raises(ValueError, match="not supported for flat-slab"):
+            _check(is_flat_slab_system=True)
+
+    @pytest.mark.parametrize("field", ["is_roof_joint", "is_flat_slab_system"])
+    def test_applicability_flags_must_be_known_booleans(self, field: str) -> None:
+        with pytest.raises(TypeError, match=field):
+            _check(**{field: None})
+
+
+class TestSupportedTopologies:
+    def test_interior_joint_uses_both_beams(self) -> None:
+        result = _check(
+            beam_left_capacity_knm=90.0,
+            beam_right_capacity_knm=110.0,
         )
-        assert result.is_satisfied is True
-        assert result.ratio == pytest.approx(1.0, rel=1e-6)
+        assert result.topology is JointTopology.INTERIOR
+        assert result.sum_beam_capacity_knm == 200.0
 
-    def test_factor_1_2_fail(self) -> None:
-        """factor=1.2 causes failure that would pass with default 1.1."""
-        # ΣMb = 200, required@1.1 = 220, required@1.2 = 240, ΣMc = 230
-        result = check_scwb(
-            column_moments_top_knm=115.0,
-            column_moments_bottom_knm=115.0,
-            beam_moments_left_knm=100.0,
-            beam_moments_right_knm=100.0,
-            factor=1.2,
+    def test_left_exterior_joint_uses_only_left_beam(self) -> None:
+        result = _check(
+            topology=JointTopology.EXTERIOR_LEFT,
+            beam_left_capacity_knm=120.0,
+            beam_right_capacity_knm=None,
         )
-        assert result.is_satisfied is False
-        # Same inputs with default factor should pass
-        result_default = check_scwb(115.0, 115.0, 100.0, 100.0)
-        assert result_default.is_satisfied is True
+        assert result.sum_beam_capacity_knm == 120.0
+
+    def test_right_exterior_joint_uses_only_right_beam(self) -> None:
+        result = _check(
+            topology=JointTopology.EXTERIOR_RIGHT,
+            beam_left_capacity_knm=None,
+            beam_right_capacity_knm=130.0,
+        )
+        assert result.sum_beam_capacity_knm == 130.0
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"beam_right_capacity_knm": None},
+            {
+                "topology": JointTopology.EXTERIOR_LEFT,
+                "beam_right_capacity_knm": 100.0,
+            },
+            {
+                "topology": JointTopology.EXTERIOR_RIGHT,
+                "beam_left_capacity_knm": 100.0,
+                "beam_right_capacity_knm": None,
+            },
+        ],
+    )
+    def test_topology_and_present_beam_sides_must_agree(
+        self,
+        overrides: dict[str, Any],
+    ) -> None:
+        with pytest.raises(ValueError, match="topology"):
+            _check(**overrides)
 
 
-# =============================================================================
-# 6. Result Methods
-# =============================================================================
+class TestValidationAndResultMethods:
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("column_top_capacity_knm", 0.0),
+            ("column_bottom_capacity_knm", -1.0),
+            ("beam_left_capacity_knm", float("inf")),
+        ],
+    )
+    def test_capacities_must_be_positive_and_finite(
+        self,
+        field: str,
+        value: float,
+    ) -> None:
+        with pytest.raises(ValueError):
+            _check(**{field: value})
 
+    def test_to_dict_preserves_contract_fields(self) -> None:
+        result_dict = _check().to_dict()
 
-class TestSCWBResultMethods:
-    """Test is_safe(), to_dict(), summary() methods."""
+        assert result_dict["topology"] == "INTERIOR"
+        assert result_dict["principal_plane"] == "X"
+        assert result_dict["shaking_direction"] == "POSITIVE"
+        assert result_dict["beam_capacity_direction"] == "POSITIVE"
+        assert result_dict["column_capacity_direction"] == "NEGATIVE"
+        assert result_dict["column_capacity_basis"] == "FACTORED_AXIAL_LOAD"
+        assert result_dict["factor"] == 1.4
+        assert result_dict["standard"] == "IS 13920:2016"
+        assert result_dict["clause"] == result_dict["source_reference"]
 
-    def test_to_dict_keys(self) -> None:
-        result = check_scwb(200.0, 200.0, 150.0, 150.0)
-        d = result.to_dict()
-        expected_keys = {
-            "sum_column_capacity_knm",
-            "sum_beam_capacity_knm",
-            "required_column_capacity_knm",
-            "ratio",
-            "factor",
-            "is_satisfied",
-            "clause",
-            "errors",
-            "warnings",
-        }
-        assert set(d.keys()) == expected_keys
+    def test_summary_and_case_safety_are_directional(self) -> None:
+        passing = _check()
+        failing = _check(
+            column_top_capacity_knm=100.0,
+            column_bottom_capacity_knm=100.0,
+        )
 
-    def test_summary_contains_pass(self) -> None:
-        result = check_scwb(200.0, 200.0, 150.0, 150.0)
-        assert "PASS" in result.summary()
+        assert passing.is_safe() is True
+        assert "directional case" in passing.summary()
+        assert "PASS" in passing.summary()
+        assert failing.is_safe() is False
+        assert "FAIL" in failing.summary()
 
-    def test_summary_contains_fail(self) -> None:
-        result = check_scwb(100.0, 100.0, 200.0, 200.0)
-        assert "FAIL" in result.summary()
-
-    def test_clause_in_result(self) -> None:
-        result = check_scwb(200.0, 200.0, 150.0, 150.0)
-        assert "7.2.1" in result.clause
-
-    def test_frozen_result(self) -> None:
-        """SCWBResult is frozen — attributes cannot be changed."""
-        result = check_scwb(200.0, 200.0, 150.0, 150.0)
+    def test_result_is_frozen(self) -> None:
+        result = _check()
         with pytest.raises(AttributeError):
-            result.is_satisfied = False  # type: ignore[misc]
+            result.factor = 1.0  # type: ignore[misc]

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,125 @@
 
 ---
 
+## 2026-08-24 — Session: INDIA-3-JOINT-R1 bounded SCWB contract repair
+
+**Agent:** Codex (`orchestrator`, sole writer; no subagents)
+
+**Branch:** `codex/india-3-joint-r1`, from exact hosted
+INDIA-3-SOURCE-META-R1 merge
+`20b60a047e5c6d88b800f7094dd64fcf4bebad28`, tree
+`ff65c71e1b875acdf5c53ee1b9723b4637639717`.
+
+**Git handoff receipt:**
+`docs/verification/india-3-joint-r1-git-handoff-receipt.json`
+
+**Focus:** Repair only the G0-bounded IS 13920 beam-column-joint SCWB
+contract. Keep the factor fixed at 1.4, encode direction and factored-axial-load
+capacity provenance, enforce applicability, represent supported interior and
+exterior topologies, and preserve every adjacent formula, source,
+distribution, support, version, release, and professional-use hold.
+
+### Summary
+
+- Verified live `origin/main` and merged PR #864 at exact predecessor
+  `20b60a04`, tree `ff65c71e`, before creating one source-bound task branch.
+  Every unrelated dirty, detached, divergent, or unknown lane remains retained.
+- Reproduced the G0 false pass: 250 kNm column capacity against 200 kNm beam
+  capacity passed because the implementation used 1.1 and required only 220
+  kNm. The corrected fixed 1.4 requirement needs 280 kNm and fails that case;
+  equality at 280 kNm passes.
+- Removed the caller-controlled factor from the IS 13920 function. A result is
+  always labeled with fixed factor 1.4 plus its IS 13920 source/amendment basis,
+  so a custom scalar cannot be presented as a standard check.
+- Made every result one explicitly bounded principal-plane and shaking-direction
+  case. Beam capacities act with the declared shaking direction; column
+  capacities must oppose it and retain the exact top/bottom factored axial
+  loads plus the required capacity basis. A directional pass is explicitly not
+  a whole-joint assessment.
+- Enforced known applicability. Roof joints and flat-slab systems receive no
+  PASS/FAIL result. Interior topology requires both beam sides; left and right
+  exterior topologies require exactly their one present side.
+- Kept the repair code-namespace-only. No package-root facade, service,
+  FastAPI, React, Excel, generated capability promotion, package version,
+  release, source/distribution, support, or professional-use state changed.
+  `INDIA-3-BEAM-R1` is next and was not started.
+
+### Issues encountered
+
+- The delegated worktree was clean and at the exact predecessor but detached,
+  so it was not `READY_LOCAL` for implementation.
+- The existing joint check produced the source-audited false pass and could not
+  represent direction, factored-axial-load capacity basis, applicability, or an
+  exterior one-beam topology.
+- The first focused Ruff sequence stopped before its chained tests because the
+  new string enums used the older `str, Enum` inheritance form.
+- Focused mypy then rejected branch-inferred fixed-length tuple types in the
+  topology helper even though the runtime tests were green.
+
+### Root causes and resolutions
+
+- Confirmed root cause: the delegated lane intentionally began detached at the
+  exact requested hosted commit. Resolution: after live fetch, PR, worktree,
+  branch, and tree inspection, bind this worktree to
+  `codex/india-3-joint-r1` at unchanged `origin/main`. Proof:
+  `git_state.py --strict` reports `READY_LOCAL` and runtime diagnosis reports
+  `source_bound=true` at exact `20b60a04`.
+- Confirmed root cause: commit `c974f362` introduced the entire joint module,
+  the 1.1 constant, custom-factor escape hatch, four-scalar input, and tests in
+  one change without an independent source-bound benchmark or applicability
+  model. The tests therefore repeated the implementation assumption instead of
+  falsifying it. Resolution: implement the accepted G0 source map directly as
+  a fixed 1.4, keyword-only directional-case contract with explicit capacity
+  basis, applicability, and topology. Proof: the independent 250/200 benchmark
+  now fails at required 280, the exact boundary passes, and all 29 focused
+  cases pass.
+- Confirmed root cause: Python 3.11 Ruff rule UP042 requires `StrEnum` rather
+  than combined `str, Enum` bases. Resolution: use `StrEnum` for the four
+  contract enums. Proof: targeted Ruff and Black checks pass.
+- Confirmed root cause: mypy inferred the first interior assignment as a
+  two-element tuple and rejected later one-element exterior assignments.
+  Resolution: annotate the local collection as `tuple[float, ...]`. Proof:
+  focused mypy reports success with no issues.
+
+### Validation through content freeze
+
+- Targeted Black and Ruff pass on the joint owner, shared SCWB error, and direct
+  test module. Focused mypy passes on the joint owner.
+- Architecture boundaries report zero violations; all 1,513 scanned
+  structural-library imports resolve. Documentation frontmatter, links, budget,
+  and context validation pass, as do both private-source boundary regressions.
+- `Python/tests/codes/is13920/test_joint.py` passes all 29 cases, including the
+  independent false-pass benchmark, fixed boundary, rejected override, all
+  X/Y positive/negative direction combinations, opposing column direction,
+  axial-load basis, roof/flat-slab applicability, and interior/left-exterior/
+  right-exterior topology.
+- Caller inventory finds only the core definition and its direct test helper;
+  no service or transport migration is required. Changed-path routing selects
+  Python, FastAPI, and documentation; the broad repository gate remains
+  deferred to the cumulative INDIA-3 milestone unless a material failure
+  requires it.
+- The immutable candidate still requires the sole post-freeze quick gate,
+  normal commit hooks, clean-commit `session end`, all required hosted checks,
+  unchanged-head merge, and candidate/merge tree equality. Those later facts
+  remain external and are not pre-claimed here.
+
+### Preserved holds
+
+- One directional case is not a whole-joint or cumulative IS 13920 engineering
+  acceptance claim. Both shaking directions in every applicable principal
+  plane remain caller-owned inputs to later cumulative acceptance.
+- `INDIA-3-BEAM-R1`, `INDIA-3-COLUMN-R1`, and `INDIA-3-IS13920-M0` remain
+  separate sequential packets. Wall/foundation detailing and IS 875/1893
+  remain held.
+- No protected/private source byte, text, image, hash, path, or database content
+  changed or entered the tracked candidate. Source/distribution, support,
+  version, release, package publication, and professional-use approval remain
+  separate claims.
+- Branch, worktree, archive, source-copy, alias, and unrelated-file deletion
+  remain unauthorized.
+
+---
+
 ## 2026-08-24 — Session: INDIA-3-SOURCE-META-R1 private catalogue repair
 
 **Agent:** Codex (`orchestrator`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-24 — INDIA-3-SOURCE-META-R1 private catalogue repair
+**Updated:** 2026-08-24 — INDIA-3-JOINT-R1 bounded SCWB contract repair
 
 ---
 
@@ -125,10 +125,12 @@
 
 ## Active
 
-No implementation task is active. `INDIA-3-SOURCE-META-R1` has completed its
-bounded private catalogue repair and becomes complete only when its unchanged
-green candidate merges. `INDIA-3-JOINT-R1` is the next sequential packet and
-has not started.
+`INDIA-3-JOINT-R1` has completed its bounded local implementation and becomes
+complete only when its unchanged green candidate merges. It fixes the SCWB
+factor at 1.4, makes each principal-plane/shaking-direction case and factored
+axial-load capacity basis explicit, enforces roof/flat-slab applicability, and
+supports interior plus left/right exterior beam topologies. `INDIA-3-BEAM-R1`
+is the next sequential packet and has not started.
 
 `LIB-PRO-006` merged through PR #851 at `2d6df18e`. It confirms the practical
 10 m x 4 m audit arithmetic and fail-closed footing-detailing `HOLD`, adds a
@@ -240,12 +242,13 @@ product packets. INDIA-3-G0 now runs on fresh branch
 INDIA-2 remains administratively complete within its recorded accepted/held
 boundary. The reproduced public-route safety packet and M0 are integrated.
 INDIA-3-G0 merged through PR #863 at `c0e34235`: beam, column, and joint each
-require a separate repair packet. `INDIA-3-SOURCE-META-R1` corrected only the
-ignored private catalogue's document-kind, page-content, and renderability
-truth. All 25 catalogue documents, 27 aliases, 732 cached pages, six IS 13920
-documents, and four standalone amendment copies remain intact. No new formula,
-support claim, IS 875 or IS 1893 implementation, next package version, release,
-or professional approval is activated.
+require a separate repair packet. `INDIA-3-SOURCE-META-R1` merged through PR
+#864 at `20b60a04` and corrected only ignored private catalogue metadata while
+retaining all 25 documents, 27 aliases, 732 cached pages, six IS 13920
+documents, and four standalone amendment copies. `INDIA-3-JOINT-R1` corrects
+only the code-namespace SCWB contract and direct tests; it adds no service,
+route, React/Excel surface, support promotion, package version, release, or
+professional approval.
 
 `LIB-PRO-008` merged through PR #862 at `3bcc3422`: torsion and WebSocket
 checking fail closed on invalid or missing engineering inputs; compatibility
@@ -317,6 +320,7 @@ approval.
 
 | ID | Task | Agent | Status |
 |----|------|-------|--------|
+| INDIA-3-JOINT-R1 | Repair the G0-bounded IS 13920 joint SCWB factor, directional/axial basis, applicability, and supported topology contract | Main Agent | ✅ COMPLETE ON UNCHANGED GREEN MERGE — focused 29-case contract evidence passes; no API/product surface or support/release/approval promotion; `INDIA-3-BEAM-R1` not started |
 | INDIA-3-SOURCE-META-R1 | Correct private IS 13920 document-kind and page-renderability metadata while preserving every source and alias | Main Agent | ✅ COMPLETE ON UNCHANGED GREEN MERGE — private archive verifies; no formula, runtime, support, release, or approval scope changed; `INDIA-3-JOINT-R1` not started |
 | INDIA-3-G0 | Audit the current IS 13920 beam/column/joint surface and freeze one bounded companion-code acceptance sequence | Main Agent | ✅ COMPLETE ON MERGE — source chain resolved; all three current families are `REPAIR_PACKET_REQUIRED`; no formula or support promotion occurred |
 | LIB-PRO-008 | Close confirmed torsion, WebSocket, compatibility/CI, and stirrup-geometry safety gaps before resuming INDIA-3-G0 | Main Agent | ✅ COMPLETE ON MERGE — focused behavior and compatibility evidence pass; quick/full/hooks and hosted checks remain immutable-candidate prerequisites |

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,9 +4,9 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-24
-- Focus: Repair only ignored private IS 13920 catalogue document-kind,
-- Git receipt: docs/verification/india-3-source-meta-r1-git-handoff-receipt.json | sha256:2f4a94cb6be0ce08927fb59c3b7f8daa6e9b888b730e7c97998f42ced4fb4e5c | HOLD
-- Git identity: codex/india-3-source-meta-r1@c0e34235b485799d26fcb55df45f74ed9104e003 | upstream=origin/main@c0e34235b485799d26fcb55df45f74ed9104e003 | base=origin/main@c0e34235b485799d26fcb55df45f74ed9104e003 | tree=dirty | operation=none
+- Focus: Repair only the G0-bounded IS 13920 beam-column-joint SCWB
+- Git receipt: docs/verification/india-3-joint-r1-git-handoff-receipt.json | sha256:11f497065d6553de74732bd19dd159eb33e4f91d10e701cb69fbb95c8ffd79e1 | HOLD
+- Git identity: codex/india-3-joint-r1@20b60a047e5c6d88b800f7094dd64fcf4bebad28 | upstream=origin/main@20b60a047e5c6d88b800f7094dd64fcf4bebad28 | base=origin/main@20b60a047e5c6d88b800f7094dd64fcf4bebad28 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
 - Next action: CREATE_IMMUTABLE_CANDIDATE_AFTER_FOCUSED_QUICK_AND_HOOKS
 <!-- HANDOFF:END -->
@@ -15,46 +15,47 @@
 
 | State | Boundary |
 |---|---|
-| **Current** | `INDIA-3-SOURCE-META-R1` has completed its bounded private catalogue repair on source-bound `codex/india-3-source-meta-r1` from exact hosted G0 merge `c0e34235` |
-| **Decision** | Document-kind, page-content, and actual renderer metadata are corrected; every retained source and alias remains intact |
-| **Next** | Integrate this unchanged candidate with required hosted checks green, then create `INDIA-3-JOINT-R1`; it was not started here |
+| **Current** | `INDIA-3-JOINT-R1` has completed its bounded local repair on source-bound `codex/india-3-joint-r1` from exact hosted source-metadata merge `20b60a04` |
+| **Decision** | The joint SCWB contract uses fixed factor 1.4 and explicit direction, factored-axial-load capacity basis, applicability, and interior/exterior topology |
+| **Next** | Integrate this unchanged candidate with required hosted checks green, then create `INDIA-3-BEAM-R1`; it was not started here |
 | **Source** | IS 13920:2016 First Revision plus Amendment 1 (2017) and Amendment 2 (2020); 2021 reaffirmation is not a new edition; the draft successor is not used |
-| **Held** | Formula/runtime/API changes, current support acceptance, walls/foundations, IS 875/1893, release, professional use, and branch/worktree/archive/source/alias deletion |
+| **Held** | Whole-joint acceptance from one directional case, beam/column repairs, walls/foundations, IS 875/1893, source/distribution/support/version/release/professional-use changes, and branch/worktree/archive/source/alias deletion |
 
-## Source metadata repair result
+## Joint repair result
 
-- The base acquisition identity is now truthfully classified as a standard
-  with appended Amendment 1 and Amendment 2 sheets; it is not base-only.
-- The consolidated candidate and all four byte-distinct standalone amendment
-  copies have explicit content-range identity. All 25 catalogue documents, 27
-  aliases, 732 cached pages, and six IS 13920 documents remain intact.
-- Page-by-page rendering checks all 84 IS 13920 pages: 84 render, 42 record
-  parser warnings, and zero fail. Text-layer visual-review flags remain separate
-  from actual renderability.
-- Private verification, the tracked boundary regression, and zero-private-file
-  tracking checks pass. No protected bytes, text, images, private hash values,
-  or private paths entered tracked evidence.
-- Beam, column, and joint source/formula findings from G0 are unchanged; no
-  runtime behavior, support status, package version, release, or professional
-  approval changed.
+- The reproduced G0 case now fails truthfully: column capacity 250 kNm against
+  beam capacity 200 kNm requires 280 kNm, not the former 220 kNm false-pass
+  threshold. Equality at exactly 1.4 passes.
+- The IS 13920 entry point has no factor argument. Every result remains fixed
+  to 1.4 and records the standard plus source/amendment basis.
+- Each bounded result identifies one principal plane, one shaking direction,
+  the beam capacity direction, the opposing column capacity direction, and the
+  top/bottom factored axial loads used for column capacities. It explicitly
+  refuses a whole-joint claim from one directional case.
+- Roof joints and flat-slab systems cannot receive a passing or failing result.
+  Interior joints require two beam sides; left and right exterior joints each
+  require exactly their one present beam side.
+- The code-namespace owner and 29 direct tests are the only callers. No package
+  export, service, FastAPI route, React/Excel surface, capability promotion,
+  package version, release, or professional-use state changed.
 
 ## Frozen follow-on sequence
 
-1. Merge the unchanged green `INDIA-3-SOURCE-META-R1` candidate. Do not delete
-   its branch, worktree, archive, source copy, or alias.
-2. Create `INDIA-3-JOINT-R1` as the next sequential formula/contract packet;
-   it was intentionally not started by this task.
-3. `INDIA-3-BEAM-R1` and `INDIA-3-COLUMN-R1` remain separately frozen repair
-   packets after the owner-authorized sequence.
+1. Merge the unchanged green `INDIA-3-JOINT-R1` candidate. Do not delete its
+   branch, worktree, archive, source copy, alias, or any unrelated lane.
+2. Create `INDIA-3-BEAM-R1` as the next sequential formula/contract packet; it
+   was intentionally not started by this task.
+3. `INDIA-3-COLUMN-R1` remains the separately frozen repair packet after beam.
 4. `INDIA-3-IS13920-M0` runs cumulative source, benchmark, transport,
    capability, package, and qualified-review acceptance after the repairs.
 5. Wall/foundation detailing and the later IS 875/1893 sequence remain separate.
 
 ## Required Reading
 
-1. [Source metadata repair evidence](../verification/india-3-source-meta-r1-evidence.json)
+1. [Joint repair evidence](../verification/india-3-joint-r1-evidence.json)
 2. [G0 decision evidence](../verification/india-3-g0-is13920-audit-decision.json)
-3. [G0 truth-audit plan](india-3-g0-is13920-truth-audit.md)
-4. [Private source-library boundary](../verification/india-3-g0-private-source-library-evidence.md)
-5. [Generated Indian-code capability truth](../verification/indian-code-capability-coverage.json)
-6. [Current task board](../TASKS.md)
+3. [Source metadata repair evidence](../verification/india-3-source-meta-r1-evidence.json)
+4. [G0 truth-audit plan](india-3-g0-is13920-truth-audit.md)
+5. [Private source-library boundary](../verification/india-3-g0-private-source-library-evidence.md)
+6. [Generated Indian-code capability truth](../verification/indian-code-capability-coverage.json)
+7. [Current task board](../TASKS.md)

--- a/docs/verification/india-3-joint-r1-evidence.json
+++ b/docs/verification/india-3-joint-r1-evidence.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": 1,
+  "task_id": "INDIA-3-JOINT-R1",
+  "observed_at_utc": "2026-08-24T04:44:08Z",
+  "status": "BOUNDED_IMPLEMENTATION_COMPLETE_PENDING_IMMUTABLE_CANDIDATE_AND_HOSTED_CLOSEOUT",
+  "predecessor_binding": {
+    "hosted_main_commit": "20b60a047e5c6d88b800f7094dd64fcf4bebad28",
+    "hosted_main_tree": "ff65c71e1b875acdf5c53ee1b9723b4637639717",
+    "predecessor_pull_request": 864,
+    "predecessor_task": "INDIA-3-SOURCE-META-R1",
+    "branch": "codex/india-3-joint-r1",
+    "source_bound": true
+  },
+  "accepted_source_boundary": {
+    "standard": "IS 13920:2016 First Revision",
+    "amendment_chain": [
+      "Amendment 1 (2017)",
+      "Amendment 2 (2020)"
+    ],
+    "reaffirmation_2021_is_new_edition": false,
+    "draft_successor_used": false,
+    "normalized_references": [
+      "7.2.1_WITH_AMENDMENT_1_COLUMN_CAPACITY_BASIS",
+      "7.2.1.1_AND_7.2.1.2_WITH_AMENDMENT_1",
+      "7.2.1.3_AND_SECTION_7.2_LIMITATIONS"
+    ],
+    "source_decision_evidence": "docs/verification/india-3-g0-is13920-audit-decision.json",
+    "protected_content_added": false,
+    "private_source_mutated": false
+  },
+  "root_cause": {
+    "introduction_commit": "c974f362ddfab7061dc9dbccf0b7a77b3682ef20",
+    "finding": "The joint implementation, 1.1 factor, caller-controlled override, four-scalar contract, and tests were introduced together without an independent source-bound benchmark or applicability model. The tests mirrored that implementation and therefore certified its false-pass behavior instead of falsifying it.",
+    "reproduced_pre_repair_case": {
+      "sum_column_capacity_knm": 250.0,
+      "sum_beam_capacity_knm": 200.0,
+      "old_factor": 1.1,
+      "old_required_column_capacity_knm": 220.00000000000003,
+      "old_is_satisfied": true
+    }
+  },
+  "corrected_contract": {
+    "owner": "Python/structural_lib/codes/is13920/joint.py::check_scwb",
+    "assessment_scope": "ONE_PRINCIPAL_PLANE_ONE_SHAKING_DIRECTION",
+    "fixed_factor": 1.4,
+    "custom_factor_override": "REMOVED_FROM_IS13920_CONTRACT",
+    "required_directional_provenance": {
+      "principal_planes": [
+        "X",
+        "Y"
+      ],
+      "shaking_directions": [
+        "POSITIVE",
+        "NEGATIVE"
+      ],
+      "beam_capacity_direction": "DECLARED_SHAKING_DIRECTION",
+      "column_capacity_direction": "OPPOSITE_DECLARED_SHAKING_DIRECTION",
+      "whole_joint_claim": "NOT_EMITTED_BY_ONE_DIRECTIONAL_CASE"
+    },
+    "required_column_capacity_provenance": {
+      "basis": "FACTORED_AXIAL_LOAD",
+      "top_factored_axial_load_kn": "REQUIRED_FINITE_INPUT_AND_RESULT_FIELD",
+      "bottom_factored_axial_load_kn": "REQUIRED_FINITE_INPUT_AND_RESULT_FIELD"
+    },
+    "applicability": {
+      "supported": "NON_ROOF_BEAM_COLUMN_JOINT",
+      "roof_joint": "WAIVED_NO_PASS_OR_FAIL_RESULT",
+      "flat_slab_system": "EXCLUDED_NO_PASS_OR_FAIL_RESULT",
+      "unknown_flags": "REJECTED"
+    },
+    "supported_topologies": {
+      "INTERIOR": "LEFT_AND_RIGHT_BEAM_CAPACITIES_REQUIRED",
+      "EXTERIOR_LEFT": "ONLY_LEFT_BEAM_CAPACITY_REQUIRED",
+      "EXTERIOR_RIGHT": "ONLY_RIGHT_BEAM_CAPACITY_REQUIRED"
+    }
+  },
+  "independent_benchmark_replay": {
+    "inputs": {
+      "sum_column_capacity_knm": 250.0,
+      "sum_beam_capacity_knm": 200.0
+    },
+    "expected": {
+      "required_column_capacity_knm": 280.0,
+      "ratio": 0.8928571428571429,
+      "is_satisfied": false
+    },
+    "observed": {
+      "required_column_capacity_knm": 280.0,
+      "ratio": 0.8928571428571429,
+      "is_satisfied": false
+    },
+    "boundary": "sum_column_capacity_knm=280.0 passes exactly for sum_beam_capacity_knm=200.0",
+    "result": "PASS"
+  },
+  "focused_verification": {
+    "joint_contract_tests": "PASS_29",
+    "black_targeted": "PASS",
+    "ruff_targeted": "PASS",
+    "mypy_joint_module": "PASS",
+    "private_source_boundary_tests": "PASS_2",
+    "architecture_boundaries": "PASS_0_VIOLATIONS",
+    "structural_lib_imports": "PASS_1513_IMPORTS_0_BROKEN",
+    "documentation_frontmatter_links_budget_and_context": "PASS",
+    "caller_inventory": "ONLY_CORE_OWNER_AND_DIRECT_TEST_CALLER",
+    "impact_domains": [
+      "python",
+      "fastapi",
+      "docs"
+    ],
+    "broad_gate": "DEFERRED_TO_CUMULATIVE_INDIA_3_MILESTONE_UNLESS_MATERIAL_FAILURE_REQUIRES_IT"
+  },
+  "scope_guard": {
+    "package_root_export_added": false,
+    "service_added": false,
+    "fastapi_route_added": false,
+    "react_or_excel_surface_added": false,
+    "beam_or_column_formula_changed": false,
+    "generated_capability_status_changed": false,
+    "package_version_changed": false,
+    "release_or_publication_changed": false,
+    "professional_use_approval_changed": false
+  },
+  "holds": [
+    "ONE_DIRECTIONAL_CASE_IS_NOT_A_COMPLETE_WHOLE_JOINT_ASSESSMENT",
+    "INDIA_3_BEAM_R1_NOT_STARTED",
+    "INDIA_3_COLUMN_R1_NOT_STARTED",
+    "NO_CURRENT_IS13920_CUMULATIVE_ENGINEERING_ACCEPTANCE",
+    "WALL_AND_FOUNDATION_DETAILING_REMAIN_HELD",
+    "IS875_AND_IS1893_REMAIN_HELD",
+    "SOURCE_DISTRIBUTION_RELEASE_PACKAGE_VERSION_SUPPORT_STATUS_AND_PROFESSIONAL_USE_REMAIN_SEPARATE",
+    "PRIVATE_SOURCE_BYTES_TEXT_IMAGES_HASHES_AND_PATHS_REMAIN_UNTRACKED",
+    "BRANCH_WORKTREE_ARCHIVE_SOURCE_COPY_ALIAS_AND_UNRELATED_FILE_DELETION_NOT_AUTHORIZED"
+  ],
+  "next_packet": {
+    "packet_id": "INDIA-3-BEAM-R1",
+    "status": "NOT_STARTED",
+    "start_condition": "CREATE_ONLY_AFTER_THIS_PACKET_MERGES_UNCHANGED_WITH_REQUIRED_HOSTED_CHECKS_GREEN"
+  }
+}

--- a/docs/verification/india-3-joint-r1-git-handoff-receipt.json
+++ b/docs/verification/india-3-joint-r1-git-handoff-receipt.json
@@ -1,0 +1,190 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-24T04:44:08Z",
+      "query_status": "OK",
+      "reference": "Complete INDIA-3-JOINT-R1 autonomously as the next sequential packet, create and merge one unchanged green PR, preserve all adjacent holds, stop before the next packet, and use no subagents.",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "REPAIR_G0_BOUNDED_IS13920_JOINT_SCWB_CONTRACT",
+      "FIX_FACTOR_AT_1_4_AND_REMOVE_NONSTANDARD_IS13920_OVERRIDE",
+      "ENCODE_DIRECTION_AXIAL_CAPACITY_BASIS_APPLICABILITY_AND_SUPPORTED_TOPOLOGIES",
+      "ADD_BOUNDED_TEST_AND_TRACKED_EVIDENCE",
+      "UPDATE_TASK_SESSION_AND_HANDOFF_DOCUMENTATION",
+      "RUN_IMPACT_MAPPED_FOCUSED_AND_QUICK_CHECKS",
+      "CREATE_IMMUTABLE_CANDIDATE_AFTER_FOCUSED_QUICK_AND_HOOKS",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_ONE_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_ONE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "next_action": "CREATE_IMMUTABLE_CANDIDATE_AFTER_FOCUSED_QUICK_AND_HOOKS",
+    "observed_at_utc": "2026-08-24T04:44:08Z",
+    "prohibited_actions": [
+      "ADD_UNRELATED_API_PRODUCT_OR_PACKAGE_ROOT_SURFACE",
+      "CHANGE_BEAM_COLUMN_WALL_FOUNDATION_IS875_OR_IS1893_FORMULAS",
+      "CHANGE_SOURCE_DISTRIBUTION_SUPPORT_VERSION_RELEASE_OR_PROFESSIONAL_USE_STATUS",
+      "DISTRIBUTE_OR_TRACK_PRIVATE_SOURCE_BYTES_TEXT_IMAGES_HASH_VALUES_OR_PATHS",
+      "DELETE_DEDUPLICATE_RENAME_OR_MOVE_ANY_SOURCE_ALIAS_BRANCH_WORKTREE_ARCHIVE_OR_UNRELATED_FILE",
+      "START_INDIA3_BEAM_R1_OR_ANY_LATER_PACKET",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_REWRITE_FORCE_PUSH_OR_BYPASS_CHECKS"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "REPAIR_G0_BOUNDED_IS13920_JOINT_SCWB_CONTRACT",
+        "FIX_FACTOR_AT_1_4_AND_REMOVE_NONSTANDARD_IS13920_OVERRIDE",
+        "ENCODE_DIRECTION_AXIAL_CAPACITY_BASIS_APPLICABILITY_AND_SUPPORTED_TOPOLOGIES",
+        "ADD_BOUNDED_TEST_AND_TRACKED_EVIDENCE",
+        "UPDATE_TASK_SESSION_AND_HANDOFF_DOCUMENTATION",
+        "RUN_IMPACT_MAPPED_FOCUSED_AND_QUICK_CHECKS",
+        "CREATE_IMMUTABLE_CANDIDATE_AFTER_FOCUSED_QUICK_AND_HOOKS",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_ONE_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_ONE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/india-3-joint-r1",
+      "head_sha": "20b60a047e5c6d88b800f7094dd64fcf4bebad28",
+      "task_id": "INDIA-3-JOINT-R1"
+    }
+  },
+  "holds": [
+    "BRANCH_WORKTREE_ARCHIVE_SOURCE_COPY_ALIAS_AND_UNRELATED_FILE_DELETION_NOT_AUTHORIZED",
+    "LOCAL_HOLD_DIRTY",
+    "PRESERVE_ALL_EXISTING_INDIA3_CANDIDATE_LANES",
+    "PRESERVE_PRIVATE_SOURCE_ARCHIVE_ALL_SOURCE_COPIES_AND_ALIASES",
+    "PRESERVE_UNRELATED_DIRTY_AND_UNKNOWN_LANES",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "observed_at_utc": "2026-08-24T04:44:08Z",
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "11f497065d6553de74732bd19dd159eb33e4f91d10e701cb69fbb95c8ffd79e1",
+    "state": {
+      "branch": "codex/india-3-joint-r1",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "20b60a047e5c6d88b800f7094dd64fcf4bebad28",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 101.502,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib16",
+      "head_sha": "20b60a047e5c6d88b800f7094dd64fcf4bebad28",
+      "hold_reasons": [
+        "changed paths: 8"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-24T04:47:06.173128+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/ef1b/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 8,
+        "modified_paths": [
+          "Python/structural_lib/codes/is13920/joint.py",
+          "Python/structural_lib/core/errors.py",
+          "Python/tests/codes/is13920/test_joint.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/next-session-brief.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/india-3-joint-r1-evidence.json",
+          "docs/verification/india-3-joint-r1-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "20b60a047e5c6d88b800f7094dd64fcf4bebad28",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/ef1b/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:11f497065d6553de74732bd19dd159eb33e4f91d10e701cb69fbb95c8ffd79e1",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-24T04:47:06.173272+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_ALL_EXISTING_LANES_AND_PRIVATE_SOURCE_MATERIAL",
+    "holds": [
+      "PRESERVE_UNRELATED_DIRTY_AND_UNKNOWN_LANES",
+      "PRESERVE_ALL_EXISTING_INDIA3_CANDIDATE_LANES",
+      "PRESERVE_PRIVATE_SOURCE_ARCHIVE_ALL_SOURCE_COPIES_AND_ALIASES",
+      "BRANCH_WORKTREE_ARCHIVE_SOURCE_COPY_ALIAS_AND_UNRELATED_FILE_DELETION_NOT_AUTHORIZED"
+    ],
+    "observed_at_utc": "2026-08-24T04:44:08Z",
+    "owner": "Main Agent under explicit user and repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources",
+      "Python/structural_lib/codes/is13920/beam.py",
+      "Python/structural_lib/codes/is13920/column.py",
+      "fastapi_app",
+      "react_app",
+      "excel"
+    ],
+    "integration_owner": "orchestrator",
+    "owned_paths": [
+      "Python/structural_lib/codes/is13920/joint.py",
+      "Python/tests/codes/is13920/test_joint.py",
+      "docs/verification/india-3-joint-r1-evidence.json",
+      "docs/verification/india-3-joint-r1-git-handoff-source-evidence.json",
+      "docs/verification/india-3-joint-r1-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "Python/structural_lib/core/errors.py",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "INDIA-3-JOINT-R1"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/india-3-joint-r1-git-handoff-source-evidence.json
+++ b/docs/verification/india-3-joint-r1-git-handoff-source-evidence.json
@@ -1,0 +1,77 @@
+{
+  "authorization": {
+    "status": "OBSERVED",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-24T04:44:08Z",
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "reference": "Complete INDIA-3-JOINT-R1 autonomously as the next sequential packet, create and merge one unchanged green PR, preserve all adjacent holds, stop before the next packet, and use no subagents.",
+      "status": "OBSERVED",
+      "query_status": "OK",
+      "observed_at_utc": "2026-08-24T04:44:08Z"
+    },
+    "authorized_actions": [
+      "REPAIR_G0_BOUNDED_IS13920_JOINT_SCWB_CONTRACT",
+      "FIX_FACTOR_AT_1_4_AND_REMOVE_NONSTANDARD_IS13920_OVERRIDE",
+      "ENCODE_DIRECTION_AXIAL_CAPACITY_BASIS_APPLICABILITY_AND_SUPPORTED_TOPOLOGIES",
+      "ADD_BOUNDED_TEST_AND_TRACKED_EVIDENCE",
+      "UPDATE_TASK_SESSION_AND_HANDOFF_DOCUMENTATION",
+      "RUN_IMPACT_MAPPED_FOCUSED_AND_QUICK_CHECKS",
+      "CREATE_IMMUTABLE_CANDIDATE_AFTER_FOCUSED_QUICK_AND_HOOKS",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_ONE_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_ONE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "prohibited_actions": [
+      "ADD_UNRELATED_API_PRODUCT_OR_PACKAGE_ROOT_SURFACE",
+      "CHANGE_BEAM_COLUMN_WALL_FOUNDATION_IS875_OR_IS1893_FORMULAS",
+      "CHANGE_SOURCE_DISTRIBUTION_SUPPORT_VERSION_RELEASE_OR_PROFESSIONAL_USE_STATUS",
+      "DISTRIBUTE_OR_TRACK_PRIVATE_SOURCE_BYTES_TEXT_IMAGES_HASH_VALUES_OR_PATHS",
+      "DELETE_DEDUPLICATE_RENAME_OR_MOVE_ANY_SOURCE_ALIAS_BRANCH_WORKTREE_ARCHIVE_OR_UNRELATED_FILE",
+      "START_INDIA3_BEAM_R1_OR_ANY_LATER_PACKET",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_REWRITE_FORCE_PUSH_OR_BYPASS_CHECKS"
+    ],
+    "next_action": "CREATE_IMMUTABLE_CANDIDATE_AFTER_FOCUSED_QUICK_AND_HOOKS",
+    "target_binding": {
+      "task_id": "INDIA-3-JOINT-R1",
+      "branch": "codex/india-3-joint-r1",
+      "head_sha": "20b60a047e5c6d88b800f7094dd64fcf4bebad28",
+      "actions": [
+        "REPAIR_G0_BOUNDED_IS13920_JOINT_SCWB_CONTRACT",
+        "FIX_FACTOR_AT_1_4_AND_REMOVE_NONSTANDARD_IS13920_OVERRIDE",
+        "ENCODE_DIRECTION_AXIAL_CAPACITY_BASIS_APPLICABILITY_AND_SUPPORTED_TOPOLOGIES",
+        "ADD_BOUNDED_TEST_AND_TRACKED_EVIDENCE",
+        "UPDATE_TASK_SESSION_AND_HANDOFF_DOCUMENTATION",
+        "RUN_IMPACT_MAPPED_FOCUSED_AND_QUICK_CHECKS",
+        "CREATE_IMMUTABLE_CANDIDATE_AFTER_FOCUSED_QUICK_AND_HOOKS",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_ONE_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_ONE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ]
+    }
+  },
+  "integration": {
+    "status": "NOT_APPLICABLE",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-24T04:44:08Z",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR"
+  },
+  "retention": {
+    "status": "OBSERVED",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-24T04:44:08Z",
+    "decision": "RETAIN_ALL_EXISTING_LANES_AND_PRIVATE_SOURCE_MATERIAL",
+    "owner": "Main Agent under explicit user and repository preservation policy",
+    "holds": [
+      "PRESERVE_UNRELATED_DIRTY_AND_UNKNOWN_LANES",
+      "PRESERVE_ALL_EXISTING_INDIA3_CANDIDATE_LANES",
+      "PRESERVE_PRIVATE_SOURCE_ARCHIVE_ALL_SOURCE_COPIES_AND_ALIASES",
+      "BRANCH_WORKTREE_ARCHIVE_SOURCE_COPY_ALIAS_AND_UNRELATED_FILE_DELETION_NOT_AUTHORIZED"
+    ]
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}


### PR DESCRIPTION
## Summary
- fix the IS 13920 joint SCWB factor at 1.4 and remove caller-controlled standard overrides
- require explicit principal-plane, shaking-direction, opposing column direction, and factored axial-load capacity basis
- enforce non-roof/non-flat-slab applicability and interior/left-exterior/right-exterior beam topology
- preserve all beam, column, wall, foundation, IS 875/1893, capability, version, release, and professional-use holds

## Verification
- 29 focused joint contract tests
- 2 private-source boundary tests
- targeted Black, Ruff, and mypy
- architecture boundaries and structural-lib imports
- quick gate 10/10
- normal commit hooks and clean-commit session end

## Scope
No service, FastAPI, React, Excel, package-root export, capability promotion, package version, release, or private-source change.