### PR TITLE
chore(maintenance): freeze cleanup preservation evidence

### DIFF
--- a/Python/tests/test_cleanup_preservation.py
+++ b/Python/tests/test_cleanup_preservation.py
@@ -1,0 +1,135 @@
+"""Focused tests for fail-closed cleanup preservation evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_only
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+cleanup = importlib.import_module("scripts._lib.cleanup_preservation")
+
+
+def _worktree(path: Path, *, dirty_count: int = 0) -> dict[str, object]:
+    return {"path": str(path), "dirty_count": dirty_count}
+
+
+def test_worktree_dispositions_fail_closed(tmp_path: Path):
+    current = tmp_path / "current"
+    primary = tmp_path / "primary"
+    dirty = tmp_path / "dirty"
+    other = tmp_path / "other"
+
+    assert (
+        cleanup.classify_worktree(
+            _worktree(current),
+            current_path=current,
+            primary_path=primary,
+            dirty_path=dirty,
+        )[0]
+        == "RETAIN_CURRENT_TASK"
+    )
+    assert (
+        cleanup.classify_worktree(
+            _worktree(primary),
+            current_path=current,
+            primary_path=primary,
+            dirty_path=dirty,
+        )[0]
+        == "RETAIN_INTEGRATION_ANCHOR"
+    )
+    assert (
+        cleanup.classify_worktree(
+            _worktree(dirty, dirty_count=1),
+            current_path=current,
+            primary_path=primary,
+            dirty_path=dirty,
+        )[0]
+        == "RETAIN_DIRTY_UNIQUE"
+    )
+    assert (
+        cleanup.classify_worktree(
+            _worktree(other),
+            current_path=current,
+            primary_path=primary,
+            dirty_path=dirty,
+        )[0]
+        == "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED"
+    )
+
+
+def test_cache_candidates_exclude_primary_current_and_dirty(tmp_path: Path):
+    current = tmp_path / "current"
+    primary = tmp_path / "primary"
+    other = tmp_path / "other"
+
+    assert (
+        cleanup.classify_cache(
+            worktree_path=primary,
+            current_path=current,
+            primary_path=primary,
+            dirty=False,
+        )[0]
+        == "RETAIN_PRIMARY_RUNTIME"
+    )
+    assert (
+        cleanup.classify_cache(
+            worktree_path=current,
+            current_path=current,
+            primary_path=primary,
+            dirty=False,
+        )[0]
+        == "RETAIN_CURRENT_TASK_RUNTIME"
+    )
+    assert (
+        cleanup.classify_cache(
+            worktree_path=other,
+            current_path=current,
+            primary_path=primary,
+            dirty=True,
+        )[0]
+        == "RETAIN_DIRTY_LANE_RUNTIME"
+    )
+    assert (
+        cleanup.classify_cache(
+            worktree_path=other,
+            current_path=current,
+            primary_path=primary,
+            dirty=False,
+        )[0]
+        == "CACHE_CANDIDATE_NOT_AUTHORIZED"
+    )
+
+
+def test_protected_source_digest_is_deterministic_and_excludes_archives(
+    tmp_path: Path,
+):
+    private_root = tmp_path / "private_sources"
+    (private_root / "library").mkdir(parents=True)
+    (private_root / "library" / "one.bin").write_bytes(b"one")
+    (private_root / "library" / "two.bin").write_bytes(b"two")
+    archive = private_root / "worktree_cleanup_archives" / "packet"
+    archive.mkdir(parents=True)
+    (archive / "ignored.bundle").write_bytes(b"first")
+    pycache = private_root / "library" / "__pycache__"
+    pycache.mkdir()
+    (pycache / "ignored.pyc").write_bytes(b"compiled")
+
+    first = cleanup.protected_source_inventory(private_root)
+    (archive / "ignored.bundle").write_bytes(b"second")
+    second = cleanup.protected_source_inventory(private_root)
+
+    assert first == second
+    assert first["file_count"] == 2
+    assert first["byte_count"] == 6
+    assert first["aggregate_sha256"] != hashlib.sha256(b"").hexdigest()
+    assert first["filenames_recorded"] is False
+    assert first["content_recorded"] is False

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,124 @@
 
 ---
 
+## 2026-08-26 — Session: MAINT-0136 cleanup preservation
+
+**Agent:** Codex (`orchestrator`, sole writer; two prior read-only plan reviews)
+
+**Branch:** `codex/maint-0136-cleanup-preservation`, from exact fetched and
+hosted `origin/main` commit
+`ee04bfbf76b1a3a022d07c8203b5274a0f71998f`.
+
+**Git handoff receipt:**
+`docs/verification/maint-0136-cleanup-preservation-git-handoff-receipt.json`
+
+**Focus:** Execute only the owner-authorized cleanup Phase 0 and Phase 1:
+reconcile the session ledger, inspect current topology, preserve unique work,
+prove local recovery, and freeze a fail-closed manifest without deleting any
+file, cache, worktree, branch, ref, or pull request.
+
+### Summary
+
+- Closed the unmatched `ARCH-FOCUS-REVIEW-001` session against its inspected
+  head with zero mutations, zero verification reruns, zero hosted runs, and no
+  remaining active ledger entry.
+- Created one isolated MAINT-0136 lane from fresh hosted/local `main` identity
+  and froze 73 worktrees: 72 pre-existing, seven detached, and one pre-existing
+  dirty lane. The primary, current task, and dirty lane are retained; all other
+  70 worktrees remain held for owner/retention proof.
+- Froze 83 current local/remote branch or PR heads. `main` and the current task
+  are retained; 81 remain held. Nine current branch rows have open PRs. No old
+  retirement decision was reused as present authority.
+- Measured 17.587 GiB across worktrees and 7.183 GiB of clean-inactive cache
+  candidates. The primary, active, and dirty lanes are excluded, and Phase 2
+  is explicitly not authorized.
+- Preserved a 303-ref complete-history Git bundle and the detached `e54a`
+  session-log patch. A managed temporary clone reproduced the exact dirty file
+  SHA and passed patch preflight, application, and Git integrity checks.
+- Verified an exact temporary copy of the protected-source library while
+  proving the canonical 42-file/72,025,193-byte aggregate remained unchanged.
+  The local recovery directory is ignored and same-disk only; no external
+  destination is available, so disaster-recovery and all cleanup execution
+  remain held.
+
+### Issues encountered
+
+- The inherited ledger contained one unmatched historical session, preventing
+  a trustworthy new-session baseline.
+- The primary `main` checkout was clean but behind the freshly observed hosted
+  `main`, and it owns ignored protected sources that must not be moved or lost.
+- The first combined recovery-proof command was rejected before execution
+  because its temporary-directory trap contained an `rm -rf` cleanup.
+- Repeated runs of the private library's nominal `verify` command changed the
+  canonical SQLite database hash even though the logical verification passed.
+- Time Machine reports no configured destination and no external/off-device
+  recovery volume is available.
+- The first staged diff check rejected the new planning document because it
+  contained one extra blank line at end of file.
+- The first normal commit hook rejected the new top session entry because the
+  inherited next-session briefing still identified 2026-08-24 as its latest
+  handoff date.
+
+### Root causes and resolutions
+
+- Confirmed root cause: `ARCH-FOCUS-REVIEW-001` had a recorded start but no
+  closeout. Resolution: close it truthfully with the inspected head and zero
+  candidate/retry/hosted counters; `session usage --active --json` then returned
+  `null`.
+- Confirmed root cause: the primary checkout intentionally remained on older
+  commit `e2fac741` while hosted `main` advanced to `ee04bfbf`; updating it
+  would mix cleanup work with the protected-source owner lane. Resolution:
+  fetch without prune and create the isolated MAINT-0136 worktree directly
+  from exact `origin/main`; `git_state.py` reported `READY_LOCAL` and the
+  runtime reported `source_bound=true`.
+- Confirmed root cause: destructive-looking shell cleanup is rejected even
+  when aimed at a temporary directory. Resolution: split bundle creation from
+  restore proof and use Python-managed temporary directories that remove
+  themselves. The rejected command created no files. ⚠️ TERMINAL ISSUE:
+  recovery proof rejected due to an `rm`-style temp trap -> reran through a
+  managed temporary directory.
+- Confirmed root cause: the private verifier opens the canonical database in
+  writable WAL mode, executes schema initialization, writes `PRAGMA
+  user_version`, and commits on every verification. Repeated inspection proved
+  the database byte hash changed on each run. Resolution: copy the exact
+  private library into a temporary ignored sibling, run the maintained verifier
+  there, remove the copy automatically, and compare canonical aggregate
+  digests before/after. Verification passes and the canonical digest remains
+  unchanged during the final proof.
+- Confirmed root cause: no Time Machine target or external volume is
+  configured. Resolution: label the verified bundle/patch as same-disk local
+  recovery only and retain `HOLD_DESTINATION_UNAVAILABLE`; never promote it to
+  disaster-recovery evidence or authorize Phase 2 from it.
+- Confirmed root cause: the plan's initial patch left two newline records after
+  its final sentence. Resolution: remove only the extra blank line, restage the
+  plan and session record, and rerun the affected diff/document checks. This
+  formatting-only repair does not change evidence or outcomes.
+- Confirmed root cause: the session consistency check derives the expected top
+  log date from `next-session-brief.md`; MAINT-0136 had changed task state but
+  had not yet refreshed that maintained handoff. Resolution: add the briefing
+  to the receipt's owned/shared paths and run the canonical `session handoff`
+  update. The current 2026-08-26 handoff now embeds the exact receipt identity.
+
+### Validation through content freeze
+
+- The three cleanup-preservation regressions plus the complete existing Git
+  state and branch-disposition focused suites pass. Changed Python files also
+  pass Ruff and Black.
+- Documentation front matter passes for 361 maintained documents with zero
+  invalid records; 486 maintained Markdown files, 1,015 local links, and six
+  local images pass with zero broken links.
+- Context validation passes with ten areas and zero generated folder indexes;
+  the control plane passes 115 operations and 101/101 scripts; token-efficiency
+  policy and the exact MAINT-0136 evidence invariants pass.
+- Bundle verification, temporary clone, exact-base checkout, patch preflight,
+  patch application, restored-file SHA equality, and `git fsck --full
+  --no-dangling` pass. The protected-source temporary snapshot verifier passes
+  while the canonical aggregate remains unchanged.
+- The one consolidated quick gate, normal commit hooks, immutable candidate
+  audit, push, and required hosted checks remain the closeout sequence. Broad
+  engineering suites are not independently selected by this preservation-only
+  packet unless impact routing requires them.
+
 ## 2026-08-24 — Session: RELEASE-SMOOTH-001 next-publication controls
 
 **Agent:** Codex (`ops`, sole writer; no subagents)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-24 — RELEASE-SMOOTH-001 next-publication controls
+**Updated:** 2026-08-26 — MAINT-0136 cleanup preservation
 
 ---
 
@@ -125,6 +125,16 @@
 ---
 
 ## Active
+
+`MAINT-0136` executes only the owner-authorized cleanup Phase 0 and Phase 1.
+The unmatched historical session is reconciled; the fresh live manifest holds
+70 of 73 worktrees and 81 of 83 current local/remote branch or PR heads while
+retaining the primary checkout, current task, dirty detached lane, and default
+branch. A 303-ref Git bundle and the dirty patch pass a sampled restore, and an
+exact temporary protected-source copy verifies without changing the canonical
+aggregate. Same-disk recovery is not disaster recovery: no external
+destination is available, and the 7.183 GiB clean-inactive cache ceiling plus
+all worktree/branch/ref cleanup remain Phase 2 candidates without authority.
 
 `RELEASE-SMOOTH-001` is the active release-control task. It converts the
 `v0.24.0a1` delays into a single-candidate next-release flow: fail-fast final

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -5,7 +5,7 @@
 **Status:** Production Ready
 **Importance:** High
 **Created:** 2025-01-01
-**Last Updated:** 2026-08-17
+**Last Updated:** 2026-08-26
 
 ---
 
@@ -19,6 +19,7 @@ Internal planning documents and research notes.
 |----------|---------|
 | [Next Session Brief](next-session-brief.md) | What to work on next |
 | [TASKS.md](../TASKS.md) | Canonical task backlog |
+| [MAINT-0136 Cleanup Preservation](maint-0136-cleanup-preservation-plan.md) | Current topology, verified local recovery, and fail-closed Phase 2 gate |
 | [MAINT-0133 Cleanup Completion](maint-0133-cleanup-inventory-and-authorization.md) | Exact inventory, four retained holds, and the owner-authorized two-move Packet A result |
 | [Pre-Release Input Safety and Professional Readiness Plan](pre-release-input-safety-and-professional-readiness-plan.md) | Active contract-first remediation and release holds from the one-storey usability pilot |
 | [Public Route Safety Closure Plan](public-route-safety-closure-plan.md) | Current exact-tree remediation sequence for reproduced lower-level public-route safety defects |
@@ -35,6 +36,7 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
+| `maint-0136-cleanup-preservation-plan.md` | 2026-08-26 | 🚧 Phase 0 reconciled and Phase 1 locally preserved; off-device recovery and all cleanup execution held |
 | `maint-0133-cleanup-inventory-and-authorization.md` | 2026-08-23 | 🚧 Immutable inventory candidate; two moves ready for later authorization, four held, zero deletes |
 | `public-route-safety-closure-plan.md` | 2026-08-22 | ✅ LIB-PRO-003-D local candidate accepted; hosted/exact-tree closure pending; release and professional claims held by PARTIAL readiness |
 | `next-session-brief.md` | 2026-08-22 | 🚧 Publish/validate the immutable Packet D candidate, then resume read-only INDIA-3-G0 |

--- a/docs/planning/maint-0136-cleanup-preservation-plan.md
+++ b/docs/planning/maint-0136-cleanup-preservation-plan.md
@@ -1,0 +1,113 @@
+---
+owner: Main Agent
+status: active
+last_updated: 2026-08-26
+doc_type: spec
+complexity: intermediate
+tags: [maintenance, cleanup, git, preservation, recovery]
+---
+
+# MAINT-0136 Cleanup Preservation Plan
+
+## Decision
+
+The owner authorized Phase 0 and Phase 1 only. Those phases reconcile the
+existing session ledger, inspect current topology, preserve unique work, prove
+local recovery, and freeze an exact manifest. They do not delete a file, cache,
+worktree, branch, remote ref, or pull request.
+
+The machine-readable authorities are:
+
+- [cleanup preservation manifest](../verification/maint-0136-cleanup-preservation-manifest.json);
+- [cleanup recovery evidence](../verification/maint-0136-cleanup-recovery-evidence.json); and
+- the later immutable-candidate
+  `maint-0136-cleanup-preservation-git-handoff-receipt.json`.
+
+Historical cleanup evidence is comparison material only. Its old retirement
+decisions are not promoted to current authority.
+
+## Phase 0 result — ledger reconciliation
+
+The unmatched `ARCH-FOCUS-REVIEW-001` start was closed against its inspected
+head `e2fac7419551988def59101ac63a5f8e491bc7a2`. The closeout truthfully records
+zero mutations, zero verification reruns, zero hosted runs, and all elapsed
+time in contract/intake. The active-session query then returned no unmatched
+session.
+
+## Phase 1 result — current preservation baseline
+
+The frozen baseline was observed on 2026-08-26 from fresh hosted and local
+`main` identity `ee04bfbf76b1a3a022d07c8203b5274a0f71998f`.
+
+| Surface | Observed result | Phase 1 disposition |
+|---|---:|---|
+| Worktrees | 73 total; 72 pre-existing; 7 detached | Primary, current task, and dirty lane retained; 70 held |
+| Dirty worktrees | 2 at freeze; 1 pre-existing | Current task writes retained; detached `e54a` preserved with verified patch |
+| Worktree disk use | 17.587 GiB | Measured only; no removal |
+| Current local/remote branch or PR heads | 83 | `main` and current task retained; 81 held |
+| Remote branch heads | 80 | No remote deletion or prune |
+| Open-PR branch rows | 9 | Preserved; no PR closure |
+| Existing cache paths | 157 / 7.698 GiB | Inventoried only |
+| Clean inactive Phase 2 cache ceiling | 149 / 7.183 GiB | Candidate only; not authorized |
+| Filesystem free space | 27.900 GiB; 87% used | No emergency deletion justified |
+
+The 7.183 GiB Phase 2 ceiling is dominated by 16 inactive
+`react_app/node_modules` directories (6.531 GiB) and 14 inactive
+`.mypy_cache` directories (0.608 GiB). The remaining candidate caches are
+small pytest, Ruff, and React build outputs. The primary runtime, current task
+runtime, and every dirty-lane runtime remain excluded.
+
+## Recovery proof
+
+The same-disk recovery directory is ignored under
+`private_sources/worktree_cleanup_archives/maint-0136-20260826T144500Z`.
+
+- The 40.93 MiB all-ref Git bundle has SHA-256
+  `c57240f207b5730de92b9d27d5d64a819a89e0b0496d92351f4eec580c637dac`,
+  contains 303 refs and complete history, and passes `git bundle verify`.
+- The 7,146-byte detached-worktree patch has SHA-256
+  `cf70f18f57ea3c7e14c85fe06cdd00d0171ac65da42dce08eef6a286b4930394`.
+  A temporary clone checked out its exact base, passed `git apply --check`,
+  applied the patch, passed `git fsck --full --no-dangling`, and reproduced the
+  dirty `docs/SESSION_LOG.md` SHA-256 exactly.
+- The ignored protected-source surface contains 42 files and 72,025,193 bytes
+  outside the recovery/archive and Python-cache exclusions. Zero paths are
+  Git-tracked. An exact temporary copy passes the private library verifier, and
+  the canonical aggregate remains unchanged during that proof.
+
+The recovery directory is on the same physical disk. Time Machine reports no
+configured destination and no external volume is available, so this evidence
+is `LOCAL_RECOVERY_VERIFIED_OFF_DEVICE_HOLD`, not disaster-recovery proof.
+
+## Efficiency and correctness controls
+
+Phase 1 uses one generator and three focused regression tests to keep later
+refreshes deterministic. The collector:
+
+1. consumes the canonical read-only `git_state.py --json --worktrees` result;
+2. refreshes remote heads, hosted `main`, and pull-request associations once;
+3. measures each live worktree and only known cache roots;
+4. fails closed to retention/hold dispositions; and
+5. verifies recovery in managed temporary directories that are removed on
+   exit.
+
+The private verifier initializes and commits its SQLite schema even in
+`verify` mode, which changes database bytes. MAINT-0136 therefore verifies an
+exact temporary copy and proves the canonical aggregate is unchanged, rather
+than running that command against the canonical database during evidence
+freeze.
+
+## Phase 2 gate — not authorized
+
+No cleanup execution may begin from this plan alone. A later Phase 2 requires:
+
+1. a usable encrypted external or off-device recovery destination, or an
+   explicit owner decision accepting the narrower recovery tier;
+2. a fresh topology and current-PR reinspection;
+3. separate owner authorization bound to exact cache/worktree/branch targets;
+4. exclusion of the primary checkout, active task, dirty `e54a` lane, open PRs,
+   unknown owners, protected sources, and shared `.venv`; and
+5. recoverable execution with before/after evidence and no broad `git clean`,
+   reset, force push, ref deletion, or prune.
+
+Until those gates pass, the correct outcome is preservation, not deletion.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -3,12 +3,12 @@
 ## Latest Handoff (auto)
 
 <!-- HANDOFF:START -->
-- Date: 2026-08-24
-- Focus: Make the next publication single-candidate, fail-early, and free of duplicate broad validation
-- Git receipt: docs/verification/release-smooth-001-git-handoff-receipt.json | sha256:cff5d30385815d5a9f2b293743b2aa67ac2bd1d366fcae81a59bc98545c81fd5 | HOLD
-- Git identity: codex/release-smoothness@71b7065216d4266d63ad6b31bd39bba81fa16efc | upstream=origin/main@71b7065216d4266d63ad6b31bd39bba81fa16efc | tree=dirty | operation=none
-- Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=UNKNOWN
-- Next action: FREEZE_COMMIT_AND_PUBLISH_ONE_CONTROL_PR
+- Date: 2026-08-26
+- Focus: Execute only the owner-authorized cleanup Phase 0 and Phase 1:
+- Git receipt: docs/verification/maint-0136-cleanup-preservation-git-handoff-receipt.json | sha256:f86af26a6db44d06ca21b6473184bc1c47b9be33cc448dc89812cde8c6a7bf45 | HOLD
+- Git identity: codex/maint-0136-cleanup-preservation@ee04bfbf76b1a3a022d07c8203b5274a0f71998f | upstream=origin/main@ee04bfbf76b1a3a022d07c8203b5274a0f71998f | base=origin/main@ee04bfbf76b1a3a022d07c8203b5274a0f71998f | tree=dirty | operation=none
+- Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
+- Next action: COMMIT_INTENDED_PATHS
 <!-- HANDOFF:END -->
 
 ## Latest Handoff

--- a/docs/verification/maint-0136-cleanup-preservation-git-handoff-receipt.json
+++ b/docs/verification/maint-0136-cleanup-preservation-git-handoff-receipt.json
@@ -1,0 +1,179 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-26T15:03:08.193998+00:00",
+      "query_status": "OK",
+      "reference": "active Codex task: okay I authorize Phase 0 and Phase 1",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "INSPECT_LIVE_GIT_AND_DISK_STATE",
+      "CREATE_ISOLATED_PHASE_1_WORKTREE",
+      "CREATE_AND_VERIFY_RECOVERY_ARTIFACTS",
+      "FREEZE_PRESERVATION_MANIFEST",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "authorized_phases": [
+      0,
+      1
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-26T15:03:08.193998+00:00",
+    "prohibited_actions": [
+      "DELETE_FILE",
+      "DELETE_CACHE",
+      "REMOVE_WORKTREE",
+      "DELETE_LOCAL_BRANCH",
+      "DELETE_REMOTE_BRANCH",
+      "DELETE_REF",
+      "PRUNE",
+      "GIT_CLEAN",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "INSPECT_LIVE_GIT_AND_DISK_STATE",
+        "CREATE_ISOLATED_PHASE_1_WORKTREE",
+        "CREATE_AND_VERIFY_RECOVERY_ARTIFACTS",
+        "FREEZE_PRESERVATION_MANIFEST",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/maint-0136-cleanup-preservation",
+      "head_sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+      "task_id": "MAINT-0136"
+    }
+  },
+  "holds": [
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "f86af26a6db44d06ca21b6473184bc1c47b9be33cc448dc89812cde8c6a7bf45",
+    "state": {
+      "branch": "codex/maint-0136-cleanup-preservation",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 94.536,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib-maint-0136-cleanup-preservation",
+      "head_sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+      "hold_reasons": [
+        "changed paths: 9"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-26T15:06:51.482693+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0136-cleanup-preservation",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 9,
+        "modified_paths": [],
+        "staged_paths": [
+          "Python/tests/test_cleanup_preservation.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/README.md",
+          "docs/planning/maint-0136-cleanup-preservation-plan.md",
+          "docs/verification/maint-0136-cleanup-preservation-git-handoff-receipt.json",
+          "docs/verification/maint-0136-cleanup-preservation-manifest.json",
+          "docs/verification/maint-0136-cleanup-recovery-evidence.json",
+          "scripts/_lib/cleanup_preservation.py"
+        ],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0136-cleanup-preservation"
+    }
+  },
+  "local_state_receipt_hash": "sha256:f86af26a6db44d06ca21b6473184bc1c47b9be33cc448dc89812cde8c6a7bf45",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-26T15:06:51.482835+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources/**",
+      "Python/structural_lib/**",
+      "fastapi_app/**",
+      "react_app/**"
+    ],
+    "integration_owner": "Main Agent",
+    "owned_paths": [
+      "scripts/_lib/cleanup_preservation.py",
+      "Python/tests/test_cleanup_preservation.py",
+      "docs/planning/maint-0136-cleanup-preservation-plan.md",
+      "docs/verification/maint-0136-cleanup-preservation-manifest.json",
+      "docs/verification/maint-0136-cleanup-recovery-evidence.json",
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/README.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/README.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "MAINT-0136"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/maint-0136-cleanup-preservation-manifest.json
+++ b/docs/verification/maint-0136-cleanup-preservation-manifest.json
@@ -1,0 +1,6580 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-26T15:03:08.193998+00:00",
+      "query_status": "OK",
+      "reference": "active Codex task: okay I authorize Phase 0 and Phase 1",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "INSPECT_LIVE_GIT_AND_DISK_STATE",
+      "CREATE_ISOLATED_PHASE_1_WORKTREE",
+      "CREATE_AND_VERIFY_RECOVERY_ARTIFACTS",
+      "FREEZE_PRESERVATION_MANIFEST",
+      "COMMIT_INTENDED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_OR_UPDATE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "authorized_phases": [
+      0,
+      1
+    ],
+    "next_action": "COMMIT_INTENDED_PATHS",
+    "observed_at_utc": "2026-08-26T15:03:08.193998+00:00",
+    "prohibited_actions": [
+      "DELETE_FILE",
+      "DELETE_CACHE",
+      "REMOVE_WORKTREE",
+      "DELETE_LOCAL_BRANCH",
+      "DELETE_REMOTE_BRANCH",
+      "DELETE_REF",
+      "PRUNE",
+      "GIT_CLEAN",
+      "PUBLISH_RELEASE"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "INSPECT_LIVE_GIT_AND_DISK_STATE",
+        "CREATE_ISOLATED_PHASE_1_WORKTREE",
+        "CREATE_AND_VERIFY_RECOVERY_ARTIFACTS",
+        "FREEZE_PRESERVATION_MANIFEST",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/maint-0136-cleanup-preservation",
+      "head_sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+      "task_id": "MAINT-0136"
+    }
+  },
+  "baseline": {
+    "current_branch": "codex/maint-0136-cleanup-preservation",
+    "current_head_sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+    "git_state_query_status": "OK",
+    "historical_cleanup_evidence": {
+      "path": "docs/verification/post-india2-cleanup-disposition-evidence.json",
+      "status": "HISTORICAL_NOT_CURRENT_AUTHORITY"
+    },
+    "hosted_main_sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+    "main_identity_match": true,
+    "origin_main_sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+    "pull_requests_query_status": "OK",
+    "remote_heads_query_status": "OK"
+  },
+  "branches": [
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "85872c846020ee9fb7cf654e8b5b3943f44fa531",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a1-canonical-transport"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "85872c846020ee9fb7cf654e8b5b3943f44fa531",
+        "upstream": "origin/codex/a1-canonical-transport-contract"
+      },
+      "name": "codex/a1-canonical-transport-contract",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-17T14:53:45Z",
+          "headRefName": "codex/a1-canonical-transport-contract",
+          "headRefOid": "85872c846020ee9fb7cf654e8b5b3943f44fa531",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "a0458e1935e9f14bcba47a838d5fe61b46174b05"
+          },
+          "mergedAt": "2026-08-17T14:53:45Z",
+          "number": 822,
+          "state": "MERGED",
+          "title": "feat(api): freeze canonical truth and transport contract",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/822"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "85872c846020ee9fb7cf654e8b5b3943f44fa531",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "2a6889b363aad85f5b45f5ba23b344efd08084d6",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a2-lossless-intake"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "2a6889b363aad85f5b45f5ba23b344efd08084d6",
+        "upstream": "origin/codex/a2-lossless-intake-calculation"
+      },
+      "name": "codex/a2-lossless-intake-calculation",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-17T16:16:19Z",
+          "headRefName": "codex/a2-lossless-intake-calculation",
+          "headRefOid": "2a6889b363aad85f5b45f5ba23b344efd08084d6",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "32daa0138b969be0b77b59dd33d938ad170f3a9e"
+          },
+          "mergedAt": "2026-08-17T16:16:19Z",
+          "number": 823,
+          "state": "MERGED",
+          "title": "fix(contracts): close lossless intake and load semantics",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/823"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "2a6889b363aad85f5b45f5ba23b344efd08084d6",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "4a7f13bca2fadfdb45017a296e6235c3b95dd401",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b1-gravity-model-ledger"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "4a7f13bca2fadfdb45017a296e6235c3b95dd401",
+        "upstream": "origin/codex/b1-gravity-model-load-ledger"
+      },
+      "name": "codex/b1-gravity-model-load-ledger",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-17T16:43:47Z",
+          "headRefName": "codex/b1-gravity-model-load-ledger",
+          "headRefOid": "4a7f13bca2fadfdb45017a296e6235c3b95dd401",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "cb49234f93283e35a87789bf631596f35c8cfcb1"
+          },
+          "mergedAt": "2026-08-17T16:43:47Z",
+          "number": 824,
+          "state": "MERGED",
+          "title": "feat(gravity): add V1 model and load ledger",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/824"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "4a7f13bca2fadfdb45017a296e6235c3b95dd401",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "b337efc73d0af9ff7bef623916cfe808dd79bed6",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b2-gravity-workflow-v1"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "b337efc73d0af9ff7bef623916cfe808dd79bed6",
+        "upstream": "origin/codex/b2-gravity-workflow-v1"
+      },
+      "name": "codex/b2-gravity-workflow-v1",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-17T17:38:10Z",
+          "headRefName": "codex/b2-gravity-workflow-v1",
+          "headRefOid": "b337efc73d0af9ff7bef623916cfe808dd79bed6",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "c127e4b2325fceb9adebf3d29d59e549f7ae4aa6"
+          },
+          "mergedAt": "2026-08-17T17:38:09Z",
+          "number": 825,
+          "state": "MERGED",
+          "title": "feat(gravity): add Building Gravity Workflow V1",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/825"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "b337efc73d0af9ff7bef623916cfe808dd79bed6",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "codex/column-pmm-experimental",
+      "pull_requests": [],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "remote": {
+        "sha": "8a52ed0ff3d98113b47cf0c6791468684cac6c27",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "514155b266af6dff3e30bf39ee28671c17345454",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-blank-workbook-guard"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "514155b266af6dff3e30bf39ee28671c17345454",
+        "upstream": "origin/codex/e1-blank-workbook-guard"
+      },
+      "name": "codex/e1-blank-workbook-guard",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "codex/e1-w0-maintenance-plan",
+          "closedAt": "2026-08-22T07:47:45Z",
+          "headRefName": "codex/e1-blank-workbook-guard",
+          "headRefOid": "514155b266af6dff3e30bf39ee28671c17345454",
+          "isDraft": true,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 828,
+          "state": "CLOSED",
+          "title": "fix(excel): guard blank workbook startup",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/828"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "514155b266af6dff3e30bf39ee28671c17345454",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "ef5ee05c785904e1a01c2d09cc65649edc8745ab",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-excel-workbench"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "ef5ee05c785904e1a01c2d09cc65649edc8745ab",
+        "upstream": "origin/codex/e1-excel-routine-workbench"
+      },
+      "name": "codex/e1-excel-routine-workbench",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T07:47:39Z",
+          "headRefName": "codex/e1-excel-routine-workbench",
+          "headRefOid": "ef5ee05c785904e1a01c2d09cc65649edc8745ab",
+          "isDraft": true,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 826,
+          "state": "CLOSED",
+          "title": "feat(excel): add Routine Workbench V1",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/826"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "ef5ee05c785904e1a01c2d09cc65649edc8745ab",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "53b9f56e5af0bae064ba3a545dbb9b86b4b336d7",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-g3-closeout"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "53b9f56e5af0bae064ba3a545dbb9b86b4b336d7",
+        "upstream": "origin/codex/e1-g3-closeout"
+      },
+      "name": "codex/e1-g3-closeout",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T08:01:17Z",
+          "headRefName": "codex/e1-g3-closeout",
+          "headRefOid": "53b9f56e5af0bae064ba3a545dbb9b86b4b336d7",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "e40c0b564acae82f6696e204e8b382342fbf4321"
+          },
+          "mergedAt": "2026-08-22T08:01:17Z",
+          "number": 831,
+          "state": "MERGED",
+          "title": "docs(excel): record E1 G3 closeout and next work",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/831"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "53b9f56e5af0bae064ba3a545dbb9b86b4b336d7",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "98c60bc1f7c3899c28f662e82399cb25d80bbf26",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-review-bundle-export"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "98c60bc1f7c3899c28f662e82399cb25d80bbf26",
+        "upstream": "origin/codex/e1-review-bundle-export"
+      },
+      "name": "codex/e1-review-bundle-export",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "codex/e1-blank-workbook-guard",
+          "closedAt": "2026-08-22T07:47:49Z",
+          "headRefName": "codex/e1-review-bundle-export",
+          "headRefOid": "98c60bc1f7c3899c28f662e82399cb25d80bbf26",
+          "isDraft": true,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 829,
+          "state": "CLOSED",
+          "title": "feat(excel): add deterministic review bundle export",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/829"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "98c60bc1f7c3899c28f662e82399cb25d80bbf26",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "654e40b1370d098fca4d001146a030b9937536a8",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-w0-maintenance"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "654e40b1370d098fca4d001146a030b9937536a8",
+        "upstream": "origin/codex/e1-w0-maintenance-plan"
+      },
+      "name": "codex/e1-w0-maintenance-plan",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "codex/e1-excel-routine-workbench",
+          "closedAt": "2026-08-22T07:47:42Z",
+          "headRefName": "codex/e1-w0-maintenance-plan",
+          "headRefOid": "654e40b1370d098fca4d001146a030b9937536a8",
+          "isDraft": true,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 827,
+          "state": "CLOSED",
+          "title": "docs(excel): record Windows W0 maintenance handoff",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/827"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "654e40b1370d098fca4d001146a030b9937536a8",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "ede01ef4fb6182a27e3f176e872478304fb5f256",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-workbook-open-repair"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "ede01ef4fb6182a27e3f176e872478304fb5f256",
+        "upstream": "origin/codex/e1-workbook-open-repair"
+      },
+      "name": "codex/e1-workbook-open-repair",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T07:47:01Z",
+          "headRefName": "codex/e1-workbook-open-repair",
+          "headRefOid": "ede01ef4fb6182a27e3f176e872478304fb5f256",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "b720119ea6a22a2b1963be0a0b9b300fca333d4a"
+          },
+          "mergedAt": "2026-08-22T07:47:01Z",
+          "number": 830,
+          "state": "MERGED",
+          "title": "feat(excel): deliver Routine Workbench V1",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/830"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "ede01ef4fb6182a27e3f176e872478304fb5f256",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_BEHIND",
+          "dirty_count": 0,
+          "head_sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-excel-product-planning"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
+        "upstream": "origin/main"
+      },
+      "name": "codex/excel-product-planning",
+      "pull_requests": [],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": null,
+        "status": "ABSENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "886871aef93d9a955a3cc2fa613fe49bad589ce7",
+        "upstream": "origin/codex/footing-isolated-v1"
+      },
+      "name": "codex/footing-isolated-v1",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-11T04:52:10Z",
+          "headRefName": "codex/footing-isolated-v1",
+          "headRefOid": "886871aef93d9a955a3cc2fa613fe49bad589ce7",
+          "isDraft": true,
+          "mergeCommit": {
+            "oid": "dedebaae9af186ede0f287c9582adf73002bad5f"
+          },
+          "mergedAt": "2026-08-11T04:52:10Z",
+          "number": 727,
+          "state": "MERGED",
+          "title": "chore(footing): preserve isolated footing workbench implementation",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/727"
+        }
+      ],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "remote": {
+        "sha": "886871aef93d9a955a3cc2fa613fe49bad589ce7",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "657037364bbb49f2ef834c70f3a3c704bac83c7b",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-git-governance-research"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "657037364bbb49f2ef834c70f3a3c704bac83c7b",
+        "upstream": "origin/codex/git-governance-research"
+      },
+      "name": "codex/git-governance-research",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-12T16:30:46Z",
+          "headRefName": "codex/git-governance-research",
+          "headRefOid": "3be4790df857a10adaa9c10e381d8dfc13de3168",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "9778a4c26dc26fb800690f7263dfcc2a599aecc5"
+          },
+          "mergedAt": "2026-08-12T16:30:46Z",
+          "number": 735,
+          "state": "MERGED",
+          "title": "docs(git): start governance research program",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/735"
+        },
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-12T18:34:29Z",
+          "headRefName": "codex/git-governance-research",
+          "headRefOid": "51a8a57a7e4eaba5841f2fee86c83ae6287182bf",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "f3ad94dc3c4e44d2dba137cfd32534e6ca13ea3d"
+          },
+          "mergedAt": "2026-08-12T18:34:29Z",
+          "number": 743,
+          "state": "MERGED",
+          "title": "docs(git): complete GIT-001 Phase 1 lifecycle research",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/743"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "51a8a57a7e4eaba5841f2fee86c83ae6287182bf",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "fffbfaaa0d928768efe7b703a0d8091555ad9a8e",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-implementation-first-verification-policy"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "fffbfaaa0d928768efe7b703a0d8091555ad9a8e",
+        "upstream": "origin/codex/implementation-first-verification-policy"
+      },
+      "name": "codex/implementation-first-verification-policy",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T19:38:19Z",
+          "headRefName": "codex/implementation-first-verification-policy",
+          "headRefOid": "fffbfaaa0d928768efe7b703a0d8091555ad9a8e",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "87205d64990c96db75dbae9056c9a0066605e1f8"
+          },
+          "mergedAt": "2026-08-16T19:38:19Z",
+          "number": 813,
+          "state": "MERGED",
+          "title": "docs(governance): batch verification after implementation",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/813"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "fffbfaaa0d928768efe7b703a0d8091555ad9a8e",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "65c37ad0836bd59ebef56b6d01faa144b791d020",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-index-local-artifact-determinism"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "65c37ad0836bd59ebef56b6d01faa144b791d020",
+        "upstream": "origin/codex/index-local-artifact-determinism"
+      },
+      "name": "codex/index-local-artifact-determinism",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T18:08:50Z",
+          "headRefName": "codex/index-local-artifact-determinism",
+          "headRefOid": "65c37ad0836bd59ebef56b6d01faa144b791d020",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "904a2f8cf0ea5d4595f57c46dac06e2e837bba45"
+          },
+          "mergedAt": "2026-08-16T18:08:50Z",
+          "number": 811,
+          "state": "MERGED",
+          "title": "fix(governance): ignore hidden index artifacts",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/811"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "65c37ad0836bd59ebef56b6d01faa144b791d020",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "cfb98da58af391bdefb23f8cfc83295876b44876",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-index-mtime-determinism"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "cfb98da58af391bdefb23f8cfc83295876b44876",
+        "upstream": "origin/codex/index-mtime-determinism"
+      },
+      "name": "codex/index-mtime-determinism",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T18:00:37Z",
+          "headRefName": "codex/index-mtime-determinism",
+          "headRefOid": "cfb98da58af391bdefb23f8cfc83295876b44876",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "755ed9d95c0a8f7e8c4a2165ddb748262df54482"
+          },
+          "mergedAt": "2026-08-16T18:00:37Z",
+          "number": 810,
+          "state": "MERGED",
+          "title": "fix(governance): make index freshness deterministic",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/810"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "cfb98da58af391bdefb23f8cfc83295876b44876",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "099937dc3da7c0083de793ed3b2972690a44d423",
+          "path": "/Users/pravinsurawase/.codex/worktrees/india-3-beam-r1/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "099937dc3da7c0083de793ed3b2972690a44d423",
+        "upstream": "origin/codex/india-3-beam-r1"
+      },
+      "name": "codex/india-3-beam-r1",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-24T05:27:27Z",
+          "headRefName": "codex/india-3-beam-r1",
+          "headRefOid": "099937dc3da7c0083de793ed3b2972690a44d423",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "cfe29f890e62c40546f3a91c8810e1daf7c0d722"
+          },
+          "mergedAt": "2026-08-24T05:27:27Z",
+          "number": 867,
+          "state": "MERGED",
+          "title": "fix(is13920): repair beam ductility contract",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/867"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "099937dc3da7c0083de793ed3b2972690a44d423",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "4df72ea258610179a1496a255c1d6d320e3416bf",
+          "path": "/Users/pravinsurawase/.codex/worktrees/india-3-column-r1/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "4df72ea258610179a1496a255c1d6d320e3416bf",
+        "upstream": "origin/codex/india-3-column-r1"
+      },
+      "name": "codex/india-3-column-r1",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-24T06:21:18Z",
+          "headRefName": "codex/india-3-column-r1",
+          "headRefOid": "4df72ea258610179a1496a255c1d6d320e3416bf",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "306e2a46328ce2b519d1352131b64ef310271b5e"
+          },
+          "mergedAt": "2026-08-24T06:21:18Z",
+          "number": 868,
+          "state": "MERGED",
+          "title": "fix(is13920): repair column confinement contract",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/868"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "4df72ea258610179a1496a255c1d6d320e3416bf",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "8466fb1458f41cb767117f5a49b4495b23d794eb",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-3-g0-acceptance"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "8466fb1458f41cb767117f5a49b4495b23d794eb",
+        "upstream": "origin/codex/india-3-g0-acceptance"
+      },
+      "name": "codex/india-3-g0-acceptance",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T22:50:01Z",
+          "headRefName": "codex/india-3-g0-acceptance",
+          "headRefOid": "8466fb1458f41cb767117f5a49b4495b23d794eb",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "c0e34235b485799d26fcb55df45f74ed9104e003"
+          },
+          "mergedAt": "2026-08-23T22:50:01Z",
+          "number": 863,
+          "state": "MERGED",
+          "title": "docs(india3): freeze IS 13920 G0 decision",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/863"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "8466fb1458f41cb767117f5a49b4495b23d794eb",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "9c976b1f4afd0540a5ec9eb3cab16861916ac89b",
+          "path": "/Users/pravinsurawase/.codex/worktrees/india-3-g0-source-library/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "9c976b1f4afd0540a5ec9eb3cab16861916ac89b",
+        "upstream": "origin/codex/india-3-g0-source-library"
+      },
+      "name": "codex/india-3-g0-source-library",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T08:41:01Z",
+          "headRefName": "codex/india-3-g0-source-library",
+          "headRefOid": "9c976b1f4afd0540a5ec9eb3cab16861916ac89b",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "40aa5864194a7296caea13def1ccf82f44aca917"
+          },
+          "mergedAt": "2026-08-23T08:41:01Z",
+          "number": 849,
+          "state": "MERGED",
+          "title": "docs(india-3): establish private source library boundary",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/849"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "9c976b1f4afd0540a5ec9eb3cab16861916ac89b",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "b39fcda534ec757744a2d6f203f42e4350871cd1",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-3-g0-truth-audit"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "b39fcda534ec757744a2d6f203f42e4350871cd1",
+        "upstream": "origin/codex/india-3-g0-truth-audit"
+      },
+      "name": "codex/india-3-g0-truth-audit",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T21:10:15Z",
+          "headRefName": "codex/india-3-g0-truth-audit",
+          "headRefOid": "b39fcda534ec757744a2d6f203f42e4350871cd1",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "e2fac7419551988def59101ac63a5f8e491bc7a2"
+          },
+          "mergedAt": "2026-08-23T21:10:15Z",
+          "number": 861,
+          "state": "MERGED",
+          "title": "docs(india-3): freeze G0 truth-audit readiness",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/861"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "b39fcda534ec757744a2d6f203f42e4350871cd1",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "0a20774ec8978b7dcea6d7cd7db6966068b70703",
+          "path": "/Users/pravinsurawase/.codex/worktrees/india-3-is13920-m0/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "0a20774ec8978b7dcea6d7cd7db6966068b70703",
+        "upstream": "origin/codex/india-3-is13920-m0"
+      },
+      "name": "codex/india-3-is13920-m0",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-24T06:57:52Z",
+          "headRefName": "codex/india-3-is13920-m0",
+          "headRefOid": "0a20774ec8978b7dcea6d7cd7db6966068b70703",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "b85d514ed93e22a154badde990ef1c3fb02ae0d9"
+          },
+          "mergedAt": "2026-08-24T06:57:52Z",
+          "number": 869,
+          "state": "MERGED",
+          "title": "test(is13920): accept bounded cumulative contracts",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/869"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "0a20774ec8978b7dcea6d7cd7db6966068b70703",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "a5657e1bbcea16079af527005c47b296cf95f742",
+          "path": "/Users/pravinsurawase/.codex/worktrees/ef1b/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "a5657e1bbcea16079af527005c47b296cf95f742",
+        "upstream": "origin/codex/india-3-joint-r1"
+      },
+      "name": "codex/india-3-joint-r1",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-24T04:51:41Z",
+          "headRefName": "codex/india-3-joint-r1",
+          "headRefOid": "a5657e1bbcea16079af527005c47b296cf95f742",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "b59e6ea02e52056d1024bb4dc90204f149f112eb"
+          },
+          "mergedAt": "2026-08-24T04:51:41Z",
+          "number": 866,
+          "state": "MERGED",
+          "title": "fix(is13920): repair joint scwb contract",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/866"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "a5657e1bbcea16079af527005c47b296cf95f742",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "13f0ff916a0d7c167e34b46ab9ae6cb2c50c9efd",
+          "path": "/Users/pravinsurawase/.codex/worktrees/7c3898d2-40f8-4e2b-bee5-fb7e8ebb0250/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "13f0ff916a0d7c167e34b46ab9ae6cb2c50c9efd",
+        "upstream": "origin/codex/india-3-source-meta-r1"
+      },
+      "name": "codex/india-3-source-meta-r1",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T23:21:50Z",
+          "headRefName": "codex/india-3-source-meta-r1",
+          "headRefOid": "13f0ff916a0d7c167e34b46ab9ae6cb2c50c9efd",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "20b60a047e5c6d88b800f7094dd64fcf4bebad28"
+          },
+          "mergedAt": "2026-08-23T23:21:50Z",
+          "number": 864,
+          "state": "MERGED",
+          "title": "docs(india3): repair private source metadata",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/864"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "13f0ff916a0d7c167e34b46ab9ae6cb2c50c9efd",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "7e623984e027141fff62e5129c23fdc16264f8e0",
+        "upstream": "origin/codex/is456-slabs-plan"
+      },
+      "name": "codex/is456-slabs-plan",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-11T04:52:10Z",
+          "headRefName": "codex/is456-slabs-plan",
+          "headRefOid": "7e623984e027141fff62e5129c23fdc16264f8e0",
+          "isDraft": true,
+          "mergeCommit": {
+            "oid": "be148d392d4c2f0c9e286ff46bb269039f8943c5"
+          },
+          "mergedAt": "2026-08-11T04:52:10Z",
+          "number": 728,
+          "state": "MERGED",
+          "title": "docs(release): preserve slab planning and release guard baseline",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/728"
+        }
+      ],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "remote": {
+        "sha": "7e623984e027141fff62e5129c23fdc16264f8e0",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "18d043ef9ac6221936335e1b20676863b3c5bc9b",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-a-strict-input"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "18d043ef9ac6221936335e1b20676863b3c5bc9b",
+        "upstream": "origin/codex/lib-pro-002-a-strict-input"
+      },
+      "name": "codex/lib-pro-002-a-strict-input",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T20:06:52Z",
+          "headRefName": "codex/lib-pro-002-a-strict-input",
+          "headRefOid": "18d043ef9ac6221936335e1b20676863b3c5bc9b",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "3986935ecb473c1f9d56dec44aeb4218d9192f84"
+          },
+          "mergedAt": "2026-08-16T20:06:52Z",
+          "number": 814,
+          "state": "MERGED",
+          "title": "fix(batch): enforce strict project beam input",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/814"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "18d043ef9ac6221936335e1b20676863b3c5bc9b",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "22c65d17874ec877a7f90f56ae6950131eddd462",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-b-lossless-import"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "22c65d17874ec877a7f90f56ae6950131eddd462",
+        "upstream": "origin/codex/lib-pro-002-b-lossless-import"
+      },
+      "name": "codex/lib-pro-002-b-lossless-import",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T22:10:55Z",
+          "headRefName": "codex/lib-pro-002-b-lossless-import",
+          "headRefOid": "22c65d17874ec877a7f90f56ae6950131eddd462",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "fe4ab025419b834c6d0f840e9492c0604ae74201"
+          },
+          "mergedAt": "2026-08-16T22:10:55Z",
+          "number": 815,
+          "state": "MERGED",
+          "title": "fix(safety): complete LIB-PRO-002 A-G readiness gates",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/815"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "22c65d17874ec877a7f90f56ae6950131eddd462",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "911b6e3d288db85bc3f2770a061598689a4e8ec3",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-i-cli"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "911b6e3d288db85bc3f2770a061598689a4e8ec3",
+        "upstream": "origin/codex/lib-pro-002-i-cli"
+      },
+      "name": "codex/lib-pro-002-i-cli",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-17T05:21:24Z",
+          "headRefName": "codex/lib-pro-002-i-cli",
+          "headRefOid": "911b6e3d288db85bc3f2770a061598689a4e8ec3",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "0ba2f397aec267bc74a31281f9158189fde2749d"
+          },
+          "mergedAt": "2026-08-17T05:21:24Z",
+          "number": 819,
+          "state": "MERGED",
+          "title": "fix(cli): enforce strict lossless design intake",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/819"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "911b6e3d288db85bc3f2770a061598689a4e8ec3",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "280dd9a9a31e8f318d385cb2ec43418d195ca4b3",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-j-release-signal"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "280dd9a9a31e8f318d385cb2ec43418d195ca4b3",
+        "upstream": "origin/codex/lib-pro-002-j-release-signal"
+      },
+      "name": "codex/lib-pro-002-j-release-signal",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-17T06:17:29Z",
+          "headRefName": "codex/lib-pro-002-j-release-signal",
+          "headRefOid": "280dd9a9a31e8f318d385cb2ec43418d195ca4b3",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "970a78c1931a3aa0439f487e6892a888bb113962"
+          },
+          "mergedAt": "2026-08-17T06:17:29Z",
+          "number": 820,
+          "state": "MERGED",
+          "title": "fix(release): converge hosted and preflight signals",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/820"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "280dd9a9a31e8f318d385cb2ec43418d195ca4b3",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "e17d57f8a6ae4f050892d07adf26856f45ffcec0",
+        "upstream": "origin/codex/lib-pro-002-usability-refresh"
+      },
+      "name": "codex/lib-pro-002-usability-refresh",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-17T04:39:56Z",
+          "headRefName": "codex/lib-pro-002-usability-refresh",
+          "headRefOid": "e17d57f8a6ae4f050892d07adf26856f45ffcec0",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "b3a9c367de012982a8b9adefda0db60e2d762d7b"
+          },
+          "mergedAt": "2026-08-17T04:39:56Z",
+          "number": 818,
+          "state": "MERGED",
+          "title": "docs(planning): close remaining publication blockers",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/818"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "remote": {
+        "sha": "e17d57f8a6ae4f050892d07adf26856f45ffcec0",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "ff55471c9b75a7c70369f857c387fdffad05899d",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-004-safety-auditors"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "ff55471c9b75a7c70369f857c387fdffad05899d",
+        "upstream": "origin/codex/lib-pro-004-safety-auditors"
+      },
+      "name": "codex/lib-pro-004-safety-auditors",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T13:01:34Z",
+          "headRefName": "codex/lib-pro-004-safety-auditors",
+          "headRefOid": "ff55471c9b75a7c70369f857c387fdffad05899d",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "f1a9937cfdba4c72c22e6219ffaf02f94809f1a5"
+          },
+          "mergedAt": "2026-08-22T13:01:34Z",
+          "number": 836,
+          "state": "MERGED",
+          "title": "fix(is456): enforce lower-level safety boundaries",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/836"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "ff55471c9b75a7c70369f857c387fdffad05899d",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "0979200d00ea32bd7464232f20558f353509be8a",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-005-release-safety-closure"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "0979200d00ea32bd7464232f20558f353509be8a",
+        "upstream": "origin/codex/lib-pro-005-release-safety-closure"
+      },
+      "name": "codex/lib-pro-005-release-safety-closure",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T15:47:04Z",
+          "headRefName": "codex/lib-pro-005-release-safety-closure",
+          "headRefOid": "0979200d00ea32bd7464232f20558f353509be8a",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "3f61bd93d92b7092a55e25b8ca99eda4b3335ff1"
+          },
+          "mergedAt": "2026-08-22T15:47:04Z",
+          "number": 837,
+          "state": "MERGED",
+          "title": "fix(safety): close confirmed release blockers",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/837"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "0979200d00ea32bd7464232f20558f353509be8a",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "6db242171427b93a2586de9c2c772ccba03243de",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-006-gravity-foundation"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "6db242171427b93a2586de9c2c772ccba03243de",
+        "upstream": "origin/codex/lib-pro-006-gravity-foundation"
+      },
+      "name": "codex/lib-pro-006-gravity-foundation",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T12:00:04Z",
+          "headRefName": "codex/lib-pro-006-gravity-foundation",
+          "headRefOid": "6db242171427b93a2586de9c2c772ccba03243de",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "2d6df18efa9228afbf593f36fa95d2ce574977ac"
+          },
+          "mergedAt": "2026-08-23T12:00:04Z",
+          "number": 851,
+          "state": "MERGED",
+          "title": "feat(gravity): improve workflow usability foundation",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/851"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "6db242171427b93a2586de9c2c772ccba03243de",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "3b0c0c2551d5f1d31b1dd8251489e6ec632f57a4",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-g0"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "3b0c0c2551d5f1d31b1dd8251489e6ec632f57a4",
+        "upstream": "origin/codex/lib-pro-007-g0-contract-freeze"
+      },
+      "name": "codex/lib-pro-007-g0-contract-freeze",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T13:26:06Z",
+          "headRefName": "codex/lib-pro-007-g0-contract-freeze",
+          "headRefOid": "3b0c0c2551d5f1d31b1dd8251489e6ec632f57a4",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "a6d47a85b78e3dc8317f65bb33b2247b69aa9bf9"
+          },
+          "mergedAt": "2026-08-23T13:26:06Z",
+          "number": 852,
+          "state": "MERGED",
+          "title": "docs(product): freeze product foundation contracts",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/852"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "3b0c0c2551d5f1d31b1dd8251489e6ec632f57a4",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "eb92db482734e531561f739cf6818104281ef451",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-m0"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "eb92db482734e531561f739cf6818104281ef451",
+        "upstream": "origin/codex/lib-pro-007-m0-cumulative-acceptance"
+      },
+      "name": "codex/lib-pro-007-m0-cumulative-acceptance",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T20:39:44Z",
+          "headRefName": "codex/lib-pro-007-m0-cumulative-acceptance",
+          "headRefOid": "eb92db482734e531561f739cf6818104281ef451",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "3e9796872fbf79bf4d0a7c09c018e4978664f079"
+          },
+          "mergedAt": "2026-08-23T20:39:44Z",
+          "number": 860,
+          "state": "MERGED",
+          "title": "fix(m0): close cumulative product acceptance",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/860"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "eb92db482734e531561f739cf6818104281ef451",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "6dd3fd4e17354f27846869ee48d10277c4703d0f",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p1"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "6dd3fd4e17354f27846869ee48d10277c4703d0f",
+        "upstream": "origin/codex/lib-pro-007-p1-optimization-truth"
+      },
+      "name": "codex/lib-pro-007-p1-optimization-truth",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T14:17:51Z",
+          "headRefName": "codex/lib-pro-007-p1-optimization-truth",
+          "headRefOid": "6dd3fd4e17354f27846869ee48d10277c4703d0f",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "9119cadc1322a718a00dd4e00f5650a21f100af4"
+          },
+          "mergedAt": "2026-08-23T14:17:51Z",
+          "number": 853,
+          "state": "MERGED",
+          "title": "fix(optimization): make beam cost contract truthful",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/853"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "6dd3fd4e17354f27846869ee48d10277c4703d0f",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "fa81954852285d59fe7c1e58de7c2b6cb3fa7971",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p2"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "fa81954852285d59fe7c1e58de7c2b6cb3fa7971",
+        "upstream": "origin/codex/lib-pro-007-p2-supplied-beam-reinforcement"
+      },
+      "name": "codex/lib-pro-007-p2-supplied-beam-reinforcement",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T15:01:39Z",
+          "headRefName": "codex/lib-pro-007-p2-supplied-beam-reinforcement",
+          "headRefOid": "fa81954852285d59fe7c1e58de7c2b6cb3fa7971",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "e4d86d13e671516ca65d27028defb791e7d277c0"
+          },
+          "mergedAt": "2026-08-23T15:01:39Z",
+          "number": 854,
+          "state": "MERGED",
+          "title": "feat(beam): evaluate supplied reinforcement truth",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/854"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "fa81954852285d59fe7c1e58de7c2b6cb3fa7971",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "bfec16d13409519979135abc99b7b31ebc600688",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p3"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "bfec16d13409519979135abc99b7b31ebc600688",
+        "upstream": "origin/codex/lib-pro-007-p3-footing-anchorage"
+      },
+      "name": "codex/lib-pro-007-p3-footing-anchorage",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T15:42:35Z",
+          "headRefName": "codex/lib-pro-007-p3-footing-anchorage",
+          "headRefOid": "bfec16d13409519979135abc99b7b31ebc600688",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "0ea3e2d43343d70f007b0771896b41566e3b5064"
+          },
+          "mergedAt": "2026-08-23T15:42:35Z",
+          "number": 855,
+          "state": "MERGED",
+          "title": "feat(footing): evaluate supported end anchorage",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/855"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "bfec16d13409519979135abc99b7b31ebc600688",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "a2b813dbc2c5a873edabab30c36087ff7fea7eda",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p4"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "a2b813dbc2c5a873edabab30c36087ff7fea7eda",
+        "upstream": "origin/codex/lib-pro-007-p4-practical-actions"
+      },
+      "name": "codex/lib-pro-007-p4-practical-actions",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T16:19:47Z",
+          "headRefName": "codex/lib-pro-007-p4-practical-actions",
+          "headRefOid": "a2b813dbc2c5a873edabab30c36087ff7fea7eda",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "426d401bb2afde417ff989bd7349c99b8f7cb438"
+          },
+          "mergedAt": "2026-08-23T16:19:47Z",
+          "number": 856,
+          "state": "MERGED",
+          "title": "feat(gravity): reconcile explicit practical actions",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/856"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "a2b813dbc2c5a873edabab30c36087ff7fea7eda",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "783cc15e37385d616044d00478f282d8bb6716f0",
+        "upstream": "origin/codex/lib-pro-007-p5-etabs-snapshot"
+      },
+      "name": "codex/lib-pro-007-p5-etabs-snapshot",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T18:27:21Z",
+          "headRefName": "codex/lib-pro-007-p5-etabs-snapshot",
+          "headRefOid": "783cc15e37385d616044d00478f282d8bb6716f0",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "6d533b6f3754e4fe41522e042f17192d550a1d1b"
+          },
+          "mergedAt": "2026-08-23T18:27:21Z",
+          "number": 857,
+          "state": "MERGED",
+          "title": "feat(import): add canonical ETABS exported snapshot",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/857"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "remote": {
+        "sha": "783cc15e37385d616044d00478f282d8bb6716f0",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "9647feddb672428e4f89348f5f82ad8c2cbe71cf",
+          "path": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "9647feddb672428e4f89348f5f82ad8c2cbe71cf",
+        "upstream": "origin/codex/lib-pro-007-p6-cross-surface-parity"
+      },
+      "name": "codex/lib-pro-007-p6-cross-surface-parity",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T19:02:48Z",
+          "headRefName": "codex/lib-pro-007-p6-cross-surface-parity",
+          "headRefOid": "9647feddb672428e4f89348f5f82ad8c2cbe71cf",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "6cb4722103bfc018dc3889fcc1a5a437e3579897"
+          },
+          "mergedAt": "2026-08-23T19:02:48Z",
+          "number": 858,
+          "state": "MERGED",
+          "title": "fix(parity): preserve canonical cross-surface identity",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/858"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "9647feddb672428e4f89348f5f82ad8c2cbe71cf",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "c9589815f2d8053b1d99f61bf38623cd2aebba2f",
+          "path": "/Users/pravinsurawase/.codex/worktrees/3c84/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "c9589815f2d8053b1d99f61bf38623cd2aebba2f",
+        "upstream": "origin/codex/lib-pro-007-p7-compatibility-convergence"
+      },
+      "name": "codex/lib-pro-007-p7-compatibility-convergence",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T20:10:40Z",
+          "headRefName": "codex/lib-pro-007-p7-compatibility-convergence",
+          "headRefOid": "c9589815f2d8053b1d99f61bf38623cd2aebba2f",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "823b39896a53fde7e4c5e0805faa8ec02e075ee5"
+          },
+          "mergedAt": "2026-08-23T20:10:40Z",
+          "number": 859,
+          "state": "MERGED",
+          "title": "refactor(api): converge compatibility surfaces",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/859"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "c9589815f2d8053b1d99f61bf38623cd2aebba2f",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "f035abfa70037afab5e159f8395db1343ee346af",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0135-cleanup-refresh"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "f035abfa70037afab5e159f8395db1343ee346af",
+        "upstream": "origin/codex/lib-pro-008-pre-india3-safety"
+      },
+      "name": "codex/lib-pro-008-pre-india3-safety",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T22:15:40Z",
+          "headRefName": "codex/lib-pro-008-pre-india3-safety",
+          "headRefOid": "f035abfa70037afab5e159f8395db1343ee346af",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "3bcc34223d8eaf236c62a5f54dfe4b7960876457"
+          },
+          "mergedAt": "2026-08-23T22:15:40Z",
+          "number": 862,
+          "state": "MERGED",
+          "title": "fix(safety): close pre-INDIA-3 validation gaps",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/862"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "f035abfa70037afab5e159f8395db1343ee346af",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "b4428e23adc8374d1acc6e7f2a2125d5aebff453",
+          "path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-009-rc-trust"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "b4428e23adc8374d1acc6e7f2a2125d5aebff453",
+        "upstream": "origin/codex/lib-pro-009-rc-trust"
+      },
+      "name": "codex/lib-pro-009-rc-trust",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-24T08:44:43Z",
+          "headRefName": "codex/lib-pro-009-rc-trust",
+          "headRefOid": "b4428e23adc8374d1acc6e7f2a2125d5aebff453",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "b3309260686a05b4cbb9c9358c89d6218a700357"
+          },
+          "mergedAt": "2026-08-24T08:44:43Z",
+          "number": 870,
+          "state": "MERGED",
+          "title": "fix(safety): close bounded release trust gaps",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/870"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "b4428e23adc8374d1acc6e7f2a2125d5aebff453",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "595b3bcb1bb55bae0261016a3dddd87da4aca8e9",
+          "path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-010-rc-artifact"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "595b3bcb1bb55bae0261016a3dddd87da4aca8e9",
+        "upstream": "origin/codex/lib-pro-010-rc-artifact"
+      },
+      "name": "codex/lib-pro-010-rc-artifact",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-24T10:56:04Z",
+          "headRefName": "codex/lib-pro-010-rc-artifact",
+          "headRefOid": "595b3bcb1bb55bae0261016a3dddd87da4aca8e9",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "510163041fec4329b5b47ea749a5f8d74bab12b3"
+          },
+          "mergedAt": "2026-08-24T10:56:04Z",
+          "number": 871,
+          "state": "MERGED",
+          "title": "chore(release): prepare bounded v0.24.0a1 candidate",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/871"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "595b3bcb1bb55bae0261016a3dddd87da4aca8e9",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "1f203f40ec162a5caf141b1c44444ec4f6d3470c",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-011"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "1f203f40ec162a5caf141b1c44444ec4f6d3470c",
+        "upstream": "origin/codex/maint-011-developer-gate-hygiene"
+      },
+      "name": "codex/maint-011-developer-gate-hygiene",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T17:47:55Z",
+          "headRefName": "codex/maint-011-developer-gate-hygiene",
+          "headRefOid": "1f203f40ec162a5caf141b1c44444ec4f6d3470c",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "fc904511cc7b9683b2b464cdef71a45d2e9ee277"
+          },
+          "mergedAt": "2026-08-22T17:47:55Z",
+          "number": 838,
+          "state": "MERGED",
+          "title": "chore(maint): repair developer gate hygiene",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/838"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "1f203f40ec162a5caf141b1c44444ec4f6d3470c",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "f0cdf631d6c7d698c0a7b47b04030b4e23fb32a2",
+          "path": "/Users/pravinsurawase/.codex/worktrees/maint-012a/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "f0cdf631d6c7d698c0a7b47b04030b4e23fb32a2",
+        "upstream": "origin/codex/maint-012a-control-registry"
+      },
+      "name": "codex/maint-012a-control-registry",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T20:06:27Z",
+          "headRefName": "codex/maint-012a-control-registry",
+          "headRefOid": "f0cdf631d6c7d698c0a7b47b04030b4e23fb32a2",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "efd219178c4293ab106f43e37b903c5c268283aa"
+          },
+          "mergedAt": "2026-08-22T20:06:27Z",
+          "number": 840,
+          "state": "MERGED",
+          "title": "refactor: add canonical control registry (MAINT-012A)",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/840"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "f0cdf631d6c7d698c0a7b47b04030b4e23fb32a2",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "74bfd69ebf610b6cb324b7298b95ac840652ed4c",
+          "path": "/Users/pravinsurawase/.codex/worktrees/maint-012b/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "74bfd69ebf610b6cb324b7298b95ac840652ed4c",
+        "upstream": "origin/codex/maint-012b-index-architecture"
+      },
+      "name": "codex/maint-012b-index-architecture",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T20:54:28Z",
+          "headRefName": "codex/maint-012b-index-architecture",
+          "headRefOid": "74bfd69ebf610b6cb324b7298b95ac840652ed4c",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "646660e323b65118a805b554c6cf4dbef46ef479"
+          },
+          "mergedAt": "2026-08-22T20:54:28Z",
+          "number": 841,
+          "state": "MERGED",
+          "title": "refactor(maint): retire generated indexes",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/841"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "74bfd69ebf610b6cb324b7298b95ac840652ed4c",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "56eff4d357ca62332fb0e50c6a55c2336af57c65",
+          "path": "/Users/pravinsurawase/.codex/worktrees/maint-012c/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "56eff4d357ca62332fb0e50c6a55c2336af57c65",
+        "upstream": "origin/codex/maint-012c-evidence-scheduling"
+      },
+      "name": "codex/maint-012c-evidence-scheduling",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T22:11:28Z",
+          "headRefName": "codex/maint-012c-evidence-scheduling",
+          "headRefOid": "56eff4d357ca62332fb0e50c6a55c2336af57c65",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "84f3cbe6ce576a6c3a22882ddec2e1c08415c4e0"
+          },
+          "mergedAt": "2026-08-22T22:11:28Z",
+          "number": 842,
+          "state": "MERGED",
+          "title": "refactor(ci): add exact verification evidence",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/842"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "56eff4d357ca62332fb0e50c6a55c2336af57c65",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "66cd2bb51b9f4f1fd7f6c1f8ab57e5a4f188e20d",
+          "path": "/Users/pravinsurawase/.codex/worktrees/maint-012d/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "66cd2bb51b9f4f1fd7f6c1f8ab57e5a4f188e20d",
+        "upstream": "origin/codex/maint-012d-scanner-consolidation"
+      },
+      "name": "codex/maint-012d-scanner-consolidation",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T03:36:36Z",
+          "headRefName": "codex/maint-012d-scanner-consolidation",
+          "headRefOid": "66cd2bb51b9f4f1fd7f6c1f8ab57e5a4f188e20d",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "242ba386925d29766b1467810044e276ebbceb64"
+          },
+          "mergedAt": "2026-08-23T03:36:35Z",
+          "number": 843,
+          "state": "MERGED",
+          "title": "refactor(control-plane): consolidate scanners and scripts",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/843"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "66cd2bb51b9f4f1fd7f6c1f8ab57e5a4f188e20d",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "b7b9623966c3131b8d5628496ea06328ce7210a6",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0130-safe-file"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "b7b9623966c3131b8d5628496ea06328ce7210a6",
+        "upstream": "origin/codex/maint-0130-safe-file-foundation"
+      },
+      "name": "codex/maint-0130-safe-file-foundation",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T05:10:23Z",
+          "headRefName": "codex/maint-0130-safe-file-foundation",
+          "headRefOid": "b7b9623966c3131b8d5628496ea06328ce7210a6",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "58ecc149bd4525ae92c4affb369851919fe1c402"
+          },
+          "mergedAt": "2026-08-23T05:10:23Z",
+          "number": 844,
+          "state": "MERGED",
+          "title": "refactor(governance): make file operations transactional",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/844"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "b7b9623966c3131b8d5628496ea06328ce7210a6",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "a4dbb38e113fb2383997e1b294ab53f64325716a",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0131-efficiency-controls"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "a4dbb38e113fb2383997e1b294ab53f64325716a",
+        "upstream": "origin/codex/maint-0131-efficiency-controls"
+      },
+      "name": "codex/maint-0131-efficiency-controls",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T05:54:07Z",
+          "headRefName": "codex/maint-0131-efficiency-controls",
+          "headRefOid": "a4dbb38e113fb2383997e1b294ab53f64325716a",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "d4e5b122e903e3c0e1229d2255bcaf3e03ed9d94"
+          },
+          "mergedAt": "2026-08-23T05:54:07Z",
+          "number": 845,
+          "state": "MERGED",
+          "title": "fix(governance): make efficiency controls executable",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/845"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "a4dbb38e113fb2383997e1b294ab53f64325716a",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "2573b0d7959913b550eea6d6f15f34fd4e6edff5",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0132-efficiency-observability"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "2573b0d7959913b550eea6d6f15f34fd4e6edff5",
+        "upstream": "origin/codex/maint-0132-efficiency-observability"
+      },
+      "name": "codex/maint-0132-efficiency-observability",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T07:14:50Z",
+          "headRefName": "codex/maint-0132-efficiency-observability",
+          "headRefOid": "2573b0d7959913b550eea6d6f15f34fd4e6edff5",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "60e95bbe52575d3335e7195db944b2c82630ed2e"
+          },
+          "mergedAt": "2026-08-23T07:14:50Z",
+          "number": 846,
+          "state": "MERGED",
+          "title": "chore(governance): measure session efficiency end to end",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/846"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "2573b0d7959913b550eea6d6f15f34fd4e6edff5",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "f8c8d2642fa1f61f78366b3a05ff8dded692b75d",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0133-cleanup-inventory"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "f8c8d2642fa1f61f78366b3a05ff8dded692b75d",
+        "upstream": "origin/codex/maint-0133-cleanup-inventory"
+      },
+      "name": "codex/maint-0133-cleanup-inventory",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T07:38:53Z",
+          "headRefName": "codex/maint-0133-cleanup-inventory",
+          "headRefOid": "f8c8d2642fa1f61f78366b3a05ff8dded692b75d",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "417a16590892d176ea288bbda93ad4d48b4603c4"
+          },
+          "mergedAt": "2026-08-23T07:38:53Z",
+          "number": 847,
+          "state": "MERGED",
+          "title": "docs(governance): freeze cleanup authorization inventory",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/847"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "f8c8d2642fa1f61f78366b3a05ff8dded692b75d",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "203b33e9611dd27d5aecc0d47b7f49f607dc3dde",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0133b-packet-a"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "203b33e9611dd27d5aecc0d47b7f49f607dc3dde",
+        "upstream": "origin/codex/maint-0133b-packet-a"
+      },
+      "name": "codex/maint-0133b-packet-a",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T07:54:34Z",
+          "headRefName": "codex/maint-0133b-packet-a",
+          "headRefOid": "203b33e9611dd27d5aecc0d47b7f49f607dc3dde",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "f24c3904b4af7d768f71342f11ac70f21e7b1dfa"
+          },
+          "mergedAt": "2026-08-23T07:54:34Z",
+          "number": 848,
+          "state": "MERGED",
+          "title": "docs(governance): complete approved MAINT-0133 cleanup",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/848"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "203b33e9611dd27d5aecc0d47b7f49f607dc3dde",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "3e753959a006b640357c46a711689be46f076102",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0134-agent-instructions"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "3e753959a006b640357c46a711689be46f076102",
+        "upstream": "origin/codex/maint-0134-agent-instructions"
+      },
+      "name": "codex/maint-0134-agent-instructions",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-23T09:41:51Z",
+          "headRefName": "codex/maint-0134-agent-instructions",
+          "headRefOid": "3e753959a006b640357c46a711689be46f076102",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "69c09cc741e11ba50521cb2cadaf2ba560ba4c51"
+          },
+          "mergedAt": "2026-08-23T09:41:51Z",
+          "number": 850,
+          "state": "MERGED",
+          "title": "chore(governance): consolidate agent instruction contract",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/850"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "3e753959a006b640357c46a711689be46f076102",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIRTY",
+          "dirty_count": 9,
+          "head_sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0136-cleanup-preservation"
+        }
+      ],
+      "disposition": "RETAIN_CURRENT_TASK",
+      "local": {
+        "sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+        "upstream": "origin/main"
+      },
+      "name": "codex/maint-0136-cleanup-preservation",
+      "pull_requests": [],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "ACTIVE_PHASE_1_LANE"
+      ],
+      "remote": {
+        "sha": null,
+        "status": "ABSENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "codex/parallel-task-policy",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-12T16:40:31Z",
+          "headRefName": "codex/parallel-task-policy",
+          "headRefOid": "75d666813b116b65f1620d9237a7bce972d5d3c6",
+          "isDraft": true,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 723,
+          "state": "CLOSED",
+          "title": "feat(workflow): enable collision-safe parallel tasks",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/723"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "remote": {
+        "sha": "75d666813b116b65f1620d9237a7bce972d5d3c6",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "db07cdf843eccd2fea4fd7977c28a2d6ea60b24e",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-cleanup-audit"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "db07cdf843eccd2fea4fd7977c28a2d6ea60b24e",
+        "upstream": "origin/codex/post-india2-cleanup-audit"
+      },
+      "name": "codex/post-india2-cleanup-audit",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T16:43:41Z",
+          "headRefName": "codex/post-india2-cleanup-audit",
+          "headRefOid": "db07cdf843eccd2fea4fd7977c28a2d6ea60b24e",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "cbe10638fcba3f8919f8776462af34247b0604d0"
+          },
+          "mergedAt": "2026-08-16T16:43:41Z",
+          "number": 807,
+          "state": "MERGED",
+          "title": "docs(git): audit post-INDIA2 cleanup candidates",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/807"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "db07cdf843eccd2fea4fd7977c28a2d6ea60b24e",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "a4e7ab4a148bd1fc2869bac566660e9881e507dd",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-cleanup-execution"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "a4e7ab4a148bd1fc2869bac566660e9881e507dd",
+        "upstream": "origin/codex/post-india2-cleanup-execution"
+      },
+      "name": "codex/post-india2-cleanup-execution",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T17:23:00Z",
+          "headRefName": "codex/post-india2-cleanup-execution",
+          "headRefOid": "a4e7ab4a148bd1fc2869bac566660e9881e507dd",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "3b08a9c1a0471dea86ac36e7a0ca1e03b045b82e"
+          },
+          "mergedAt": "2026-08-16T17:23:00Z",
+          "number": 808,
+          "state": "MERGED",
+          "title": "docs(git): record post-INDIA2 cleanup execution",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/808"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "a4e7ab4a148bd1fc2869bac566660e9881e507dd",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "9e681a2ec41944d4964733c0bf337bfe9018ea45",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-maintenance"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "9e681a2ec41944d4964733c0bf337bfe9018ea45",
+        "upstream": "origin/codex/post-india2-maintenance"
+      },
+      "name": "codex/post-india2-maintenance",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T17:44:06Z",
+          "headRefName": "codex/post-india2-maintenance",
+          "headRefOid": "9e681a2ec41944d4964733c0bf337bfe9018ea45",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "7541a7c768aee408e38bf8e7b4a1997469b0b9b1"
+          },
+          "mergedAt": "2026-08-16T17:44:06Z",
+          "number": 809,
+          "state": "MERGED",
+          "title": "chore(maintenance): compact post-INDIA2 governance state",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/809"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "9e681a2ec41944d4964733c0bf337bfe9018ea45",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "40cfc02e5b8d6752f5805eef9e437b3b1a01de8d",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-pre-release-input-safety-plan"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "40cfc02e5b8d6752f5805eef9e437b3b1a01de8d",
+        "upstream": "origin/codex/pre-release-input-safety-plan"
+      },
+      "name": "codex/pre-release-input-safety-plan",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-16T18:58:45Z",
+          "headRefName": "codex/pre-release-input-safety-plan",
+          "headRefOid": "40cfc02e5b8d6752f5805eef9e437b3b1a01de8d",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "55104e11257937b0a42fb06f931a70b8484cef39"
+          },
+          "mergedAt": "2026-08-16T18:58:45Z",
+          "number": 812,
+          "state": "MERGED",
+          "title": "docs(governance): plan pre-release input safety",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/812"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "40cfc02e5b8d6752f5805eef9e437b3b1a01de8d",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "4d7e7e14faf4947d54364de73439927e69c26fc7",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-decisive-gates"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "4d7e7e14faf4947d54364de73439927e69c26fc7",
+        "upstream": "origin/codex/public-route-decisive-gates"
+      },
+      "name": "codex/public-route-decisive-gates",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T11:32:25Z",
+          "headRefName": "codex/public-route-decisive-gates",
+          "headRefOid": "4d7e7e14faf4947d54364de73439927e69c26fc7",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "640c7839f043adb0e7db02d924a9e1a3a06e1131"
+          },
+          "mergedAt": "2026-08-22T11:32:25Z",
+          "number": 835,
+          "state": "MERGED",
+          "title": "ci(safety): make public route audit gates decisive",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/835"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "4d7e7e14faf4947d54364de73439927e69c26fc7",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "d3f77cedbd5db856893193ec79d97529bf831ede",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-domain-provenance"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "d3f77cedbd5db856893193ec79d97529bf831ede",
+        "upstream": "origin/codex/public-route-domain-provenance"
+      },
+      "name": "codex/public-route-domain-provenance",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T10:25:27Z",
+          "headRefName": "codex/public-route-domain-provenance",
+          "headRefOid": "d3f77cedbd5db856893193ec79d97529bf831ede",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "e19b757ccb9922061369a236501f037ec20503ab"
+          },
+          "mergedAt": "2026-08-22T10:25:27Z",
+          "number": 833,
+          "state": "MERGED",
+          "title": "fix(safety): enforce public route domains",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/833"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "d3f77cedbd5db856893193ec79d97529bf831ede",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "fde41089a2314b749af1b4f48c80d21f3cfa0b44",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-failure-contracts"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "fde41089a2314b749af1b4f48c80d21f3cfa0b44",
+        "upstream": "origin/codex/public-route-failure-contracts"
+      },
+      "name": "codex/public-route-failure-contracts",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T11:02:01Z",
+          "headRefName": "codex/public-route-failure-contracts",
+          "headRefOid": "fde41089a2314b749af1b4f48c80d21f3cfa0b44",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "027554457c58303f435dc4a9940dc683def22895"
+          },
+          "mergedAt": "2026-08-22T11:02:01Z",
+          "number": 834,
+          "state": "MERGED",
+          "title": "fix(safety): structure public failure contracts",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/834"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "fde41089a2314b749af1b4f48c80d21f3cfa0b44",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_DIVERGED",
+          "dirty_count": 0,
+          "head_sha": "dca370088cd458d014fda9829b9f0e6cf003e158",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-numeric-boundaries"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "dca370088cd458d014fda9829b9f0e6cf003e158",
+        "upstream": "origin/codex/public-route-numeric-boundaries"
+      },
+      "name": "codex/public-route-numeric-boundaries",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-22T10:00:06Z",
+          "headRefName": "codex/public-route-numeric-boundaries",
+          "headRefOid": "dca370088cd458d014fda9829b9f0e6cf003e158",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "e7698a63b86d2db6db2f3970871122af1ce562f6"
+          },
+          "mergedAt": "2026-08-22T10:00:06Z",
+          "number": 832,
+          "state": "MERGED",
+          "title": "fix(safety): close public numeric boundaries",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/832"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "dca370088cd458d014fda9829b9f0e6cf003e158",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_BEHIND",
+          "dirty_count": 0,
+          "head_sha": "09861d3d5ef758abbe0f7c40b8b49b2f90510765",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-release-0231a2"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "09861d3d5ef758abbe0f7c40b8b49b2f90510765",
+        "upstream": "origin/main"
+      },
+      "name": "codex/release-0231-stable",
+      "pull_requests": [],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": null,
+        "status": "ABSENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "6f2f449a3fda1fe927d47c8d7d070a39a9e8c5b7",
+        "upstream": "origin/codex/release-0231a2"
+      },
+      "name": "codex/release-0231a2",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-17T08:49:04Z",
+          "headRefName": "codex/release-0231a2",
+          "headRefOid": "6f2f449a3fda1fe927d47c8d7d070a39a9e8c5b7",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "09861d3d5ef758abbe0f7c40b8b49b2f90510765"
+          },
+          "mergedAt": "2026-08-17T08:49:04Z",
+          "number": 821,
+          "state": "MERGED",
+          "title": "chore(release): prepare 0.23.1a2",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/821"
+        }
+      ],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "remote": {
+        "sha": "6f2f449a3fda1fe927d47c8d7d070a39a9e8c5b7",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_BEHIND",
+          "dirty_count": 0,
+          "head_sha": "d3a4d2235d1811ab4bc2c860640f5660c6eed057",
+          "path": "/Users/pravinsurawase/.codex/worktrees/release-0240a1-publication"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "d3a4d2235d1811ab4bc2c860640f5660c6eed057",
+        "upstream": "origin/codex/release-0240a1-publication"
+      },
+      "name": "codex/release-0240a1-publication",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-24T13:52:18Z",
+          "headRefName": "codex/release-0240a1-publication",
+          "headRefOid": "d3a4d2235d1811ab4bc2c860640f5660c6eed057",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "71b7065216d4266d63ad6b31bd39bba81fa16efc"
+          },
+          "mergedAt": "2026-08-24T13:52:18Z",
+          "number": 872,
+          "state": "MERGED",
+          "title": "fix(release): stabilize exact hosted verification",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/872"
+        }
+      ],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "d3a4d2235d1811ab4bc2c860640f5660c6eed057",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_BEHIND",
+          "dirty_count": 0,
+          "head_sha": "5da9c66a0f962fc08a6431fe95e39ec664a353f6",
+          "path": "/Users/pravinsurawase/.codex/worktrees/alpha-release/structural_engineering_lib"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "5da9c66a0f962fc08a6431fe95e39ec664a353f6",
+        "upstream": "origin/codex/release-preflight-alpha-policy"
+      },
+      "name": "codex/release-preflight-alpha-policy",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-11T04:55:31Z",
+          "headRefName": "codex/release-preflight-alpha-policy",
+          "headRefOid": "20180a40137cb43f8a4d8f51093c6337ac94ced1",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "5da9c66a0f962fc08a6431fe95e39ec664a353f6"
+          },
+          "mergedAt": "2026-08-11T04:55:31Z",
+          "number": 731,
+          "state": "MERGED",
+          "title": "docs(release): document Alpha version policy",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/731"
+        }
+      ],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "20180a40137cb43f8a4d8f51093c6337ac94ced1",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_BEHIND",
+          "dirty_count": 0,
+          "head_sha": "3cec0bd40eee30a6757cb1af87c5d63d307dce4d",
+          "path": "/Users/pravinsurawase/.codex/worktrees/release-smoothness"
+        }
+      ],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": {
+        "sha": "3cec0bd40eee30a6757cb1af87c5d63d307dce4d",
+        "upstream": "origin/codex/release-smoothness"
+      },
+      "name": "codex/release-smoothness",
+      "pull_requests": [
+        {
+          "author": {
+            "id": "U_kgDOB3bthQ",
+            "is_bot": false,
+            "login": "Pravin-surawase",
+            "name": "Pravin Surawase"
+          },
+          "baseRefName": "main",
+          "closedAt": "2026-08-24T14:26:31Z",
+          "headRefName": "codex/release-smoothness",
+          "headRefOid": "3cec0bd40eee30a6757cb1af87c5d63d307dce4d",
+          "isDraft": false,
+          "mergeCommit": {
+            "oid": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f"
+          },
+          "mergedAt": "2026-08-24T14:26:31Z",
+          "number": 873,
+          "state": "MERGED",
+          "title": "fix(release): streamline next publication",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/873"
+        }
+      ],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "ATTACHED_WORKTREE"
+      ],
+      "remote": {
+        "sha": "3cec0bd40eee30a6757cb1af87c5d63d307dce4d",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/npm_and_yarn/react_app/eslint-10.8.0",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/npm_and_yarn/react_app/eslint-10.8.0",
+          "headRefOid": "fbb0d7f781795bc05d50c1a93709d688ab455893",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 713,
+          "state": "OPEN",
+          "title": "chore(deps): bump eslint from 9.39.2 to 10.8.1 in /react_app",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/713"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "fbb0d7f781795bc05d50c1a93709d688ab455893",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/npm_and_yarn/react_app/eslint/js-10.0.1",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/npm_and_yarn/react_app/eslint/js-10.0.1",
+          "headRefOid": "31f92162c1ca5dc06beca270821f7ebc8582a0ff",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 683,
+          "state": "OPEN",
+          "title": "chore(deps): bump @eslint/js from 9.39.2 to 10.0.1 in /react_app",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/683"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "31f92162c1ca5dc06beca270821f7ebc8582a0ff",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/npm_and_yarn/react_app/framer-motion-13.0.0",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/npm_and_yarn/react_app/framer-motion-13.0.0",
+          "headRefOid": "f889f6de4ed8a2323544a34b77b09f6c88b9e375",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 716,
+          "state": "OPEN",
+          "title": "chore(deps): bump framer-motion from 12.29.2 to 13.1.1 in /react_app",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/716"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "f889f6de4ed8a2323544a34b77b09f6c88b9e375",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/npm_and_yarn/react_app/types/node-26.1.2",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/npm_and_yarn/react_app/types/node-26.1.2",
+          "headRefOid": "c4d813f2bf9361c4db9863315a6294709c0261ed",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 714,
+          "state": "OPEN",
+          "title": "chore(deps): bump @types/node from 24.10.9 to 26.2.0 in /react_app",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/714"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "c4d813f2bf9361c4db9863315a6294709c0261ed",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/npm_and_yarn/react_app/vitejs/plugin-react-6.0.5",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/npm_and_yarn/react_app/vitejs/plugin-react-6.0.5",
+          "headRefOid": "1f710133fc76b32d6e4cbf47dae610023bc65633",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 684,
+          "state": "OPEN",
+          "title": "chore(deps): bump @vitejs/plugin-react from 5.1.2 to 6.1.0 in /react_app",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/684"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "1f710133fc76b32d6e4cbf47dae610023bc65633",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/pip/Python/dev-dependencies-e904d59df0",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/pip/Python/dev-dependencies-e904d59df0",
+          "headRefOid": "6fc9356afd44fa3476f56f1f222868c7c349c35f",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 816,
+          "state": "OPEN",
+          "title": "chore(deps): bump ruff from 0.16.1 to 0.16.4 in /Python in the dev-dependencies group across 1 directory",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/816"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "6fc9356afd44fa3476f56f1f222868c7c349c35f",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/pip/Python/mypy-gte-1.19-and-lt-3",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/pip/Python/mypy-gte-1.19-and-lt-3",
+          "headRefOid": "2f8de4a079c4e7a1329048796816dedd026f5f3f",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 715,
+          "state": "OPEN",
+          "title": "chore(deps): update mypy requirement from <2,>=1.19 to >=1.19,<3 in /Python",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/715"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "2f8de4a079c4e7a1329048796816dedd026f5f3f",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/pip/mypy-2.3.0",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/pip/mypy-2.3.0",
+          "headRefOid": "ff9dfb21ea8745bdb48e4742dc3f73b0c0fff8fd",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 717,
+          "state": "OPEN",
+          "title": "chore(deps): bump mypy from 1.20.2 to 2.3.1",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/717"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "ff9dfb21ea8745bdb48e4742dc3f73b0c0fff8fd",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "dependabot/pip/root-python-dependencies-fb8581aa0a",
+      "pull_requests": [
+        {
+          "author": {
+            "is_bot": true,
+            "login": "app/dependabot"
+          },
+          "baseRefName": "main",
+          "closedAt": null,
+          "headRefName": "dependabot/pip/root-python-dependencies-fb8581aa0a",
+          "headRefOid": "b67577133be1c80f3958ba82097abc731045af75",
+          "isDraft": false,
+          "mergeCommit": null,
+          "mergedAt": null,
+          "number": 865,
+          "state": "OPEN",
+          "title": "chore(deps): bump the root-python-dependencies group across 1 directory with 31 updates",
+          "url": "https://github.com/Pravin-surawase/structural_engineering_lib/pull/865"
+        }
+      ],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+        "OPEN_PULL_REQUEST"
+      ],
+      "remote": {
+        "sha": "b67577133be1c80f3958ba82097abc731045af75",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [],
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "local": null,
+      "name": "gh-pages",
+      "pull_requests": [],
+      "reachable_from_observed_origin_main": false,
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "remote": {
+        "sha": "79b200337c074e0d288ed49dfd4348602ba35952",
+        "status": "PRESENT"
+      }
+    },
+    {
+      "attached_worktrees": [
+        {
+          "derived_action": "HOLD_MAIN",
+          "dirty_count": 0,
+          "head_sha": "e2fac7419551988def59101ac63a5f8e491bc7a2",
+          "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+        }
+      ],
+      "disposition": "RETAIN_DEFAULT_BRANCH",
+      "local": {
+        "sha": "e2fac7419551988def59101ac63a5f8e491bc7a2",
+        "upstream": "origin/main"
+      },
+      "name": "main",
+      "pull_requests": [],
+      "reachable_from_observed_origin_main": true,
+      "reason_codes": [
+        "DEFAULT_BRANCH"
+      ],
+      "remote": {
+        "sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+        "status": "PRESENT"
+      }
+    }
+  ],
+  "caches": [
+    {
+      "disposition": "RETAIN_PRIMARY_RUNTIME",
+      "reason_codes": [
+        "PRIMARY_RUNTIME_DEPENDENCY"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 473759744,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    },
+    {
+      "disposition": "RETAIN_PRIMARY_RUNTIME",
+      "reason_codes": [
+        "PRIMARY_RUNTIME_DEPENDENCY"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 75288576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    },
+    {
+      "disposition": "RETAIN_PRIMARY_RUNTIME",
+      "reason_codes": [
+        "PRIMARY_RUNTIME_DEPENDENCY"
+      ],
+      "relative_path": ".pytest_cache",
+      "size_bytes": 57344,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    },
+    {
+      "disposition": "RETAIN_PRIMARY_RUNTIME",
+      "reason_codes": [
+        "PRIMARY_RUNTIME_DEPENDENCY"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    },
+    {
+      "disposition": "RETAIN_PRIMARY_RUNTIME",
+      "reason_codes": [
+        "PRIMARY_RUNTIME_DEPENDENCY"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 720896,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    },
+    {
+      "disposition": "RETAIN_PRIMARY_RUNTIME",
+      "reason_codes": [
+        "PRIMARY_RUNTIME_DEPENDENCY"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2887680,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 94539776,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/3c84/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/3c84/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 40960,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/3c84/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/7c3898d2-40f8-4e2b-bee5-fb7e8ebb0250/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 573440,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/alpha-release/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2887680,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/alpha-release/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438308864,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 33124352,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 45056,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2912256,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 33112064,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/ef1b/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/ef1b/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/ef1b/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 34496512,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-beam-r1/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-beam-r1/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 36864,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-beam-r1/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-column-r1/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 40960,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-column-r1/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-g0-source-library/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-g0-source-library/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-is13920-m0/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 749568,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/india-3-is13920-m0/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 33144832,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-009-rc-trust"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-009-rc-trust"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-009-rc-trust"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438304768,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-010-rc-artifact"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-010-rc-artifact"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 749568,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-010-rc-artifact"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2912256,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-010-rc-artifact"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012a/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 45056,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012a/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012b/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 61440,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012b/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012c/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 65536,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012c/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".pytest_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012d/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012d/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 729088,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/maint-012d/structural_engineering_lib"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/release-0240a1-publication"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 53248,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/release-0240a1-publication"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/release-smoothness"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 32768,
+      "worktree_path": "/Users/pravinsurawase/.codex/worktrees/release-smoothness"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438317056,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a1-canonical-transport"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a1-canonical-transport"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 53248,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a1-canonical-transport"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2895872,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a1-canonical-transport"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438304768,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a2-lossless-intake"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 76513280,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a2-lossless-intake"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a2-lossless-intake"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 684032,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a2-lossless-intake"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2895872,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a2-lossless-intake"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 31907840,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b1-gravity-model-ledger"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b1-gravity-model-ledger"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 24576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b1-gravity-model-ledger"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438308864,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b2-gravity-workflow-v1"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b2-gravity-workflow-v1"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 684032,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b2-gravity-workflow-v1"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2908160,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b2-gravity-workflow-v1"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-excel-workbench"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 20480,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-excel-workbench"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 24576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-g3-closeout"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-review-bundle-export"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 20480,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-review-bundle-export"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-workbook-open-repair"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 679936,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-workbook-open-repair"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-index-local-artifact-determinism"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 32768,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-index-local-artifact-determinism"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-index-mtime-determinism"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 32768,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-index-mtime-determinism"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 20480,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-3-g0-acceptance"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 20480,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-3-g0-truth-audit"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 31158272,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-a-strict-input"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-a-strict-input"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 24576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-a-strict-input"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438308864,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-b-lossless-import"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 76324864,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-b-lossless-import"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-b-lossless-import"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 675840,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-b-lossless-import"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2887680,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-b-lossless-import"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-i-cli"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 28672,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-i-cli"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438308864,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-j-release-signal"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-j-release-signal"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 671744,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-j-release-signal"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438296576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-004-safety-auditors"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-004-safety-auditors"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 712704,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-004-safety-auditors"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438296576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-005-release-safety-closure"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-005-release-safety-closure"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 716800,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-005-release-safety-closure"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-006-gravity-foundation"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 20480,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-006-gravity-foundation"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2908160,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-006-gravity-foundation"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438312960,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-m0"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-m0"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 733184,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-m0"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2912256,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-m0"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438296576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p1"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p1"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p1"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438308864,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p2"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 32612352,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p2"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p2"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 28672,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p2"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2908160,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p2"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 34787328,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p3"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p3"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 32768,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p3"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438308864,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p4"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 32747520,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p4"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p4"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 24576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p4"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2908160,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p4"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438288384,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-011"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-011"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 73728,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-011"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".pytest_cache",
+      "size_bytes": 20480,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0130-safe-file"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 20480,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0130-safe-file"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 724992,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0130-safe-file"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0131-efficiency-controls"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 40960,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0131-efficiency-controls"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0132-efficiency-observability"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 57344,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0132-efficiency-observability"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".pytest_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0133-cleanup-inventory"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".pytest_cache",
+      "size_bytes": 16384,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0133b-packet-a"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0134-agent-instructions"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 36864,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0134-agent-instructions"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0135-cleanup-refresh"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 53248,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0135-cleanup-refresh"
+    },
+    {
+      "disposition": "RETAIN_CURRENT_TASK_RUNTIME",
+      "reason_codes": [
+        "ACTIVE_PHASE_1_LANE"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0136-cleanup-preservation"
+    },
+    {
+      "disposition": "RETAIN_CURRENT_TASK_RUNTIME",
+      "reason_codes": [
+        "ACTIVE_PHASE_1_LANE"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 24576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0136-cleanup-preservation"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 24576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-cleanup-audit"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 24576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-cleanup-execution"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-maintenance"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 36864,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-maintenance"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438296576,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-decisive-gates"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 12288,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-decisive-gates"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 700416,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-decisive-gates"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 75792384,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-domain-provenance"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-domain-provenance"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 114688,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-domain-provenance"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-failure-contracts"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 57344,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-failure-contracts"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".mypy_cache",
+      "size_bytes": 32141312,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-numeric-boundaries"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-numeric-boundaries"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 57344,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-numeric-boundaries"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/node_modules",
+      "size_bytes": 438312960,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-release-0231a2"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": ".ruff_cache",
+      "size_bytes": 8192,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-release-0231a2"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "Python/.pytest_cache",
+      "size_bytes": 675840,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-release-0231a2"
+    },
+    {
+      "disposition": "CACHE_CANDIDATE_NOT_AUTHORIZED",
+      "reason_codes": [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "relative_path": "react_app/dist",
+      "size_bytes": 2887680,
+      "worktree_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-release-0231a2"
+    }
+  ],
+  "decision": "Freeze and preserve the observed topology. No file, cache, worktree, branch, remote ref, or pull request is authorized for cleanup.",
+  "disk_capacity": {
+    "available_bytes": 29924573184,
+    "capacity_percent": 87,
+    "total_bytes": 245107195904,
+    "used_bytes": 192034156544
+  },
+  "observed_at_utc": "2026-08-26T15:03:08.193998+00:00",
+  "recovery_evidence": {
+    "dirty_patch_sha256": "cf70f18f57ea3c7e14c85fe06cdd00d0171ac65da42dce08eef6a286b4930394",
+    "git_bundle_sha256": "c57240f207b5730de92b9d27d5d64a819a89e0b0496d92351f4eec580c637dac",
+    "off_device_recovery_status": "HOLD_DESTINATION_UNAVAILABLE",
+    "path": "docs/verification/maint-0136-cleanup-recovery-evidence.json",
+    "status": "LOCAL_RECOVERY_VERIFIED_OFF_DEVICE_HOLD"
+  },
+  "schema_version": 1,
+  "status": "PHASE_1_LOCAL_PRESERVATION_COMPLETE_OFF_DEVICE_HOLD",
+  "summary": {
+    "branch_or_pr_head_count": 83,
+    "cache_path_count": 157,
+    "cache_total_bytes": 8265424896,
+    "detached_worktree_count": 7,
+    "dirty_worktree_count": 2,
+    "phase_2_authorized": false,
+    "phase_2_cache_candidate_bytes": 7712661504,
+    "phase_2_cache_candidate_count": 149,
+    "preexisting_dirty_worktree_count": 1,
+    "preexisting_worktree_count": 72,
+    "remote_branch_count": 80,
+    "worktree_count": 73,
+    "worktree_total_bytes": 18884534272
+  },
+  "task_id": "MAINT-0136",
+  "worktrees": [
+    {
+      "branch": "main",
+      "current": false,
+      "derived_action": "HOLD_MAIN",
+      "dirty_count": 0,
+      "disposition": "RETAIN_INTEGRATION_ANCHOR",
+      "head_sha": "e2fac7419551988def59101ac63a5f8e491bc7a2",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "PRIMARY_CHECKOUT",
+        "IGNORED_SOURCES_OWNER"
+      ],
+      "size_bytes": 2905141248
+    },
+    {
+      "branch": "DETACHED",
+      "current": false,
+      "derived_action": "HOLD_DETACHED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "98c60bc1f7c3899c28f662e82399cb25d80bbf26",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/1ee2/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 71479296
+    },
+    {
+      "branch": "codex/lib-pro-007-p7-compatibility-convergence",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "c9589815f2d8053b1d99f61bf38623cd2aebba2f",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/3c84/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 250531840
+    },
+    {
+      "branch": "DETACHED",
+      "current": false,
+      "derived_action": "HOLD_DETACHED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/5986/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 67637248
+    },
+    {
+      "branch": "DETACHED",
+      "current": false,
+      "derived_action": "HOLD_DETACHED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "514155b266af6dff3e30bf39ee28671c17345454",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/5da5/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 74215424
+    },
+    {
+      "branch": "codex/india-3-source-meta-r1",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "13f0ff916a0d7c167e34b46ab9ae6cb2c50c9efd",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/7c3898d2-40f8-4e2b-bee5-fb7e8ebb0250/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 90976256
+    },
+    {
+      "branch": "codex/release-preflight-alpha-policy",
+      "current": false,
+      "derived_action": "HOLD_BEHIND",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "5da9c66a0f962fc08a6431fe95e39ec664a353f6",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/alpha-release/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 81518592
+    },
+    {
+      "branch": "DETACHED",
+      "current": false,
+      "derived_action": "HOLD_DETACHED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "670ea4beeb2a8765fff59e05bb130ff54752369e",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/b026/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 67637248
+    },
+    {
+      "branch": "DETACHED",
+      "current": false,
+      "derived_action": "HOLD_DETACHED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "bf4065f071f1245461df6d3c42f1cc070efbae70",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/b94c/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 67653632
+    },
+    {
+      "branch": "codex/lib-pro-007-p6-cross-surface-parity",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "9647feddb672428e4f89348f5f82ad8c2cbe71cf",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/cace/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 635617280
+    },
+    {
+      "branch": "DETACHED",
+      "current": false,
+      "derived_action": "HOLD_DETACHED",
+      "dirty_count": 1,
+      "disposition": "RETAIN_DIRTY_UNIQUE",
+      "head_sha": "0fdb48edbb73114288feb8a246d6f30b80ac4d95",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/e54a/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "UNCOMMITTED_WORK",
+        "PATCH_RECOVERY_REQUIRED"
+      ],
+      "size_bytes": 67584000
+    },
+    {
+      "branch": "codex/india-3-joint-r1",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "a5657e1bbcea16079af527005c47b296cf95f742",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/ef1b/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 187305984
+    },
+    {
+      "branch": "DETACHED",
+      "current": false,
+      "derived_action": "HOLD_DETACHED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "b91838f594a04aff1d21c43bf6f87a64710b0748",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/fa98/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 67637248
+    },
+    {
+      "branch": "codex/india-3-beam-r1",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "099937dc3da7c0083de793ed3b2972690a44d423",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/india-3-beam-r1/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 285356032
+    },
+    {
+      "branch": "codex/india-3-column-r1",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "4df72ea258610179a1496a255c1d6d320e3416bf",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/india-3-column-r1/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 157700096
+    },
+    {
+      "branch": "codex/india-3-g0-source-library",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "9c976b1f4afd0540a5ec9eb3cab16861916ac89b",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/india-3-g0-source-library/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 73965568
+    },
+    {
+      "branch": "codex/india-3-is13920-m0",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "0a20774ec8978b7dcea6d7cd7db6966068b70703",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/india-3-is13920-m0/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 98684928
+    },
+    {
+      "branch": "codex/lib-pro-009-rc-trust",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "b4428e23adc8374d1acc6e7f2a2125d5aebff453",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-009-rc-trust",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 187600896
+    },
+    {
+      "branch": "codex/lib-pro-010-rc-artifact",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "595b3bcb1bb55bae0261016a3dddd87da4aca8e9",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/lib-pro-010-rc-artifact",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 632537088
+    },
+    {
+      "branch": "codex/maint-012a-control-registry",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "f0cdf631d6c7d698c0a7b47b04030b4e23fb32a2",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/maint-012a/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 76390400
+    },
+    {
+      "branch": "codex/maint-012b-index-architecture",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "74bfd69ebf610b6cb324b7298b95ac840652ed4c",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/maint-012b/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 74887168
+    },
+    {
+      "branch": "codex/maint-012c-evidence-scheduling",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "56eff4d357ca62332fb0e50c6a55c2336af57c65",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/maint-012c/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 74997760
+    },
+    {
+      "branch": "codex/maint-012d-scanner-consolidation",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "66cd2bb51b9f4f1fd7f6c1f8ab57e5a4f188e20d",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/maint-012d/structural_engineering_lib",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 89899008
+    },
+    {
+      "branch": "codex/release-0240a1-publication",
+      "current": false,
+      "derived_action": "HOLD_BEHIND",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "d3a4d2235d1811ab4bc2c860640f5660c6eed057",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/release-0240a1-publication",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 174702592
+    },
+    {
+      "branch": "codex/release-smoothness",
+      "current": false,
+      "derived_action": "HOLD_BEHIND",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "3cec0bd40eee30a6757cb1af87c5d63d307dce4d",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/.codex/worktrees/release-smoothness",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 76537856
+    },
+    {
+      "branch": "codex/a1-canonical-transport-contract",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "85872c846020ee9fb7cf654e8b5b3943f44fa531",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a1-canonical-transport",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 597057536
+    },
+    {
+      "branch": "codex/a2-lossless-intake-calculation",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "2a6889b363aad85f5b45f5ba23b344efd08084d6",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-a2-lossless-intake",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 683311104
+    },
+    {
+      "branch": "codex/b1-gravity-model-load-ledger",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "4a7f13bca2fadfdb45017a296e6235c3b95dd401",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b1-gravity-model-ledger",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 182837248
+    },
+    {
+      "branch": "codex/b2-gravity-workflow-v1",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "b337efc73d0af9ff7bef623916cfe808dd79bed6",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-b2-gravity-workflow-v1",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 609280000
+    },
+    {
+      "branch": "codex/e1-blank-workbook-guard",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "514155b266af6dff3e30bf39ee28671c17345454",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-blank-workbook-guard",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 74420224
+    },
+    {
+      "branch": "codex/e1-excel-routine-workbench",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "ef5ee05c785904e1a01c2d09cc65649edc8745ab",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-excel-workbench",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 156639232
+    },
+    {
+      "branch": "codex/e1-g3-closeout",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "53b9f56e5af0bae064ba3a545dbb9b86b4b336d7",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-g3-closeout",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 89382912
+    },
+    {
+      "branch": "codex/e1-review-bundle-export",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "98c60bc1f7c3899c28f662e82399cb25d80bbf26",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-review-bundle-export",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 156803072
+    },
+    {
+      "branch": "codex/e1-w0-maintenance-plan",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "654e40b1370d098fca4d001146a030b9937536a8",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-w0-maintenance",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 88981504
+    },
+    {
+      "branch": "codex/e1-workbook-open-repair",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "ede01ef4fb6182a27e3f176e872478304fb5f256",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-e1-workbook-open-repair",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 171053056
+    },
+    {
+      "branch": "codex/excel-product-planning",
+      "current": false,
+      "derived_action": "HOLD_BEHIND",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "a0e115e17009cc14b3d883e3c291d47c32f7ca4e",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-excel-product-planning",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 64163840
+    },
+    {
+      "branch": "codex/git-governance-research",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "657037364bbb49f2ef834c70f3a3c704bac83c7b",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-git-governance-research",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 67510272
+    },
+    {
+      "branch": "codex/implementation-first-verification-policy",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "fffbfaaa0d928768efe7b703a0d8091555ad9a8e",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-implementation-first-verification-policy",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 72237056
+    },
+    {
+      "branch": "codex/index-local-artifact-determinism",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "65c37ad0836bd59ebef56b6d01faa144b791d020",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-index-local-artifact-determinism",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 85946368
+    },
+    {
+      "branch": "codex/index-mtime-determinism",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "cfb98da58af391bdefb23f8cfc83295876b44876",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-index-mtime-determinism",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 85909504
+    },
+    {
+      "branch": "codex/india-3-g0-acceptance",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "8466fb1458f41cb767117f5a49b4495b23d794eb",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-3-g0-acceptance",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 156626944
+    },
+    {
+      "branch": "codex/india-3-g0-truth-audit",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "b39fcda534ec757744a2d6f203f42e4350871cd1",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-india-3-g0-truth-audit",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 76476416
+    },
+    {
+      "branch": "codex/lib-pro-002-a-strict-input",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "18d043ef9ac6221936335e1b20676863b3c5bc9b",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-a-strict-input",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 179654656
+    },
+    {
+      "branch": "codex/lib-pro-002-b-lossless-import",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "22c65d17874ec877a7f90f56ae6950131eddd462",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-b-lossless-import",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 685973504
+    },
+    {
+      "branch": "codex/lib-pro-002-i-cli",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "911b6e3d288db85bc3f2770a061598689a4e8ec3",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-i-cli",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 149364736
+    },
+    {
+      "branch": "codex/lib-pro-002-j-release-signal",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "280dd9a9a31e8f318d385cb2ec43418d195ca4b3",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-002-j-release-signal",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 527532032
+    },
+    {
+      "branch": "codex/lib-pro-004-safety-auditors",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "ff55471c9b75a7c70369f857c387fdffad05899d",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-004-safety-auditors",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 608833536
+    },
+    {
+      "branch": "codex/lib-pro-005-release-safety-closure",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "0979200d00ea32bd7464232f20558f353509be8a",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-005-release-safety-closure",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 608096256
+    },
+    {
+      "branch": "codex/lib-pro-006-gravity-foundation",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "6db242171427b93a2586de9c2c772ccba03243de",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-006-gravity-foundation",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 156139520
+    },
+    {
+      "branch": "codex/lib-pro-007-g0-contract-freeze",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "3b0c0c2551d5f1d31b1dd8251489e6ec632f57a4",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-g0",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 89395200
+    },
+    {
+      "branch": "codex/lib-pro-007-m0-cumulative-acceptance",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "eb92db482734e531561f739cf6818104281ef451",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-m0",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 548667392
+    },
+    {
+      "branch": "codex/lib-pro-007-p1-optimization-truth",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "6dd3fd4e17354f27846869ee48d10277c4703d0f",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p1",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 591859712
+    },
+    {
+      "branch": "codex/lib-pro-007-p2-supplied-beam-reinforcement",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "fa81954852285d59fe7c1e58de7c2b6cb3fa7971",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p2",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 627843072
+    },
+    {
+      "branch": "codex/lib-pro-007-p3-footing-anchorage",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "bfec16d13409519979135abc99b7b31ebc600688",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p3",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 189300736
+    },
+    {
+      "branch": "codex/lib-pro-007-p4-practical-actions",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "a2b813dbc2c5a873edabab30c36087ff7fea7eda",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-lib-pro-007-p4",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 628224000
+    },
+    {
+      "branch": "codex/maint-011-developer-gate-hygiene",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "1f203f40ec162a5caf141b1c44444ec4f6d3470c",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-011",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 594534400
+    },
+    {
+      "branch": "codex/maint-0130-safe-file-foundation",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "b7b9623966c3131b8d5628496ea06328ce7210a6",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0130-safe-file",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 89407488
+    },
+    {
+      "branch": "codex/maint-0131-efficiency-controls",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "a4dbb38e113fb2383997e1b294ab53f64325716a",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0131-efficiency-controls",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 74625024
+    },
+    {
+      "branch": "codex/maint-0132-efficiency-observability",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "2573b0d7959913b550eea6d6f15f34fd4e6edff5",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0132-efficiency-observability",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 75075584
+    },
+    {
+      "branch": "codex/maint-0133-cleanup-inventory",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "f8c8d2642fa1f61f78366b3a05ff8dded692b75d",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0133-cleanup-inventory",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 73945088
+    },
+    {
+      "branch": "codex/maint-0133b-packet-a",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "203b33e9611dd27d5aecc0d47b7f49f607dc3dde",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0133b-packet-a",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 73981952
+    },
+    {
+      "branch": "codex/maint-0134-agent-instructions",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "3e753959a006b640357c46a711689be46f076102",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0134-agent-instructions",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 74985472
+    },
+    {
+      "branch": "codex/lib-pro-008-pre-india3-safety",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "f035abfa70037afab5e159f8395db1343ee346af",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0135-cleanup-refresh",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 156549120
+    },
+    {
+      "branch": "codex/maint-0136-cleanup-preservation",
+      "current": true,
+      "derived_action": "HOLD_DIRTY",
+      "dirty_count": 9,
+      "disposition": "RETAIN_CURRENT_TASK",
+      "head_sha": "ee04bfbf76b1a3a022d07c8203b5274a0f71998f",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-maint-0136-cleanup-preservation",
+      "query_status": "OK",
+      "reason_codes": [
+        "ACTIVE_PHASE_1_LANE"
+      ],
+      "size_bytes": 76476416
+    },
+    {
+      "branch": "codex/post-india2-cleanup-audit",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "db07cdf843eccd2fea4fd7977c28a2d6ea60b24e",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-cleanup-audit",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 71983104
+    },
+    {
+      "branch": "codex/post-india2-cleanup-execution",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "a4e7ab4a148bd1fc2869bac566660e9881e507dd",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-cleanup-execution",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 72298496
+    },
+    {
+      "branch": "codex/post-india2-maintenance",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "9e681a2ec41944d4964733c0bf337bfe9018ea45",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-post-india2-maintenance",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 85913600
+    },
+    {
+      "branch": "codex/pre-release-input-safety-plan",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "40cfc02e5b8d6752f5805eef9e437b3b1a01de8d",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-pre-release-input-safety-plan",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 72224768
+    },
+    {
+      "branch": "codex/public-route-decisive-gates",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "4d7e7e14faf4947d54364de73439927e69c26fc7",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-decisive-gates",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 530944000
+    },
+    {
+      "branch": "codex/public-route-domain-provenance",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "d3f77cedbd5db856893193ec79d97529bf831ede",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-domain-provenance",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 230404096
+    },
+    {
+      "branch": "codex/public-route-failure-contracts",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "fde41089a2314b749af1b4f48c80d21f3cfa0b44",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-failure-contracts",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 156442624
+    },
+    {
+      "branch": "codex/public-route-numeric-boundaries",
+      "current": false,
+      "derived_action": "HOLD_DIVERGED",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "dca370088cd458d014fda9829b9f0e6cf003e158",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-public-route-numeric-boundaries",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 185692160
+    },
+    {
+      "branch": "codex/release-0231-stable",
+      "current": false,
+      "derived_action": "HOLD_BEHIND",
+      "dirty_count": 0,
+      "disposition": "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED",
+      "head_sha": "09861d3d5ef758abbe0f7c40b8b49b2f90510765",
+      "operation": "none",
+      "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib-release-0231a2",
+      "query_status": "OK",
+      "reason_codes": [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED"
+      ],
+      "size_bytes": 541335552
+    }
+  ]
+}

--- a/docs/verification/maint-0136-cleanup-recovery-evidence.json
+++ b/docs/verification/maint-0136-cleanup-recovery-evidence.json
@@ -1,0 +1,68 @@
+{
+  "archive_directory": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/private_sources/worktree_cleanup_archives/maint-0136-20260826T144500Z",
+  "decision": "The same-disk bundle and patch are verified recovery aids. They do not qualify as external disaster recovery, so Phase 2 remains held.",
+  "dirty_worktree": {
+    "base_sha": "0fdb48edbb73114288feb8a246d6f30b80ac4d95",
+    "patch_path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/private_sources/worktree_cleanup_archives/maint-0136-20260826T144500Z/e54a-session-log.patch",
+    "patch_sha256": "cf70f18f57ea3c7e14c85fe06cdd00d0171ac65da42dce08eef6a286b4930394",
+    "patch_size_bytes": 7146,
+    "path": "/Users/pravinsurawase/.codex/worktrees/e54a/structural_engineering_lib",
+    "restore_sample": {
+      "checked_out_base": "0fdb48edbb73114288feb8a246d6f30b80ac4d95",
+      "content_match": true,
+      "git_fsck": "PASS",
+      "patch_apply": "PASS",
+      "patch_apply_check": "PASS",
+      "restored_session_log_sha256": "35903e436ce2bf90752c62ef8e4ae3e162e23f7a4b6ebc97e1ddfbc0a6af3cb9",
+      "source_session_log_sha256": "35903e436ce2bf90752c62ef8e4ae3e162e23f7a4b6ebc97e1ddfbc0a6af3cb9",
+      "temporary_restore_removed": true
+    }
+  },
+  "git_bundle": {
+    "contains_complete_history": true,
+    "path": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/private_sources/worktree_cleanup_archives/maint-0136-20260826T144500Z/structural-engineering-lib-all-refs.bundle",
+    "ref_count": 303,
+    "sha256": "c57240f207b5730de92b9d27d5d64a819a89e0b0496d92351f4eec580c637dac",
+    "size_bytes": 42922979,
+    "verification": "PASS"
+  },
+  "mutations_performed": {
+    "branch_deletions": 0,
+    "cache_deletions": 0,
+    "file_deletions": 0,
+    "pr_closures": 0,
+    "ref_deletions": 0,
+    "worktree_removals": 0
+  },
+  "observed_at_utc": "2026-08-26T15:03:08.193998+00:00",
+  "off_device_recovery": {
+    "same_disk_artifacts_are_disaster_recovery": false,
+    "status": "HOLD_DESTINATION_UNAVAILABLE",
+    "tmutil_exit_code": 0
+  },
+  "protected_sources": {
+    "aggregate_sha256": "a65d2fbcf5172544164d5ed61535f18fb40ed2d04446a48185811838493abee4",
+    "byte_count": 72025193,
+    "content_recorded": false,
+    "excluded_from_digest": [
+      "worktree_cleanup_archives/**",
+      "**/__pycache__/**"
+    ],
+    "file_count": 42,
+    "filenames_recorded": false,
+    "git_ignore_check": "PASS",
+    "git_tracked_path_count": 0,
+    "library_verifier": {
+      "canonical_aggregate_unchanged": true,
+      "status": "PASS",
+      "summary": "VERIFIED documents=25 aliases=27 pages=732 normalized_references=3 visual_review_pages=142 visual_render_checked_pages=84 visual_render_warning_pages=42 visual_render_failed_pages=0",
+      "target": "EXACT_TEMPORARY_SNAPSHOT",
+      "temporary_snapshot_removed": true
+    },
+    "root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/private_sources"
+  },
+  "recovery_tier": "SAME_DISK_ONLY",
+  "schema_version": 1,
+  "status": "LOCAL_RECOVERY_VERIFIED_OFF_DEVICE_HOLD",
+  "task_id": "MAINT-0136"
+}

--- a/scripts/_lib/cleanup_preservation.py
+++ b/scripts/_lib/cleanup_preservation.py
@@ -1,0 +1,697 @@
+"""Build fail-closed cleanup preservation and recovery evidence.
+
+This helper is intentionally inspection-first. It records worktrees, refs,
+large per-worktree caches, protected-source aggregates, and recovery proof. It
+does not remove files, worktrees, refs, caches, or branches, and it never turns
+an old cleanup decision into current authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+SCHEMA_VERSION = 1
+TASK_ID = "MAINT-0136"
+PRIMARY_REPO = Path("/Users/pravinsurawase/VS_code_project/structural_engineering_lib")
+DIRTY_WORKTREE = Path(
+    "/Users/pravinsurawase/.codex/worktrees/e54a/structural_engineering_lib"
+)
+DIRTY_BASE_SHA = "0fdb48edbb73114288feb8a246d6f30b80ac4d95"
+CACHE_PATHS = (
+    "react_app/node_modules",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "Python/.pytest_cache",
+    "react_app/dist",
+    "react_app/.vite",
+)
+
+
+class EvidenceError(RuntimeError):
+    """Raised when required preservation evidence cannot be collected."""
+
+
+def _environment() -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+        }
+    )
+    return env
+
+
+def _run(
+    args: Sequence[str],
+    *,
+    cwd: Path,
+    timeout: float = 120.0,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+        env=_environment(),
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise EvidenceError(f"{' '.join(args)} failed: {detail}")
+    return result
+
+
+def _json_command(args: Sequence[str], *, cwd: Path, timeout: float = 120.0) -> Any:
+    result = _run(args, cwd=cwd, timeout=timeout)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise EvidenceError(f"{' '.join(args)} returned invalid JSON: {exc}") from exc
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def path_size_bytes(path: Path) -> int:
+    """Return the on-disk size measured by the platform du utility."""
+    result = _run(["du", "-sk", "--", str(path)], cwd=path.parent)
+    try:
+        kib = int(result.stdout.split()[0])
+    except (IndexError, ValueError) as exc:
+        raise EvidenceError(f"could not parse du output for {path}") from exc
+    return kib * 1024
+
+
+def classify_worktree(
+    item: dict[str, Any],
+    *,
+    current_path: Path,
+    primary_path: Path,
+    dirty_path: Path,
+) -> tuple[str, list[str]]:
+    """Return a preservation-only disposition for one live worktree."""
+    path = Path(item["path"])
+    if path == current_path:
+        return "RETAIN_CURRENT_TASK", ["ACTIVE_PHASE_1_LANE"]
+    if path == primary_path:
+        return "RETAIN_INTEGRATION_ANCHOR", [
+            "PRIMARY_CHECKOUT",
+            "IGNORED_SOURCES_OWNER",
+        ]
+    if path == dirty_path or item.get("dirty_count", 0):
+        return "RETAIN_DIRTY_UNIQUE", ["UNCOMMITTED_WORK", "PATCH_RECOVERY_REQUIRED"]
+    return "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED", [
+        "NO_CURRENT_OWNER_RETENTION_PROOF",
+        "PHASE_2_NOT_AUTHORIZED",
+    ]
+
+
+def classify_cache(
+    *,
+    worktree_path: Path,
+    current_path: Path,
+    primary_path: Path,
+    dirty: bool,
+) -> tuple[str, list[str]]:
+    """Return a non-destructive cache disposition."""
+    if worktree_path == primary_path:
+        return "RETAIN_PRIMARY_RUNTIME", ["PRIMARY_RUNTIME_DEPENDENCY"]
+    if worktree_path == current_path:
+        return "RETAIN_CURRENT_TASK_RUNTIME", ["ACTIVE_PHASE_1_LANE"]
+    if dirty:
+        return "RETAIN_DIRTY_LANE_RUNTIME", ["DIRTY_LANE_PRESERVATION"]
+    return "CACHE_CANDIDATE_NOT_AUTHORIZED", [
+        "CLEAN_INACTIVE_WORKTREE",
+        "PHASE_2_NOT_AUTHORIZED",
+    ]
+
+
+def protected_source_inventory(private_root: Path) -> dict[str, Any]:
+    """Digest protected sources without exposing filenames or content."""
+    aggregate = hashlib.sha256()
+    file_count = 0
+    byte_count = 0
+    excluded_roots = {"worktree_cleanup_archives", "__pycache__"}
+    for path in sorted(private_root.rglob("*")):
+        relative = path.relative_to(private_root)
+        if any(part in excluded_roots for part in relative.parts) or not path.is_file():
+            continue
+        data_digest = sha256_file(path)
+        size = path.stat().st_size
+        aggregate.update(relative.as_posix().encode("utf-8"))
+        aggregate.update(b"\0")
+        aggregate.update(str(size).encode("ascii"))
+        aggregate.update(b"\0")
+        aggregate.update(data_digest.encode("ascii"))
+        aggregate.update(b"\n")
+        file_count += 1
+        byte_count += size
+    return {
+        "root": str(private_root),
+        "file_count": file_count,
+        "byte_count": byte_count,
+        "aggregate_sha256": aggregate.hexdigest(),
+        "filenames_recorded": False,
+        "content_recorded": False,
+        "excluded_from_digest": [
+            "worktree_cleanup_archives/**",
+            "**/__pycache__/**",
+        ],
+    }
+
+
+def verify_private_library_snapshot(
+    *, private_root: Path, runtime: Path
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Verify an exact temporary copy without changing the canonical database."""
+    before = protected_source_inventory(private_root)
+    source_library = private_root / "is_code_library"
+    with tempfile.TemporaryDirectory(
+        prefix="maint-0136-private-verify-", dir=private_root
+    ) as temp_root:
+        snapshot = Path(temp_root)
+        shutil.copytree(source_library, snapshot, dirs_exist_ok=True)
+        verifier = _run(
+            [
+                str(runtime),
+                str(source_library / "library.py"),
+                "--library-root",
+                str(snapshot),
+                "verify",
+            ],
+            cwd=private_root.parent,
+            timeout=180.0,
+        )
+        summary = verifier.stdout.strip().splitlines()[-1]
+        summary = summary.rsplit(" database=", 1)[0]
+    after = protected_source_inventory(private_root)
+    if before != after:
+        raise EvidenceError(
+            "canonical protected-source aggregate changed during verification"
+        )
+    return after, {
+        "status": "PASS",
+        "target": "EXACT_TEMPORARY_SNAPSHOT",
+        "summary": summary,
+        "canonical_aggregate_unchanged": True,
+        "temporary_snapshot_removed": True,
+    }
+
+
+def restore_sample(
+    *,
+    bundle: Path,
+    patch: Path,
+    source_log: Path,
+    base_sha: str,
+) -> dict[str, Any]:
+    """Prove that the recovery bundle and dirty patch reproduce the source."""
+    with tempfile.TemporaryDirectory(prefix="maint-0136-restore-") as temp_root:
+        restored = Path(temp_root) / "restored"
+        _run(["git", "clone", "--quiet", str(bundle), str(restored)], cwd=bundle.parent)
+        _run(["git", "checkout", "--quiet", base_sha], cwd=restored)
+        _run(["git", "apply", "--check", str(patch)], cwd=restored)
+        _run(["git", "apply", str(patch)], cwd=restored)
+        _run(["git", "fsck", "--full", "--no-dangling"], cwd=restored)
+        restored_log = restored / "docs" / "SESSION_LOG.md"
+        source_sha = sha256_file(source_log)
+        restored_sha = sha256_file(restored_log)
+        if source_sha != restored_sha:
+            raise EvidenceError("restored dirty session log does not match source")
+        checked_out_base = _run(
+            ["git", "rev-parse", "HEAD"], cwd=restored
+        ).stdout.strip()
+    return {
+        "checked_out_base": checked_out_base,
+        "patch_apply_check": "PASS",
+        "patch_apply": "PASS",
+        "source_session_log_sha256": source_sha,
+        "restored_session_log_sha256": restored_sha,
+        "content_match": True,
+        "git_fsck": "PASS",
+        "temporary_restore_removed": True,
+    }
+
+
+def _worktree_inventory(repo: Path) -> dict[str, Any]:
+    return _json_command(
+        [sys.executable, str(repo / "scripts/git_state.py"), "--json", "--worktrees"],
+        cwd=repo,
+        timeout=180.0,
+    )
+
+
+def _remote_heads(repo: Path) -> dict[str, str]:
+    result = _run(["git", "ls-remote", "--heads", "origin"], cwd=repo)
+    heads: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        sha, ref = line.split("\t", 1)
+        heads[ref.removeprefix("refs/heads/")] = sha
+    return heads
+
+
+def _pull_requests(repo: Path) -> list[dict[str, Any]]:
+    fields = (
+        "number,state,isDraft,headRefName,baseRefName,headRefOid,mergeCommit,"
+        "mergedAt,closedAt,title,url,author"
+    )
+    payload = _json_command(
+        ["gh", "pr", "list", "--state", "all", "--limit", "1000", "--json", fields],
+        cwd=repo,
+        timeout=180.0,
+    )
+    if not isinstance(payload, list):
+        raise EvidenceError("gh pr list did not return an array")
+    return payload
+
+
+def _local_branches(repo: Path) -> dict[str, dict[str, Any]]:
+    template = "%(refname:strip=2)%09%(objectname)%09%(upstream:short)"
+    result = _run(
+        ["git", "for-each-ref", f"--format={template}", "refs/heads"], cwd=repo
+    )
+    branches: dict[str, dict[str, Any]] = {}
+    for line in result.stdout.splitlines():
+        name, sha, upstream = (line.split("\t") + [""])[:3]
+        branches[name] = {"sha": sha, "upstream": upstream or None}
+    return branches
+
+
+def _is_ancestor(repo: Path, sha: str, default_ref: str) -> bool:
+    result = _run(
+        ["git", "merge-base", "--is-ancestor", sha, default_ref],
+        cwd=repo,
+        check=False,
+    )
+    if result.returncode not in {0, 1}:
+        raise EvidenceError(f"could not compare {sha} with {default_ref}")
+    return result.returncode == 0
+
+
+def _branch_inventory(
+    *,
+    repo: Path,
+    worktrees: list[dict[str, Any]],
+    remote_heads: dict[str, str],
+    pull_requests: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    local = _local_branches(repo)
+    worktrees_by_branch: dict[str, list[dict[str, Any]]] = {}
+    for item in worktrees:
+        branch = item.get("branch")
+        if branch and branch != "DETACHED":
+            worktrees_by_branch.setdefault(branch, []).append(
+                {
+                    "path": item["path"],
+                    "head_sha": item.get("head_sha"),
+                    "dirty_count": item.get("dirty_count"),
+                    "derived_action": item.get("derived_action"),
+                }
+            )
+    prs_by_branch: dict[str, list[dict[str, Any]]] = {}
+    for item in pull_requests:
+        prs_by_branch.setdefault(item["headRefName"], []).append(item)
+    rows: list[dict[str, Any]] = []
+    for name in sorted(set(local) | set(remote_heads)):
+        local_item = local.get(name)
+        remote_sha = remote_heads.get(name)
+        attached = worktrees_by_branch.get(name, [])
+        if name == "main":
+            disposition = "RETAIN_DEFAULT_BRANCH"
+            reasons = ["DEFAULT_BRANCH"]
+        elif name == "codex/maint-0136-cleanup-preservation":
+            disposition = "RETAIN_CURRENT_TASK"
+            reasons = ["ACTIVE_PHASE_1_LANE"]
+        else:
+            disposition = "HOLD_OWNER_RETENTION_EVIDENCE_REQUIRED"
+            reasons = ["NO_CURRENT_OWNER_RETENTION_PROOF", "PHASE_2_NOT_AUTHORIZED"]
+            if attached:
+                reasons.append("ATTACHED_WORKTREE")
+            if any(pr["state"] == "OPEN" for pr in prs_by_branch.get(name, [])):
+                reasons.append("OPEN_PULL_REQUEST")
+        sha = local_item["sha"] if local_item else remote_sha
+        rows.append(
+            {
+                "name": name,
+                "local": local_item,
+                "remote": (
+                    {"status": "PRESENT", "sha": remote_sha}
+                    if remote_sha
+                    else {"status": "ABSENT", "sha": None}
+                ),
+                "attached_worktrees": attached,
+                "pull_requests": sorted(
+                    prs_by_branch.get(name, []), key=lambda item: item["number"]
+                ),
+                "reachable_from_observed_origin_main": (
+                    _is_ancestor(repo, sha, "origin/main") if sha else None
+                ),
+                "disposition": disposition,
+                "reason_codes": reasons,
+            }
+        )
+    return rows
+
+
+def _destination_status() -> dict[str, Any]:
+    result = subprocess.run(
+        ["tmutil", "destinationinfo"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30.0,
+    )
+    available = result.returncode == 0 and "No destinations configured" not in (
+        result.stdout + result.stderr
+    )
+    return {
+        "status": "AVAILABLE" if available else "HOLD_DESTINATION_UNAVAILABLE",
+        "tmutil_exit_code": result.returncode,
+        "same_disk_artifacts_are_disaster_recovery": False,
+    }
+
+
+def _disk_capacity(repo: Path) -> dict[str, int]:
+    result = _run(["df", "-k", str(repo)], cwd=repo)
+    fields = result.stdout.splitlines()[-1].split()
+    return {
+        "total_bytes": int(fields[1]) * 1024,
+        "used_bytes": int(fields[2]) * 1024,
+        "available_bytes": int(fields[3]) * 1024,
+        "capacity_percent": int(fields[4].removesuffix("%")),
+    }
+
+
+def build_evidence(
+    *,
+    repo: Path,
+    primary_repo: Path,
+    dirty_worktree: Path,
+    recovery_dir: Path,
+    observed_at_utc: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Collect and return the manifest and recovery evidence payloads."""
+    inventory = _worktree_inventory(repo)
+    worktrees = inventory["worktrees"]
+    current_path = repo.resolve()
+    worktree_rows: list[dict[str, Any]] = []
+    cache_rows: list[dict[str, Any]] = []
+    for item in worktrees:
+        path = Path(item["path"])
+        disposition, reasons = classify_worktree(
+            item,
+            current_path=current_path,
+            primary_path=primary_repo,
+            dirty_path=dirty_worktree,
+        )
+        row = dict(item)
+        row.update(
+            {
+                "size_bytes": path_size_bytes(path),
+                "disposition": disposition,
+                "reason_codes": reasons,
+            }
+        )
+        worktree_rows.append(row)
+        for relative in CACHE_PATHS:
+            cache_path = path / relative
+            if not cache_path.exists():
+                continue
+            cache_disposition, cache_reasons = classify_cache(
+                worktree_path=path,
+                current_path=current_path,
+                primary_path=primary_repo,
+                dirty=bool(item.get("dirty_count")),
+            )
+            cache_rows.append(
+                {
+                    "worktree_path": str(path),
+                    "relative_path": relative,
+                    "size_bytes": path_size_bytes(cache_path),
+                    "disposition": cache_disposition,
+                    "reason_codes": cache_reasons,
+                }
+            )
+
+    bundle = recovery_dir / "structural-engineering-lib-all-refs.bundle"
+    patch = recovery_dir / "e54a-session-log.patch"
+    source_log = dirty_worktree / "docs" / "SESSION_LOG.md"
+    bundle_verify = _run(["git", "bundle", "verify", str(bundle)], cwd=repo)
+    bundle_heads = _run(["git", "bundle", "list-heads", str(bundle)], cwd=repo)
+    restore = restore_sample(
+        bundle=bundle,
+        patch=patch,
+        source_log=source_log,
+        base_sha=DIRTY_BASE_SHA,
+    )
+    private_root = primary_repo / "private_sources"
+    private_inventory, private_verifier = verify_private_library_snapshot(
+        private_root=private_root,
+        runtime=Path(sys.executable),
+    )
+    tracked_private = _run(
+        ["git", "ls-files", "--", "private_sources"], cwd=primary_repo
+    ).stdout.splitlines()
+    ignored = _run(
+        ["git", "check-ignore", "private_sources"], cwd=primary_repo
+    ).stdout.strip()
+    destination = _destination_status()
+    recovery = {
+        "schema_version": SCHEMA_VERSION,
+        "task_id": TASK_ID,
+        "observed_at_utc": observed_at_utc,
+        "status": "LOCAL_RECOVERY_VERIFIED_OFF_DEVICE_HOLD",
+        "recovery_tier": "SAME_DISK_ONLY",
+        "archive_directory": str(recovery_dir),
+        "git_bundle": {
+            "path": str(bundle),
+            "size_bytes": bundle.stat().st_size,
+            "sha256": sha256_file(bundle),
+            "verification": "PASS" if bundle_verify.returncode == 0 else "FAIL",
+            "ref_count": len(bundle_heads.stdout.splitlines()),
+            "contains_complete_history": "complete history"
+            in (bundle_verify.stdout + bundle_verify.stderr),
+        },
+        "dirty_worktree": {
+            "path": str(dirty_worktree),
+            "base_sha": DIRTY_BASE_SHA,
+            "patch_path": str(patch),
+            "patch_size_bytes": patch.stat().st_size,
+            "patch_sha256": sha256_file(patch),
+            "restore_sample": restore,
+        },
+        "protected_sources": {
+            **private_inventory,
+            "git_tracked_path_count": len(tracked_private),
+            "git_ignore_check": "PASS" if ignored == "private_sources" else "FAIL",
+            "library_verifier": private_verifier,
+        },
+        "off_device_recovery": destination,
+        "decision": (
+            "The same-disk bundle and patch are verified recovery aids. They do not "
+            "qualify as external disaster recovery, so Phase 2 remains held."
+        ),
+        "mutations_performed": {
+            "file_deletions": 0,
+            "cache_deletions": 0,
+            "worktree_removals": 0,
+            "branch_deletions": 0,
+            "ref_deletions": 0,
+            "pr_closures": 0,
+        },
+    }
+
+    remote_heads = _remote_heads(repo)
+    pull_requests = _pull_requests(repo)
+    live_main = _json_command(
+        ["gh", "api", "repos/{owner}/{repo}/commits/main"], cwd=repo
+    )
+    branches = _branch_inventory(
+        repo=repo,
+        worktrees=worktrees,
+        remote_heads=remote_heads,
+        pull_requests=pull_requests,
+    )
+    candidate_cache_rows = [
+        row
+        for row in cache_rows
+        if row["disposition"] == "CACHE_CANDIDATE_NOT_AUTHORIZED"
+    ]
+    authorized_actions = [
+        "INSPECT_LIVE_GIT_AND_DISK_STATE",
+        "CREATE_ISOLATED_PHASE_1_WORKTREE",
+        "CREATE_AND_VERIFY_RECOVERY_ARTIFACTS",
+        "FREEZE_PRESERVATION_MANIFEST",
+        "COMMIT_INTENDED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_OR_UPDATE_PR",
+        "MERGE_UNCHANGED_GREEN_PR",
+    ]
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "task_id": TASK_ID,
+        "observed_at_utc": observed_at_utc,
+        "status": "PHASE_1_LOCAL_PRESERVATION_COMPLETE_OFF_DEVICE_HOLD",
+        "authorization": {
+            "status": "OBSERVED",
+            "query_status": "OK",
+            "observed_at_utc": observed_at_utc,
+            "authority_source": {
+                "kind": "USER_DELEGATION",
+                "status": "OBSERVED",
+                "query_status": "OK",
+                "observed_at_utc": observed_at_utc,
+                "reference": (
+                    "active Codex task: okay I authorize Phase 0 and Phase 1"
+                ),
+            },
+            "authorized_phases": [0, 1],
+            "authorized_actions": authorized_actions,
+            "next_action": "COMMIT_INTENDED_PATHS",
+            "target_binding": {
+                "task_id": TASK_ID,
+                "branch": inventory["current"]["branch"],
+                "head_sha": inventory["current"]["head_sha"],
+                "actions": authorized_actions,
+            },
+            "prohibited_actions": [
+                "DELETE_FILE",
+                "DELETE_CACHE",
+                "REMOVE_WORKTREE",
+                "DELETE_LOCAL_BRANCH",
+                "DELETE_REMOTE_BRANCH",
+                "DELETE_REF",
+                "PRUNE",
+                "GIT_CLEAN",
+                "PUBLISH_RELEASE",
+            ],
+        },
+        "baseline": {
+            "origin_main_sha": inventory["current"]["default_base"]["sha"],
+            "hosted_main_sha": live_main["sha"],
+            "main_identity_match": inventory["current"]["default_base"]["sha"]
+            == live_main["sha"],
+            "current_branch": inventory["current"]["branch"],
+            "current_head_sha": inventory["current"]["head_sha"],
+            "git_state_query_status": (
+                "OK" if not inventory.get("query_failures") else "FAILED"
+            ),
+            "remote_heads_query_status": "OK",
+            "pull_requests_query_status": "OK",
+            "historical_cleanup_evidence": {
+                "path": "docs/verification/post-india2-cleanup-disposition-evidence.json",
+                "status": "HISTORICAL_NOT_CURRENT_AUTHORITY",
+            },
+        },
+        "summary": {
+            "worktree_count": len(worktree_rows),
+            "preexisting_worktree_count": len(worktree_rows) - 1,
+            "detached_worktree_count": sum(
+                row["branch"] == "DETACHED" for row in worktree_rows
+            ),
+            "dirty_worktree_count": sum(
+                row["dirty_count"] > 0 for row in worktree_rows
+            ),
+            "preexisting_dirty_worktree_count": sum(
+                row["dirty_count"] > 0 and not row["current"] for row in worktree_rows
+            ),
+            "worktree_total_bytes": sum(row["size_bytes"] for row in worktree_rows),
+            "branch_or_pr_head_count": len(branches),
+            "remote_branch_count": len(remote_heads),
+            "cache_path_count": len(cache_rows),
+            "cache_total_bytes": sum(row["size_bytes"] for row in cache_rows),
+            "phase_2_cache_candidate_count": len(candidate_cache_rows),
+            "phase_2_cache_candidate_bytes": sum(
+                row["size_bytes"] for row in candidate_cache_rows
+            ),
+            "phase_2_authorized": False,
+        },
+        "disk_capacity": _disk_capacity(repo),
+        "worktrees": worktree_rows,
+        "branches": branches,
+        "caches": cache_rows,
+        "recovery_evidence": {
+            "path": "docs/verification/maint-0136-cleanup-recovery-evidence.json",
+            "status": recovery["status"],
+            "git_bundle_sha256": recovery["git_bundle"]["sha256"],
+            "dirty_patch_sha256": recovery["dirty_worktree"]["patch_sha256"],
+            "off_device_recovery_status": destination["status"],
+        },
+        "decision": (
+            "Freeze and preserve the observed topology. No file, cache, worktree, "
+            "branch, remote ref, or pull request is authorized for cleanup."
+        ),
+    }
+    return manifest, recovery
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--primary-repo", type=Path, default=PRIMARY_REPO)
+    parser.add_argument("--dirty-worktree", type=Path, default=DIRTY_WORKTREE)
+    parser.add_argument("--recovery-dir", type=Path, required=True)
+    parser.add_argument("--manifest-output", type=Path, required=True)
+    parser.add_argument("--recovery-output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    observed_at_utc = datetime.now(UTC).isoformat()
+    manifest, recovery = build_evidence(
+        repo=args.repo.resolve(),
+        primary_repo=args.primary_repo.resolve(),
+        dirty_worktree=args.dirty_worktree.resolve(),
+        recovery_dir=args.recovery_dir.resolve(),
+        observed_at_utc=observed_at_utc,
+    )
+    args.manifest_output.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    args.recovery_output.write_text(
+        json.dumps(recovery, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        json.dumps(
+            {
+                "status": manifest["status"],
+                "worktree_count": manifest["summary"]["worktree_count"],
+                "branch_or_pr_head_count": manifest["summary"][
+                    "branch_or_pr_head_count"
+                ],
+                "phase_2_cache_candidate_bytes": manifest["summary"][
+                    "phase_2_cache_candidate_bytes"
+                ],
+                "off_device_recovery_status": recovery["off_device_recovery"]["status"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- reconciles the unmatched historical session and freezes the fresh 73-worktree, 83-head preservation baseline
- adds a fail-closed collector plus focused regressions for worktree, cache, and protected-source dispositions
- verifies a complete-history Git bundle and exact dirty-lane patch restore while keeping off-device recovery and all Phase 2 cleanup held
- performs no file, cache, worktree, branch, ref, PR, or protected-source deletion

## Validation

- focused cleanup, Git-state, and branch-disposition suites pass
- Ruff and Black pass on changed Python files
- documentation metadata and 1,015 maintained links pass
- context, control-plane, token-efficiency, and frozen evidence invariants pass
- quick gate passes 10/10 with zero initial reuse
- normal commit hooks and clean session closeout pass

## Holds

- same-disk recovery is not disaster recovery; no external destination is configured
- Phase 2 remains not authorized
- all 70 ordinary worktrees and 81 ordinary branch heads remain held for current owner and retention evidence