### PR TITLE
fix(release): streamline next publication

### DIFF
--- a/.github/skills/release-preflight/SKILL.md
+++ b/.github/skills/release-preflight/SKILL.md
@@ -41,14 +41,27 @@ step 3, then establish the final green current-candidate preflight with:
 ./run.sh release preflight --wheel <exact-wheel-path>
 ```
 
-A preparation-authorized candidate must retain explicit unpublished/on-hold
-CHANGELOG, release-ledger, and CITATION wording. Do not pre-check tag or
-publication authorization in `docs/planning/pre-release-checklist.md` before
-the immutable review. After that review, record exact target authorization only
-through the maintained authorization JSON and exact-candidate receipt flow;
-post-review changes remain limited to paths accepted by the release validator.
-The exact-wheel form accepts the historical candidate-freeze wording and fails
-closed unless those later evidence records authorize the selected target.
+A prepared candidate must retain explicit unpublished/on-hold CHANGELOG,
+release-ledger, and CITATION wording. Do not pre-check tag or publication
+authorization in `docs/planning/pre-release-checklist.md` before the immutable
+review. Run the exact PR and Weekly checks once on that frozen candidate.
+
+After review, make one bounded publication packet containing all final release
+state together: the dated `CITATION.cff`, dated `CHANGELOG.md`, one appended
+authorized entry in `docs/getting-started/releases.md`, and the maintained
+authorization JSON. These are the only publication-metadata paths accepted after
+the reviewed candidate; the Python tree must remain identical. Before committing
+the packet, run:
+
+```bash
+./run.sh release publication-surface-check --version <target-version>
+```
+
+After the clean commit, run `authorization-check` for each requested target.
+That command revalidates the same final metadata before any publication workflow
+can spend time on release tests. Do not rerun Weekly verification for this
+bounded metadata packet. Any other post-review path change invalidates the exact
+candidate and requires a new review/hosted decision.
 
 This is read-only. Run it once. If local resource checks fail and Docker is the intended fallback, start Colima and run the Docker variant instead of running both full paths:
 
@@ -101,11 +114,20 @@ environment before and after tests. It installs only the wheel's declared test
 extras plus explicitly documented generated-client requirements; broad root
 requirements are not acceptable artifact evidence.
 
-After publication, verify the exact public version separately:
+After publication, first compare the public artifact hashes with the exact
+publication manifest. When the publication workflow already recorded the full
+installed-package UAT for those bytes, verify only the public package identity;
+do not repeat the same UAT:
 
 ```bash
-./run.sh release verify --version <target-version> --source pypi
+./run.sh release verify --version <target-version> --source pypi --identity-only
 ```
+
+The verifier waits up to 90 seconds for the exact version to appear on the PyPI
+simple index and retries only that install. It does not retry a real install
+failure or rerun tests. Run the full public-source verifier only when the
+publication workflow lacks exact installed-package UAT evidence or the public
+artifact identity differs from the recorded manifest.
 
 ### 5. Owner-only actions
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -53,7 +53,7 @@ updating and verifying the ruleset in the same approved operation.
 |---|---|---|
 | `fast-checks.yml` | Pull requests and short main-branch verification | Manifest-planned Python, FastAPI, React, Excel, control, docs, and repository validation with required `PR Gate` |
 | `nightly.yml` | Weekly schedule and manual dispatch | Full Ubuntu verification, clean-wheel/CLI checks, dependency audits, Docker health, and optional manual cross-platform smoke |
-| `publish.yml` | Version tag or manual dispatch | Build/install/SBOM verification; exact independent-review receipt or explicit repository-owner review waiver; manual TestPyPI publication; tag-only production PyPI and GitHub Release |
+| `publish.yml` | Version tag or manual dispatch | Fail-fast authorization plus final publication-metadata validation before release tests; build/install/SBOM verification; exact independent-review receipt or explicit repository-owner review waiver; manual TestPyPI publication; tag-only production PyPI and GitHub Release |
 | `deploy-docs.yml` | Relevant main-branch documentation changes or manual dispatch | Strict MkDocs build validation; no public deployment until the owner enables and verifies GitHub Pages |
 
 All workflows default to read-only repository contents. Only publication jobs

--- a/Python/tests/test_bump_version_semantics.py
+++ b/Python/tests/test_bump_version_semantics.py
@@ -88,6 +88,32 @@ def test_candidate_bump_preserves_published_release_evidence(
     assert bump_version.main() == 0
 
 
+def test_candidate_bump_resets_published_citation_state(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pyproject = tmp_path / "Python" / "pyproject.toml"
+    pyproject.parent.mkdir()
+    pyproject.write_text('[project]\nversion = "0.24.0a1"\n', encoding="utf-8")
+    citation = tmp_path / "CITATION.cff"
+    citation.write_text(
+        "cff-version: 1.2.0\n"
+        "version: 0.24.0a1\n"
+        "date-released: 2026-08-24\n"
+        'message: "Alpha v0.24.0a1 is owner-authorized for publication."\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(bump_version, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["bump_version.py", "0.24.0a2"])
+
+    assert bump_version.main() == 0
+
+    content = citation.read_text(encoding="utf-8")
+    assert "version: 0.24.0a2" in content
+    assert "date-released:" not in content
+    assert "Prepared Alpha candidate v0.24.0a2; not tagged or published" in content
+    assert "owner-authorized" not in content
+
+
 def test_doc_sync_preserves_public_release_identity(tmp_path: Path, monkeypatch):
     """A prepared source version must not relabel the last public release."""
     readme, checklist = _write_public_candidate_fixture(tmp_path)

--- a/Python/tests/test_ci_workflow_contract.py
+++ b/Python/tests/test_ci_workflow_contract.py
@@ -66,6 +66,16 @@ def test_hosted_full_suites_bind_the_setup_python_interpreter():
     assert expected in publication
 
 
+def test_publication_metadata_and_authorization_fail_before_release_tests():
+    workflow = yaml.safe_load(PUBLISH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["validate"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    assert names.index(
+        "Enforce separate owner publication authorization"
+    ) < names.index("Run release tests")
+
+
 def test_weekly_benchmark_evidence_does_not_mutate_indexed_docs():
     workflow = yaml.safe_load(NIGHTLY.read_text(encoding="utf-8"))
     steps = workflow["jobs"]["full-verification"]["steps"]

--- a/Python/tests/test_release_scripts.py
+++ b/Python/tests/test_release_scripts.py
@@ -236,6 +236,59 @@ def test_release_publication_authorization_holds_by_default(tmp_path: Path) -> N
     assert "release publication decision is HOLD, not AUTHORIZED" in errors
 
 
+def test_publication_surface_check_forces_the_final_authorized_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = release._version_from_pyproject()
+    monkeypatch.setattr(
+        release, "_release_authorization_recorded", lambda _version: False
+    )
+
+    candidate_errors = release._source_surface_version_errors(
+        current, allow_authorized_release=True
+    )
+
+    assert "CITATION.cff declares date-released for an unpublished candidate" in (
+        candidate_errors
+    )
+    assert release._publication_surface_errors(current) == []
+
+
+def test_authorization_check_rejects_incomplete_publication_metadata(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        release, "_release_publication_authorization_errors", lambda *_args: []
+    )
+    monkeypatch.setattr(
+        release,
+        "_publication_surface_errors",
+        lambda _version: ["CITATION.cff must declare date-released"],
+    )
+
+    result = release.cmd_authorization_check(
+        argparse.Namespace(version="0.24.0a1", target="testpypi")
+    )
+
+    assert result == 1
+    assert "CITATION.cff must declare date-released" in capsys.readouterr().out
+
+
+def test_publication_surface_check_is_narrow_and_does_not_authorize(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(release, "_publication_surface_errors", lambda _version: [])
+
+    result = release.cmd_publication_surface_check(
+        argparse.Namespace(version="0.24.0a1")
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "publication metadata is complete" in output
+    assert "does not grant publication authorization" in output
+
+
 @pytest.mark.parametrize(
     ("errors", "wheel_supplied", "authorization_errors", "verdict", "exit_code"),
     [
@@ -486,6 +539,47 @@ def _authorized_owner_waiver_fixture(tmp_path: Path) -> Path:
     return authorization_path
 
 
+def _commit_publication_metadata(repo: Path) -> None:
+    surfaces = {
+        "CITATION.cff": "version: 0.24.0a1\ndate-released: 2026-08-24\n",
+        "CHANGELOG.md": "## [0.24.0a1] — 2026-08-24\n",
+        "docs/getting-started/releases.md": (
+            "## v0.24.0a1 — Authorized Alpha Release (2026-08-24)\n"
+        ),
+    }
+    for relative_path, content in surfaces.items():
+        path = repo / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    _git(repo, "add", *surfaces)
+    _git(repo, "commit", "-q", "-m", "record final publication metadata")
+
+
+def test_post_review_publication_metadata_does_not_invalidate_exact_candidate(
+    tmp_path: Path,
+) -> None:
+    reviewed_record, _receipt = _authorized_release_fixture(tmp_path / "reviewed")
+    reviewed_repo = reviewed_record.parents[2]
+    _commit_publication_metadata(reviewed_repo)
+
+    waived_record = _authorized_owner_waiver_fixture(tmp_path / "waived")
+    waived_repo = waived_record.parents[2]
+    _commit_publication_metadata(waived_repo)
+
+    assert (
+        release._release_publication_authorization_errors(
+            "0.24.0a1", "pypi", reviewed_record, repo_root=reviewed_repo
+        )
+        == []
+    )
+    assert (
+        release._release_publication_authorization_errors(
+            "0.24.0a1", "pypi", waived_record, repo_root=waived_repo
+        )
+        == []
+    )
+
+
 def test_release_publication_accepts_explicit_owner_review_waiver(
     tmp_path: Path,
 ) -> None:
@@ -701,6 +795,8 @@ class TestReleaseHelp:
         output = result.stdout
         assert "--version" in output
         assert "--source" in output
+        assert "--identity-only" in output
+        assert "--index-wait-seconds" in output
 
 
 class TestReleaseVerifyDependencies:
@@ -735,6 +831,7 @@ class TestReleaseVerifyDependencies:
         )[0]
 
         assert "_assert_package_import_from_venv" in verify_block
+        assert "expected_version=args.version" in verify_block
         assert "_isolated_pytest_config" in verify_block
         assert '"--import-mode=importlib"' in verify_block
         assert '"not slow and not repo_only"' in verify_block
@@ -811,6 +908,7 @@ class TestReleaseVerifyDependencies:
 
     def test_pypi_verify_forces_fresh_official_index(self, tmp_path, monkeypatch):
         calls: list[list[str]] = []
+        pypi_calls: list[tuple[list[str], int]] = []
 
         class TemporaryDirectory:
             def __enter__(self):
@@ -822,7 +920,13 @@ class TestReleaseVerifyDependencies:
         def record_run_check(cmd, *, cwd=None, timeout=600, env=None):
             calls.append(cmd)
 
+        def record_pypi_install(cmd, *, env, wait_seconds):
+            pypi_calls.append((cmd, wait_seconds))
+
         monkeypatch.setattr(release, "_run_check", record_run_check)
+        monkeypatch.setattr(
+            release, "_run_pypi_install_with_retry", record_pypi_install
+        )
         monkeypatch.setattr(
             release.tempfile, "TemporaryDirectory", lambda **_: TemporaryDirectory()
         )
@@ -834,19 +938,112 @@ class TestReleaseVerifyDependencies:
                 source="pypi",
                 version="0.23.1a1",
                 skip_cli=True,
+                identity_only=False,
+                index_wait_seconds=90,
             )
         )
 
         assert result == 0
-        assert [
-            str(tmp_path / "venv" / "bin" / "pip"),
-            "install",
-            "--no-cache-dir",
-            "--index-url",
-            "https://pypi.org/simple/",
-            "structural-lib-is456[dev,validation]===0.23.1a1",
-            "httpx>=0.27",
-        ] in calls
+        assert pypi_calls == [
+            (
+                [
+                    str(tmp_path / "venv" / "bin" / "pip"),
+                    "install",
+                    "--no-cache-dir",
+                    "--index-url",
+                    "https://pypi.org/simple/",
+                    "structural-lib-is456[dev,validation]===0.23.1a1",
+                    "httpx>=0.27",
+                ],
+                90,
+            )
+        ]
+
+    def test_identity_only_verifies_public_package_without_repeating_uat(
+        self, tmp_path, monkeypatch
+    ):
+        calls: list[list[str]] = []
+        pypi_calls: list[list[str]] = []
+
+        class TemporaryDirectory:
+            def __enter__(self):
+                return str(tmp_path)
+
+            def __exit__(self, *_):
+                return False
+
+        def record_run_check(cmd, *, cwd=None, timeout=600, env=None):
+            calls.append(cmd)
+
+        def record_pypi_install(cmd, *, env, wait_seconds):
+            pypi_calls.append(cmd)
+
+        monkeypatch.setattr(release, "_run_check", record_run_check)
+        monkeypatch.setattr(
+            release, "_run_pypi_install_with_retry", record_pypi_install
+        )
+        monkeypatch.setattr(
+            release.tempfile, "TemporaryDirectory", lambda **_: TemporaryDirectory()
+        )
+
+        result = release.cmd_verify(
+            argparse.Namespace(
+                wheel_dir="Python/dist",
+                job="Python/examples/sample_job_is456.json",
+                source="pypi",
+                version="0.24.0a1",
+                skip_cli=False,
+                identity_only=True,
+                index_wait_seconds=90,
+            )
+        )
+
+        assert result == 0
+        assert pypi_calls[0][-1] == "structural-lib-is456===0.24.0a1"
+        assert not any("pytest" in cmd for cmd in calls)
+        assert not any("structural_lib" in cmd and "job" in cmd for cmd in calls)
+
+    def test_pypi_propagation_retry_is_bounded_to_the_install(self, monkeypatch):
+        command = ["pip", "install", "structural-lib-is456===0.24.0a1"]
+        results = iter(
+            [
+                subprocess.CompletedProcess(
+                    command,
+                    1,
+                    "",
+                    "No matching distribution found for structural-lib-is456===0.24.0a1",
+                ),
+                subprocess.CompletedProcess(command, 0, "installed", ""),
+            ]
+        )
+        monotonic = iter([100.0, 101.0])
+        sleeps: list[float] = []
+
+        monkeypatch.setattr(release.subprocess, "run", lambda *_, **__: next(results))
+        monkeypatch.setattr(release.time, "monotonic", lambda: next(monotonic))
+        monkeypatch.setattr(release.time, "sleep", sleeps.append)
+
+        release._run_pypi_install_with_retry(
+            command, env={"PATH": "test"}, wait_seconds=90
+        )
+
+        assert sleeps == [10.0]
+
+    def test_pypi_install_does_not_retry_a_real_install_failure(self, monkeypatch):
+        command = ["pip", "install", "structural-lib-is456===0.24.0a1"]
+        result = subprocess.CompletedProcess(command, 1, "", "hash mismatch")
+        sleeps: list[float] = []
+
+        monkeypatch.setattr(release.subprocess, "run", lambda *_, **__: result)
+        monkeypatch.setattr(release.time, "monotonic", lambda: 100.0)
+        monkeypatch.setattr(release.time, "sleep", sleeps.append)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            release._run_pypi_install_with_retry(
+                command, env={"PATH": "test"}, wait_seconds=90
+            )
+
+        assert sleeps == []
 
 
 class TestReleaseReactDependencies:
@@ -892,9 +1089,9 @@ class TestReleaseReactDependencies:
         assert not release._ensure_react_dependencies(react_dir, {"PATH": "test"})
         assert not called
 
-    def test_release_run_and_preflight_share_dependency_provisioner(self):
+    def test_frozen_preflight_alone_owns_react_dependency_provisioning(self):
         source = RELEASE_SCRIPT.read_text(encoding="utf-8")
-        assert source.count("_ensure_react_dependencies(react_dir, node_env)") == 2
+        assert source.count("_ensure_react_dependencies(react_dir, node_env)") == 1
 
 
 class TestPublishWorkflow:
@@ -1014,6 +1211,16 @@ class TestReleasePreflight:
             in preflight
         )
         assert '"test-fastapi"' in preflight
+
+    def test_version_mutation_does_not_repeat_unchanged_broad_suites(self):
+        source = RELEASE_SCRIPT.read_text(encoding="utf-8")
+        release_run = source.split("def cmd_run", 1)[1].split("# ─── Verify", 1)[0]
+
+        assert '"pytest"' not in release_run
+        assert '"npm", "run", "build"' not in release_run
+        assert "No unchanged broad suites rerun before the version mutation" in (
+            release_run
+        )
 
     def test_fastapi_image_retries_slow_dependency_downloads(self):
         dockerfile = (REPO_ROOT / "Dockerfile.fastapi").read_text(encoding="utf-8")

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,118 @@
 
 ---
 
+## 2026-08-24 — Session: RELEASE-SMOOTH-001 next-publication controls
+
+**Agent:** Codex (`ops`, sole writer; no subagents)
+
+**Branch:** `codex/release-smoothness`, from released `origin/main` commit
+`71b7065216d4266d63ad6b31bd39bba81fa16efc`.
+
+**Git handoff receipt:**
+`docs/verification/release-smooth-001-git-handoff-receipt.json`
+
+**Focus:** Convert the concrete `v0.24.0a1` release delays into fail-early,
+single-candidate controls so the next publish does not repeat unchanged local or
+hosted suites.
+
+### Summary
+
+- Bound the release order to one prepared candidate, one exact PR/Weekly run,
+  and one post-review publication packet limited to release metadata and
+  authorization; the Python tree must remain identical.
+- Made publication authorization validate final dated `CITATION.cff`,
+  `CHANGELOG.md`, and release-ledger state before expensive release tests begin.
+- Reset citation date and authorization wording on every new candidate bump so
+  a prior published version cannot leak into the next candidate.
+- Removed pre-mutation broad Python and React runs from `release run`; the
+  frozen-candidate preflight remains their single local owner.
+- Added public-package identity-only verification after an exact workflow UAT,
+  with a bounded 90-second PyPI-index wait that retries only a missing-version
+  install and never retries a real failure or the test suite.
+- Updated the release workflow skill and token-efficiency contract to state the
+  exact sequence and the narrow exception paths.
+
+### Issues encountered
+
+- The combined worktree-create/session-start terminal command continued in the
+  primary checkout because a command's working directory does not follow a
+  preceding `git worktree add`.
+- `./run.sh context show release` rejected the guessed context area, and the
+  guessed `.github/workflows/weekly-verification.yml` path did not exist.
+- The first two attempts to compact the PyPI JSON response used the same
+  malformed Python one-liner.
+- The previous release's authorization passed before final release metadata was
+  complete; its first TestPyPI run therefore spent setup time and failed only
+  when release tests evaluated the dated metadata contract.
+- Post-review metadata changes were not recognized as an exact-candidate-safe
+  packet, so they forced another candidate/hosted verification cycle.
+- Candidate bumps retained the prior version's published citation date and
+  authorized message, and `release run` repeated broad suites before mutating
+  the versioned files.
+- Public verification repeated the full installed-package UAT already proven
+  by the publication workflow and failed once while the PyPI simple index was
+  still propagating the exact version.
+- The focused release batch found one stale regression that still required
+  both `release run` and frozen preflight to provision React dependencies.
+
+### Root causes and resolutions
+
+- Confirmed root cause: shell process working directories are fixed when each
+  command starts. Resolution: run every subsequent command with the fresh
+  worktree as its explicit working directory. Proof: `git_state.py --json
+  --worktrees` reports `codex/release-smoothness` at exact `origin/main` with no
+  operation. ⚠️ TERMINAL ISSUE: session start initially ran in the primary
+  checkout -> all task writes and validation use the explicit fresh worktree.
+- Confirmed root cause: context areas and workflow names are registry-owned, not
+  inferable. Resolution: read the release-preflight skill and locate the actual
+  `.github/workflows/nightly.yml` and `publish.yml` consumers with targeted
+  `rg`. ⚠️ TERMINAL ISSUE: guessed release context/workflow names were invalid ->
+  used the maintained skill and exact discovered paths.
+- Confirmed root cause: the inline JSON list comprehension closed with a brace,
+  and the same unchecked command was repeated. Resolution: replace that
+  ad-hoc parser with one reviewed `jq` projection. Proof: PyPI reports the exact
+  `0.24.0a1` wheel and sdist hashes. ⚠️ TERMINAL ISSUE: malformed inline Python
+  failed twice -> the bounded `jq` command succeeded once.
+- Confirmed root cause: `authorization-check` evaluated the authorization record
+  but not the final publication surfaces. Resolution: reuse the final
+  authorized publication-surface contract inside that check and lock workflow
+  ordering before release tests. Proof: focused surface and workflow-ordering
+  regressions pass, and the live final-metadata check is green.
+- Confirmed root cause: the post-review exact-candidate allowlist was empty.
+  Resolution: accept only `CITATION.cff`, `CHANGELOG.md`, and
+  `docs/getting-started/releases.md` in addition to the separately governed
+  review/waiver and authorization records; reject every other path. Proof:
+  focused exact-review and owner-waiver candidate regressions pass.
+- Confirmed root cause: the bump script replaced the version but preserved
+  release-final citation state, while `release run` placed broad validation
+  before its mutation. Resolution: strip the release date, restore explicit
+  unpublished-candidate wording, and leave broad validation to one frozen
+  preflight. Proof: focused bump and single-preflight-owner regressions pass.
+- Confirmed root cause: public verification had no identity-only mode or
+  propagation-specific retry boundary. Resolution: install the exact base
+  package, prove its environment/version identity, return before UAT, and retry
+  only recognized missing-version index responses for at most 90 seconds.
+  Proof: focused retry, real-failure, exact-version, and no-UAT regressions pass.
+- Confirmed root cause: the old React-provisioning regression encoded the
+  superseded duplicate owner instead of the intended single frozen-preflight
+  owner. Resolution: change only that expectation to require one call site.
+  Proof: every other focused case passed on the frozen batch, and the one failed
+  regression passes on its exact narrow repair rerun.
+
+### Validation
+
+- The one focused batch covered `test_release_scripts.py`,
+  `test_bump_version_semantics.py`, and `test_ci_workflow_contract.py`. All
+  unaffected cases passed; its one stale React-provisioning ownership assertion
+  was repaired and its exact single-test rerun passed.
+- `./run.sh release publication-surface-check --version 0.24.0a1` passes against
+  the final published metadata without granting authorization.
+- `./run.sh check --quick` passed 10/10 on its first and only run with zero
+  reused checks.
+- The full local suite and Weekly verification were not run because this packet
+  changes release controls, tests, and guidance—not engineering runtime—and the
+  required focused plus quick evidence is green.
+
 ## 2026-08-24 — Session: RELEASE-0240A1 publication
 
 **Agent:** Codex (`ops`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-24 — RELEASE-0240A1 protected Alpha publication
+**Updated:** 2026-08-24 — RELEASE-SMOOTH-001 next-publication controls
 
 ---
 
@@ -69,9 +69,9 @@
 
 ## Current Release
 
-| **Current public release** | v0.23.1a2 | ✅ ALPHA RELEASED — immutable tag/public artifacts recorded; later `main` work is not included |
-| **Release candidate** | v0.24.0a1 | 🧪 RELEASE-0240A1 — owner-waiver candidate `993212fb` passed exact PR/Weekly checks and authorization descendant `b50cc348` passed all target gates; the first TestPyPI rehearsal stopped before build/upload on missing authorized-date metadata, so one release-surface repair candidate, exact hosted checks, authorization rebind, publication, and public UAT remain |
-- **Release evidence:** tag target `09861d3d`; public wheel SHA-256 `279b8270…43a9`; public installed-package UAT green
+| **Current public release** | v0.24.0a1 | ✅ ALPHA RELEASED — immutable tag and GitHub/PyPI artifacts recorded; later `main` work is not included |
+| **Release candidate** | None | Next candidate is not yet selected or authorized |
+- **Release evidence:** tag target `71b70652`; public wheel SHA-256 `b5e0df7b…6201a`; public sdist SHA-256 `8c1d6b76…0a53b`; exact workflow UAT and public identity are green
 - **Strategy:** Incremental micro-releases — each focuses on one quality dimension (tests, API, security, performance)
 - **Focus:** API introspection → security hardening → performance baselines → stabilization
 - **Target:** keep later roadmap work inactive until separately activated
@@ -126,15 +126,14 @@
 
 ## Active
 
-`RELEASE-0240A1` is the active protected Alpha publication task. It preserves
-the frozen `v0.24.0a1` engineering scope while repairing one clean-runner
-classification defect in source-free wheel verification, cross-Python API
-identity drift, and the hosted revalidation of an intentionally historical Git
-handoff receipt. It then requires one successor candidate, PR Gate, exact-head
-Weekly Verification and either independent software acceptance or the owner's
-explicit truthful waiver, followed by exact authorization, protected tag
-publication, and public artifact verification. The owner selected the waiver
-path for this Alpha. Stable/engineering-use wording, INDIA-4 qualified review,
+`RELEASE-SMOOTH-001` is the active release-control task. It converts the
+`v0.24.0a1` delays into a single-candidate next-release flow: fail-fast final
+metadata validation, one bounded post-review packet, clean candidate citation
+state, no broad pre-mutation suite, and public identity-only verification with a
+bounded propagation retry. It does not select, authorize, tag, or publish a new
+version. The focused local release-control batch is green after one exact stale-
+expectation repair, and the one quick gate passed 10/10. Only impact-mapped PR
+checks remain. Stable/engineering-use wording, INDIA-4 qualified review,
 professional approval, later scope, and cleanup remain separate held decisions.
 
 `INDIA-3-IS13920-M0` merged through PR #869 at `b85d514e` with exact

--- a/docs/guidelines/ai-token-efficiency.md
+++ b/docs/guidelines/ai-token-efficiency.md
@@ -206,6 +206,14 @@ controls:
 - if the audited head changes, invalidate the PASS rather than spending another
   hosted run on unaudited work.
 
+For a release, freeze the prepared code candidate before its one exact-head
+Weekly run. After review, one bounded publication packet may change only
+`CITATION.cff`, `CHANGELOG.md`, the append-only release ledger, and the
+authorization evidence while retaining the reviewed Python tree. Run the narrow
+publication-surface and target-authorization checks on that packet; do not rerun
+Weekly verification for those metadata-only changes. The TestPyPI rehearsal and
+tag-triggered production workflow remain distinct publication gates.
+
 Use non-overlapping timing labels: `contract/intake`, `writer implementation +
 focused verification`, `independent local audit`, `writer rework`, `final local
 closeout`, `hosted/network wait`, and `merge + post-merge verification`. Report

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,20 +4,20 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-24
-- Focus: Release the bounded `v0.24.0a1` Alpha with exact-candidate hosted
-- Git receipt: docs/verification/release-0240a1-git-handoff-receipt-4.json | sha256:c9b09ca99c04eafc354c2b30c753692d74201193856b9f62ee74794521c862a7 | HOLD
-- Git identity: codex/release-0240a1-publication@b50cc3480efb56dccb53d4648b1c3aced16dca05 | upstream=origin/codex/release-0240a1-publication@b50cc3480efb56dccb53d4648b1c3aced16dca05 | base=origin/main@510163041fec4329b5b47ea749a5f8d74bab12b3 | tree=dirty | operation=none
+- Focus: Make the next publication single-candidate, fail-early, and free of duplicate broad validation
+- Git receipt: docs/verification/release-smooth-001-git-handoff-receipt.json | sha256:cff5d30385815d5a9f2b293743b2aa67ac2bd1d366fcae81a59bc98545c81fd5 | HOLD
+- Git identity: codex/release-smoothness@71b7065216d4266d63ad6b31bd39bba81fa16efc | upstream=origin/main@71b7065216d4266d63ad6b31bd39bba81fa16efc | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=UNKNOWN
-- Next action: IMPLEMENT_TRUTHFUL_OWNER_INDEPENDENT_REVIEW_WAIVER_GATE
+- Next action: FREEZE_COMMIT_AND_PUBLISH_ONE_CONTROL_PR
 <!-- HANDOFF:END -->
 
 ## Latest Handoff
 
 | State | Boundary |
 |---|---|
-| **Current** | Owner-waiver candidate `993212fb` passed exact PR run 32732480794 and Weekly run 32732644271; authorization descendant `b50cc348` passed all three target checks, then TestPyPI run 32733403735 stopped before build/upload because authorized release dates were absent from `CITATION.cff` and `CHANGELOG.md` |
-| **Decision** | The user authorized bounded `v0.24.0a1` Alpha publication and explicitly waived independent exact-candidate software review. The evidence must state that no independent review occurred; stable/engineering-use wording, INDIA-4 qualified review, and professional approval remain false |
-| **Next** | Freeze the two-surface release-metadata repair plus task handoff, run only its affected/consolidated local gate and required exact PR/Weekly checks, rebind the authorization-only descendant, then resume TestPyPI, merge, tag, publish, and verify public artifacts |
+| **Current** | `v0.24.0a1` is released from tag `71b70652`; GitHub and PyPI expose the same exact wheel and sdist hashes. `RELEASE-SMOOTH-001` focused release-control evidence is green after one exact stale-expectation repair, and its one quick gate passed 10/10 |
+| **Decision** | The next publish uses one prepared candidate and one exact PR/Weekly run. After review, only one bounded metadata/authorization packet is allowed; authorization must validate final metadata before release tests, and public verification reuses exact workflow UAT instead of repeating it |
+| **Next** | Freeze the candidate commit and publish one normal control PR with impact-mapped hosted checks only; do not run Weekly or a broad local suite |
 | **Source** | IS 13920:2016 First Revision plus Amendment 1 (2017) and Amendment 2 (2020); reaffirmation is not a new edition and the draft successor is unused |
 | **Held** | Beam provided-reinforcement compliance, column derived applicability/non-rectangular/provided-longitudinal checks, whole-joint assessment, walls/foundations, IS 875/1893, INDIA-4 qualified review, source/distribution/support/version/release/professional-use changes, and branch/worktree/archive/source/alias deletion |
 
@@ -42,17 +42,21 @@
 
 ## Ordered follow-on gates
 
-1. Freeze one successor `RELEASE-0240A1` repair candidate, pass its consolidated
-   local/PR gates, then run Weekly Verification once on that exact head. Do not
-   delete any branch, worktree, archive, source copy, alias, or unrelated lane.
-2. Bind the owner's explicit independent-review waiver, the exact candidate, and
-   both hosted PASS runs in an authorization-only descendant; do not claim that
-   an independent review occurred.
-3. Publish `v0.24.0a1` only after those gates pass and verify PyPI, GitHub
-   Release assets, clean installation, and installed-package UAT.
-4. Keep benchmark replay separate from engineering check and qualified review;
+1. Merge `RELEASE-SMOOTH-001` only after its one focused local batch, one quick
+   gate, and impact-mapped PR checks pass. Do not run Weekly for this
+   release-control-only packet.
+2. For the next selected release, freeze one prepared candidate and run its PR
+   and Weekly verification once on the exact head.
+3. After exact review or truthful waiver, create one bounded final metadata and
+   authorization packet; do not rerun Weekly unless a non-allowlisted path or
+   Python content changes.
+4. Let TestPyPI and production publication workflows retain their distinct
+   protected checks. After matching public hashes to the workflow manifest, run
+   public identity-only verification; run full public UAT only if exact workflow
+   evidence is missing or identity differs.
+5. Keep benchmark replay separate from engineering check and qualified review;
    keep stable/engineering-use wording and professional approval held.
-5. Conduct INDIA-4 qualified review before any stable or engineering-use claim,
+6. Conduct INDIA-4 qualified review before any stable or engineering-use claim,
    then expand in order: IS 13920 walls, foundations, IS 875, then IS 1893.
 
 ## Required Reading

--- a/docs/verification/release-smooth-001-git-handoff-receipt.json
+++ b/docs/verification/release-smooth-001-git-handoff-receipt.json
@@ -1,0 +1,176 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-24T14:00:00Z",
+      "query_status": "OK",
+      "reference": "now based on this experience please make sure next publish will be really smooth.",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "IMPLEMENT_RELEASE_PROCESS_CONTROLS",
+      "RUN_ONE_FOCUSED_TEST_BATCH_AND_ONE_QUICK_GATE",
+      "CREATE_COMMIT_PUSH_PULL_REQUEST_AND_MERGE_WHEN_REQUIRED_CHECKS_PASS"
+    ],
+    "next_action": "FREEZE_RELEASE_CONTROL_CANDIDATE",
+    "observed_at_utc": "2026-08-24T14:00:00Z",
+    "prohibited_actions": [
+      "SELECT_BUMP_TAG_OR_PUBLISH_A_NEW_VERSION",
+      "RERUN_UNCHANGED_BROAD_OR_WEEKLY_SUITES",
+      "DELETE_RESET_STASH_CLEAN_REBASE_REWRITE_FORCE_PUSH_OR_BYPASS_CHECKS",
+      "CHANGE_STRUCTURAL_FORMULAS_OR_DECLARED_ENGINEERING_SCOPE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "IMPLEMENT_RELEASE_PROCESS_CONTROLS",
+        "RUN_ONE_FOCUSED_TEST_BATCH_AND_ONE_QUICK_GATE",
+        "CREATE_COMMIT_PUSH_PULL_REQUEST_AND_MERGE_WHEN_REQUIRED_CHECKS_PASS"
+      ],
+      "branch": "codex/release-smoothness",
+      "head_sha": "71b7065216d4266d63ad6b31bd39bba81fa16efc",
+      "task_id": "RELEASE-SMOOTH-001"
+    }
+  },
+  "holds": [
+    "AUTHORIZATION_SOURCE_STALE_EVIDENCE",
+    "AUTHORIZATION_STALE_EVIDENCE",
+    "LOCAL_HOLD_DIRTY",
+    "NEXT_ACTION_NOT_AUTHORIZED",
+    "PRESERVE_ALL_HISTORICAL_RELEASE_AND_ENGINEERING_LANES",
+    "PRESERVE_ALL_PRE_EXISTING_DIRTY_DETACHED_DIVERGENT_AND_UNKNOWN_LANES",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_STALE_EVIDENCE",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_FINAL_CANDIDATE",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "cff5d30385815d5a9f2b293743b2aa67ac2bd1d366fcae81a59bc98545c81fd5",
+    "state": {
+      "branch": "codex/release-smoothness",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "71b7065216d4266d63ad6b31bd39bba81fa16efc",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 112.781,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/release-smoothness",
+      "head_sha": "71b7065216d4266d63ad6b31bd39bba81fa16efc",
+      "hold_reasons": [
+        "changed paths: 13"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-24T14:20:06.310077+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/release-smoothness",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 13,
+        "modified_paths": [
+          ".github/skills/release-preflight/SKILL.md",
+          ".github/workflows/README.md",
+          "Python/tests/test_bump_version_semantics.py",
+          "Python/tests/test_ci_workflow_contract.py",
+          "Python/tests/test_release_scripts.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/guidelines/ai-token-efficiency.md",
+          "docs/planning/next-session-brief.md",
+          "run.sh",
+          "scripts/bump_version.py",
+          "scripts/release.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/release-smooth-001-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "71b7065216d4266d63ad6b31bd39bba81fa16efc",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/release-smoothness"
+    }
+  },
+  "local_state_receipt_hash": "sha256:cff5d30385815d5a9f2b293743b2aa67ac2bd1d366fcae81a59bc98545c81fd5",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-24T14:20:06.310227+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "evidence_error": "STALE_EVIDENCE",
+    "holds": [
+      "PRESERVE_ALL_PRE_EXISTING_DIRTY_DETACHED_DIVERGENT_AND_UNKNOWN_LANES",
+      "PRESERVE_ALL_HISTORICAL_RELEASE_AND_ENGINEERING_LANES"
+    ],
+    "observed_at_utc": "2026-08-24T14:00:00Z",
+    "owner": "Main Agent under repository preservation policy",
+    "query_status": "UNKNOWN",
+    "status": "UNKNOWN"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources"
+    ],
+    "integration_owner": "orchestrator",
+    "owned_paths": [
+      "scripts/release.py",
+      "scripts/bump_version.py",
+      "run.sh",
+      "Python/tests/test_release_scripts.py",
+      "Python/tests/test_bump_version_semantics.py",
+      "Python/tests/test_ci_workflow_contract.py",
+      ".github/workflows/README.md",
+      ".github/skills/release-preflight/SKILL.md",
+      "docs/guidelines/ai-token-efficiency.md",
+      "docs/verification/release-smooth-001-git-handoff-source-evidence.json",
+      "docs/verification/release-smooth-001-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "RELEASE-SMOOTH-001"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/release-smooth-001-git-handoff-source-evidence.json
+++ b/docs/verification/release-smooth-001-git-handoff-source-evidence.json
@@ -1,0 +1,55 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-24T14:00:00Z",
+      "query_status": "OK",
+      "reference": "now based on this experience please make sure next publish will be really smooth.",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "IMPLEMENT_RELEASE_PROCESS_CONTROLS",
+      "RUN_ONE_FOCUSED_TEST_BATCH_AND_ONE_QUICK_GATE",
+      "CREATE_COMMIT_PUSH_PULL_REQUEST_AND_MERGE_WHEN_REQUIRED_CHECKS_PASS"
+    ],
+    "next_action": "FREEZE_RELEASE_CONTROL_CANDIDATE",
+    "observed_at_utc": "2026-08-24T14:00:00Z",
+    "prohibited_actions": [
+      "SELECT_BUMP_TAG_OR_PUBLISH_A_NEW_VERSION",
+      "RERUN_UNCHANGED_BROAD_OR_WEEKLY_SUITES",
+      "DELETE_RESET_STASH_CLEAN_REBASE_REWRITE_FORCE_PUSH_OR_BYPASS_CHECKS",
+      "CHANGE_STRUCTURAL_FORMULAS_OR_DECLARED_ENGINEERING_SCOPE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "IMPLEMENT_RELEASE_PROCESS_CONTROLS",
+        "RUN_ONE_FOCUSED_TEST_BATCH_AND_ONE_QUICK_GATE",
+        "CREATE_COMMIT_PUSH_PULL_REQUEST_AND_MERGE_WHEN_REQUIRED_CHECKS_PASS"
+      ],
+      "branch": "codex/release-smoothness",
+      "head_sha": "71b7065216d4266d63ad6b31bd39bba81fa16efc",
+      "task_id": "RELEASE-SMOOTH-001"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_FINAL_CANDIDATE",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_FEATURE_BRANCH_AND_WORKTREE",
+    "holds": [
+      "PRESERVE_ALL_PRE_EXISTING_DIRTY_DETACHED_DIVERGENT_AND_UNKNOWN_LANES",
+      "PRESERVE_ALL_HISTORICAL_RELEASE_AND_ENGINEERING_LANES"
+    ],
+    "observed_at_utc": "2026-08-24T14:00:00Z",
+    "owner": "Main Agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -319,14 +319,17 @@ Subcommands:
   checklist                Print release checklist
   permission-check         Verify public-distribution permission record
   footing-inclusion-check  Verify complete footing D1 integration
+  publication-surface-check Validate final dated metadata before authorization
 
 Examples:
   ./run.sh release preflight 0.24.0a1  # Validate an Alpha publication candidate
   ./run.sh release run 0.24.0a1        # Bump to an Alpha publication candidate
   ./run.sh release verify --version 0.24.0a1  # Verify exact release artifact
+  ./run.sh release verify --version 0.24.0a1 --source pypi --identity-only
   ./run.sh release check-docs        # Check version in docs
   ./run.sh release permission-check  # Check standing distribution permission
   ./run.sh release footing-inclusion-check  # Check footing release inclusion
+  ./run.sh release publication-surface-check --version 0.24.0a1
 EOF
 }
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -41,7 +41,13 @@ VERSION_FILES = {
     # Academic citation
     "CITATION.cff": [
         (r"^version: [0-9]+\.[0-9]+\.[0-9]+(?:a[0-9]+)?", "version: {version}"),
-        (r"^date-released: .+", "date-released: {date}"),
+        (r"^date-released: .+\n?", ""),
+        (
+            r"^message: .+",
+            'message: "Prepared Alpha candidate v{version}; not tagged or published. '
+            "Case-qualified workflows still require independent verification and "
+            'qualified professional review for engineering use."',
+        ),
     ],
     # FastAPI backend version
     "fastapi_app/__init__.py": [

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -27,6 +27,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 import tomllib
 import zipfile
 from pathlib import Path
@@ -82,7 +83,11 @@ _REQUIRED_NORMALIZED_CONTENT = {
 
 _GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
-_POST_REVIEW_EVIDENCE_PATHS: set[str] = set()
+_POST_REVIEW_EVIDENCE_PATHS = {
+    "CHANGELOG.md",
+    "CITATION.cff",
+    "docs/getting-started/releases.md",
+}
 
 
 def _public_distribution_permission_errors(path: Path | None = None) -> list[str]:
@@ -689,6 +694,7 @@ def cmd_authorization_check(args: argparse.Namespace) -> int:
 
     version = args.version or _version_from_pyproject()
     errors = _release_publication_authorization_errors(version, args.target)
+    errors.extend(_publication_surface_errors(version))
     if errors:
         _print_version_errors(errors)
         return 1
@@ -698,6 +704,19 @@ def cmd_authorization_check(args: argparse.Namespace) -> int:
         "Python tree verified"
     )
     print("  ✓ Authorization does not imply professional approval")
+    return 0
+
+
+def cmd_publication_surface_check(args: argparse.Namespace) -> int:
+    """Validate final publication metadata without requiring a clean commit."""
+
+    version = args.version or _version_from_pyproject()
+    errors = _publication_surface_errors(version)
+    if errors:
+        _print_version_errors(errors)
+        return 1
+    print(f"  ✓ v{version} publication metadata is complete and internally consistent")
+    print("  ✓ This check does not grant publication authorization")
     return 0
 
 
@@ -878,7 +897,10 @@ def _release_authorization_recorded(expected: str) -> bool:
 
 
 def _source_surface_version_errors(
-    expected: str, *, allow_authorized_release: bool = False
+    expected: str,
+    *,
+    allow_authorized_release: bool = False,
+    authorized_release: bool | None = None,
 ) -> list[str]:
     """Return exact source/doc version contradictions for a release candidate."""
     try:
@@ -921,9 +943,10 @@ def _source_surface_version_errors(
     changelog_text = CHANGELOG.read_text(encoding="utf-8")
     release_text = RELEASES.read_text(encoding="utf-8")
     has_release_date = bool(re.search(r"^date-released:", citation_text, re.MULTILINE))
-    authorization_recorded = _release_authorization_recorded(expected)
+    if authorized_release is None:
+        authorized_release = _release_authorization_recorded(expected)
 
-    if allow_authorized_release and authorization_recorded:
+    if allow_authorized_release and authorized_release:
         if not has_release_date:
             errors.append(
                 "CITATION.cff must declare date-released for an authorized release"
@@ -966,6 +989,16 @@ def _source_surface_version_errors(
             errors.append(f"CITATION.cff must not imply v{expected} is published")
 
     return errors
+
+
+def _publication_surface_errors(expected: str) -> list[str]:
+    """Return final metadata errors as if owner authorization were recorded."""
+
+    return _source_surface_version_errors(
+        expected,
+        allow_authorized_release=True,
+        authorized_release=True,
+    )
 
 
 def _wheel_metadata_version(wheel: Path) -> str:
@@ -1333,15 +1366,25 @@ def _print_checklist(version: str) -> None:
     print("  ✓ Doc version references synced")
     print("  ✓ Doc dates updated to today")
     print()
-    print("Manual steps (you must do these):")
+    print("Ordered release steps (one verification cycle per state):")
     print(
-        f"  [ ] 1. Edit CHANGELOG.md — Add release notes under [Unreleased] → [{version}]"
+        f"  [ ] 1. Complete the prepared [{version}] CHANGELOG and release-ledger entry"
     )
-    print("  [ ] 2. Edit docs/getting-started/releases.md — Add release entry")
-    print("  [ ] 3. Review changes: git diff")
-    print(f"  [ ] 4. Codex commit and PR update: 'chore: release v{version}'")
-    print(f"  [ ] 5. Tag and push: git tag v{version} && git push origin v{version}")
-    print("  [ ] 6. Monitor GitHub Actions → Publish to PyPI workflow")
+    print("  [ ] 2. Freeze content, build one exact wheel, and run preflight once")
+    print(
+        "  [ ] 3. Push once; pass required PR and Weekly checks on that exact candidate"
+    )
+    print("  [ ] 4. Record the independent review decision or explicit owner waiver")
+    print(
+        "  [ ] 5. In one publication packet, date CITATION/CHANGELOG, append the "
+        "authorized ledger entry, and record owner authorization"
+    )
+    print(
+        f"  [ ] 6. Run: ./run.sh release publication-surface-check --version {version}"
+    )
+    print("  [ ] 7. Commit the packet; run authorization-check for each target")
+    print("  [ ] 8. Rehearse TestPyPI, merge with candidate ancestry, then tag once")
+    print("  [ ] 9. Monitor the tag-triggered PyPI and GitHub prerelease workflow")
     print()
     print("Verification:")
     print(f"  [ ] Check PyPI: pip install structural-lib-is456=={version}")
@@ -1452,89 +1495,10 @@ def cmd_run(args: argparse.Namespace) -> int:
     except (ValueError, IndexError):
         print(f"  WARNING: Could not compare versions ({current_version} → {version})")
 
-    # Run tests
-    print("\n  Running Python tests...")
-    try:
-        test_result = _run_with_timeout(
-            [
-                sys.executable,
-                "-m",
-                "pytest",
-                "Python/tests/",
-                "-v",
-                "--tb=short",
-                "-q",
-                "-m",
-                "not slow",
-            ],
-            timeout=600,
-        )
-    except subprocess.TimeoutExpired:
-        print("  ERROR: Tests TIMED OUT (>600s)")
-        if not dry_run:
-            return 1
-        print("  (continuing in dry-run mode)")
-        test_result = None
-
-    if test_result is None:
-        pass
-    elif test_result.returncode != 0:
-        print("  ERROR: Tests failed! Fix failures before releasing.")
-        print(
-            test_result.stdout[-500:]
-            if len(test_result.stdout) > 500
-            else test_result.stdout
-        )
-        if not dry_run:
-            return 1
-        print("  (continuing in dry-run mode)")
-    else:
-        # Extract test count from output
-        lines = test_result.stdout.strip().split("\n")
-        summary = lines[-1] if lines else "tests passed"
-        print(f"  ✓ Tests: {summary}")
-
-    # Check React build
-    react_dir = REPO_ROOT / "react_app"
-    if react_dir.exists():
-        print("  Checking React build...")
-        node_env, node_version = _node_runtime_env()
-        if node_env is None:
-            print(f"  ERROR: {node_version}")
-            return 1
-        node_env["NODE_OPTIONS"] = "--max-old-space-size=1536"
-        print(f"  → Selected {node_version}")
-        if not _ensure_react_dependencies(react_dir, node_env):
-            print("  ERROR: React dependencies are unavailable")
-            return 1
-        try:
-            react_result = _run_with_timeout(
-                ["npm", "run", "build"],
-                timeout=300,
-                cwd=react_dir,
-                env=node_env,
-            )
-        except subprocess.TimeoutExpired:
-            print("  ERROR: React build TIMED OUT (>300s)")
-            if not dry_run:
-                return 1
-            print("  (continuing in dry-run mode)")
-            react_result = None
-
-        if react_result is None:
-            pass
-        elif react_result.returncode != 0:
-            print("  ERROR: React build failed!")
-            print(
-                react_result.stderr[-500:]
-                if len(react_result.stderr) > 500
-                else react_result.stderr
-            )
-            if not dry_run:
-                return 1
-            print("  (continuing in dry-run mode)")
-        else:
-            print("  ✓ React build succeeds")
+    print(
+        "  ✓ No unchanged broad suites rerun before the version mutation; "
+        "the frozen candidate preflight owns Python, FastAPI, React, and wheel evidence"
+    )
 
     print()
 
@@ -1588,6 +1552,7 @@ def _assert_package_import_from_venv(
     venv_dir: Path,
     clean_env: dict[str, str],
     cwd: Path,
+    expected_version: str | None = None,
 ) -> None:
     """Fail if the verification interpreter imports the checkout instead of its venv."""
     _run_check(
@@ -1609,8 +1574,14 @@ def _assert_package_import_from_venv(
                 "    raise RuntimeError(\n"
                 "        f'structural_lib imported from {package_file}, not {site_packages}'\n"
                 "    )\n"
+                "installed_version = api.get_library_version()\n"
+                f"expected_version = {expected_version!r}\n"
+                "if expected_version is not None and installed_version != expected_version:\n"
+                "    raise RuntimeError(\n"
+                "        f'installed package version {installed_version}, expected {expected_version}'\n"
+                "    )\n"
                 "print(package_file)\n"
-                "print(api.get_library_version())"
+                "print(installed_version)"
             ),
         ],
         cwd=cwd,
@@ -1667,9 +1638,61 @@ def _find_wheel(wheel_dir: Path, version: str | None) -> Path:
     return wheels[0]
 
 
+_PYPI_PROPAGATION_RETRY_MARKERS = (
+    "No matching distribution found",
+    "Could not find a version that satisfies the requirement",
+)
+
+
+def _run_pypi_install_with_retry(
+    cmd: list[str],
+    *,
+    env: dict[str, str],
+    wait_seconds: int,
+) -> None:
+    """Retry only the exact-version install while PyPI propagates its index."""
+    if wait_seconds < 0:
+        raise ValueError("PyPI index wait must be non-negative")
+
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        print(f"+ {' '.join(str(part) for part in cmd)}")
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=600,
+        )
+        if result.returncode == 0:
+            return
+
+        detail = f"{result.stdout}\n{result.stderr}"
+        remaining = deadline - time.monotonic()
+        propagation_pending = any(
+            marker in detail for marker in _PYPI_PROPAGATION_RETRY_MARKERS
+        )
+        if not propagation_pending or remaining <= 0:
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                cmd,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+
+        delay = min(10.0, remaining)
+        print(
+            "  PyPI has not indexed the exact version yet; "
+            f"waiting {delay:g}s before retrying the install only."
+        )
+        time.sleep(delay)
+
+
 def cmd_verify(args: argparse.Namespace) -> int:
     wheel_dir = REPO_ROOT / args.wheel_dir
     job_path = REPO_ROOT / args.job
+    identity_only = getattr(args, "identity_only", False)
+    index_wait_seconds = getattr(args, "index_wait_seconds", 90)
 
     with tempfile.TemporaryDirectory(prefix="verify_release_") as tmp:
         venv_dir = Path(tmp) / "venv"
@@ -1687,12 +1710,17 @@ def cmd_verify(args: argparse.Namespace) -> int:
 
         if args.source == "wheel":
             wheel = _find_wheel(wheel_dir, args.version)
+            wheel_target = str(wheel)
+            install_dependencies: list[str] = []
+            if not identity_only:
+                wheel_target = f"{wheel}[dev,validation]"
+                install_dependencies = ["httpx>=0.27"]
             _run_check(
                 [
                     str(pip),
                     "install",
-                    f"{wheel}[dev,validation]",
-                    "httpx>=0.27",
+                    wheel_target,
+                    *install_dependencies,
                 ],
                 env=clean_env,
             )
@@ -1700,21 +1728,42 @@ def cmd_verify(args: argparse.Namespace) -> int:
             if not args.version:
                 print("error: --version is required when using --source pypi")
                 return 2
-            _run_check(
+            package_target = f"structural-lib-is456==={args.version}"
+            install_dependencies = []
+            if not identity_only:
+                package_target = (
+                    f"structural-lib-is456[dev,validation]==={args.version}"
+                )
+                install_dependencies = ["httpx>=0.27"]
+            _run_pypi_install_with_retry(
                 [
                     str(pip),
                     "install",
                     "--no-cache-dir",
                     "--index-url",
                     "https://pypi.org/simple/",
-                    f"structural-lib-is456[dev,validation]==={args.version}",
-                    "httpx>=0.27",
+                    package_target,
+                    *install_dependencies,
                 ],
                 env=clean_env,
+                wait_seconds=index_wait_seconds,
             )
 
         temp_root = venv_dir.parent
-        _assert_package_import_from_venv(python, venv_dir, clean_env, temp_root)
+        _assert_package_import_from_venv(
+            python,
+            venv_dir,
+            clean_env,
+            temp_root,
+            expected_version=args.version,
+        )
+
+        if identity_only:
+            print(
+                "Release artifact identity verification OK "
+                "(installed-package UAT was not rerun)."
+            )
+            return 0
 
         # Run core tests
         print("\nRunning core tests in clean venv...")
@@ -1739,7 +1788,13 @@ def cmd_verify(args: argparse.Namespace) -> int:
             cwd=temp_root,
             env=clean_env,
         )
-        _assert_package_import_from_venv(python, venv_dir, clean_env, temp_root)
+        _assert_package_import_from_venv(
+            python,
+            venv_dir,
+            clean_env,
+            temp_root,
+            expected_version=args.version,
+        )
 
         if not args.skip_cli:
             if not job_path.exists():
@@ -2382,6 +2437,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_verify.add_argument(
         "--skip-cli", action="store_true", help="Skip CLI smoke checks"
     )
+    p_verify.add_argument(
+        "--identity-only",
+        action="store_true",
+        help=(
+            "Verify exact installed package identity without repeating the "
+            "already-passed installed-package UAT"
+        ),
+    )
+    p_verify.add_argument(
+        "--index-wait-seconds",
+        type=int,
+        default=90,
+        help="Maximum bounded wait for exact-version PyPI index propagation",
+    )
 
     # check-docs
     sub.add_parser("check-docs", help="Validate CHANGELOG ↔ releases.md versions")
@@ -2410,6 +2479,12 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         choices=["testpypi", "pypi", "github-release"],
     )
+
+    p_publication_surfaces = sub.add_parser(
+        "publication-surface-check",
+        help="Validate final dated release metadata before authorization commit",
+    )
+    p_publication_surfaces.add_argument("--version", help="Exact package version")
 
     # preflight
     p_preflight = sub.add_parser("preflight", help="Run pre-release validation checks")
@@ -2463,6 +2538,7 @@ def main() -> int:
         "permission-check": cmd_permission_check,
         "footing-inclusion-check": cmd_footing_inclusion_check,
         "authorization-check": cmd_authorization_check,
+        "publication-surface-check": cmd_publication_surface_check,
         "preflight": cmd_preflight,
         "candidate-check": cmd_candidate_check,
     }


### PR DESCRIPTION
## Outcome

Makes the next release a single-candidate, fail-early flow based on the v0.24.0a1 publication experience.

- validates final dated publication metadata before expensive release tests
- permits one bounded post-review metadata and authorization packet without invalidating the reviewed Python tree
- resets published citation state when preparing a new candidate
- removes duplicate broad validation before the version mutation
- adds exact public-package identity verification with a bounded PyPI propagation retry
- updates the maintained release workflow and efficiency contracts

## Validation

- focused release, bump, and publication-workflow tests: green after one exact stale-expectation repair
- `./run.sh release publication-surface-check --version 0.24.0a1`: pass
- `./run.sh check --quick`: 10/10 pass
- normal commit hooks: pass
- full local suites and Weekly were intentionally not run because this packet changes release controls and guidance, not engineering runtime

No new version, tag, package publication, engineering-scope change, or professional-approval claim is included.