### PR TITLE
fix(api): close post-merge S0 transport gaps

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -53,6 +53,9 @@ efficient read-only LIB-PRO-013 A0 execution plan without starting A0.
 - One existing combined BBS/DXF scope-hold test reused primary beam fields
   that are not part of the exact export model; strict extra-field rejection
   correctly stopped it before the intended assertion.
+- The first clean read-only session closeout occurred after the original
+  handoff receipt's short evidence-freshness window and failed only with
+  `HOLD_SET_MISMATCH` / `RETENTION_STALE_EVIDENCE`.
 
 ### Root causes and resolutions
 
@@ -83,6 +86,12 @@ efficient read-only LIB-PRO-013 A0 execution plan without starting A0.
   rather than an exact valid export request. Resolution: use only maintained
   export fields plus explicit span before applying the scope hold. Proof: the
   47-case focused FastAPI repair set and 788-case cross-layer selection pass.
+- Confirmed root cause: task-to-Git handoff receipts are deliberately
+  time-bound transition observations, and the verification/build/commit cycle
+  exceeded the first receipt's freshness window. Resolution: preserve that
+  historical candidate receipt and add a fresh successor closeout observation
+  in an explicit repair candidate; no runtime or test result changed. Proof:
+  the successor receipt validates and clean read-only session closeout passes.
 
 ### Validation through content freeze
 
@@ -102,7 +111,7 @@ efficient read-only LIB-PRO-013 A0 execution plan without starting A0.
   checks are owned by the immutable candidate after all versioned content
   freezes.
 
-**Git handoff receipt:** `docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-receipt.json`
+**Git handoff receipt:** `docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-closeout-repair-git-handoff-receipt.json`
 
 ## 2026-08-27 — Session: LIB-PRO-012 S0 P0 safety closure
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,105 @@
 
 ---
 
+## 2026-08-27 — Session: LIB-PRO-012 S0 post-merge audit and A0 planning
+
+**Agent:** Codex (`reviewer`, sole writer; no subagents).
+
+**Branch:** `codex/lib-pro-012-s0-post-merge-audit-a0-plan`.
+
+**Focus:** Independently inspect merged LIB-PRO-012 S0, repair only confirmed
+outcome-changing omissions, reconcile final acceptance truth, and prepare one
+efficient read-only LIB-PRO-013 A0 execution plan without starting A0.
+
+**Completed:**
+
+- Re-established exact fetched-main, PR, hosted-check, tree-equivalence,
+  worktree-preservation, authority, prior-evidence, and installed-artifact
+  identity. The detached dirty `e54a` lane remains untouched.
+- Replayed every mapped S0 route class against direct expert, composed service,
+  typed, primary REST, BBS/DXF, and exact-wheel boundaries. The original beam,
+  detailing, BBS, torsion, column, typed-input, identity, and primary REST
+  controls remain numerically stable.
+- Closed the three confirmed transport manifestations left outside the merged
+  repair: unused `rebar_layers`, invented BBS/DXF span, and coercive/extra-
+  ignoring export intake. Invalid requests now stop at HTTP 422 before
+  calculation, detailing, BBS, DXF, or artifact creation.
+- Updated the maintained React export contract, exact OpenAPI baseline, REST
+  reference, focused regressions, and source-free artifact verifier. Added a
+  successor post-merge acceptance receipt without rewriting historical S0
+  evidence or append-only usage telemetry.
+- Prepared the derivative LIB-PRO-013 A0 plan as one 15–24 engineer-day,
+  read-only audit cycle with four evidence passes, one report, one candidate,
+  one PR, evidence reuse by unchanged owner, and explicit B0/F0/R0 routing.
+
+### Issues encountered
+
+- `/api/v1/design/beam` accepted a populated `rebar_layers` field and returned
+  HTTP 200 although the maintained route never read or applied that engineering
+  input.
+- `/api/v1/export/bbs` and `/api/v1/export/dxf` accepted omitted or zero span
+  and substituted `depth * 12`; their request model also coerced numeric/string
+  booleans and ignored unknown engineering fields.
+- The merged task board, handoff, immutable evidence, and append-only usage
+  records ended at the first candidate or pending hosted-repair state rather
+  than recording a successor post-merge acceptance observation.
+- Tightening the React export contract exposed a stale `ExportPanel` test
+  fixture that omitted the now-required span. The first production TypeScript
+  build therefore stopped before bundle creation.
+- One existing combined BBS/DXF scope-hold test reused primary beam fields
+  that are not part of the exact export model; strict extra-field rejection
+  correctly stopped it before the intended assertion.
+
+### Root causes and resolutions
+
+- Confirmed root cause: the dormant `rebar_layers` property remained on the
+  strict primary request after S0, but no calculation or detailing owner
+  consumed it. Resolution: reject any supplied value with stable
+  `REBAR_LAYERS_SCOPE_HOLD` intake evidence while preserving omission
+  compatibility. Proof: focused primary-route tests and exact-artifact REST
+  replay return 422.
+- Confirmed root cause: S0 hardened the primary request but only made export
+  steel positive after the hosted failure; `ExportBeamRequest` retained its
+  coercive defaults and `_run_detailing` retained a structural span fallback.
+  Resolution: require an explicit positive span, remove the fallback, enable
+  strict/finite/extra-forbid intake, and update the maintained React caller.
+  Proof: missing/zero span, numeric string, string boolean, unknown field, and
+  zero steel all return 422; valid BBS remains HTTP 200 with exactly nine items.
+- Confirmed root cause: repository evidence correctly froze before the final
+  hosted repair, but no successor acceptance receipt reconciled final head,
+  merge tree, hosted run, and post-merge review. Resolution: preserve the
+  historical artifact and add a successor receipt plus current task/session/
+  handoff truth; do not mutate append-only telemetry retroactively. Proof: PR
+  #877 head/tree/merge equivalence and hosted run 33080623445 were re-queried.
+- Confirmed root cause: caller and test fixtures still modeled `span_length` as
+  optional after the fail-closed export decision. Resolution: make the TypeScript
+  field required and supply explicit valid spans in maintained fixtures. Proof:
+  66 focused React cases, lint, TypeScript compilation, and production build pass.
+- Confirmed root cause: the scope-hold test passed the wrong transport schema
+  rather than an exact valid export request. Resolution: use only maintained
+  export fields plus explicit span before applying the scope hold. Proof: the
+  47-case focused FastAPI repair set and 788-case cross-layer selection pass.
+
+### Validation through content freeze
+
+- Focused Python/FastAPI selection: 788 collected and passed; focused repair
+  tests: 47 passed. Focused React: 66 passed; lint and production build pass.
+- Architecture: 222 files, zero violations; circular imports: 202 files, zero
+  cycles; library imports: 247 files, zero broken imports.
+- OpenAPI matches its refreshed baseline at 89 endpoints and 444 schemas. API
+  manifest and API classification/compatibility checks pass.
+- Rebuilt isolated wheel SHA-256
+  `4f8e89f7b0280a998b426e56042685db2884c59f549d79839dfecba1e7445adb`
+  rejects 15 invalid source-free Python routes. Exact-head FastAPI bound to the
+  installed wheel rejects nine primary omissions, five primary strict/domain
+  vectors, and six invalid BBS transport vectors; valid BBS and engineering
+  `FAIL` retain HTTP 200 with distinct result semantics.
+- Consolidated quick gate, normal hooks, exact candidate closeout, and hosted
+  checks are owned by the immutable candidate after all versioned content
+  freezes.
+
+**Git handoff receipt:** `docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-receipt.json`
+
 ## 2026-08-27 — Session: LIB-PRO-012 S0 P0 safety closure
 
 **Agent:** Codex (`structural-math`, sole writer; no subagents).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-27 — LIB-PRO-012 S0 P0 safety closure candidate
+**Updated:** 2026-08-27 — LIB-PRO-012 S0 post-merge acceptance and A0 plan
 
 ---
 
@@ -126,20 +126,19 @@
 
 ## Active
 
-`LIB-PRO-012-S0-P0-SAFETY-CLOSURE` is the active implementation cycle. G0
-started from merged planning baseline
-`d3242731e94dacd74e804a1f4a25c4c0da11790f`; the combined A/B safety work is
-locally complete on `codex/lib-pro-012-s0-p0-safety-closure`. The exact-cycle
-[evidence matrix](verification/lib-pro-012-s0-p0-safety-closure-evidence.json)
-records 51 dedicated regressions, a 607-case focused Python/FastAPI pass,
-focused React/lint/build, architecture/import/OpenAPI/generated-contract
-checks, source-free exact-wheel replay, and a repaired-candidate 10/10 quick
-gate. PR #877 first head `a9613331` passed Python, React, control-plane, and
-documentation checks but exposed one BBS-export intake defect and one stale
-workflow test fixture in FastAPI validation. The surgical repair passes 13
-focused cases, the exact 506-case hosted FastAPI command, OpenAPI, and
-exact-wheel-to-head replay; a repair commit and its required exact-head hosted
-checks remain before S0 integration can be claimed.
+`LIB-PRO-012-S0-P0-SAFETY-CLOSURE` merged through PR #877. Final reviewed head
+`efcd4126e120fe3b19723d349681475a1625c30c` and squash merge
+`4cebcccb3a07b8046e31b23332236321ebee1d25` share tree
+`e989ccba44ab89774db17bdf3d0d18ba435fa109`; hosted run 33080623445 passed all
+required checks. The required post-merge review then reproduced three unsafe
+transport manifestations left outside the original root-owner repair: the
+primary beam route accepted unused `rebar_layers`, while BBS/DXF accepted an
+omitted or zero span by inventing `depth * 12` and retained coercive/extra-
+ignoring intake. `LIB-PRO-012-S0-POST-MERGE-AUDIT-A0-PLAN` closes those gaps
+locally with focused regressions, a rebuilt source-free wheel replay, and
+reconciled successor [acceptance evidence](verification/lib-pro-012-s0-post-merge-acceptance.json).
+Its immutable candidate and exact-head hosted checks remain before the merged
+S0 boundary can be treated as fully accepted.
 
 `LIB-PRO-013` owns the whole-library renewal audit. Its
 [master plan](planning/lib-pro-013-whole-library-renewal-audit-plan.md) defines
@@ -147,15 +146,20 @@ the truth freeze, audit-of-audits, external-user/API, engineering-evidence,
 application, package/dependency, test, Git/CI/release, agent/skill/automation,
 efficiency, retention, and peer-comparison lanes. The audit itself is unstarted;
 the plan authorizes no runtime change, deletion, dependency addition, signature
-break, release, or professional claim.
+break, release, or professional claim. The derivative
+[A0 execution plan](planning/lib-pro-013-a0-execution-plan.md) groups the
+15–24 engineer-day audit into four evidence passes inside one read-only
+session, branch, candidate, PR, and hosted cycle. A0 remains unstarted until
+the post-merge S0 repair is integrated.
 
-`LIB-PRO-012` remains the remediation specification and scope authority. S0
-closes the mapped beam/detailing/BBS, torsion, column, typed-input, identity,
-and existing REST v1 safety findings locally; `/api/v2`, the canonical facade,
-final transport parity, generated signature prose, cumulative broad gates, and
-Packets C–I remain later work. After an unchanged green S0 merge, the next
-authorized programme step is the LIB-PRO-013 A0 architecture/truth freeze, not
-automatic implementation of later LIB-PRO-012 packets. Shared validation,
+`LIB-PRO-012` remains the remediation specification and scope authority. Once
+the unchanged green post-merge repair is integrated, S0 closes the mapped
+beam/detailing/BBS, torsion, column, typed-input, identity, and existing REST
+v1 safety boundary. `/api/v2`, EXT-REST-002, the canonical facade, final
+transport parity, generated signature prose, cumulative broad gates, and
+Packets C–I remain later work. The next authorized programme step is then the
+read-only LIB-PRO-013 A0 architecture/truth freeze, not automatic runtime
+implementation of later LIB-PRO-012 packets. Shared validation,
 facade, result, manifest, generated API, documentation, task, and session
 owners remain single-writer surfaces.
 

--- a/docs/planning/lib-pro-013-a0-execution-plan.md
+++ b/docs/planning/lib-pro-013-a0-execution-plan.md
@@ -1,0 +1,182 @@
+---
+owner: Main Agent
+status: ready
+last_updated: 2026-08-27
+doc_type: spec
+complexity: advanced
+tags: [lib-pro-013, a0, audit, execution, efficiency]
+---
+
+# LIB-PRO-013 A0 Consolidated Renewal Audit — Execution Plan
+
+## 1. Authority and boundary
+
+This is a derivative execution plan for the **A0 Consolidated Renewal Audit**
+defined by Sections 9–16 of
+[LIB-PRO-013](lib-pro-013-whole-library-renewal-audit-plan.md). LIB-PRO-013
+remains the scope, method, severity, and acceptance authority. LIB-PRO-012
+remains the remediation authority for known external-API work. If this file
+and either master plan disagree, the master plan wins.
+
+A0 begins only after the post-merge S0 acceptance task is integrated on the
+project default branch. It is one read-only audit cycle covering G1 and every
+remaining initial audit lane through C2. It may write audit evidence, the task
+board, session log, and handoff documents; it may not edit runtime,
+dependencies, public signatures, generated API/client owners, protected
+sources, retained worktrees, or release artifacts.
+
+## 2. Entry gate
+
+At A0 start, one parent must prove all of the following before any audit
+evidence is written:
+
+1. `origin/main` is freshly fetched, clean, conflict-free, and contains the
+   accepted S0 merge plus this plan or a clean descendant.
+2. `git_state.py --json --worktrees` shows no overlapping active candidate on
+   audit evidence, task, session, or shared generated owners. Every dirty,
+   detached, ignored, stashed, archived, and protected item is preserved.
+3. The public `0.24.0a1` wheel/sdist/tag identities, the current source head and
+   tree, and a newly built source-free current-head wheel are recorded as
+   different evidence objects.
+4. Current control, context, API classification, compatibility, workflow,
+   capability, package, dependency, test, agent, skill, worktree, and CI
+   authorities are queryable. A stale retained count is never promoted to live
+   truth.
+5. One session is started as `LIB-PRO-013-A0-CONSOLIDATED-RENEWAL-AUDIT` on
+   `codex/lib-pro-013-a0-consolidated-renewal-audit` using the maintained routed
+   role.
+
+Identity ambiguity, an overlapping writer, or missing preservation evidence is
+a stop condition, not a reason to reset, rebase, clean, or reorganize another
+lane.
+
+## 3. One-cycle deliverable
+
+The canonical A0 output is one report:
+
+`docs/verification/lib-pro-013-a0-renewal-audit.md`
+
+It contains the exact baseline, Section 7 coverage crosswalk, audit-of-audits
+matrix, advertised journey inventory, finding register, evidence-class matrix,
+retention proposals, peer decisions, and C2 remediation portfolio. Existing
+classification, compatibility, capability, workflow, package, and control
+files are referenced as authorities; A0 does not copy or silently rewrite
+them.
+
+Each finding uses the LIB-PRO-013 schema: stable ID, domain, priority, evidence
+state, exact identity, journey/reproducer, expected and observed outcomes,
+impact, cause state, owner, compatibility effect, disposition, dependency,
+focused proof, cumulative gate, provenance, and review boundary. Route-level
+evidence remains visible even when several findings share one root cause.
+
+## 4. Four batched passes
+
+The master estimate remains **15–24 engineer-days**. Efficiency comes from
+shared inventories and evidence reuse, not from claiming less audit work.
+
+| Pass | Included LIB-PRO-013 packets | Estimate | Frozen outcome |
+|---|---|---:|---|
+| **A0.1 Authority and recurrence truth** | G1, U1, U2, R2, R3 | 2–3 days | Exact audit-of-audits, installed-user journeys, public contract census, architecture/generated ownership, and test/evidence taxonomy |
+| **A0.2 Product and engineering outcomes** | U3, U4, E1, E2, E3, P1, P2, P3, P4 | 6–9 days | Validation/result/composition, every supported family, engineering evidence classes, CLI/export, REST/client, React, and separately labelled Windows evidence |
+| **A0.3 Professional development system** | R1, R4, R5, A1, A2, A3, A4, C1 | 4–7 days | Package/dependency/platform, docs/support/naming, Git/CI/recovery, agent/skill/tool/efficiency, retention, and official-source peer decisions |
+| **A0.4 C2 synthesis** | C2 plus the Section 7 completeness gate | 3–5 days | Deduplicated prioritized portfolio with every finding owned, dependency-ordered, estimated by class, and assigned to a later cycle or explicit hold |
+
+The passes are evidence checkpoints inside one session and branch. They are not
+separate commits, PRs, hosted runs, or status-only handoffs.
+
+## 5. Efficient method
+
+### 5.1 Inventory once, replay by class
+
+- Query maintained registries and generators once during A0.1 and store their
+  command, source bytes/hash, runtime, platform, and observation time in the
+  report.
+- Build one advertised-workflow-to-owner matrix. Use it to drive Python,
+  transport, consumer, documentation, and artifact sampling instead of keeping
+  separate hand lists.
+- Sample every distinct route/contract class. When a class fails, expand from
+  the maintained inventory to every member of that class; do not broaden an
+  already passing class without a stated risk.
+- Reuse the accepted S0 direct-source and exact-wheel evidence for unchanged
+  owners. Reproduce only claims whose source bytes, environment, artifact, or
+  contract changed.
+- Deduplicate by confirmed root cause while retaining all journey identities
+  and affected consumers.
+
+### 5.2 Separate evidence classes
+
+For every promoted engineering journey, label evidence as independent
+arithmetic, controlled source example, external-software comparison, blind
+internal recomputation, wrapper/transport parity, generated regression, UI
+projection, qualified review, or `NOT_TESTED`. No generated or wrapper parity
+is upgraded into independent validation.
+
+The Windows Excel/ETABS lane is satisfied only by exact installed Windows
+evidence or an explicit `NOT_TESTED / HELD` record naming what is needed. Mac
+or source-only evidence cannot satisfy it.
+
+### 5.3 External research once
+
+C1 uses current official documentation and primary sources only. Each source
+is captured once with access date, comparable journey, local finding, benefit,
+cost, compatibility/dependency effect, and `ADOPT`, `ADAPT`, or `REJECT`
+decision. Popularity alone is not evidence.
+
+### 5.4 Verification cadence
+
+During the audit, run only bounded inventories, reproducers, source-free
+journeys, and browser/transport checks required by the active pass. Do not run
+the broad repository suites as discovery tools.
+
+After the report, task, session, and handoff content freezes:
+
+1. replay every finding reproducer and the report's completeness validator;
+2. run relevant architecture/import, package-content, documentation/link,
+   generated-drift **check-only**, control/context, and evidence-schema checks;
+3. run `./run.sh check --quick` once;
+4. stage only A0-owned evidence/status paths and run normal commit hooks;
+5. create one immutable evidence candidate, push once, open one PR, and wait for
+   every changed-path hosted check on that exact head.
+
+The broad Python/React/full cumulative gate remains owned by the later R0
+candidate unless A0 itself exposes a repository-wide outcome whose diagnosis
+requires it.
+
+## 6. Decisions and routing
+
+Each C2 item must be routed without duplicating LIB-PRO-012:
+
+| Finding outcome | Route after A0 |
+|---|---|
+| Common contract, canonical beam, or downstream convergence | B0 (LIB-PRO-012 C/D/E) |
+| Family facade/construction convergence | F0 (LIB-PRO-012 F1/F2/F3) |
+| Documentation, generated gates, package, cumulative artifact, or independent audit closure | R0 (LIB-PRO-012 G/H/I plus LIB-PRO-013 C3) |
+| New outcome-changing P0 | Stop A0 completion and request a separately authorized, bounded safety repair before B0 |
+| Unsupported scope, unavailable Windows/professional evidence, release, publication, or qualified review | Explicit `HOLD` with exact authority/evidence required |
+| Cosmetic, speculative, or no-main-outcome concern | Exclude as P3; do not create remediation work |
+
+No finding may silently expand the supported engineering scope or add a
+dependency. A proposed dependency, formula change, signature break, deletion,
+or public claim needs its own authority after the audit.
+
+## 7. Acceptance and stop rules
+
+A0 is complete only when every Section 7 domain has an owner, method, artifact,
+and disposition; every advertised journey is accounted for; every earlier
+audit is reconciled within its original scope; every finding has exact evidence
+and a dependency-ordered disposition; and C2 has no unresolved P0.
+
+Stop early and report the exact blocker when:
+
+- a new P0 safe-looking result or artifact is reproduced;
+- identity, preservation, or generated ownership is ambiguous;
+- a valid golden engineering result changes during read-only replay;
+- an audit conclusion needs protected source content copied into Git;
+- an active candidate overlaps the report/task/session owners; or
+- release, deletion, dependency, signature, formula, or professional authority
+  is required.
+
+Software/audit acceptance does not authorize B0 automatically. After the
+unchanged green A0 merge, the owner may start B0 from the integrated C2
+portfolio. Release, publication, qualified review, professional approval, and
+engineering-use claims remain separate.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,64 +4,65 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-27
-- Focus: Implement the combined LIB-PRO-012 A/B safety cycle from merged
-- Completed: Froze the G0 Git, worktree, artifact, owner, required-field, and stable; Added shared finite, strict-type, sign, identity, domain, geometry, and; Protected design-only, combined, compliance, smart-analysis,
-- Git receipt: docs/verification/lib-pro-012-s0-p0-safety-closure-git-handoff-receipt.json | sha256:8a255baf2909935aa35b1d98ac18bbcef7168bdad6143d797476b5e2a6ecab5c | HOLD
-- Git identity: codex/lib-pro-012-s0-p0-safety-closure@a9613331d83da0915b054e5d9a4595e6db53f33d | upstream=origin/codex/lib-pro-012-s0-p0-safety-closure@a9613331d83da0915b054e5d9a4595e6db53f33d | base=origin/main@d3242731e94dacd74e804a1f4a25c4c0da11790f | tree=dirty | operation=none
-- Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=UNKNOWN
-- Next action: FREEZE_ONE_CANDIDATE_AND_RUN_ONE_HOSTED_CYCLE
+- Focus: Independently inspect merged LIB-PRO-012 S0, repair only confirmed
+- Completed: Re-established exact fetched-main, PR, hosted-check, tree-equivalence,; Replayed every mapped S0 route class against direct expert, composed service,; Closed the three confirmed transport manifestations left outside the merged
+- Git receipt: docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-receipt.json | sha256:2e5fd5bb22f423218627242cd168d96cff2136fed0b25c5a7532ecb614172164 | HOLD
+- Git identity: codex/lib-pro-012-s0-post-merge-audit-a0-plan@4cebcccb3a07b8046e31b23332236321ebee1d25 | upstream=origin/main@4cebcccb3a07b8046e31b23332236321ebee1d25 | base=origin/main@4cebcccb3a07b8046e31b23332236321ebee1d25 | tree=dirty | operation=none
+- Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
+- Next action: FREEZE_ONE_POST_MERGE_REPAIR_CANDIDATE_AND_RUN_ONE_HOSTED_CYCLE
 <!-- HANDOFF:END -->
 
 ## Latest Handoff
 
 | State | Boundary |
 |---|---|
-| **Current** | PR #877 first head `a9613331` passed Python, React, control, and docs but failed FastAPI on zero-steel BBS export plus a stale workflow fixture; the surgical repair is locally accepted and awaits its immutable repair commit and exact-head hosted checks |
-| **Decision** | Existing `/api/v1` field names remain, but width, depth, moment, shear, fck, fy, clear cover, stirrup diameter, and main-bar diameter are strict required inputs; effective depth may be explicit or derived only from that complete explicit basis |
-| **Next** | Commit the explicit hosted-failure repair through normal hooks, rerun clean session closeout, push the unchanged PR, and merge only if the repair head remains unchanged and every required check passes |
-| **After S0** | Start LIB-PRO-013 A0 architecture/truth freeze only after the unchanged green S0 merge; do not automatically begin later LIB-PRO-012 runtime packets |
+| **Current** | PR #877 merged at final reviewed head `efcd4126e120fe3b19723d349681475a1625c30c`; merge `4cebcccb3a07b8046e31b23332236321ebee1d25` has the identical reviewed tree. A post-merge review found and locally repaired unused `rebar_layers` intake plus unsafe BBS/DXF span fallback and coercion. |
+| **Decision** | `/api/v1/design/beam` rejects supplied dormant `rebar_layers`. BBS/DXF require an explicit positive `span_length`, use strict types, and forbid unknown fields; no structural span is invented from depth. |
+| **Next** | Freeze, commit, push, and host-check the single post-merge repair candidate. Merge only when its exact head is unchanged, green, and conflict-free. |
+| **After repair** | Start the read-only LIB-PRO-013 A0 audit using the derivative four-pass execution plan; do not automatically begin later LIB-PRO-012 runtime packets. |
 | **Held** | `/api/v2`, canonical facade, Packets C–I, final parity, cumulative broad gate, release/publication, qualified review, professional/engineering-use claims, protected-source changes, and branch/worktree deletion |
 
-## S0 local acceptance
+## Post-merge S0 acceptance
 
-- The 51 dedicated regressions close the mapped beam, detailing, BBS,
-  torsion, column, typed-input, and identity findings. Valid beam and torsion
-  numerical controls remain exact; valid BBS remains exactly nine items.
-- The focused cross-layer selection passes 607 Python/FastAPI cases. The React
-  client passes 51 focused cases, lint, TypeScript compilation, and production
-  build.
+- The original S0 mapped routes were independently replayed against merged
+  source and artifact boundaries. Valid beam and torsion controls remain exact;
+  valid BBS remains exactly nine items.
+- The repaired cross-layer selection passes 788 Python/FastAPI cases. The
+  maintained React caller passes 66 focused cases, lint, TypeScript
+  compilation, and production build.
 - Architecture, circular-import, library-import, OpenAPI, generated API
   manifest/classification/compatibility, and generated-client replay checks
-  pass. The repaired candidate also passes the consolidated quick gate 10/10.
-- The exact candidate wheel at local SHA-256
-  `f81f6274a24b9aaaeef904ceb2f5317b00ac880c967815b0f1b50d192e83089d`
+  pass. The current frozen candidate owns one consolidated quick gate.
+- The rebuilt isolated wheel at local SHA-256
+  `4f8e89f7b0280a998b426e56042685db2884c59f549d79839dfecba1e7445adb`
   rejects 15 source-free Python invalid-route vectors. Exact-head FastAPI bound
-  to that installed wheel rejects all nine required-field omissions, numeric
-  strings, booleans used as numbers, unknown fields, and invalid domains.
+  to that installed wheel rejects all nine primary required-field omissions,
+  five primary strict/domain vectors, and six invalid BBS transport vectors.
 - A valid ordinary integer REST payload returns HTTP 200 with derived effective
   depth 457 mm. A valid but inadequate engineering case remains HTTP 200 with
   engineering status `FAIL`, distinct from invalid intake and internal failure.
-- The first PR head exposed five FastAPI failures. Zero-steel BBS export now
-  returns the maintained 422 field-path envelope before detailing/BBS, and the
-  workflow transport's valid fixture now supplies the complete explicit depth
-  derivation basis. The 13 affected cases and exact 506-case hosted command
-  pass; the exact-wheel replay includes the repaired BBS transport vector.
+- The post-merge review additionally proved that dormant reinforcement-layer
+  input and export span/coercion were outside the earlier primary-model repair.
+  All now return 422 before calculation or artifact creation. The historical
+  pre-commit evidence remains immutable; the successor post-merge acceptance
+  receipt records the final merge and corrected boundary.
 
 ## Ordered follow-on gates
 
-1. Stage only repair-owned paths, inspect the staged diff, and create one
-   explicit repair commit through normal hooks.
+1. Stage only post-merge repair and planning paths, inspect the staged diff,
+   and create one immutable candidate through normal hooks.
 2. Rerun read-only `session end` on the clean exact repair commit.
-3. Push normally to PR #877 and wait for every required hosted check on the
-   unchanged repair head. Do not bypass checks or rewrite history.
+3. Push normally to one successor PR and wait for every required hosted check
+   on the unchanged repair head. Do not bypass checks or rewrite history.
 4. Merge only when the exact reviewed head is unchanged, green, conflict-free,
    and repository policy permits it. Do not delete the branch or worktree.
-5. After the exact S0 merge, begin the read-only LIB-PRO-013 A0 truth freeze.
+5. After the exact repair merge, begin the read-only LIB-PRO-013 A0 truth freeze.
 
 ## Required Reading
 
-1. [S0 exact-cycle evidence](../verification/lib-pro-012-s0-p0-safety-closure-evidence.json)
-2. [LIB-PRO-012 remediation authority](lib-pro-012-external-api-remediation-plan.md)
-3. [LIB-PRO-013 later audit authority](lib-pro-013-whole-library-renewal-audit-plan.md)
-4. [LIB-PRO-011 finding authority](../verification/lib-pro-011-external-api-readiness-audit.md)
-5. [Current task board](../TASKS.md)
+1. [Post-merge S0 acceptance](../verification/lib-pro-012-s0-post-merge-acceptance.json)
+2. [A0 derivative execution plan](lib-pro-013-a0-execution-plan.md)
+3. [LIB-PRO-013 master audit authority](lib-pro-013-whole-library-renewal-audit-plan.md)
+4. [LIB-PRO-012 remediation authority](lib-pro-012-external-api-remediation-plan.md)
+5. [LIB-PRO-011 finding authority](../verification/lib-pro-011-external-api-readiness-audit.md)
+6. [Current task board](../TASKS.md)

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -6,10 +6,10 @@
 - Date: 2026-08-27
 - Focus: Independently inspect merged LIB-PRO-012 S0, repair only confirmed
 - Completed: Re-established exact fetched-main, PR, hosted-check, tree-equivalence,; Replayed every mapped S0 route class against direct expert, composed service,; Closed the three confirmed transport manifestations left outside the merged
-- Git receipt: docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-receipt.json | sha256:2e5fd5bb22f423218627242cd168d96cff2136fed0b25c5a7532ecb614172164 | HOLD
-- Git identity: codex/lib-pro-012-s0-post-merge-audit-a0-plan@4cebcccb3a07b8046e31b23332236321ebee1d25 | upstream=origin/main@4cebcccb3a07b8046e31b23332236321ebee1d25 | base=origin/main@4cebcccb3a07b8046e31b23332236321ebee1d25 | tree=dirty | operation=none
+- Git receipt: docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-closeout-repair-git-handoff-receipt.json | sha256:4e1abf3c439a9e0a80503b0f3c0a73c729ef3e7e52f83c61dc0d3e921743dc80 | HOLD
+- Git identity: codex/lib-pro-012-s0-post-merge-audit-a0-plan@8916c2c5effae006c0701a4e3f5b04b315eb722a | upstream=origin/main@4cebcccb3a07b8046e31b23332236321ebee1d25 | base=origin/main@4cebcccb3a07b8046e31b23332236321ebee1d25 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
-- Next action: FREEZE_ONE_POST_MERGE_REPAIR_CANDIDATE_AND_RUN_ONE_HOSTED_CYCLE
+- Next action: PUBLISH_ONE_EXACT_POST_MERGE_REPAIR_HEAD
 <!-- HANDOFF:END -->
 
 ## Latest Handoff

--- a/docs/reference/fastapi-rest-api.md
+++ b/docs/reference/fastapi-rest-api.md
@@ -274,6 +274,14 @@ Three preview contracts have additional fail-closed boundaries:
   `span_length`. It exposes canonical flexure/shear checks, utilization,
   remaining-capacity margin, core advisory scores, and core cost analysis; the
   transport does not invent a depth, span, clause check, score meaning, or cost.
+- `POST /api/v1/export/bbs` and `/api/v1/export/dxf` require a finite positive
+  `span_length` and strict request types. They reject unknown fields before
+  detailing or artifact creation instead of substituting a span from section
+  depth. The valid BBS reference remains exactly nine line items.
+- `POST /api/v1/design/beam` rejects `rebar_layers` with an explicit scope hold
+  because the v1 calculation does not consume supplied layer layouts. Use the
+  maintained detailing/check workflow rather than assuming those values affect
+  the primary design response.
 - `POST /api/v1/geometry/building` is visualization-only. Every member and its
   section are typed and validated together, duplicate identities block, and
   `unit_scale` is receipted as millimetres per source coordinate unit. This

--- a/docs/verification/lib-pro-012-s0-post-merge-acceptance.json
+++ b/docs/verification/lib-pro-012-s0-post-merge-acceptance.json
@@ -1,0 +1,172 @@
+{
+  "schema_version": "1.0",
+  "evidence_id": "LIB-PRO-012-S0-POST-MERGE-ACCEPTANCE",
+  "status": "LOCAL_ACCEPTANCE_PASS_PENDING_IMMUTABLE_COMMIT_AND_HOSTED_CHECKS",
+  "observed_at_utc": "2026-08-27T15:05:01Z",
+  "candidate_identity_policy": {
+    "branch": "codex/lib-pro-012-s0-post-merge-audit-a0-plan",
+    "source_merge_commit": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+    "source_merge_tree": "e989ccba44ab89774db17bdf3d0d18ba435fa109",
+    "candidate_commit": "RECORDED_EXTERNALLY_AFTER_IMMUTABLE_COMMIT",
+    "reason": "All versioned acceptance evidence is frozen before the immutable candidate commit. The exact candidate, PR head, hosted checks, and successor merge identity are recorded externally without changing the reviewed tree."
+  },
+  "merged_s0_identity": {
+    "planning_baseline": "d3242731e94dacd74e804a1f4a25c4c0da11790f",
+    "final_pr_head": "efcd4126e120fe3b19723d349681475a1625c30c",
+    "squash_merge_commit": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+    "reviewed_and_merged_tree": "e989ccba44ab89774db17bdf3d0d18ba435fa109",
+    "pull_request": 877,
+    "hosted_run": 33080623445,
+    "hosted_outcome": "7 SUCCESS, 2 SKIPPED, REQUIRED PR GATE SUCCESS",
+    "tree_equivalence": "PASS"
+  },
+  "authorities": [
+    {
+      "path": "docs/planning/lib-pro-012-external-api-remediation-plan.md",
+      "sha256": "4e77edcf813797b7b09a95ec3cd532d1f6631e8a4daea1caab5df620ae2539e5"
+    },
+    {
+      "path": "docs/planning/lib-pro-013-whole-library-renewal-audit-plan.md",
+      "sha256": "f63add72483dfcb0c06bf0f7a134600265ed11b00b52dbd0ad8892332e4f1755"
+    },
+    {
+      "path": "docs/verification/lib-pro-011-external-api-readiness-audit.md",
+      "sha256": "b80a9d46e9674de38b6e0821f421c4a01f5c790c86e7cac27068ee87c47a37b3"
+    },
+    {
+      "path": "docs/verification/lib-pro-012-s0-p0-safety-closure-evidence.json",
+      "sha256": "f3a7064ea1ae191ec509d97da064e2a7b5d09e639f883dacf63b9a9d3bc1a4f5",
+      "role": "immutable pre-commit S0 cycle evidence; superseded only for final hosted and post-merge acceptance facts"
+    },
+    {
+      "path": "docs/planning/lib-pro-013-a0-execution-plan.md",
+      "sha256": "95fb1d8a059083ecd9b020e7f6bf27a2a1b5911778046a82c7f73909264131b1",
+      "role": "derivative A0 execution plan; the LIB-PRO-013 master remains authoritative"
+    }
+  ],
+  "worktree_safety": {
+    "source_branch_started_at_fetched_origin_main": true,
+    "operation_or_conflict": false,
+    "overlapping_active_runtime_or_generated_candidate": false,
+    "preserved_dirty_sibling": {
+      "path": "/Users/pravinsurawase/.codex/worktrees/e54a/structural_engineering_lib",
+      "head_sha": "0fdb48edbb73114288feb8a246d6f30b80ac4d95",
+      "disposition": "PRESERVED_UNTOUCHED"
+    },
+    "destructive_actions": []
+  },
+  "review_scope": {
+    "mapped_s0_findings_replayed": [
+      "EXT-BEAM-001..008",
+      "EXT-DETAIL-001..002",
+      "EXT-BBS-001",
+      "EXT-REST-001",
+      "EXT-REST-003",
+      "EXT-TORSION-001..006",
+      "EXT-COLUMN-001..002",
+      "EXT-TYPED-001..007",
+      "EXT-ID-001"
+    ],
+    "routes_reviewed": [
+      "design-only",
+      "combined",
+      "compliance",
+      "smart-analysis",
+      "direct-detailing",
+      "BBS",
+      "torsion",
+      "column",
+      "structured-input",
+      "/api/v1/design/beam",
+      "/api/v1/export/bbs",
+      "/api/v1/export/dxf"
+    ],
+    "unchanged_valid_controls": {
+      "beam_ast_required_mm2": 883.7158126109596,
+      "torsion_equivalent_shear_kn": 153.33333333333334,
+      "bbs_items": 9,
+      "derived_effective_depth_mm": 457.0
+    }
+  },
+  "post_merge_findings": {
+    "S0-POST-REST-001": {
+      "priority": "P0",
+      "prechange": "POST /api/v1/design/beam accepted rebar_layers and returned HTTP 200 although the route never consumed the field.",
+      "root_cause": "The field remained in BeamDesignRequest after the primary route was hardened, but no maintained route owner consumed it.",
+      "resolution": "Reject any supplied rebar_layers with HTTP 422 and stable REBAR_LAYERS_SCOPE_HOLD text; omission remains compatible.",
+      "status": "CLOSED_LOCAL_PENDING_HOSTED"
+    },
+    "S0-POST-BBS-001": {
+      "priority": "P0",
+      "prechange": "POST /api/v1/export/bbs returned HTTP 200 and created an artifact when span_length was omitted or zero by substituting depth * 12.",
+      "root_cause": "ExportBeamRequest retained an optional zero span and _run_detailing invented a structural span downstream.",
+      "resolution": "Require explicit positive span_length and remove the depth-based fallback before detailing, BBS, or DXF creation.",
+      "status": "CLOSED_LOCAL_PENDING_HOSTED"
+    },
+    "S0-POST-BBS-002": {
+      "priority": "P0",
+      "prechange": "The BBS/DXF request boundary coerced numeric strings and string booleans and ignored unknown engineering fields.",
+      "root_cause": "Strict Pydantic configuration was applied to the primary beam model but not to the shared export request model.",
+      "resolution": "Use strict types, forbid extras, reject nonfinite values, and update the maintained React caller contract.",
+      "status": "CLOSED_LOCAL_PENDING_HOSTED"
+    },
+    "S0-POST-EVIDENCE-001": {
+      "priority": "P1_TRUTH",
+      "prechange": "The task board, handoff, and immutable pre-commit evidence stopped at the first PR head or pending repair state; append-only usage telemetry also recorded only that first candidate.",
+      "root_cause": "Repository closeout correctly froze versioned evidence before the final hosted repair and had no successor post-merge acceptance receipt.",
+      "resolution": "Retain the historical evidence unchanged and add this successor receipt plus reconciled task, session, and handoff state. Do not retroactively alter append-only telemetry.",
+      "status": "CLOSED_BY_SUCCESSOR_RECEIPT_PENDING_THIS_TASK_INTEGRATION"
+    }
+  },
+  "compatibility_decisions": {
+    "primary_v1": "Existing field names remain. Supplying dormant rebar_layers now fails closed because accepting unused engineering input is unsafe; callers may omit it.",
+    "export_v1": "BBS and DXF now require explicit positive span_length. No derivation basis existed for the historical depth * 12 substitution, so omission is ambiguous and fails closed.",
+    "result_separation": "Invalid intake remains HTTP 422; a valid engineering FAIL remains HTTP 200; internal failure remains HTTP 500."
+  },
+  "validation": {
+    "independent_adversarial_matrix": "PASS: no misses across mapped direct, composed, typed, primary REST, and export routes after repair",
+    "focused_python_fastapi": "788 collected and 788 passed",
+    "focused_repair_fastapi": "47 passed",
+    "focused_react": "66 passed across 3 files",
+    "react_lint": "PASS",
+    "react_production_build": "PASS",
+    "architecture": "222 files, zero violations",
+    "circular_imports": "202 files, zero cycles",
+    "library_imports": "247 files, zero broken imports",
+    "openapi": "PASS: 89 endpoints and 444 schemas match refreshed baseline",
+    "api_manifest": "PASS",
+    "api_classification_and_compatibility": "PASS",
+    "quick_gate": "PENDING_CONTENT_FREEZE",
+    "normal_commit_hooks": "PENDING_IMMUTABLE_COMMIT",
+    "hosted_checks": "PENDING_PR"
+  },
+  "exact_candidate_artifact": {
+    "wheel": "/tmp/lib-pro-012-s0-post-audit.PIJ833/structural_lib_is456-0.24.0a1-py3-none-any.whl",
+    "sha256": "4f8e89f7b0280a998b426e56042685db2884c59f549d79839dfecba1e7445adb",
+    "build_environment": "isolated python-build environment",
+    "install_environment": "temporary source-free pip --target installation with no dependencies",
+    "source_free_invalid_python_routes_rejected": 15,
+    "strict_primary_rest_vectors_rejected": 5,
+    "required_primary_fields_rejected_when_omitted": 9,
+    "invalid_bbs_transport_vectors_rejected": 6,
+    "valid_bbs_http_status": 200,
+    "valid_engineering_fail_http_status": 200,
+    "valid_engineering_fail_status": "FAIL"
+  },
+  "a0_readiness": {
+    "status": "PLAN_READY_START_HELD_UNTIL_THIS_REPAIR_MERGES",
+    "plan": "docs/planning/lib-pro-013-a0-execution-plan.md",
+    "delivery_model": "one read-only audit session, branch, evidence candidate, PR, and hosted cycle",
+    "batched_passes": 4,
+    "master_estimate_engineer_days": "15-24"
+  },
+  "remaining_holds": [
+    "/api/v2 and EXT-REST-002",
+    "canonical facade and LIB-PRO-012 Packets C-I",
+    "generated signature prose",
+    "cumulative broad Python/React/full gate",
+    "LIB-PRO-013 A0 execution until this repair is merged",
+    "release, publication, qualified review, professional approval, and public engineering-use claims",
+    "branch or worktree deletion"
+  ]
+}

--- a/docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-closeout-repair-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-closeout-repair-git-handoff-receipt.json
@@ -1,0 +1,174 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-27T15:24:03Z",
+      "query_status": "OK",
+      "reference": "Before going to A0, check the last completed work, find and fix mistakes or missed issues, then plan A0 efficiently.",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "AUDIT_AND_REPAIR_MERGED_LIB_PRO_012_S0",
+      "PLAN_LIB_PRO_013_A0_WITHOUT_STARTING_IT",
+      "PRESERVE_A_TIME_BOUND_SUCCESSOR_HANDOFF_OBSERVATION",
+      "COMMIT_PUSH_CREATE_PR_AND_MERGE_UNCHANGED_GREEN_HEAD"
+    ],
+    "next_action": "PUBLISH_ONE_EXACT_POST_MERGE_REPAIR_HEAD",
+    "observed_at_utc": "2026-08-27T15:24:03Z",
+    "prohibited_actions": [
+      "START_LIB_PRO_013_A0_BEFORE_REPAIR_INTEGRATION",
+      "START_LIB_PRO_012_PACKETS_C_THROUGH_I",
+      "CREATE_API_V2_OR_NEW_FACADE",
+      "DELETE_BRANCH_OR_WORKTREE",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_OR_REWRITE",
+      "BYPASS_CHECKS_OR_FORCE_PUSH",
+      "PUBLISH_RELEASE_VERSION_TAG_OR_PACKAGE",
+      "TRACK_OR_MODIFY_PROTECTED_STANDARD_CONTENT",
+      "ACTIVATE_PROFESSIONAL_OR_ENGINEERING_USE_APPROVAL"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "AUDIT_AND_REPAIR_MERGED_LIB_PRO_012_S0",
+        "PLAN_LIB_PRO_013_A0_WITHOUT_STARTING_IT",
+        "PRESERVE_A_TIME_BOUND_SUCCESSOR_HANDOFF_OBSERVATION",
+        "COMMIT_PUSH_CREATE_PR_AND_MERGE_UNCHANGED_GREEN_HEAD"
+      ],
+      "branch": "codex/lib-pro-012-s0-post-merge-audit-a0-plan",
+      "head_sha": "8916c2c5effae006c0701a4e3f5b04b315eb722a",
+      "task_id": "LIB-PRO-012-S0-POST-MERGE-AUDIT-A0-PLAN"
+    }
+  },
+  "holds": [
+    "BRANCH_AND_WORKTREE_DELETION_NOT_AUTHORIZED",
+    "LOCAL_HOLD_DIRTY",
+    "NEXT_ACTION_NOT_AUTHORIZED",
+    "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+    "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "4e1abf3c439a9e0a80503b0f3c0a73c729ef3e7e52f83c61dc0d3e921743dc80",
+    "state": {
+      "branch": "codex/lib-pro-012-s0-post-merge-audit-a0-plan",
+      "default_base": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+        "status": "ahead"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 105.327,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib5",
+      "head_sha": "8916c2c5effae006c0701a4e3f5b04b315eb722a",
+      "hold_reasons": [
+        "changed paths: 2"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-27T15:28:57.438514+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/04f5/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 2,
+        "modified_paths": [
+          "docs/SESSION_LOG.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-closeout-repair-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 1,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+        "status": "ahead"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/04f5/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:4e1abf3c439a9e0a80503b0f3c0a73c729ef3e7e52f83c61dc0d3e921743dc80",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-27T15:28:57.438656+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_TASK_BRANCH_AND_ALL_UNRELATED_WORKTREES",
+    "holds": [
+      "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+      "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+      "BRANCH_AND_WORKTREE_DELETION_NOT_AUTHORIZED"
+    ],
+    "observed_at_utc": "2026-08-27T15:24:03Z",
+    "owner": "Main agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources",
+      "Python/structural_lib/data/excel"
+    ],
+    "integration_owner": "reviewer",
+    "owned_paths": [
+      "fastapi_app/models/beam.py",
+      "fastapi_app/routers/export.py",
+      "fastapi_app/openapi_baseline.json",
+      "fastapi_app/tests/test_beam_primary_route.py",
+      "fastapi_app/tests/test_export_bbs_dxf.py",
+      "react_app/src/hooks/useExport.ts",
+      "react_app/src/components/__tests__/ExportPanel.test.tsx",
+      "scripts/verify_lib_pro_012_s0_artifact.py",
+      "docs/reference/fastapi-rest-api.md",
+      "docs/planning/lib-pro-013-a0-execution-plan.md",
+      "docs/verification/lib-pro-012-s0-post-merge-acceptance.json",
+      "docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-source-evidence.json",
+      "docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-receipt.json",
+      "docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-closeout-repair-source-evidence.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "LIB-PRO-012-S0-POST-MERGE-AUDIT-A0-PLAN"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-closeout-repair-source-evidence.json
+++ b/docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-closeout-repair-source-evidence.json
@@ -1,0 +1,63 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-27T15:24:03Z",
+      "query_status": "OK",
+      "reference": "Before going to A0, check the last completed work, find and fix mistakes or missed issues, then plan A0 efficiently.",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "AUDIT_AND_REPAIR_MERGED_LIB_PRO_012_S0",
+      "PLAN_LIB_PRO_013_A0_WITHOUT_STARTING_IT",
+      "PRESERVE_A_TIME_BOUND_SUCCESSOR_HANDOFF_OBSERVATION",
+      "COMMIT_PUSH_CREATE_PR_AND_MERGE_UNCHANGED_GREEN_HEAD"
+    ],
+    "next_action": "PUBLISH_ONE_EXACT_POST_MERGE_REPAIR_HEAD",
+    "observed_at_utc": "2026-08-27T15:24:03Z",
+    "prohibited_actions": [
+      "START_LIB_PRO_013_A0_BEFORE_REPAIR_INTEGRATION",
+      "START_LIB_PRO_012_PACKETS_C_THROUGH_I",
+      "CREATE_API_V2_OR_NEW_FACADE",
+      "DELETE_BRANCH_OR_WORKTREE",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_OR_REWRITE",
+      "BYPASS_CHECKS_OR_FORCE_PUSH",
+      "PUBLISH_RELEASE_VERSION_TAG_OR_PACKAGE",
+      "TRACK_OR_MODIFY_PROTECTED_STANDARD_CONTENT",
+      "ACTIVATE_PROFESSIONAL_OR_ENGINEERING_USE_APPROVAL"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "AUDIT_AND_REPAIR_MERGED_LIB_PRO_012_S0",
+        "PLAN_LIB_PRO_013_A0_WITHOUT_STARTING_IT",
+        "PRESERVE_A_TIME_BOUND_SUCCESSOR_HANDOFF_OBSERVATION",
+        "COMMIT_PUSH_CREATE_PR_AND_MERGE_UNCHANGED_GREEN_HEAD"
+      ],
+      "branch": "codex/lib-pro-012-s0-post-merge-audit-a0-plan",
+      "head_sha": "8916c2c5effae006c0701a4e3f5b04b315eb722a",
+      "task_id": "LIB-PRO-012-S0-POST-MERGE-AUDIT-A0-PLAN"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_TASK_BRANCH_AND_ALL_UNRELATED_WORKTREES",
+    "holds": [
+      "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+      "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+      "BRANCH_AND_WORKTREE_DELETION_NOT_AUTHORIZED"
+    ],
+    "observed_at_utc": "2026-08-27T15:24:03Z",
+    "owner": "Main agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-receipt.json
@@ -1,0 +1,198 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-27T14:25:00Z",
+      "query_status": "OK",
+      "reference": "Before going to A0, check the last completed work, find and fix mistakes or missed issues, then plan A0 efficiently.",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "AUDIT_MERGED_LIB_PRO_012_S0",
+      "FIX_CONFIRMED_S0_OUTCOME_DEFECTS",
+      "ADD_FOCUSED_REGRESSIONS_AND_ACCEPTANCE_EVIDENCE",
+      "PLAN_LIB_PRO_013_A0_EFFICIENTLY",
+      "RUN_FOCUSED_EXACT_ARTIFACT_QUICK_AND_HOSTED_CHECKS",
+      "COMMIT_OWNED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_ONE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "next_action": "FREEZE_ONE_POST_MERGE_REPAIR_CANDIDATE_AND_RUN_ONE_HOSTED_CYCLE",
+    "observed_at_utc": "2026-08-27T14:25:00Z",
+    "prohibited_actions": [
+      "START_LIB_PRO_013_A0_BEFORE_REPAIR_INTEGRATION",
+      "EDIT_RUNTIME_DURING_LIB_PRO_013_A0",
+      "START_LIB_PRO_012_PACKETS_C_THROUGH_I",
+      "CREATE_API_V2_OR_NEW_FACADE",
+      "DELETE_BRANCH_OR_WORKTREE",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_OR_REWRITE",
+      "BYPASS_CHECKS_OR_FORCE_PUSH",
+      "PUBLISH_RELEASE_VERSION_TAG_OR_PACKAGE",
+      "TRACK_OR_MODIFY_PROTECTED_STANDARD_CONTENT",
+      "ACTIVATE_PROFESSIONAL_OR_ENGINEERING_USE_APPROVAL"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "AUDIT_MERGED_LIB_PRO_012_S0",
+        "FIX_CONFIRMED_S0_OUTCOME_DEFECTS",
+        "ADD_FOCUSED_REGRESSIONS_AND_ACCEPTANCE_EVIDENCE",
+        "PLAN_LIB_PRO_013_A0_EFFICIENTLY",
+        "RUN_FOCUSED_EXACT_ARTIFACT_QUICK_AND_HOSTED_CHECKS",
+        "COMMIT_OWNED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_ONE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/lib-pro-012-s0-post-merge-audit-a0-plan",
+      "head_sha": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+      "task_id": "LIB-PRO-012-S0-POST-MERGE-AUDIT-A0-PLAN"
+    }
+  },
+  "holds": [
+    "AUTHORIZATION_SOURCE_STALE_EVIDENCE",
+    "AUTHORIZATION_STALE_EVIDENCE",
+    "BRANCH_AND_WORKTREE_DELETION_NOT_AUTHORIZED",
+    "LOCAL_HOLD_DIRTY",
+    "NEXT_ACTION_NOT_AUTHORIZED",
+    "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+    "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "2e5fd5bb22f423218627242cd168d96cff2136fed0b25c5a7532ecb614172164",
+    "state": {
+      "branch": "codex/lib-pro-012-s0-post-merge-audit-a0-plan",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 110.071,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib5",
+      "head_sha": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+      "hold_reasons": [
+        "changed paths: 15"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-27T15:12:49.598741+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/04f5/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 15,
+        "modified_paths": [
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/planning/next-session-brief.md",
+          "docs/reference/fastapi-rest-api.md",
+          "fastapi_app/models/beam.py",
+          "fastapi_app/openapi_baseline.json",
+          "fastapi_app/routers/export.py",
+          "fastapi_app/tests/test_beam_primary_route.py",
+          "fastapi_app/tests/test_export_bbs_dxf.py",
+          "react_app/src/components/__tests__/ExportPanel.test.tsx",
+          "react_app/src/hooks/useExport.ts",
+          "scripts/verify_lib_pro_012_s0_artifact.py"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/planning/lib-pro-013-a0-execution-plan.md",
+          "docs/verification/lib-pro-012-s0-post-merge-acceptance.json",
+          "docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-source-evidence.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/04f5/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:2e5fd5bb22f423218627242cd168d96cff2136fed0b25c5a7532ecb614172164",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-27T15:12:49.598894+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_TASK_BRANCH_AND_ALL_UNRELATED_WORKTREES",
+    "holds": [
+      "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+      "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+      "BRANCH_AND_WORKTREE_DELETION_NOT_AUTHORIZED"
+    ],
+    "observed_at_utc": "2026-08-27T15:05:01Z",
+    "owner": "Main agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources",
+      "Python/structural_lib/data/excel"
+    ],
+    "integration_owner": "reviewer",
+    "owned_paths": [
+      "fastapi_app/models/beam.py",
+      "fastapi_app/routers/export.py",
+      "fastapi_app/openapi_baseline.json",
+      "fastapi_app/tests/test_beam_primary_route.py",
+      "fastapi_app/tests/test_export_bbs_dxf.py",
+      "react_app/src/hooks/useExport.ts",
+      "react_app/src/components/__tests__/ExportPanel.test.tsx",
+      "scripts/verify_lib_pro_012_s0_artifact.py",
+      "docs/reference/fastapi-rest-api.md",
+      "docs/planning/lib-pro-013-a0-execution-plan.md",
+      "docs/verification/lib-pro-012-s0-post-merge-acceptance.json",
+      "docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-source-evidence.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "LIB-PRO-012-S0-POST-MERGE-AUDIT-A0-PLAN"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-source-evidence.json
+++ b/docs/verification/lib-pro-012-s0-post-merge-audit-a0-plan-git-handoff-source-evidence.json
@@ -1,0 +1,74 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-27T14:25:00Z",
+      "query_status": "OK",
+      "reference": "Before going to A0, check the last completed work, find and fix mistakes or missed issues, then plan A0 efficiently.",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "AUDIT_MERGED_LIB_PRO_012_S0",
+      "FIX_CONFIRMED_S0_OUTCOME_DEFECTS",
+      "ADD_FOCUSED_REGRESSIONS_AND_ACCEPTANCE_EVIDENCE",
+      "PLAN_LIB_PRO_013_A0_EFFICIENTLY",
+      "RUN_FOCUSED_EXACT_ARTIFACT_QUICK_AND_HOSTED_CHECKS",
+      "COMMIT_OWNED_PATHS",
+      "PUSH_FEATURE_BRANCH",
+      "CREATE_ONE_PR",
+      "MERGE_UNCHANGED_GREEN_PR"
+    ],
+    "next_action": "FREEZE_ONE_POST_MERGE_REPAIR_CANDIDATE_AND_RUN_ONE_HOSTED_CYCLE",
+    "observed_at_utc": "2026-08-27T14:25:00Z",
+    "prohibited_actions": [
+      "START_LIB_PRO_013_A0_BEFORE_REPAIR_INTEGRATION",
+      "EDIT_RUNTIME_DURING_LIB_PRO_013_A0",
+      "START_LIB_PRO_012_PACKETS_C_THROUGH_I",
+      "CREATE_API_V2_OR_NEW_FACADE",
+      "DELETE_BRANCH_OR_WORKTREE",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_OR_REWRITE",
+      "BYPASS_CHECKS_OR_FORCE_PUSH",
+      "PUBLISH_RELEASE_VERSION_TAG_OR_PACKAGE",
+      "TRACK_OR_MODIFY_PROTECTED_STANDARD_CONTENT",
+      "ACTIVATE_PROFESSIONAL_OR_ENGINEERING_USE_APPROVAL"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "AUDIT_MERGED_LIB_PRO_012_S0",
+        "FIX_CONFIRMED_S0_OUTCOME_DEFECTS",
+        "ADD_FOCUSED_REGRESSIONS_AND_ACCEPTANCE_EVIDENCE",
+        "PLAN_LIB_PRO_013_A0_EFFICIENTLY",
+        "RUN_FOCUSED_EXACT_ARTIFACT_QUICK_AND_HOSTED_CHECKS",
+        "COMMIT_OWNED_PATHS",
+        "PUSH_FEATURE_BRANCH",
+        "CREATE_ONE_PR",
+        "MERGE_UNCHANGED_GREEN_PR"
+      ],
+      "branch": "codex/lib-pro-012-s0-post-merge-audit-a0-plan",
+      "head_sha": "4cebcccb3a07b8046e31b23332236321ebee1d25",
+      "task_id": "LIB-PRO-012-S0-POST-MERGE-AUDIT-A0-PLAN"
+    }
+  },
+  "integration": {
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "retention": {
+    "decision": "RETAIN_TASK_BRANCH_AND_ALL_UNRELATED_WORKTREES",
+    "holds": [
+      "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+      "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+      "BRANCH_AND_WORKTREE_DELETION_NOT_AUTHORIZED"
+    ],
+    "observed_at_utc": "2026-08-27T15:05:01Z",
+    "owner": "Main agent under repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/fastapi_app/models/beam.py
+++ b/fastapi_app/models/beam.py
@@ -180,6 +180,12 @@ class BeamDesignRequest(BaseModel):
     @model_validator(mode="after")
     def validate_depth_relationships(self) -> "BeamDesignRequest":
         """Validate practical depth-to-width ratio and cross-field depth constraints."""
+        if self.rebar_layers is not None:
+            raise ValueError(
+                "REBAR_LAYERS_SCOPE_HOLD: /api/v1/design/beam does not consume "
+                "supplied reinforcement layers; omit rebar_layers and use the "
+                "maintained detailing/check workflow."
+            )
         if self.depth / self.width > 6:
             raise ValueError(
                 f"Depth/width ratio {self.depth / self.width:.1f} exceeds practical limit of 6"

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -15686,6 +15686,7 @@
         "type": "string"
       },
       "ExportBeamRequest": {
+        "additionalProperties": false,
         "description": "Beam parameters for generating export artifacts.",
         "properties": {
           "asc_required": {
@@ -15754,9 +15755,8 @@
             "type": "number"
           },
           "span_length": {
-            "default": 0,
-            "description": "Span in mm",
-            "minimum": 0.0,
+            "description": "Explicit beam span in mm",
+            "exclusiveMinimum": 0.0,
             "title": "Span Length",
             "type": "number"
           },
@@ -15777,6 +15777,7 @@
         "required": [
           "width",
           "depth",
+          "span_length",
           "fck",
           "fy",
           "ast_required"

--- a/fastapi_app/routers/export.py
+++ b/fastapi_app/routers/export.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from fastapi_app.models.beam import BeamCrackWidthParams
 
@@ -47,12 +47,14 @@ router = APIRouter(
 class ExportBeamRequest(BaseModel):
     """Beam parameters for generating export artifacts."""
 
+    model_config = ConfigDict(strict=True, extra="forbid", allow_inf_nan=False)
+
     beam_id: str = Field(
         default="BEAM-1", max_length=50, pattern=r"^[A-Za-z0-9_\-\.]{1,50}$"
     )
     width: float = Field(..., gt=0, description="Beam width in mm")
     depth: float = Field(..., gt=0, description="Beam depth in mm")
-    span_length: float = Field(default=0, ge=0, description="Span in mm")
+    span_length: float = Field(..., gt=0, description="Explicit beam span in mm")
     clear_cover: float = Field(
         default=40, ge=20, le=75, description="Clear cover in mm"
     )
@@ -175,14 +177,13 @@ def _run_detailing(req: ExportBeamRequest):
             detail="structural_lib not available",
         )
 
-    span = req.span_length if req.span_length > 0 else req.depth * 12
     return detail_beam_is456(
         units="IS456",
         beam_id=req.beam_id,
         story="1F",
         b_mm=req.width,
         D_mm=req.depth,
-        span_mm=span,
+        span_mm=req.span_length,
         cover_mm=req.clear_cover,
         fck_nmm2=req.fck,
         fy_nmm2=req.fy,

--- a/fastapi_app/tests/test_beam_primary_route.py
+++ b/fastapi_app/tests/test_beam_primary_route.py
@@ -82,6 +82,22 @@ def test_v1_beam_rejects_unknown_engineering_fields(client, ordinary_payload) ->
     assert details[0]["loc"][-1] == "unexpected_engineering_field"
 
 
+def test_v1_beam_rejects_unconsumed_reinforcement_layers(
+    client, ordinary_payload
+) -> None:
+    response = client.post(
+        "/api/v1/design/beam",
+        json={
+            **ordinary_payload,
+            "rebar_layers": [{"layer": 1, "bar_count": 3, "bar_dia_mm": 20.0}],
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json()["error"]["code"] == "REQUEST_VALIDATION_ERROR"
+    assert "REBAR_LAYERS_SCOPE_HOLD" in str(response.json()["error"]["details"])
+
+
 def test_v1_beam_accepts_ordinary_integers_and_complete_derivation_basis(
     client,
 ) -> None:
@@ -323,8 +339,16 @@ def test_stale_report_and_combined_bbs_dxf_fail_closed(
     assert "STALE_CALCULATION_IDENTITY" in str(stale.json()["error"])
 
     export_payload = {
-        **ordinary_payload,
+        "beam_id": "B-COMBINED",
+        "width": ordinary_payload["width"],
+        "depth": ordinary_payload["depth"],
+        "span_length": 5000.0,
+        "clear_cover": ordinary_payload["clear_cover"],
+        "fck": ordinary_payload["fck"],
+        "fy": ordinary_payload["fy"],
         "ast_required": 900.0,
+        "moment": ordinary_payload["moment"],
+        "shear": ordinary_payload["shear"],
         "torsion": 10.0,
     }
     for endpoint in ("bbs", "dxf"):

--- a/fastapi_app/tests/test_export_bbs_dxf.py
+++ b/fastapi_app/tests/test_export_bbs_dxf.py
@@ -60,6 +60,7 @@ class TestBBSExport:
         assert "bar_mark" in content
         assert "diameter_mm" in content
         assert "total_weight_kg" in content
+        assert "9 line items" in content
 
     def test_bbs_export_with_compression(self, client):
         """BBS export with compression steel."""
@@ -67,6 +68,7 @@ class TestBBSExport:
             "beam_id": "B-DBL",
             "width": 300.0,
             "depth": 600.0,
+            "span_length": 6000.0,
             "fck": 25.0,
             "fy": 500.0,
             "ast_required": 1200.0,
@@ -80,6 +82,7 @@ class TestBBSExport:
         payload = {
             "width": 300.0,
             "depth": 500.0,
+            "span_length": 6000.0,
             "fck": 25.0,
             "fy": 500.0,
             "ast_required": 0.0,
@@ -90,6 +93,44 @@ class TestBBSExport:
             "body",
             "ast_required",
         ]
+
+    @pytest.mark.parametrize("endpoint", ["bbs", "dxf"])
+    @pytest.mark.parametrize("span", [None, 0.0])
+    def test_beam_artifact_export_requires_explicit_positive_span(
+        self, client, sample_beam_export, endpoint, span
+    ):
+        """Invalid or missing span stops before detailing and BBS creation."""
+        payload = dict(sample_beam_export)
+        if span is None:
+            del payload["span_length"]
+        else:
+            payload["span_length"] = span
+
+        resp = client.post(f"/api/v1/export/{endpoint}", json=payload)
+
+        assert resp.status_code == 422
+        assert resp.json()["error"]["details"][0]["loc"] == [
+            "body",
+            "span_length",
+        ]
+
+    @pytest.mark.parametrize("endpoint", ["bbs", "dxf"])
+    @pytest.mark.parametrize(
+        "change",
+        [
+            {"width": "300"},
+            {"include_serviceability": "false"},
+            {"unexpected_engineering_field": 999},
+        ],
+    )
+    def test_beam_artifact_export_rejects_coercion_and_unknown_fields(
+        self, client, sample_beam_export, endpoint, change
+    ):
+        resp = client.post(
+            f"/api/v1/export/{endpoint}", json={**sample_beam_export, **change}
+        )
+
+        assert resp.status_code == 422
 
 
 # =============================================================================
@@ -115,6 +156,7 @@ class TestDXFExport:
             "beam_id": "MYBEAM-001",
             "width": 250.0,
             "depth": 450.0,
+            "span_length": 5000.0,
             "fck": 30.0,
             "fy": 500.0,
             "ast_required": 600.0,

--- a/react_app/src/components/__tests__/ExportPanel.test.tsx
+++ b/react_app/src/components/__tests__/ExportPanel.test.tsx
@@ -18,6 +18,7 @@ describe('ExportPanel', () => {
   const defaultParams = {
     width: 300,
     depth: 500,
+    span_length: 5000,
     fck: 25,
     fy: 500,
     ast_required: 850,

--- a/react_app/src/hooks/useExport.ts
+++ b/react_app/src/hooks/useExport.ts
@@ -17,7 +17,7 @@ export interface ExportBeamParams {
   beam_id?: string;
   width: number;
   depth: number;
-  span_length?: number;
+  span_length: number;
   clear_cover?: number;
   fck: number;
   fy: number;
@@ -100,7 +100,7 @@ async function fetchExport(
  *
  * @example
  * const { mutate, isPending } = useExportBBS();
- * mutate({ width: 300, depth: 450, fck: 25, fy: 500, ast_required: 500 });
+ * mutate({ width: 300, depth: 450, span_length: 5000, fck: 25, fy: 500, ast_required: 500 });
  */
 export function useExportBBS() {
   return useMutation({
@@ -121,7 +121,7 @@ export function useExportBBS() {
  *
  * @example
  * const { mutate, isPending } = useExportDXF();
- * mutate({ width: 300, depth: 450, fck: 25, fy: 500, ast_required: 500 });
+ * mutate({ width: 300, depth: 450, span_length: 5000, fck: 25, fy: 500, ast_required: 500 });
  */
 export function useExportDXF() {
   return useMutation({

--- a/scripts/verify_lib_pro_012_s0_artifact.py
+++ b/scripts/verify_lib_pro_012_s0_artifact.py
@@ -208,27 +208,55 @@ strict_vectors = [
     {**payload, "moment": True},
     {**payload, "unexpected_engineering_field": 999},
     {**payload, "width": -1},
+    {
+        **payload,
+        "rebar_layers": [{"layer": 1, "bar_count": 3, "bar_dia_mm": 20.0}],
+    },
 ]
 for invalid in strict_vectors:
     response = client.post("/api/v1/design/beam", json=invalid)
     if response.status_code != 422:
         raise AssertionError((invalid, response.status_code, response.text))
 
+export_payload = {
+    "beam_id": "B-S0-EXPORT",
+    "width": 300,
+    "depth": 500,
+    "span_length": 5000,
+    "clear_cover": 40,
+    "fck": 25,
+    "fy": 500,
+    "ast_required": 900,
+}
 invalid_bbs_response = client.post(
-    "/api/v1/export/bbs",
-    json={
-        "width": 300,
-        "depth": 500,
-        "fck": 25,
-        "fy": 500,
-        "ast_required": 0,
-    },
+    "/api/v1/export/bbs", json={**export_payload, "ast_required": 0}
 )
 if invalid_bbs_response.status_code != 422:
     raise AssertionError(invalid_bbs_response.text)
 invalid_bbs_details = invalid_bbs_response.json()["error"]["details"]
 if invalid_bbs_details[0]["loc"] != ["body", "ast_required"]:
     raise AssertionError(invalid_bbs_details)
+
+invalid_bbs_vectors = []
+missing_span = dict(export_payload)
+del missing_span["span_length"]
+invalid_bbs_vectors.append(missing_span)
+invalid_bbs_vectors.extend(
+    [
+        {**export_payload, "span_length": 0},
+        {**export_payload, "width": "300"},
+        {**export_payload, "include_serviceability": "false"},
+        {**export_payload, "unexpected_engineering_field": 999},
+    ]
+)
+for invalid in invalid_bbs_vectors:
+    response = client.post("/api/v1/export/bbs", json=invalid)
+    if response.status_code != 422:
+        raise AssertionError((invalid, response.status_code, response.text))
+
+valid_bbs_response = client.post("/api/v1/export/bbs", json=export_payload)
+if valid_bbs_response.status_code != 200:
+    raise AssertionError(valid_bbs_response.text)
 
 valid_response = client.post("/api/v1/design/beam", json=payload)
 if valid_response.status_code != 200:
@@ -254,6 +282,8 @@ print(json.dumps({
     "required_field_rejections": required,
     "strict_vector_count": len(strict_vectors),
     "invalid_bbs_http_status": invalid_bbs_response.status_code,
+    "invalid_bbs_transport_vector_count": len(invalid_bbs_vectors) + 1,
+    "valid_bbs_http_status": valid_bbs_response.status_code,
     "valid_http_status": valid_response.status_code,
     "valid_effective_depth_mm": valid_data["effective_depth_used"],
     "engineering_fail_http_status": fail_response.status_code,


### PR DESCRIPTION
## Summary

- independently audit merged LIB-PRO-012 S0 and reconcile exact merge/hosted evidence
- reject unused primary `rebar_layers` input instead of silently accepting it
- require explicit positive BBS/DXF span, remove `depth * 12`, and make export intake strict/extra-forbid
- preserve valid nine-item BBS output and update React/OpenAPI callers
- add the derivative one-cycle LIB-PRO-013 A0 execution plan without starting A0

## Evidence

- 788 focused Python/FastAPI cases pass
- 66 focused React cases, lint, and production build pass
- architecture 222/0, circular imports 202/0, imports 247/0
- OpenAPI 89 endpoints / 444 schemas; API manifest and classification current
- isolated exact wheel `4f8e89f7b0280a998b426e56042685db2884c59f549d79839dfecba1e7445adb` rejects 15 source-free invalid Python routes; exact-head REST rejects 9 omissions, 5 primary strict/domain vectors, and 6 invalid BBS vectors
- consolidated quick gate 10/10; normal hooks and clean session closeout pass

## Scope holds

A0 remains unstarted until this PR integrates. `/api/v2`, EXT-REST-002, Packets C-I, the cumulative broad gate, release/publication, and professional/public engineering-use claims remain held.