### PR TITLE
fix(safety): close bounded release trust gaps

### DIFF
--- a/Python/structural_lib/services/rebar.py
+++ b/Python/structural_lib/services/rebar.py
@@ -47,6 +47,13 @@ def _to_float(value: Any, default: float) -> float:
         return float(default)
 
 
+def _positive_int_or_zero(value: Any) -> int:
+    """Return a validated positive integer, or zero for invalid input."""
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return 0
+    return int(value)
+
+
 def validate_rebar_config(
     beam: Any,
     config: Mapping[str, Any],
@@ -69,15 +76,16 @@ def validate_rebar_config(
         8.0,
     )
 
-    bar_count = int(_pick(cfg, ["bar_count", "bars", "count"], 0) or 0)
+    raw_bar_count = _pick(cfg, ["bar_count", "bars", "count"], 0)
+    bar_count = _positive_int_or_zero(raw_bar_count)
     bar_dia_mm = _to_float(_pick(cfg, ["bar_dia_mm", "bar_dia", "diameter"], 0.0), 0.0)
     layers = int(_pick(cfg, ["layers", "layer_count"], 1) or 1)
     agg_size_mm = _to_float(_pick(cfg, ["agg_size_mm", "agg_size"], 20.0), 20.0)
 
     if b_mm <= 0 or d_mm <= 0:
         errors.append("Beam width/depth must be positive")
-    if bar_count <= 0:
-        errors.append("bar_count must be positive")
+    if bar_count == 0:
+        errors.append("bar_count must be a positive integer")
     if bar_dia_mm <= 0:
         errors.append("bar_dia_mm must be positive")
     if layers <= 0:
@@ -154,7 +162,7 @@ def apply_rebar_config(
         _pick(beam_params, ["span_mm", "span", "length_mm"], 5000.0), 5000.0
     )
 
-    bar_count = int(_pick(cfg, ["bar_count", "bars", "count"], 2) or 2)
+    bar_count = report.details["bar_count"]
     bar_dia_mm = _to_float(
         _pick(cfg, ["bar_dia_mm", "bar_dia", "diameter"], 16.0), 16.0
     )

--- a/Python/tests/test_indian_code_manifest.py
+++ b/Python/tests/test_indian_code_manifest.py
@@ -20,6 +20,10 @@ from _lib.indian_code_manifest import (  # noqa: E402
     render_manifest,
 )
 
+STATUS_SEMANTICS_EVIDENCE = (
+    REPO_ROOT / "docs/verification/lib-pro-009-is13920-status-semantics.json"
+)
+
 
 def _standard(manifest: dict, namespace: str) -> dict:
     return next(
@@ -246,12 +250,40 @@ def test_is13920_supported_truth_tracks_repaired_bounded_contracts() -> None:
         assert (
             "docs/verification/india-3-is13920-m0-evidence.json" in family["evidence"]
         )
+        assert (
+            "docs/verification/lib-pro-009-is13920-status-semantics.json"
+            in family["evidence"]
+        )
 
     for held_family in ("wall_detailing", "foundation_detailing"):
         held = families[held_family]
         assert held["scope_status"] == "HELD"
         assert held["implementation_status"] == "NOT_IMPLEMENTED"
         assert held["workflows"] == []
+
+
+def test_is13920_evidence_separates_replay_from_engineering_disposition() -> None:
+    evidence = json.loads(STATUS_SEMANTICS_EVIDENCE.read_text(encoding="utf-8"))
+    cases = {item["family"]: item for item in evidence["cases"]}
+
+    assert evidence["schema_version"] == "engineering-evidence-status/v1"
+    assert evidence["historical_m0_evidence"]["mutated"] is False
+    assert set(cases) == {
+        "beam_detailing_checks",
+        "column_detailing_checks",
+        "beam_column_joint_scwb_check",
+    }
+    assert all(item["benchmark_replay_status"] == "PASS" for item in cases.values())
+    assert all(item["calculation_status"] == "COMPLETED" for item in cases.values())
+    assert all(
+        item["review_status"] == "QUALIFIED_REVIEW_REQUIRED" for item in cases.values()
+    )
+    assert cases["beam_detailing_checks"]["engineering_status"] == "NOT_EVALUATED"
+    assert cases["column_detailing_checks"]["engineering_status"] == "PASS"
+    assert cases["beam_column_joint_scwb_check"]["engineering_status"] == "FAIL"
+    assert cases["beam_column_joint_scwb_check"]["is_satisfied"] is False
+    assert evidence["professional_approval"] is False
+    assert evidence["release_authorized"] is False
 
 
 def test_clause_checker_reports_registration_not_implementation() -> None:

--- a/Python/tests/unit/test_rebar.py
+++ b/Python/tests/unit/test_rebar.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from structural_lib.services.rebar import apply_rebar_config, validate_rebar_config
 
 
@@ -36,3 +38,18 @@ def test_validate_rebar_config_error() -> None:
 
     assert report.ok is False
     assert report.errors
+
+
+@pytest.mark.parametrize("bar_count", [True, False, 2.5, "3", "bad", None, 0, -1])
+def test_bar_count_requires_an_actual_positive_integer(bar_count: object) -> None:
+    beam = {"b_mm": 300, "D_mm": 500, "cover_mm": 40, "span_mm": 5000}
+    config = {"bar_count": bar_count, "bar_dia_mm": 16}
+
+    report = validate_rebar_config(beam, config)
+    result = apply_rebar_config(beam, config)
+
+    assert report.ok is False
+    assert report.details["bar_count"] == 0
+    assert "bar_count must be a positive integer" in report.errors
+    assert result["success"] is False
+    assert result["geometry"] is None

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,138 @@
 
 ---
 
+## 2026-08-24 — Session: LIB-PRO-009 bounded release-trust closeout
+
+**Agent:** Codex (`backend`, sole writer; no subagents)
+
+**Branch:** `codex/lib-pro-009-rc-trust`, from exact hosted INDIA-3 M0 merge
+`b85d514ed93e22a154badde990ef1c3fb02ae0d9`, tree
+`8a45afa44a5fb3d227aab666d17aadf29fe1c26e`.
+
+**Git handoff receipt:**
+`docs/verification/lib-pro-009-git-handoff-receipt.json`
+
+**Focus:** Close strict rebar input, evidence-status, and living-state defects.
+Require positive-integer `bar_count` values, separate benchmark replay from
+engineering disposition, and reconcile task/roadmap/handoff state. Preserve all
+formulas, supported scope, historical receipts, release authority, qualified
+review, professional approval, and cleanup holds.
+
+### Summary
+
+- Created one clean source-bound worktree from live GitHub `main` after verifying
+  that the only open PRs were unrelated dependency updates. No existing branch,
+  worktree, source, archive, alias, or unrelated file was modified or removed.
+- Made `validate_rebar_config` accept only an actual positive Python/JSON
+  integer for `bar_count`. Booleans, strings, fractional values, zero, negatives,
+  and missing values now return the same structured validation failure and no
+  geometry. `apply_rebar_config` consumes the validated value instead of
+  reparsing raw input.
+- Preserved the immutable INDIA-3 M0 evidence and added one current status
+  clarification with independent benchmark-replay, calculation, engineering,
+  and review axes. The represented cases are beam `NOT_EVALUATED`, bounded
+  column `PASS`, and joint `FAIL` while all three replays are `PASS` and qualified
+  review remains required.
+- Added the clarification to every supported IS 13920 family in the generated
+  capability manifest and added a recurrence test for the four-axis contract.
+- Reconciled the current task board, Indian-code completion plan, and next-
+  session prose to the merged M0 state. Added one ordered bounded-release plan:
+  internal closeout, exact candidate/artifact freeze, installed UAT, qualified
+  review of the unchanged candidate, separate owner release decision, then
+  later scope expansion.
+
+### Issues encountered
+
+- The first `LIB-PRO-009` session start was blocked because the already-merged
+  `INDIA-3-IS13920-M0` task retained an unmatched start checkpoint in the shared
+  Git-common usage ledger.
+- Public rebar validation coerced `bar_count` through `int(...)` before checking
+  it, so booleans were accepted, fractional values were silently truncated, and
+  invalid text could raise instead of returning the advertised validation
+  result. The apply path independently repeated the coercion.
+- The immutable M0 evidence used one nested benchmark `result: PASS` field even
+  for the unsafe joint vector whose actual engineering check was `FAIL`.
+- Living control documents still instructed the next task to merge the M0
+  candidate after PR #869 had already merged it.
+- The first focused Black check rejected one newly added test layout.
+- The first consolidated full gate passed 30 of 31 checks and rejected the new
+  bounded-release plan's unsupported `doc_type: plan` front-matter value.
+- The first normal commit-hook run passed every other hook but mypy rejected the
+  strict helper's `Any` return even after its runtime integer guard.
+
+### Root causes and resolutions
+
+- Confirmed root cause: M0 recorded its clean local session end but no successor
+  usage closeout after the hosted merge, leaving the shared timer unmatched.
+  Resolution: verify PR #869, exact candidate `0a20774e`, merge `b85d514e`,
+  required hosted checks, reachability, and exact tree equality; then append the
+  supported late successor closeout without rewriting M0 evidence. Proof: the
+  shared ledger accepted the closeout and the canonical `LIB-PRO-009` session
+  start then passed. ⚠️ TERMINAL ISSUE: session start was blocked by a stale
+  predecessor checkpoint -> used exact hosted and Git tree evidence to close it.
+- Confirmed root cause: type conversion occurred before semantic validation and
+  the application path did not reuse the validated canonical value. Resolution:
+  add one strict positive-integer normalizer, return zero only as the internal
+  invalid sentinel, issue a structured error, and consume `report.details` in
+  the apply path. Proof: 11 rebar tests cover valid use plus booleans, strings,
+  fractional values, missing/zero/negative values, structured failure, and no
+  geometry.
+- Confirmed root cause: the historical `benchmark.result` represented replay-
+  harness success rather than case engineering truth, but its generic name did
+  not express that boundary. Resolution: preserve the historical receipt and
+  add a machine-readable four-axis clarification consumed by the capability
+  manifest. Proof: 12 manifest/status tests require replay `PASS`, beam
+  `NOT_EVALUATED`, bounded column `PASS`, joint `FAIL`, and qualified review.
+- Confirmed root cause: candidate-frozen task/handoff prose had no later living-
+  status reconciliation after the hosted merge. Resolution: record the exact
+  M0 merge/tree in current control documents while leaving historical session
+  and handoff receipts unchanged. Proof: the updated documents contain no
+  instruction to merge M0 and link the ordered successor plan.
+- Confirmed root cause: the new multi-line assertion was not in Black's
+  canonical layout. Resolution: format the affected test only and recheck all
+  four changed Python files. Proof: Black reports all four unchanged and Ruff
+  reports no findings. ⚠️ TERMINAL ISSUE: focused Black check failed one file ->
+  formatted that file and reran only the failed formatting evidence.
+- Confirmed root cause: repository front-matter uses the closed `doc_type`
+  vocabulary and `plan` is not an allowed value; maintained planning documents
+  use `spec`. Resolution: change only the new document's type to `spec` and
+  preserve its task status and content. Proof: strict documentation validation
+  and the content-addressed corrective full gate pass. ⚠️ TERMINAL ISSUE: the
+  first full gate rejected one front-matter value -> used the maintained closed
+  vocabulary and reran the failed domain through the cached consolidated gate.
+- Confirmed root cause: `_pick` intentionally returns `Any`, and mypy does not
+  promote that value to the helper's declared `int` return solely from the
+  runtime `isinstance` branch. Resolution: return `int(value)` only after the
+  bool/type/range guard, preserving the strict behavior while making the type
+  contract explicit. Proof: focused mypy and the normal commit hooks pass all
+  247 checked source files. ⚠️ TERMINAL ISSUE: the first commit hook stopped on
+  one `no-any-return` error -> made the validated return explicitly typed and
+  reran the failed type evidence before the normal hooks.
+
+### Validation through content freeze
+
+- Focused Python: 23 tests pass across rebar validation, status semantics,
+  generated capability truth, and existing Indian-code manifest behavior.
+- Ruff passes the four changed Python files. Black passes after one formatting-
+  only repair. The maintained Indian-code manifest currentness check passes.
+- Both changed JSON documents parse successfully. No formula, code-source
+  provenance, supported-family status, route, version, or public artifact was
+  changed.
+- The first full gate passed 30/31 and exposed only the new plan front-matter
+  value. The corrective run reuses unchanged domains and passes all 31 checks.
+
+### Preserved holds
+
+- Qualified structural-engineering review, INDIA-4 acceptance, stable release,
+  engineering-use wording, professional approval, versioning, tagging, package
+  publication, and GitHub Release creation remain separate and unperformed.
+- IS 13920 walls/foundations, IS 875, IS 1893, dynamic/response-spectrum/FEM
+  analysis, ETABS write-back, and broader building design remain held.
+- No historical evidence or handoff receipt was rewritten. No protected source,
+  branch, worktree, archive, source-copy, alias, or unrelated file was deleted.
+
+---
+
 ## 2026-08-24 — Session: INDIA-3-IS13920-M0 cumulative bounded acceptance
 
 **Agent:** Codex (`structural-math`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-24 — INDIA-3-COLUMN-R1 bounded column contract repair
+**Updated:** 2026-08-24 — LIB-PRO-009 bounded release-trust closeout
 
 ---
 
@@ -125,15 +125,22 @@
 
 ## Active
 
-`INDIA-3-IS13920-M0` has completed bounded local cumulative software acceptance
-and becomes complete only when its unchanged green candidate merges. Beam,
-rectangular-column, and directional joint contracts now agree with the accepted
-source/amendment chain, benchmarks, unsafe cases, transports, package artifact,
-and exact capability limitations. Every family retains
-`qualified_review_required=true`; cumulative qualified engineering review
-remains INDIA-4 rather than being inferred from software gates. IS 13920 wall
-and foundation provisions, IS 875, and IS 1893 remain held. No exact successor
-packet ID has been frozen or started.
+`LIB-PRO-009` is the active bounded release-trust closeout. It makes the public
+rebar helper reject non-integer `bar_count` values without raising or producing
+geometry, adds a current machine-readable separation between benchmark replay
+and case engineering disposition, and reconciles the living INDIA-3 status.
+The [ordered candidate plan](planning/bounded-release-candidate-plan.md) keeps
+exact-artifact UAT, qualified review, stable release, engineering-use approval,
+and later scope expansion as separate gates.
+
+`INDIA-3-IS13920-M0` merged through PR #869 at `b85d514e` with exact
+candidate/merged tree `8a45afa4`. Beam, rectangular-column, and directional
+joint contracts are accepted only as bounded source-aligned software. The
+[status clarification](verification/lib-pro-009-is13920-status-semantics.json)
+records replay `PASS` separately from beam `NOT_EVALUATED`, the bounded column
+benchmark `PASS`, and the represented joint check `FAIL`. Every family retains
+`qualified_review_required=true`; IS 13920 wall/foundation, IS 875/1893,
+INDIA-4 review, release, and professional use remain held.
 
 `LIB-PRO-006` merged through PR #851 at `2d6df18e`. It confirms the practical
 10 m x 4 m audit arithmetic and fail-closed footing-detailing `HOLD`, adds a

--- a/docs/planning/bounded-release-candidate-plan.md
+++ b/docs/planning/bounded-release-candidate-plan.md
@@ -1,0 +1,80 @@
+---
+task: LIB-PRO-009
+title: Bounded Release Candidate and Qualified Review Plan
+status: active
+owner: Main Agent and repository owner
+created: 2026-08-24
+last_updated: 2026-08-24
+doc_type: spec
+---
+
+# Bounded Release Candidate and Qualified Review Plan
+
+## 1. Decision
+
+Prioritize trust in the currently supported bounded subset before adding more
+engineering scope. The present library may become a release candidate only
+after the three internal closeout items in this packet are integrated. A stable
+release, engineering-use approval, and professional approval remain separate
+owner decisions.
+
+The current subset review is not called `INDIA-4` final acceptance unless the
+repository owner explicitly freezes that subset as the INDIA-4 scope. Until
+then it is a qualified review of one exact bounded candidate.
+
+## 2. LIB-PRO-009 internal closeout
+
+| Item | Required outcome |
+|---|---|
+| Public `bar_count` input | Accept only a positive Python/JSON integer; reject booleans, strings, fractional values, zero, and negatives through the structured validation result |
+| Evidence status | Keep benchmark replay, calculation completion, engineering disposition, and qualified review as separate fields |
+| Living status | Record INDIA-3 M0 as integrated and remove instructions to merge its already-merged candidate |
+| Historical evidence | Preserve the immutable INDIA-3 M0 evidence and handoff receipts; add a current clarification instead of rewriting them |
+
+No structural formula, supported family, API route, version, artifact, source,
+or professional claim changes in LIB-PRO-009.
+
+## 3. Ordered candidate gates
+
+1. Integrate the unchanged LIB-PRO-009 candidate after focused, quick, full,
+   commit-hook, and hosted checks pass.
+2. Freeze the exact supported subset, exclusions, candidate version, commit,
+   and artifact identities. Later IS 13920 wall/foundation and IS 875/1893 work
+   remains outside that candidate.
+3. Build the immutable wheel and source distribution, then test the installed
+   artifact outside the source checkout:
+   - clean installation and imports;
+   - one bounded one-storey gravity example without implying complete building
+     design;
+   - independent hand-calculation comparisons for every advertised family;
+   - public API and function-name review;
+   - limitations and `NOT_EVALUATED`/`FAIL`/`HOLD` visibility in every result;
+   - package, version, documentation, and artifact-digest consistency.
+4. Give a qualified structural engineer that exact unchanged candidate,
+   artifact set, source/clause map, benchmarks, unsafe cases, limitations, and
+   review ledger. Any outcome-changing repair creates a new candidate and
+   invalidates the earlier review receipt.
+5. After the exact-candidate review is accepted, obtain a separate owner
+   decision for stable release and any engineering-use wording. Tagging,
+   package publication, and GitHub Release creation require that decision.
+6. Expand only after this bounded release decision: IS 13920 walls, IS 13920
+   foundations, IS 875 actions, and then IS 1893 equivalent-static actions and
+   accepted combinations.
+
+## 4. Verification efficiency
+
+Reuse immutable evidence for unchanged calculations and artifacts. During an
+implementation packet, run only the focused reproducer needed to guide the
+change. After content freezes, batch the affected focused checks, run the quick
+gate once, normal commit hooks, and the required hosted checks. Run the broad
+Python and full repository gates once for the integrated candidate, with a
+repeat only when an outcome-changing repair invalidates their evidence.
+
+## 5. Preserved holds
+
+- No claim of complete code-compliant building design.
+- No qualified-engineer receipt or professional approval in this packet.
+- No release, version, package, tag, or public-distribution action.
+- No IS 13920 wall/foundation, IS 875, IS 1893, dynamic, response-spectrum,
+  FEM, ETABS write-back, or additional building-workflow scope.
+- No branch, worktree, archive, source-copy, alias, or unrelated-file cleanup.

--- a/docs/planning/indian-code-completion-plan.md
+++ b/docs/planning/indian-code-completion-plan.md
@@ -38,7 +38,7 @@ completed family inside the larger INDIA-2 wave.
 | INDIA-0 — Truth baseline | One generated, standard-namespaced capability/coverage manifest; repaired coverage consumers; reconciled status ledgers | **Complete** |
 | INDIA-1 — Existing-family closure | Close or explicitly hold limitations for beam, rectangular column, isolated footing, and solid slab | **Complete** |
 | INDIA-2 — Remaining practical IS 456 elements | Separately verify wall, stair, deep-beam, flat-slab/punching, and distinct foundation-system packets | **Complete within the recorded accepted/held scope** — six bounded families accepted; pile-cap and raft remain held after G0; final evidence and cumulative gates are closed |
-| INDIA-3 — Companion Indian codes | Audit and truthfully close the existing bounded IS 13920 surface, then add IS 875 inputs before IS 1893 equivalent-static actions and Indian combinations | **Bounded IS 13920 M0 local acceptance complete; integration pending** — beam, rectangular-column, and directional joint software contracts pass cumulative source, benchmark, transport, capability, package, and review-boundary checks; wall/foundation, IS 875/1893, and qualified INDIA-4 review remain held |
+| INDIA-3 — Companion Indian codes | Audit and truthfully close the existing bounded IS 13920 surface, then add IS 875 inputs before IS 1893 equivalent-static actions and Indian combinations | **Bounded IS 13920 M0 integrated through PR #869** — beam, rectangular-column, and directional joint software contracts pass cumulative source, benchmark, transport, capability, package, and review-boundary checks; wall/foundation, IS 875/1893, and qualified INDIA-4 review remain held |
 | INDIA-4 — Final acceptance | Run cumulative engineering, cross-layer, repository, and artifact acceptance for the explicitly supported subset | **Planned** |
 
 “Complete” means the bounded accepted scope and its explicit exclusions are
@@ -99,6 +99,9 @@ cumulative IS 13920 acceptance gate. Those repairs are integrated and the
 three families only as bounded source-aligned software contracts. Every family
 still requires qualified review, and the cumulative qualified structural-
 engineering review remains INDIA-4 rather than being promoted from M0 tests.
+The [current status clarification](../verification/lib-pro-009-is13920-status-semantics.json)
+preserves that immutable M0 receipt while separating successful benchmark
+replay from each represented case's engineering disposition.
 
 The wave order is:
 
@@ -125,6 +128,12 @@ After the accepted INDIA-2 and INDIA-3 scope is frozen, INDIA-4 performs:
 INDIA-4 does not authorize professional use or release. Stable-release,
 engineering-use, package publication, tag, GitHub Release, and professional
 approval remain separate owner-controlled decisions.
+
+A qualified review of an earlier, smaller bounded candidate may support a
+release decision for that candidate, but it is not labelled INDIA-4 final
+acceptance unless the repository owner explicitly freezes that supported subset
+as the INDIA-4 scope. The ordered release-candidate gates are maintained in the
+[bounded release plan](bounded-release-candidate-plan.md).
 
 ## 6. Required contract for every calculation packet
 

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,20 +4,20 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-24
-- Focus: Run the single G0-frozen cumulative source, benchmark, unsafe-case,
-- Git receipt: docs/verification/india-3-is13920-m0-git-handoff-receipt.json | sha256:bd72f4392775461491d5e16a37c9e89245490a8bef289e0fea4d668dbcdab29b | HOLD
-- Git identity: codex/india-3-is13920-m0@306e2a46328ce2b519d1352131b64ef310271b5e | upstream=origin/main@306e2a46328ce2b519d1352131b64ef310271b5e | base=origin/main@306e2a46328ce2b519d1352131b64ef310271b5e | tree=dirty | operation=none
+- Focus: Close strict rebar input, evidence-status, and living-state defects.
+- Git receipt: docs/verification/lib-pro-009-git-handoff-receipt.json | sha256:d48c0eed78c3187f7369e45ce0e6386a80f34d502a98f1a14f3aac2316e60bae | HOLD
+- Git identity: codex/lib-pro-009-rc-trust@b85d514ed93e22a154badde990ef1c3fb02ae0d9 | upstream=origin/main@b85d514ed93e22a154badde990ef1c3fb02ae0d9 | base=origin/main@b85d514ed93e22a154badde990ef1c3fb02ae0d9 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
-- Next action: CREATE_IMMUTABLE_CANDIDATE_AFTER_FROZEN_GATES
+- Next action: COMMIT_INTENDED_PATHS
 <!-- HANDOFF:END -->
 
 ## Latest Handoff
 
 | State | Boundary |
 |---|---|
-| **Current** | `INDIA-3-IS13920-M0` has completed bounded local cumulative software acceptance on source-bound `codex/india-3-is13920-m0` from exact hosted column merge `306e2a46`, tree `cbe0f8d9` |
-| **Decision** | Beam, rectangular-column, and one-plane/one-direction SCWB joint contracts are source-aligned and accepted only as bounded software; every family retains `qualified_review_required=true` |
-| **Next** | Integrate this unchanged candidate with required hosted checks green. The next sequence item is a separately sourced and benchmarked IS 13920 wall decision, but no exact successor packet ID is frozen or started |
+| **Current** | `INDIA-3-IS13920-M0` merged through PR #869 at `b85d514e`, exact candidate/merged tree `8a45afa4`; `LIB-PRO-009` is the bounded input/status/document closeout |
+| **Decision** | Replay success is separate from engineering disposition: beam `NOT_EVALUATED`, bounded column benchmark `PASS`, represented joint check `FAIL`; every family retains `QUALIFIED_REVIEW_REQUIRED` |
+| **Next** | Integrate LIB-PRO-009, then freeze an exact bounded release-candidate scope and artifact before installed UAT and qualified review of that unchanged candidate |
 | **Source** | IS 13920:2016 First Revision plus Amendment 1 (2017) and Amendment 2 (2020); reaffirmation is not a new edition and the draft successor is unused |
 | **Held** | Beam provided-reinforcement compliance, column derived applicability/non-rectangular/provided-longitudinal checks, whole-joint assessment, walls/foundations, IS 875/1893, INDIA-4 qualified review, source/distribution/support/version/release/professional-use changes, and branch/worktree/archive/source/alias deletion |
 
@@ -40,14 +40,17 @@
 - The cumulative Python gate passes 7,024 cases with 3 skipped and 6 deselected;
   FastAPI passes 498. No structural formula or runtime behavior changed in M0.
 
-## Frozen follow-on sequence
+## Ordered follow-on gates
 
-1. Merge the unchanged green `INDIA-3-IS13920-M0` candidate. Do not delete its
-   branch, worktree, archive, source copy, alias, or any unrelated lane.
-2. Freeze a separate source/benchmark decision packet for IS 13920 wall
-   provisions before implementation. No exact packet ID is authorized here.
-3. Foundation detailing, IS 875/1893, INDIA-4 qualified review, release, and
-   professional-use decisions remain separate.
+1. Integrate the unchanged green `LIB-PRO-009` candidate. Do not delete any
+   branch, worktree, archive, source copy, alias, or unrelated lane.
+2. Freeze the exact supported subset, version, commit, limitations, and artifact
+   identities for one bounded release candidate.
+3. Run source-free installed-artifact UAT and hand comparisons, then obtain
+   qualified review of that exact unchanged candidate.
+4. Keep stable release, engineering-use wording, package/tag publication, and
+   professional approval as separate owner decisions.
+5. Expand afterward in order: IS 13920 walls, foundations, IS 875, then IS 1893.
 
 ## Required Reading
 
@@ -60,3 +63,5 @@
 7. [Indian-code completion order](indian-code-completion-plan.md)
 8. [Generated Indian-code capability truth](../verification/indian-code-capability-coverage.json)
 9. [Current task board](../TASKS.md)
+10. [Bounded release candidate plan](bounded-release-candidate-plan.md)
+11. [Replay and engineering-status clarification](../verification/lib-pro-009-is13920-status-semantics.json)

--- a/docs/verification/indian-code-capability-coverage.json
+++ b/docs/verification/indian-code-capability-coverage.json
@@ -2254,7 +2254,8 @@
             "Python/structural_lib/codes/is13920/beam.py",
             "Python/tests/codes/is13920/test_beam.py",
             "Python/tests/property/test_ductile_hypothesis.py",
-            "docs/verification/india-3-is13920-m0-evidence.json"
+            "docs/verification/india-3-is13920-m0-evidence.json",
+            "docs/verification/lib-pro-009-is13920-status-semantics.json"
           ],
           "qualified_review_required": true
         },
@@ -2277,7 +2278,8 @@
           "evidence": [
             "Python/structural_lib/codes/is13920/column.py",
             "Python/tests/codes/is13920/test_column.py",
-            "docs/verification/india-3-is13920-m0-evidence.json"
+            "docs/verification/india-3-is13920-m0-evidence.json",
+            "docs/verification/lib-pro-009-is13920-status-semantics.json"
           ],
           "qualified_review_required": true
         },
@@ -2299,7 +2301,8 @@
           "evidence": [
             "Python/structural_lib/codes/is13920/joint.py",
             "Python/tests/codes/is13920/test_joint.py",
-            "docs/verification/india-3-is13920-m0-evidence.json"
+            "docs/verification/india-3-is13920-m0-evidence.json",
+            "docs/verification/lib-pro-009-is13920-status-semantics.json"
           ],
           "qualified_review_required": true
         },

--- a/docs/verification/lib-pro-009-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-009-git-handoff-receipt.json
@@ -1,0 +1,183 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-24T08:38:04Z",
+      "query_status": "OK",
+      "reference": "okay plan this work please. and implement it",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "IMPLEMENT_STRICT_BAR_COUNT_VALIDATION",
+      "ADD_FOCUSED_TESTS_AND_STATUS_EVIDENCE",
+      "RECONCILE_LIVING_TASK_PLAN_AND_HANDOFF_DOCUMENTS",
+      "RUN_FOCUSED_QUICK_FULL_HOOK_AND_HOSTED_CHECKS",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-24T08:38:04Z",
+    "prohibited_actions": [
+      "CHANGE_STRUCTURAL_FORMULAS_OR_SUPPORTED_ENGINEERING_SCOPE",
+      "REWRITE_HISTORICAL_M0_EVIDENCE_OR_HANDOFF_RECEIPTS",
+      "CLAIM_QUALIFIED_ENGINEERING_PROFESSIONAL_OR_INDIA4_APPROVAL",
+      "CHANGE_VERSION_TAG_RELEASE_OR_PACKAGE_PUBLICATION_STATUS",
+      "START_IS13920_WALL_FOUNDATION_IS875_IS1893_OR_LATER_SCOPE",
+      "TRACK_OR_MUTATE_PRIVATE_SOURCE_MATERIAL",
+      "DELETE_BRANCH_WORKTREE_ARCHIVE_SOURCE_ALIAS_OR_UNRELATED_FILE",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_REWRITE_FORCE_PUSH_OR_BYPASS_CHECKS"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "IMPLEMENT_STRICT_BAR_COUNT_VALIDATION",
+        "ADD_FOCUSED_TESTS_AND_STATUS_EVIDENCE",
+        "RECONCILE_LIVING_TASK_PLAN_AND_HANDOFF_DOCUMENTS",
+        "RUN_FOCUSED_QUICK_FULL_HOOK_AND_HOSTED_CHECKS",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/lib-pro-009-rc-trust",
+      "head_sha": "b85d514ed93e22a154badde990ef1c3fb02ae0d9",
+      "task_id": "LIB-PRO-009"
+    }
+  },
+  "holds": [
+    "LOCAL_HOLD_DIRTY",
+    "PRESERVE_ALL_PRE_EXISTING_DIRTY_DETACHED_DIVERGENT_AND_UNKNOWN_LANES",
+    "PRESERVE_INDIA3_BRANCHES_WORKTREES_ARCHIVES_SOURCE_COPIES_AND_ALIASES",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "d48c0eed78c3187f7369e45ce0e6386a80f34d502a98f1a14f3aac2316e60bae",
+    "state": {
+      "branch": "codex/lib-pro-009-rc-trust",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "b85d514ed93e22a154badde990ef1c3fb02ae0d9",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 113.679,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/lib-pro-009-rc-trust",
+      "head_sha": "b85d514ed93e22a154badde990ef1c3fb02ae0d9",
+      "hold_reasons": [
+        "changed paths: 12"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-24T08:38:37.945733+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/lib-pro-009-rc-trust",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 12,
+        "modified_paths": [
+          "Python/structural_lib/services/rebar.py",
+          "Python/tests/test_indian_code_manifest.py",
+          "Python/tests/unit/test_rebar.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/indian-code-completion-plan.md",
+          "docs/planning/next-session-brief.md",
+          "docs/verification/indian-code-capability-coverage.json",
+          "scripts/_lib/indian_code_manifest.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/planning/bounded-release-candidate-plan.md",
+          "docs/verification/lib-pro-009-git-handoff-source-evidence.json",
+          "docs/verification/lib-pro-009-is13920-status-semantics.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "b85d514ed93e22a154badde990ef1c3fb02ae0d9",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/lib-pro-009-rc-trust"
+    }
+  },
+  "local_state_receipt_hash": "sha256:d48c0eed78c3187f7369e45ce0e6386a80f34d502a98f1a14f3aac2316e60bae",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-24T08:38:37.945883+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [
+      "PRESERVE_ALL_PRE_EXISTING_DIRTY_DETACHED_DIVERGENT_AND_UNKNOWN_LANES",
+      "PRESERVE_INDIA3_BRANCHES_WORKTREES_ARCHIVES_SOURCE_COPIES_AND_ALIASES"
+    ],
+    "observed_at_utc": "2026-08-24T08:38:04Z",
+    "owner": "Main Agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources"
+    ],
+    "integration_owner": "orchestrator",
+    "owned_paths": [
+      "Python/structural_lib/services/rebar.py",
+      "Python/tests/unit/test_rebar.py",
+      "Python/tests/test_indian_code_manifest.py",
+      "scripts/_lib/indian_code_manifest.py",
+      "docs/planning/bounded-release-candidate-plan.md",
+      "docs/planning/indian-code-completion-plan.md",
+      "docs/verification/lib-pro-009-is13920-status-semantics.json",
+      "docs/verification/indian-code-capability-coverage.json",
+      "docs/verification/lib-pro-009-git-handoff-source-evidence.json",
+      "docs/verification/lib-pro-009-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "LIB-PRO-009"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-009-git-handoff-source-evidence.json
+++ b/docs/verification/lib-pro-009-git-handoff-source-evidence.json
@@ -1,0 +1,69 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-24T08:38:04Z",
+      "query_status": "OK",
+      "reference": "okay plan this work please. and implement it",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "IMPLEMENT_STRICT_BAR_COUNT_VALIDATION",
+      "ADD_FOCUSED_TESTS_AND_STATUS_EVIDENCE",
+      "RECONCILE_LIVING_TASK_PLAN_AND_HANDOFF_DOCUMENTS",
+      "RUN_FOCUSED_QUICK_FULL_HOOK_AND_HOSTED_CHECKS",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-24T08:38:04Z",
+    "prohibited_actions": [
+      "CHANGE_STRUCTURAL_FORMULAS_OR_SUPPORTED_ENGINEERING_SCOPE",
+      "REWRITE_HISTORICAL_M0_EVIDENCE_OR_HANDOFF_RECEIPTS",
+      "CLAIM_QUALIFIED_ENGINEERING_PROFESSIONAL_OR_INDIA4_APPROVAL",
+      "CHANGE_VERSION_TAG_RELEASE_OR_PACKAGE_PUBLICATION_STATUS",
+      "START_IS13920_WALL_FOUNDATION_IS875_IS1893_OR_LATER_SCOPE",
+      "TRACK_OR_MUTATE_PRIVATE_SOURCE_MATERIAL",
+      "DELETE_BRANCH_WORKTREE_ARCHIVE_SOURCE_ALIAS_OR_UNRELATED_FILE",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_REWRITE_FORCE_PUSH_OR_BYPASS_CHECKS"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "IMPLEMENT_STRICT_BAR_COUNT_VALIDATION",
+        "ADD_FOCUSED_TESTS_AND_STATUS_EVIDENCE",
+        "RECONCILE_LIVING_TASK_PLAN_AND_HANDOFF_DOCUMENTS",
+        "RUN_FOCUSED_QUICK_FULL_HOOK_AND_HOSTED_CHECKS",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/lib-pro-009-rc-trust",
+      "head_sha": "b85d514ed93e22a154badde990ef1c3fb02ae0d9",
+      "task_id": "LIB-PRO-009"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [
+      "PRESERVE_ALL_PRE_EXISTING_DIRTY_DETACHED_DIVERGENT_AND_UNKNOWN_LANES",
+      "PRESERVE_INDIA3_BRANCHES_WORKTREES_ARCHIVES_SOURCE_COPIES_AND_ALIASES"
+    ],
+    "observed_at_utc": "2026-08-24T08:38:04Z",
+    "owner": "Main Agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-009-is13920-status-semantics.json
+++ b/docs/verification/lib-pro-009-is13920-status-semantics.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "engineering-evidence-status/v1",
+  "task_id": "LIB-PRO-009",
+  "historical_m0_evidence": {
+    "path": "docs/verification/india-3-is13920-m0-evidence.json",
+    "task_id": "INDIA-3-IS13920-M0",
+    "candidate_commit": "0a20774ec8978b7dcea6d7cd7db6966068b70703",
+    "merge_commit": "b85d514ed93e22a154badde990ef1c3fb02ae0d9",
+    "candidate_and_merge_tree": "8a45afa44a5fb3d227aab666d17aadf29fe1c26e",
+    "mutated": false,
+    "legacy_benchmark_result_interpretation": "BENCHMARK_REPLAY_STATUS_ONLY"
+  },
+  "status_axes": {
+    "benchmark_replay_status": [
+      "PASS",
+      "FAIL"
+    ],
+    "calculation_status": [
+      "NOT_EVALUATED",
+      "COMPLETED",
+      "ERROR"
+    ],
+    "engineering_status": [
+      "NOT_EVALUATED",
+      "PASS",
+      "FAIL",
+      "HOLD"
+    ],
+    "review_status": [
+      "QUALIFIED_REVIEW_REQUIRED"
+    ]
+  },
+  "cases": [
+    {
+      "family": "beam_detailing_checks",
+      "benchmark_replay_status": "PASS",
+      "calculation_status": "COMPLETED",
+      "engineering_status": "NOT_EVALUATED",
+      "review_status": "QUALIFIED_REVIEW_REQUIRED",
+      "engineering_basis": "The replay proves the 72 mm requirement calculation and geometry boundary. Provided longitudinal reinforcement and link spacing are not inputs, so reinforcement compliance is not evaluated."
+    },
+    {
+      "family": "column_detailing_checks",
+      "benchmark_replay_status": "PASS",
+      "calculation_status": "COMPLETED",
+      "engineering_status": "PASS",
+      "review_status": "QUALIFIED_REVIEW_REQUIRED",
+      "engineering_basis": "The represented rectangular-column benchmark passes the bounded provided special-confinement check. Applicability remains caller-confirmed and provided longitudinal reinforcement is not evaluated."
+    },
+    {
+      "family": "beam_column_joint_scwb_check",
+      "benchmark_replay_status": "PASS",
+      "calculation_status": "COMPLETED",
+      "engineering_status": "FAIL",
+      "review_status": "QUALIFIED_REVIEW_REQUIRED",
+      "sum_column_capacity_knm": 250.0,
+      "sum_beam_capacity_knm": 200.0,
+      "required_column_capacity_knm": 280.0,
+      "ratio": 0.8928571428571429,
+      "is_satisfied": false,
+      "engineering_basis": "The replay succeeds because the software reproduces the expected unsafe result. The represented one-plane, one-direction SCWB engineering check fails because 250 kNm is less than the required 280 kNm."
+    }
+  ],
+  "qualified_engineer_receipt_present": false,
+  "professional_approval": false,
+  "engineering_use_approval": false,
+  "release_authorized": false
+}

--- a/scripts/_lib/indian_code_manifest.py
+++ b/scripts/_lib/indian_code_manifest.py
@@ -199,6 +199,7 @@ _IS13920_SUPPORTED: tuple[dict[str, Any], ...] = (
             "Python/tests/codes/is13920/test_beam.py",
             "Python/tests/property/test_ductile_hypothesis.py",
             "docs/verification/india-3-is13920-m0-evidence.json",
+            "docs/verification/lib-pro-009-is13920-status-semantics.json",
         ],
     },
     {
@@ -216,6 +217,7 @@ _IS13920_SUPPORTED: tuple[dict[str, Any], ...] = (
             "Python/structural_lib/codes/is13920/column.py",
             "Python/tests/codes/is13920/test_column.py",
             "docs/verification/india-3-is13920-m0-evidence.json",
+            "docs/verification/lib-pro-009-is13920-status-semantics.json",
         ],
     },
     {
@@ -236,6 +238,7 @@ _IS13920_SUPPORTED: tuple[dict[str, Any], ...] = (
             "Python/structural_lib/codes/is13920/joint.py",
             "Python/tests/codes/is13920/test_joint.py",
             "docs/verification/india-3-is13920-m0-evidence.json",
+            "docs/verification/lib-pro-009-is13920-status-semantics.json",
         ],
     },
 )


### PR DESCRIPTION
## Summary

- require an actual positive integer for public rebar bar_count input and fail through the structured result without geometry
- separate benchmark replay from calculation, engineering disposition, and qualified review in current IS 13920 evidence
- reconcile merged M0 task/roadmap/handoff state and add the ordered bounded release-candidate plan

## Verification

- focused Python: 23 passed
- Ruff and Black: passed
- Indian-code manifest currentness: passed
- quick gate: 10/10
- full gate: 31/31 after one metadata-only correction, with 16 unchanged checks reused
- normal commit hooks: passed, including mypy on 247 source files
- clean final session validation: passed

## Boundaries

No structural formula, supported scope, version, package, release, INDIA-4, qualified-review, professional-approval, private-source, or cleanup action is included.