### PR TITLE
docs(governance): record Windows evidence lane readiness

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -56,11 +56,13 @@ Every doc should have a clear status:
 
 Multi-session WIP docs go to `docs/_active/` first, then move to permanent location when complete.
 
-## Doc budget
+## Documentation scale
 
-Non-archived docs must stay under 400 files. Check with:
+There is no fixed numeric document-count limit. Prevent sprawl through
+canonical topic ownership, duplicate search, append-first updates, metadata,
+lifecycle status, and link validation. The active count is informational:
 ```bash
-./scripts/python_runtime.sh scripts/check_docs.py --budget
+./scripts/python_runtime.sh scripts/check_docs.py --inventory
 ```
 
 ## After structural changes

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -55,11 +55,13 @@ Every doc should have a clear status:
 
 Multi-session WIP docs go to `docs/_active/` first, then move to permanent location when complete.
 
-## Doc budget
+## Documentation scale
 
-Non-archived docs must stay under 400 files. Check with:
+There is no fixed numeric document-count limit. Prevent sprawl through
+canonical topic ownership, duplicate search, append-first updates, metadata,
+lifecycle status, and link validation. The active count is informational:
 ```bash
-./scripts/python_runtime.sh scripts/check_docs.py --budget
+./scripts/python_runtime.sh scripts/check_docs.py --inventory
 ```
 
 ## After structural changes

--- a/Python/tests/test_audit_readiness_truth.py
+++ b/Python/tests/test_audit_readiness_truth.py
@@ -110,15 +110,15 @@ def test_diagnostic_summary_keeps_first_hard_error_and_final_context() -> None:
                 "Documentation validation",
                 "ERROR: invalid doc_type 'plan' in docs/planning/new.md",
                 "Checked 405 active files",
-                "WARNING: soft documentation budget exceeded",
+                "WARNING: canonical owner description missing",
             ]
         ),
-        "Final context: hard cap is 500",
+        "Final context: metadata validation completed",
     )
 
     assert "ERROR: invalid doc_type 'plan'" in summary
-    assert "WARNING: soft documentation budget exceeded" in summary
-    assert "Final context: hard cap is 500" in summary
+    assert "WARNING: canonical owner description missing" in summary
+    assert "Final context: metadata validation completed" in summary
 
 
 def test_readiness_distinguishes_executable_performance_thresholds_from_reporting(
@@ -165,9 +165,12 @@ def test_readiness_exit_code_is_decisive(verdict: str, expected: int) -> None:
     assert readiness.verdict_exit_code(verdict) == expected
 
 
-def test_owner_selected_documentation_hard_cap_is_500() -> None:
-    assert docs_check.DOC_BUDGET_WARN == 350
-    assert docs_check.DOC_BUDGET_FAIL == 500
+def test_documentation_inventory_has_no_numeric_limit(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(docs_check, "DOCS_DIR", tmp_path)
+    for index in range(501):
+        (tmp_path / f"doc-{index}.md").write_text("# Doc\n", encoding="utf-8")
+
+    assert docs_check.check_doc_inventory() == 0
 
 
 @pytest.mark.parametrize(("unproven", "expected"), [(0, 0), (1, 1), (12, 1)])

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,97 @@
 
 ---
 
+## 2026-08-28 — Session: LIB-PRO-013 Windows evidence lane readiness
+
+**Agent:** Codex (`doc-master`, sole writer; no subagents).
+
+**Branch:** `codex/lib-pro-013-windows-evidence-lane-readiness`.
+
+**Focus:** Preserve the completed Windows laptop setup as a durable,
+non-destructive LIB-PRO-013 evidence-lane receipt; update the canonical next
+session and task authorities to accepted B0 -> F0 -> R0 sequencing; and remove
+the owner's fixed documentation-count limit without weakening documentation
+ownership, metadata, lifecycle, or link controls.
+
+**Completed:**
+
+- Freshly fetched exact `origin/main` at accepted B0 merge
+  `44ef7bc4e8c98d01f32291730ab77ed16d077823`, tree
+  `12a6f683a32df07664e22b4b3dc53edee7f9704b`; confirmed PR #880 merged and
+  no open non-Dependabot writer overlapped the task-owned documentation paths.
+- Re-read the completed remote Windows task and froze
+  `docs/verification/lib-pro-013-windows-evidence-lane-readiness.json` with the
+  exact host, B0 clone, isolated toolchain, Excel/ETABS versions, trial-license
+  boundary, passing setup checks, retained-data state, operating rules, refresh
+  triggers, and F0/R0 routing.
+- Recorded `READY_FOR_FUTURE_WINDOWS_EVIDENCE_SETUP_ONLY`: the host is ready,
+  but no post-F0 installed Excel or ETABS acceptance has run. The B0 base clone
+  is immutable; future evidence creates a task-specific worktree, operates
+  outside OneDrive, freezes source/tree/artifact/dataset/application/operator
+  identities, and runs Excel and ETABS separately.
+- Updated the canonical next-session brief, task board, remediation-plan
+  verdict, and planning status. F0 Packets F1-F3 are the next authorized cycle;
+  Windows is not an F0 prerequisite and must be rebound to exact accepted F0
+  before applicable R0 evidence.
+- Removed the 350-warning/500-failure checker thresholds and conflicting
+  400/500 documentation rules. `--inventory` now reports the active count
+  without a cap; hidden `--budget` compatibility also reports only. Canonical
+  ownership, append-first reuse, duplicate search, front matter, metadata,
+  lifecycle, index, and link validation remain active.
+- Focused readiness tests, exact GitHub/Claude instruction projection, config
+  precedence, JSON parsing, documentation metadata/front matter/index/links,
+  context validation, and the informational 411-file inventory pass.
+
+**Git handoff receipt:**
+`docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-receipt.json`
+
+### Issues encountered
+
+- The current local lane was the clean merged B0 candidate but was one commit
+  behind `origin/main`, so writing there would have bound the new receipt to
+  the reviewed candidate rather than the accepted merge.
+- The remote-host list was intermittently unavailable while the laptop task
+  continued. An earlier intermediate `PARTIAL` report also predated the
+  user's authorized isolated-runtime remediation and could have been mistaken
+  for the final state.
+- Documentation-count policy had three incompatible thresholds: checker warning
+  at 350, agent instructions at 400, and hard failure/governance text at 500.
+- The first full documentation-contract run failed on the pre-existing
+  `status: ready` front matter in the A0 execution plan.
+- The first normal commit hook rejected the frozen handoff block because its
+  refreshed Git-receipt binding used the checksum of the complete receipt file
+  instead of the receipt's embedded local-state hash.
+
+### Root causes and resolutions
+
+- Confirmed root cause: B0 candidate and merge have the same tree but different
+  commit identities, and the old worktree remained on the candidate branch.
+  Resolution: freshly fetch, verify PR #880/`origin/main`, and create this new
+  branch directly from the exact accepted merge. Evidence: Git state is clean
+  at `44ef7bc4...` before task writes.
+- Remote-listing root cause remains `unconfirmed`; direct task reads stayed
+  available and the final completed Windows turn supplied exact checks.
+  Resolution: use the latest completed remote receipt, require future entry
+  revalidation, and record remote disconnect as a refresh trigger rather than
+  inferring host failure.
+- Confirmed root cause: numeric documentation limits were duplicated across
+  checker constants, two instruction projections, governance/learning guides,
+  readiness aggregation, and tests. Resolution: remove numeric thresholds,
+  retain one informational inventory function plus a compatibility alias, and
+  update every active owner/projection. Evidence: 501-document regression
+  returns success, instruction composition is exact, and no active budget text
+  remains outside historical session records.
+- Confirmed root cause: `ready` was never a valid maintained lowercase
+  front-matter status. Resolution: use `active` because the completed derivative
+  plan remains a referenced programme authority. Evidence: the full
+  documentation front-matter/index/link contract passes.
+- Confirmed root cause: the handoff checker deliberately binds the generated
+  block to `local_state_receipt_hash`, while the manual post-refresh update had
+  substituted the whole-file SHA-256. Resolution: bind the handoff block to
+  `sha256:e16128ca2f9e3b915fe3e0523686055cb595e4f1c9a2c22e430de5dc5e893d0d`.
+  Evidence: the focused session consistency check and the replayed normal hooks
+  pass with the same staged receipt and handoff block.
+
 ## 2026-08-27 — Session: LIB-PRO-013 B0 common contract convergence
 
 **Agent:** Codex (`structural-math`, sole writer; no subagents).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-27 — LIB-PRO-013 A0 consolidated renewal audit truth freeze
+**Updated:** 2026-08-28 — LIB-PRO-013 B0 integrated; Windows evidence lane ready; F0 next
 
 ---
 
@@ -161,17 +161,32 @@ closes the mapped beam/detailing/BBS, torsion, column, typed-input, identity,
 and existing REST v1 safety boundary. A0 routes common/canonical/downstream
 contract convergence to B0, family construction/facade convergence to F0, and
 documentation/generated/package/cumulative artifact/evidence closure to R0.
-Packets C-E are locally implemented in B0: the strict canonical Python beam
-contract is frozen, exact v1/v2 parity passes, and named downstream consumers
-fail closed without partial artifacts. The final focused selection passes 451
-cases, its post-hook 416-case invalidated-path replay passes, and the
-source-free B0 wheel `25eacdd7...a803942f` passes the 29-case UAT
-with 15 registered CLI commands. One immutable candidate and hosted PR cycle
-remain before B0 integration. F0 and R0 are pre-authorized successors. Release
-remains exact-candidate work rather than a B0 gate, and the single engineer
-review occurs only after final R0 integration. Shared
+Packets C-E are integrated through B0 candidate `96d7cc93...` and merge
+`44ef7bc4...`, with exact shared tree `12a6f683...`; PR #880 and hosted run
+`33100194911` passed every required changed-path check. The strict canonical
+Python beam contract is frozen, exact v1/v2 parity passes, named downstream
+consumers fail closed without partial artifacts, the final focused selection
+passes 451 cases, the post-hook invalidated-path replay passes 416 cases, and
+the source-free B0 wheel `25eacdd7...a803942f` passes the 29-case UAT with 15
+registered CLI commands. F0 is now the active authorized successor; R0 follows
+accepted F0. Release remains exact-candidate work rather than an F0/R0 gate,
+and the single engineer review occurs only after final R0 integration. Shared
 validation, facade, result, manifest, generated API, documentation, task, and
 session owners remain single-writer surfaces.
+
+The [LIB-PRO-013 Windows evidence lane readiness receipt](verification/lib-pro-013-windows-evidence-lane-readiness.json)
+records `READY_FOR_FUTURE_WINDOWS_EVIDENCE_SETUP_ONLY` at exact B0 merge
+`44ef7bc4...`. The non-OneDrive base clone, isolated Python 3.11.15/Node 24/npm/
+Portable Git toolchain, licensed Excel installation, and ETABS 23.3.1 trial
+export-first boundary are ready. This is setup evidence, not installed
+post-F0 Excel/ETABS acceptance. The lane must be freshly rebound to accepted
+F0 before R0 uses it; Excel and ETABS remain separate evidence tasks.
+
+The owner removed the fixed documentation-count limit. `check_docs.py` now
+reports the active count only as an informational inventory; canonical topic
+ownership, duplicate search, append-first updates, metadata, lifecycle, index,
+and link checks remain enforced. The deprecated `--budget` spelling is a
+non-failing compatibility alias for `--inventory`.
 
 `MAINT-0136` is locally complete through its exact authorized cleanup boundary.
 Phase 1 PR #874 merged at reviewed head `37b36785`; Phase 2A removed the exact

--- a/docs/governance/maintenance-playbook.md
+++ b/docs/governance/maintenance-playbook.md
@@ -180,7 +180,7 @@ Enforced by `check_governance.py`:
 |------|-------|---------------|
 | Root folder files | ≤ 17 | `./run.sh check --quick` |
 | docs/ root files | ≤ 5 | `./run.sh check --quick` |
-| docs/ total files | ≤ 500 | `./scripts/python_runtime.sh scripts/check_docs.py --budget` |
+| Documentation scale | No numeric cap; canonical ownership, metadata, lifecycle, and links remain enforced | `./scripts/python_runtime.sh scripts/check_docs.py --all` |
 | WIP tasks | ≤ 2 | Review TASKS.md |
 | Draft docs age | ≤ 7 days | Archive or promote |
 

--- a/docs/guides/copilot-agents-usage-guide.md
+++ b/docs/guides/copilot-agents-usage-guide.md
@@ -157,10 +157,10 @@ The orchestrator will:
 ```
 @governance run a project health check
 @governance validate folder conventions
-@governance check doc budget
+@governance check documentation ownership and metadata
 ```
 
-**It knows about:** Doc budget, folder structure conventions, project health scoring, maintenance tasks.
+**It knows about:** Canonical documentation ownership, metadata and lifecycle rules, folder structure conventions, project health scoring, maintenance tasks.
 
 ---
 

--- a/docs/migration/learning/day-25-code-quality.md
+++ b/docs/migration/learning/day-25-code-quality.md
@@ -253,11 +253,11 @@ With 870+ internal links across hundreds of markdown files, link rot is a real p
 # Scans all .md files for [text](path) links and verifies targets exist
 ```
 
-**Doc budget:**
+**Documentation contract:**
 ```bash
-.venv/bin/python scripts/check_docs.py --budget
-# Non-archived docs must stay under 400 files
-# Prevents "doc sprawl" — creating docs faster than maintaining them
+.venv/bin/python scripts/check_docs.py --all
+# Enforces metadata, front matter, index structure, and links.
+# The active document count is informational and has no numeric cap.
 ```
 
 **Number sync:**
@@ -299,7 +299,7 @@ $ ./run.sh check --quick
 ✅ import validation ....... OK (1.2s)
 ✅ architecture boundaries . OK (0.8s)
 ✅ broken links ............ OK (2.1s)
-✅ doc budget .............. OK (0.1s)
+✅ documentation contract . OK (0.1s)
 ✅ version consistency ..... OK (0.2s)
 ✅ test suite .............. OK (8.4s)
 ✅ type check .............. OK (3.1s)

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -45,8 +45,8 @@ Internal planning documents and research notes.
 ### Active (current priorities)
 | Document | Last Updated | Status |
 |----------|-------------|--------|
-| `lib-pro-013-whole-library-renewal-audit-plan.md` | 2026-08-27 | 📋 Master audit aligned to S0/A0/B0/F0/R0; audit execution unstarted |
-| `lib-pro-012-external-api-remediation-plan.md` | 2026-08-27 | 📋 REST-complete P0 safety and later facade work grouped into four implementation cycles; runtime remediation unstarted |
+| `lib-pro-013-whole-library-renewal-audit-plan.md` | 2026-08-28 | 🔄 A0 and B0 integrated; F0 next, then R0 and one final engineer review |
+| `lib-pro-012-external-api-remediation-plan.md` | 2026-08-28 | 🔄 S0/A0/B0 integrated; F0 family convergence active next; Windows lane prepared for later exact R0 evidence |
 | `maint-0136-phase-2b-w-execution-closeout.md` | 2026-08-27 | ✅ Exact 63/63 worktree removal complete; 15 retained and all branches, refs, backups, and protected sources preserved |
 | `maint-0136-phase-2c-execution-closeout.md` | 2026-08-27 | ✅ Exact four-local/two-remote cleanup passed at `08a68419...b23c7`; all held surfaces preserved |
 | `maint-0136-phase-2c-preparation-plan.md` | 2026-08-27 | ✅ Exact digest authorized and executed through the Phase 2C closeout |

--- a/docs/planning/lib-pro-012-external-api-remediation-plan.md
+++ b/docs/planning/lib-pro-012-external-api-remediation-plan.md
@@ -927,6 +927,8 @@ facade, result, generated API, documentation, task, or session owners. Do not
 create status-only sessions, WIP PRs, or unchanged broad reruns merely to show
 progress.
 
-Current plan verdict: **S0 and A0 are integrated; B0 Packets C, D, and E are
-owner-authorized and active. F0 and R0 follow their accepted dependency gates;
-professional review occurs once after the final integrated-library candidate.**
+Current plan verdict: **S0, A0, and B0 are integrated. F0 Packets F1, F2, and
+F3 are the next authorized cycle; R0 follows accepted F0. The prepared Windows
+lane is setup-ready at the B0 identity and must be rebound to the exact accepted
+F0 merge before R0 uses it. Professional review occurs once after the final
+integrated-library candidate.**

--- a/docs/planning/lib-pro-013-a0-execution-plan.md
+++ b/docs/planning/lib-pro-013-a0-execution-plan.md
@@ -1,6 +1,6 @@
 ---
 owner: Main Agent
-status: ready
+status: active
 last_updated: 2026-08-27
 doc_type: spec
 complexity: advanced

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -3,22 +3,22 @@
 ## Latest Handoff (auto)
 
 <!-- HANDOFF:START -->
-- Date: 2026-08-27
-- Focus: Complete LIB-PRO-013 B0 common contract, canonical beam, and typed downstream convergence
-- Completed: Froze the strict Python facade and result/error contracts; proved Python/FastAPI/generated-client parity; passed the 451-case focused selection, 416-case invalidated-path replay, and source-free exact-wheel UAT
-- Git receipt: docs/verification/lib-pro-013-b0-common-contract-git-handoff-receipt.json | sha256:d446cb2e07a42aea7afc90f7f89c92b8891f76845683c2cb8049cd35515252b9 | HOLD
-- Git identity: codex/lib-pro-013-b0-common-contract-convergence@db6905c3c6b84e43b4a8ecfa2f55da260fbec3bd | upstream=origin/main@db6905c3c6b84e43b4a8ecfa2f55da260fbec3bd | base=origin/main@db6905c3c6b84e43b4a8ecfa2f55da260fbec3bd | tree=dirty | operation=none
+- Date: 2026-08-28
+- Focus: Freeze Windows evidence-lane readiness, remove the fixed documentation-count limit, and prepare the accepted B0 -> F0 handoff
+- Completed: Recorded the exact Windows host/tool/application state and operating rules; preserved setup-only claim boundaries; replaced numeric documentation caps with a non-blocking inventory while retaining ownership, metadata, lifecycle, projection, and link controls
+- Git receipt: docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-receipt.json | sha256:e16128ca2f9e3b915fe3e0523686055cb595e4f1c9a2c22e430de5dc5e893d0d | HOLD
+- Git identity: codex/lib-pro-013-windows-evidence-lane-readiness@44ef7bc4e8c98d01f32291730ab77ed16d077823 | upstream=origin/main@44ef7bc4e8c98d01f32291730ab77ed16d077823 | base=origin/main@44ef7bc4e8c98d01f32291730ab77ed16d077823 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=OBSERVED
-- Next action: CREATE_IMMUTABLE_B0_CANDIDATE_THEN_PUSH_PR_CHECK_AND_MERGE_UNCHANGED_GREEN_HEAD
+- Next action: CREATE_IMMUTABLE_DOCUMENTATION_CANDIDATE_PUSH_PR_AND_MERGE_UNCHANGED_GREEN_HEAD
 <!-- HANDOFF:END -->
 
 ## Latest Handoff
 
 | State | Boundary |
 |---|---|
-| **Current** | B0 Packets C-E are locally complete from integrated A0 main `db6905c3c6b84e43b4a8ecfa2f55da260fbec3bd`. The strict canonical beam facade, v2 transport, generated clients, compatibility projections, and named downstream consumers pass the 451-case focused selection and 416-case invalidated-path replay. |
+| **Current** | A0 and B0 are integrated. B0 candidate `96d7cc930b4bd809e5ec816a4fa6f052fd317fb3` merged through PR #880 as `44ef7bc4e8c98d01f32291730ab77ed16d077823`; candidate and merge share tree `12a6f683a32df07664e22b4b3dc53edee7f9704b`. Hosted run `33100194911` passed every required changed-path check. |
 | **Decision** | The [owner sequencing decision](../verification/lib-pro-013-owner-sequencing-decision.json) authorizes B0 now and F0/R0 after their dependency gates. Professional review is removed as an intermediate gate and deferred to one engineer review of the final integrated library after R0. |
-| **Next** | Freeze the single B0 candidate, pass consolidated local/hosted gates, and merge the unchanged head; then begin already-authorized F0 family convergence. |
+| **Next** | Begin `LIB-PRO-013-F0-FAMILY-CONVERGENCE` from freshly fetched exact B0 main. Execute Packets F1-F3 internally in one session/branch/candidate/PR unless a maintained stop condition requires a split. |
 | **Held** | Professional/engineering-use claims until the final engineer review; exact release publication until a versioned candidate passes maintained gates; protected-source tracking; destructive retained-data/worktree operations without an exact manifest and recovery proof. |
 
 ## A0 audit outcome
@@ -47,24 +47,85 @@
   data. The independent Sourcebook and protected standards were not read,
   changed, or tracked.
 
-## B0 outcome and ordered follow-on gates
+## B0 integrated outcome and ordered follow-on gates
 
 1. The exact-head wheel `25eacdd74d8d12b258e6c4a0b73d84c8e99f1eb6bbb4d684af3710b2a803942f`
    imports source-free on macOS/Python 3.11, passes the 29-case UAT, reconciles
    15 CLI commands, produces nine BBS items at 145.98 kg, and rejects the
    reproduced design/detailing stirrup-area conflict with exact code/path.
-2. Freeze one B0 candidate; run consolidated local gates, normal hooks, and
-   one hosted PR cycle on the unchanged head.
-3. Preserve every unrelated branch/worktree/source. After accepted B0, proceed
-   to the already-authorized F0 dependency cycle without requesting engineer
-   review; the engineer is assigned only after final R0 integration.
+2. B0 candidate `96d7cc93...` passed normal hooks and the required hosted cycle,
+   then merged unchanged as `44ef7bc4...`; repository-wide and Excel jobs were
+   correctly skipped by changed-path routing rather than represented as B0
+   evidence.
+3. Proceed to the already-authorized F0 dependency cycle without requesting
+   engineer review. Preserve every unrelated branch/worktree/source; the
+   engineer is assigned only after final R0 integration.
+
+## Windows evidence lane readiness
+
+The canonical machine-readable receipt is
+[LIB-PRO-013 Windows evidence lane readiness](../verification/lib-pro-013-windows-evidence-lane-readiness.json).
+Its status is `READY_FOR_FUTURE_WINDOWS_EVIDENCE_SETUP_ONLY`, not an installed
+Windows acceptance result.
+
+- Host `Laptop-360-Pravin` / `LAPTOP-360-PRAV\P` has a clean non-OneDrive base
+  clone at `C:\CodexWork\structural_engineering_lib-main-evidence`, bound to B0
+  merge `44ef7bc4...` and tree `12a6f683...` with ahead/behind `0/0`.
+- The isolated entry point is
+  `C:\CodexTools\structural-evidence-env.ps1`. It selects CPython `3.11.15`,
+  Node `24.20.0`, npm `11.19.0`, Portable Git `2.55.0.windows.5`, and Git LFS
+  `3.7.1` without changing system PATH or global runtimes.
+- Excel is Microsoft 365 x64 `16.0.20326.20100` with the active subscription
+  observed as licensed/provisioned. ETABS `23.3.1.4563` is a **trial**; the
+  supported readiness boundary is the documented manual export-first E2K/CSV
+  path, not live COM, analysis, write-back, or commercial-license proof.
+- Python source binding, locked dependencies, Node/npm selection, clean Git
+  state, and 21 non-mutating Excel add-in tests pass. No exact post-F0 installed
+  Excel or ETABS journey has run.
+- The base clone remains immutable. Every future evidence run creates a
+  task-specific `codex/<task-id>` worktree, uses disposable workbook/model
+  copies outside OneDrive, and captures exact source/tree/artifact/dataset/app/
+  operator identities before opening an application.
+- Excel and ETABS run as separate bounded tasks. A setup check, macOS result,
+  CI result, generated parity result, or one application result cannot satisfy
+  the other Windows claim.
+- Refresh the receipt when F0 merges or any source, artifact, dataset, tool,
+  application, license, operator, process/dialog, sync, or Git state changes.
+  After accepted F0, freshly fetch and rebind the Windows lane to the exact F0
+  merge before R0 uses it.
+
+## F0 entry preparation
+
+1. Freshly fetch `origin/main` and prove exact B0 merge/tree plus worktree,
+   upstream, PR, operation, and sibling-candidate safety before writes.
+2. Start one `LIB-PRO-013-F0-FAMILY-CONVERGENCE` session and branch. Keep one
+   candidate/PR by default; split only when the plan's stop conditions require
+   isolation.
+3. Freeze the 13 supported-family inventory once and map every family to its
+   maintained constructor, request/result/error owner, compatibility route,
+   advertised journey, exact-wheel recipe, and evidence class.
+4. Execute F1 (torsion/column/slabs), F2 (wall/staircase/deep beam/flat slab),
+   and F3 (isolated/combined/strap footings) internally. Do not add held
+   families or guess topology, applicability, action, geotechnical, evidence,
+   or review inputs.
+5. Preserve B0 common contracts and calculation owners. Family facades contain
+   delegation/construction only; valid golden outcomes cannot change without a
+   confirmed root cause and independent evidence.
+6. Freeze one exact-wheel valid/invalid recipe per supported family, generated
+   schema/classification/compatibility reconciliation, focused evidence,
+   architecture/import checks, one quick gate, normal hooks, and one required
+   hosted cycle.
+7. Windows execution is not an F0 prerequisite. Keep its base lane untouched
+   until accepted F0 is merged, then rebind it for the applicable R0 Windows
+   evidence packet.
 
 ## Required Reading
 
 1. [B0 evidence](../verification/lib-pro-013-b0-common-contract-evidence.json)
 2. [Owner sequencing decision](../verification/lib-pro-013-owner-sequencing-decision.json)
-3. [Canonical beam cookbook](../cookbook/python/beam.md)
-4. [LIB-PRO-012 remediation authority](lib-pro-012-external-api-remediation-plan.md)
-5. [Canonical A0 audit](../verification/lib-pro-013-a0-renewal-audit.md)
-6. [LIB-PRO-013 master audit authority](lib-pro-013-whole-library-renewal-audit-plan.md)
-7. [Current task board](../TASKS.md)
+3. [Windows evidence lane readiness](../verification/lib-pro-013-windows-evidence-lane-readiness.json)
+4. [Canonical beam cookbook](../cookbook/python/beam.md)
+5. [LIB-PRO-012 remediation authority](lib-pro-012-external-api-remediation-plan.md)
+6. [Canonical A0 audit](../verification/lib-pro-013-a0-renewal-audit.md)
+7. [LIB-PRO-013 master audit authority](lib-pro-013-whole-library-renewal-audit-plan.md)
+8. [Current task board](../TASKS.md)

--- a/docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-receipt.json
+++ b/docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-receipt.json
@@ -1,0 +1,196 @@
+{
+  "authorization": {
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "observed_at_utc": "2026-08-27T19:47:19Z",
+      "query_status": "OK",
+      "reference": "Owner asked to preserve the Windows laptop state and operating rules as durable repository truth, approved the internal preparation needed for the next library phase, and explicitly removed the fixed documentation-count limit. Professional review remains a final integrated-library activity rather than an intermediate gate.",
+      "status": "OBSERVED"
+    },
+    "authorized_actions": [
+      "FREEZE_WINDOWS_EVIDENCE_LANE_READINESS",
+      "REMOVE_FIXED_DOCUMENTATION_COUNT_LIMIT",
+      "PRESERVE_DOCUMENTATION_OWNERSHIP_METADATA_LIFECYCLE_AND_LINK_CONTROLS",
+      "UPDATE_CANONICAL_TASK_SESSION_AND_NEXT_SESSION_AUTHORITIES",
+      "CREATE_IMMUTABLE_DOCUMENTATION_CANDIDATE_PUSH_PR_AND_MERGE_UNCHANGED_GREEN_HEAD",
+      "PROCEED_TO_F0_FROM_ACCEPTED_B0_WITHOUT_INTERMEDIATE_PROFESSIONAL_REVIEW"
+    ],
+    "next_action": "CREATE_IMMUTABLE_DOCUMENTATION_CANDIDATE_PUSH_PR_AND_MERGE_UNCHANGED_GREEN_HEAD",
+    "observed_at_utc": "2026-08-27T19:47:19Z",
+    "prohibited_actions": [
+      "CLAIM_WINDOWS_EXCEL_ETABS_ACCEPTANCE_PROFESSIONAL_APPROVAL_ENGINEERING_USE_OR_WHOLE_LIBRARY_READINESS",
+      "IMPLEMENT_F0_RUNTIME_SCOPE_IN_THIS_PREPARATION_TASK",
+      "USE_ETABS_TRIAL_AS_COM_API_ANALYSIS_WRITEBACK_OR_COMMERCIAL_LICENSE_EVIDENCE",
+      "PUBLISH_VERSION_TAG_RELEASE_OR_PACKAGE_WITHOUT_EXACT_RELEASE_AUTHORITY",
+      "TRACK_PROTECTED_STANDARD_PROSE_IMAGES_OR_PRIVATE_SOURCE_CONTENT",
+      "DELETE_BRANCH_WORKTREE_REF_ARCHIVE_RETAINED_DATA_OR_WINDOWS_CLONES",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_REWRITE_FORCE_PUSH_OR_BYPASS_CHECKS"
+    ],
+    "query_status": "OK",
+    "status": "OBSERVED",
+    "target_binding": {
+      "actions": [
+        "FREEZE_WINDOWS_EVIDENCE_LANE_READINESS",
+        "REMOVE_FIXED_DOCUMENTATION_COUNT_LIMIT",
+        "PRESERVE_DOCUMENTATION_OWNERSHIP_METADATA_LIFECYCLE_AND_LINK_CONTROLS",
+        "UPDATE_CANONICAL_TASK_SESSION_AND_NEXT_SESSION_AUTHORITIES",
+        "CREATE_IMMUTABLE_DOCUMENTATION_CANDIDATE_PUSH_PR_AND_MERGE_UNCHANGED_GREEN_HEAD",
+        "PROCEED_TO_F0_FROM_ACCEPTED_B0_WITHOUT_INTERMEDIATE_PROFESSIONAL_REVIEW"
+      ],
+      "branch": "codex/lib-pro-013-windows-evidence-lane-readiness",
+      "head_sha": "44ef7bc4e8c98d01f32291730ab77ed16d077823",
+      "task_id": "LIB-PRO-013-WINDOWS-EVIDENCE-LANE-READINESS"
+    }
+  },
+  "holds": [
+    "BRANCH_WORKTREE_REF_ARCHIVE_WINDOWS_CLONE_AND_PROTECTED_SOURCE_DELETION_NOT_AUTHORIZED",
+    "LOCAL_HOLD_DIRTY",
+    "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+    "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+    "PRESERVE_WINDOWS_BASE_CLONE_AND_ALL_PREEXISTING_WINDOWS_CLONES",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "observed_at_utc": "2026-08-27T19:47:19Z",
+    "query_status": "UNKNOWN",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_WINDOWS_READINESS_PR",
+    "status": "NOT_APPLICABLE"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "e16128ca2f9e3b915fe3e0523686055cb595e4f1c9a2c22e430de5dc5e893d0d",
+    "state": {
+      "branch": "codex/lib-pro-013-windows-evidence-lane-readiness",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "44ef7bc4e8c98d01f32291730ab77ed16d077823",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 108.401,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib6",
+      "head_sha": "44ef7bc4e8c98d01f32291730ab77ed16d077823",
+      "hold_reasons": [
+        "changed paths: 17"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-27T19:50:54.089743+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/58cc/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 17,
+        "modified_paths": [],
+        "staged_paths": [
+          ".claude/rules/docs.md",
+          ".github/instructions/docs.instructions.md",
+          "Python/tests/test_audit_readiness_truth.py",
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/governance/maintenance-playbook.md",
+          "docs/guides/copilot-agents-usage-guide.md",
+          "docs/migration/learning/day-25-code-quality.md",
+          "docs/planning/README.md",
+          "docs/planning/lib-pro-012-external-api-remediation-plan.md",
+          "docs/planning/lib-pro-013-a0-execution-plan.md",
+          "docs/planning/next-session-brief.md",
+          "docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-receipt.json",
+          "docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-source-evidence.json",
+          "docs/verification/lib-pro-013-windows-evidence-lane-readiness.json",
+          "scripts/audit_readiness_report.py",
+          "scripts/check_docs.py"
+        ],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "44ef7bc4e8c98d01f32291730ab77ed16d077823",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/58cc/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:e16128ca2f9e3b915fe3e0523686055cb595e4f1c9a2c22e430de5dc5e893d0d",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-27T19:50:54.089904+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "decision": "RETAIN_ALL_UNRELATED_WORKTREES_REFS_ARCHIVES_IGNORED_DATA_PROTECTED_SOURCES_AND_WINDOWS_CLONES",
+    "holds": [
+      "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+      "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+      "PRESERVE_WINDOWS_BASE_CLONE_AND_ALL_PREEXISTING_WINDOWS_CLONES",
+      "BRANCH_WORKTREE_REF_ARCHIVE_WINDOWS_CLONE_AND_PROTECTED_SOURCE_DELETION_NOT_AUTHORIZED"
+    ],
+    "observed_at_utc": "2026-08-27T19:47:19Z",
+    "owner": "Main agent under owner and repository preservation policy",
+    "query_status": "OK",
+    "status": "OBSERVED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "private_sources",
+      "Python/structural_lib",
+      "fastapi_app",
+      "react_app",
+      "pyproject.toml",
+      "CHANGELOG.md"
+    ],
+    "integration_owner": "doc-master",
+    "owned_paths": [
+      "docs/verification/lib-pro-013-windows-evidence-lane-readiness.json",
+      "docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-source-evidence.json",
+      "docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-receipt.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/planning/next-session-brief.md",
+      "docs/planning/lib-pro-012-external-api-remediation-plan.md",
+      "docs/planning/README.md",
+      "docs/planning/lib-pro-013-a0-execution-plan.md",
+      "scripts/check_docs.py",
+      "scripts/audit_readiness_report.py",
+      "Python/tests/test_audit_readiness_truth.py",
+      ".github/instructions/docs.instructions.md",
+      ".claude/rules/docs.md",
+      "docs/governance/maintenance-playbook.md",
+      "docs/migration/learning/day-25-code-quality.md",
+      "docs/guides/copilot-agents-usage-guide.md"
+    ],
+    "task_id": "LIB-PRO-013-WINDOWS-EVIDENCE-LANE-READINESS"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-source-evidence.json
+++ b/docs/verification/lib-pro-013-windows-evidence-lane-git-handoff-source-evidence.json
@@ -1,0 +1,67 @@
+{
+  "authorization": {
+    "status": "OBSERVED",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-27T19:47:19Z",
+    "authority_source": {
+      "kind": "USER_DELEGATION",
+      "reference": "Owner asked to preserve the Windows laptop state and operating rules as durable repository truth, approved the internal preparation needed for the next library phase, and explicitly removed the fixed documentation-count limit. Professional review remains a final integrated-library activity rather than an intermediate gate.",
+      "status": "OBSERVED",
+      "query_status": "OK",
+      "observed_at_utc": "2026-08-27T19:47:19Z"
+    },
+    "authorized_actions": [
+      "FREEZE_WINDOWS_EVIDENCE_LANE_READINESS",
+      "REMOVE_FIXED_DOCUMENTATION_COUNT_LIMIT",
+      "PRESERVE_DOCUMENTATION_OWNERSHIP_METADATA_LIFECYCLE_AND_LINK_CONTROLS",
+      "UPDATE_CANONICAL_TASK_SESSION_AND_NEXT_SESSION_AUTHORITIES",
+      "CREATE_IMMUTABLE_DOCUMENTATION_CANDIDATE_PUSH_PR_AND_MERGE_UNCHANGED_GREEN_HEAD",
+      "PROCEED_TO_F0_FROM_ACCEPTED_B0_WITHOUT_INTERMEDIATE_PROFESSIONAL_REVIEW"
+    ],
+    "prohibited_actions": [
+      "CLAIM_WINDOWS_EXCEL_ETABS_ACCEPTANCE_PROFESSIONAL_APPROVAL_ENGINEERING_USE_OR_WHOLE_LIBRARY_READINESS",
+      "IMPLEMENT_F0_RUNTIME_SCOPE_IN_THIS_PREPARATION_TASK",
+      "USE_ETABS_TRIAL_AS_COM_API_ANALYSIS_WRITEBACK_OR_COMMERCIAL_LICENSE_EVIDENCE",
+      "PUBLISH_VERSION_TAG_RELEASE_OR_PACKAGE_WITHOUT_EXACT_RELEASE_AUTHORITY",
+      "TRACK_PROTECTED_STANDARD_PROSE_IMAGES_OR_PRIVATE_SOURCE_CONTENT",
+      "DELETE_BRANCH_WORKTREE_REF_ARCHIVE_RETAINED_DATA_OR_WINDOWS_CLONES",
+      "RESET_STASH_CLEAN_REBASE_DISCARD_REWRITE_FORCE_PUSH_OR_BYPASS_CHECKS"
+    ],
+    "next_action": "CREATE_IMMUTABLE_DOCUMENTATION_CANDIDATE_PUSH_PR_AND_MERGE_UNCHANGED_GREEN_HEAD",
+    "target_binding": {
+      "task_id": "LIB-PRO-013-WINDOWS-EVIDENCE-LANE-READINESS",
+      "branch": "codex/lib-pro-013-windows-evidence-lane-readiness",
+      "head_sha": "44ef7bc4e8c98d01f32291730ab77ed16d077823",
+      "actions": [
+        "FREEZE_WINDOWS_EVIDENCE_LANE_READINESS",
+        "REMOVE_FIXED_DOCUMENTATION_COUNT_LIMIT",
+        "PRESERVE_DOCUMENTATION_OWNERSHIP_METADATA_LIFECYCLE_AND_LINK_CONTROLS",
+        "UPDATE_CANONICAL_TASK_SESSION_AND_NEXT_SESSION_AUTHORITIES",
+        "CREATE_IMMUTABLE_DOCUMENTATION_CANDIDATE_PUSH_PR_AND_MERGE_UNCHANGED_GREEN_HEAD",
+        "PROCEED_TO_F0_FROM_ACCEPTED_B0_WITHOUT_INTERMEDIATE_PROFESSIONAL_REVIEW"
+      ]
+    }
+  },
+  "integration": {
+    "status": "NOT_APPLICABLE",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-27T19:47:19Z",
+    "reason_code": "NO_INTEGRATION_CLAIM_BEFORE_WINDOWS_READINESS_PR"
+  },
+  "retention": {
+    "status": "OBSERVED",
+    "query_status": "OK",
+    "observed_at_utc": "2026-08-27T19:47:19Z",
+    "decision": "RETAIN_ALL_UNRELATED_WORKTREES_REFS_ARCHIVES_IGNORED_DATA_PROTECTED_SOURCES_AND_WINDOWS_CLONES",
+    "owner": "Main agent under owner and repository preservation policy",
+    "holds": [
+      "PRESERVE_DIRTY_DETACHED_E54A_LANE",
+      "PRESERVE_EVERY_UNRELATED_DIRTY_STAGED_UNTRACKED_STASHED_DETACHED_OR_IGNORED_ITEM",
+      "PRESERVE_WINDOWS_BASE_CLONE_AND_ALL_PREEXISTING_WINDOWS_CLONES",
+      "BRANCH_WORKTREE_REF_ARCHIVE_WINDOWS_CLONE_AND_PROTECTED_SOURCE_DELETION_NOT_AUTHORIZED"
+    ]
+  },
+  "task_archive": {
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/lib-pro-013-windows-evidence-lane-readiness.json
+++ b/docs/verification/lib-pro-013-windows-evidence-lane-readiness.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": "1.0",
+  "evidence_id": "LIB-PRO-013-WINDOWS-EVIDENCE-LANE-READINESS",
+  "task_id": "LIB-PRO-013-WINDOWS-EVIDENCE-LANE-READINESS",
+  "observed_at_utc": "2026-08-27T19:16:00Z",
+  "status": "READY_FOR_FUTURE_WINDOWS_EVIDENCE_SETUP_ONLY",
+  "claim_boundary": {
+    "setup_ready": true,
+    "windows_acceptance_complete": false,
+    "excel_installed_journey_complete_for_post_f0_artifact": false,
+    "etabs_export_journey_complete_for_post_f0_artifact": false,
+    "etabs_live_com_or_analysis_validated": false,
+    "professional_review_complete": false,
+    "release_authorized": false,
+    "statement": "The host and isolated toolchain are ready. Exact post-F0 Windows, browser, professional-review, and release claims remain separate future evidence or authority gates."
+  },
+  "source_binding": {
+    "programme_baseline": "B0_MERGE",
+    "repository": "https://github.com/Pravin-surawase/structural_engineering_lib.git",
+    "branch": "main",
+    "head_sha": "44ef7bc4e8c98d01f32291730ab77ed16d077823",
+    "origin_main_sha": "44ef7bc4e8c98d01f32291730ab77ed16d077823",
+    "tree": "12a6f683a32df07664e22b4b3dc53edee7f9704b",
+    "ahead": 0,
+    "behind": 0,
+    "worktree_clean": true,
+    "operation": "none",
+    "base_clone_path": "C:\\CodexWork\\structural_engineering_lib-main-evidence",
+    "base_clone_policy": "IMMUTABLE_BASE_LANE_CREATE_TASK_SPECIFIC_CODEX_WORKTREE_BEFORE_EVIDENCE_WRITES",
+    "required_refresh": "Freshly fetch and bind the exact accepted F0 merge SHA and tree before any R0 or post-F0 Windows evidence claim."
+  },
+  "host": {
+    "codex_host_label": "Laptop-360-Pravin",
+    "remote_host_id": "remote-control:env_e_6a8364bf87f083268eba5a17d5f1a220",
+    "remote_task_id": "01a0445f-1eb8-7581-aee5-58faafe5de98",
+    "windows_identity": "LAPTOP-360-PRAV\\P",
+    "hardware": "HP Pavilion x360 Convertible 14-ba1xx; Intel i7-8550U; x64",
+    "os": "Windows 11 Home Single Language 10.0.26200 build 26200",
+    "disk": "C: NTFS; 81.35 GB free at final receipt",
+    "codex": "Desktop app 26.820.9563.0 x64; CLI 0.150.0-alpha.8; native task delegation and HTTPS access verified",
+    "ssh": "OpenSSH client present; no key or running agent; not required for the maintained native Codex and HTTPS workflow"
+  },
+  "isolated_toolchain": {
+    "environment_entry": "C:\\CodexTools\\structural-evidence-env.ps1",
+    "system_path_changed": false,
+    "admin_or_restart_used": false,
+    "uv": "0.12.6",
+    "python": "CPython 3.11.15 in the repository-local .venv; source binding verified",
+    "node": "24.20.0",
+    "npm": "11.19.0",
+    "git": "Portable Git 2.55.0.windows.5",
+    "git_lfs": "3.7.1",
+    "download_sha256": {
+      "uv_x86_64_pc_windows_msvc_zip": "df7cb9f243eae1621400d4fcf5b1b3d90f20e264ece91b64deb3b0078abca6ef",
+      "node_v24_20_0_win_x64_zip": "6cac9ffbca8f6a47091e4b5c772e0606049c3871cb67d900c0cedde630e545ba",
+      "portable_git_2_55_0_5_64_bit": "5aa8a20f6e9abb2c755f0e73c91c687701a46b309ad84a0ca6509380fa4ae290"
+    }
+  },
+  "installed_applications": {
+    "excel": {
+      "version": "Microsoft 365 x64 16.0.20326.20100 Current Channel",
+      "entitlement": "O365HomePremRetail User|Subscription Licensed Provisioned",
+      "caveat": "A parallel older expired grace SKU may show a notification; the active subscription was licensed at setup."
+    },
+    "etabs_23": {
+      "version": "23.3.1.4563",
+      "license_boundary": "TRIAL",
+      "ready_path": "Documented export-first/manual E2K and selected-table CSV workflow",
+      "not_proven": [
+        "commercial license entitlement",
+        "live COM automation",
+        "analysis execution or changes",
+        "model write-back or save",
+        "professional or engineering approval"
+      ]
+    },
+    "etabs_22": "22.5.1.3923 is also installed; future evidence must explicitly select ETABS 23.3.1.4563.",
+    "final_process_state": "Excel, ETABS, and License Assistant stopped; ETABS 23 empty start page was closed normally with no model loaded or save prompt."
+  },
+  "readiness_checks": {
+    "python_source_binding": "PASS",
+    "locked_python_dependencies": "PASS",
+    "node_npm_selector": "PASS",
+    "react_dependencies": "INSTALLED_WITH_NPM_CI",
+    "excel_addin_non_mutating_unit_tests": "PASS_21",
+    "git_state": "PASS_CLEAN_EXACT_B0_BASE",
+    "broad_repository_suite": "NOT_RUN_NOT_REQUIRED_FOR_SETUP",
+    "installed_excel_acceptance": "NOT_RUN",
+    "etabs_export_acceptance": "NOT_RUN"
+  },
+  "operating_rules": [
+    "Treat C:\\CodexWork\\structural_engineering_lib-main-evidence as an immutable base lane; create one task-specific codex/<task-id> worktree before writing session or evidence files.",
+    "Do not use the OneDrive task folder for active Git, workbook, ETABS model, build, or evidence execution; use non-OneDrive disposable copies and verify hashes before and after transfer.",
+    "Freshly fetch origin/main and record exact 40-character source SHA, tree, artifact hash, application versions, dataset hashes, operator identity, and process state at every Windows evidence entry.",
+    "Source the maintained user-local environment entry before repository commands; do not replace global Python, Node, Git, PATH, firewall, SSH, or licensed application configuration without a separately evidenced need.",
+    "Run Excel and ETABS as separate bounded evidence tasks. Do not infer either result from macOS, CI, generated parity, or the other application.",
+    "For ETABS trial evidence, prefer manual export-first E2K and selected-table CSV acquisition. Do not claim COM, analysis, write-back, commercial-license, or professional capability unless separately reproduced and authorized.",
+    "Before opening an Excel workbook or ETABS model, inventory running processes and dialogs, preserve the original, use a disposable copy, and stop on an ambiguous save, recovery, license, analysis, or model-state prompt.",
+    "Preserve older clones, linked worktrees, workbooks, ETABS models, exports, and backups. Never reset, clean, stash, rebase, overwrite, reorganize, or delete them as part of evidence preparation.",
+    "A passing setup or non-mutating unit test is not an installed-journey PASS. Capture exact inputs, outputs, screenshots or logs, hashes, row accounting, errors, and limitations in the task-owned evidence receipt.",
+    "Professional review remains deferred until the exact integrated post-R0 artifact and cumulative dossier exist; release remains a separate exact-version owner decision."
+  ],
+  "refresh_triggers": [
+    "accepted F0 or later merge changes origin/main",
+    "wheel, sdist, workbook, add-in, API/client build, ETABS export, or dataset identity changes",
+    "Windows, Excel, ETABS, Python, Node, Git, Codex, or license state changes",
+    "base clone becomes dirty, behind, diverged, conflicted, detached, or operation-locked",
+    "OneDrive or another sync process enters the execution path",
+    "Excel or ETABS is already running, a model/workbook is open, or a modal/recovery/license dialog exists",
+    "remote Codex visibility disconnects or the evidence operator changes"
+  ],
+  "next_programme_routing": {
+    "next_task": "LIB-PRO-013-F0-FAMILY-CONVERGENCE",
+    "windows_required_for_f0": false,
+    "windows_activation": "After accepted F0, rebind this lane to the exact F0 merge before applicable R0 Windows evidence.",
+    "browser_accessibility": "Separate exact API/client/browser evidence lane during R0; may reuse this host only after exact build and browser identities are frozen.",
+    "final_engineer_review": "After accepted R0 only."
+  },
+  "retention": {
+    "existing_data_deleted_or_overwritten": false,
+    "older_clones_mutated": false,
+    "workbook_or_etabs_model_opened_saved_updated_renamed_or_moved": false,
+    "protected_source_content_read_or_tracked": false,
+    "one_drive_task_folder": "PRESERVED_UNCHANGED",
+    "retained_clone_paths": [
+      "C:\\CodexWork\\structural_engineering_lib",
+      "C:\\Users\\P\\Pravin2025\\Projects\\structural_lib_repo"
+    ]
+  }
+}

--- a/scripts/audit_readiness_report.py
+++ b/scripts/audit_readiness_report.py
@@ -509,12 +509,11 @@ def collect_governance_evidence(report: AuditReport) -> None:
             )
         )
 
-    # Check active front-matter values and the enforced documentation budget.
+    # Check active front-matter values. Documentation has no numeric file cap;
+    # canonical ownership, metadata, lifecycle, and links remain the controls.
     doc_checker = _REPO_ROOT / "scripts/check_docs.py"
     if doc_checker.exists():
-        code, stdout, stderr = run_script(
-            str(doc_checker), ["--frontmatter", "--budget"]
-        )
+        code, stdout, stderr = run_script(str(doc_checker), ["--frontmatter"])
         passed = code == 0
         report.add_evidence(
             EvidenceItem(
@@ -524,7 +523,7 @@ def collect_governance_evidence(report: AuditReport) -> None:
                 required=True,
                 source=str(doc_checker),
                 details=(
-                    "Front-matter values and active-file budget are valid"
+                    "Active front-matter values are valid"
                     if passed
                     else _diagnostic_summary(stdout, stderr)
                 ),

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -9,6 +9,7 @@ Subcommands:
     --frontmatter    Check YAML front-matter validation
     --index          Check docs/README.md heading structure
     --index-links    Check docs/README.md link resolution
+    --inventory      Report the active markdown count (informational only)
     --all            Run all checks (default)
 
 Replaces:
@@ -513,19 +514,11 @@ def check_index_links() -> int:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# CHECK 5: DOC BUDGET — Prevent documentation sprawl
+# CHECK 5: DOC INVENTORY — Informational count, no numeric limit
 # ═══════════════════════════════════════════════════════════════════════════
 
-DOC_BUDGET_WARN = 350
-DOC_BUDGET_FAIL = 500
-
-
-def check_doc_budget() -> int:
-    """Check that non-archived markdown files stay within budget.
-
-    Warns if count > 350, fails if > 500.
-    Returns exit code: 0 pass, 1 fail.
-    """
+def check_doc_inventory() -> int:
+    """Report the non-archived markdown count without enforcing a limit."""
     if not DOCS_DIR.exists():
         print(f"❌ docs directory not found: {DOCS_DIR}")
         return 1
@@ -538,15 +531,8 @@ def check_doc_budget() -> int:
     )
 
     print(f"   Non-archived markdown files: {count}")
-    if count > DOC_BUDGET_FAIL:
-        print(f"❌ Doc budget EXCEEDED: {count} > {DOC_BUDGET_FAIL} (hard limit)")
-        return 1
-    elif count > DOC_BUDGET_WARN:
-        print(f"⚠️  Doc budget WARNING: {count} > {DOC_BUDGET_WARN} (soft limit)")
-        return 0
-    else:
-        print(f"✅ Doc budget OK ({count} ≤ {DOC_BUDGET_WARN})")
-        return 0
+    print("ℹ️  Documentation count is informational; no numeric cap is enforced")
+    return 0
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -565,6 +551,7 @@ def main() -> int:
             "  python scripts/check_docs.py --frontmatter    # Front-matter only\n"
             "  python scripts/check_docs.py --index          # Index heading structure\n"
             "  python scripts/check_docs.py --index-links    # Index link resolution\n"
+            "  python scripts/check_docs.py --inventory      # Informational active count\n"
             "  python scripts/check_docs.py --all --strict   # All checks, strict mode\n"
         ),
     )
@@ -584,9 +571,14 @@ def main() -> int:
         "--index-links", action="store_true", help="Check docs/README.md links"
     )
     group.add_argument(
+        "--inventory",
+        action="store_true",
+        help="Report active markdown count (informational; no limit)",
+    )
+    group.add_argument(
         "--budget",
         action="store_true",
-        help="Check doc budget (non-archived file count)",
+        help=argparse.SUPPRESS,
     )
     group.add_argument("--all", action="store_true", help="Run all checks (default)")
 
@@ -622,7 +614,14 @@ def main() -> int:
 
     # Default to --all when no selector given
     run_all = args.all or not any(
-        [args.metadata, args.frontmatter, args.index, args.index_links, args.budget]
+        [
+            args.metadata,
+            args.frontmatter,
+            args.index,
+            args.index_links,
+            args.inventory,
+            args.budget,
+        ]
     )
 
     results: list[int] = []
@@ -652,9 +651,9 @@ def main() -> int:
         rc = check_index_links()
         results.append(rc)
 
-    if run_all or args.budget:
-        print("📊 Checking documentation budget...")
-        rc = check_doc_budget()
+    if run_all or args.inventory or args.budget:
+        print("📊 Reporting documentation inventory...")
+        rc = check_doc_inventory()
         results.append(rc)
 
     # Overall exit code: 0 if all pass, 1 if any fail


### PR DESCRIPTION
## Summary
- freeze the exact Windows evidence-lane setup state, retained-data rules, and refresh triggers
- keep Excel and ETABS as separate future evidence tasks and defer professional review until the integrated post-R0 library
- remove fixed documentation-count warning/failure thresholds while retaining ownership, metadata, lifecycle, projection, and link controls
- update the canonical B0-to-F0 handoff and task/session authorities

## Verification
- 21 focused readiness tests
- documentation metadata/front matter/index/inventory checks
- 501 Markdown files and 1,058 local links with zero broken links
- instruction projection and configuration precedence checks
- context validation
- quick gate 10/10
- token-efficiency policy PASS
- normal commit hooks PASS
- clean read-only session closeout PASS

## Claim boundary
This is Windows setup readiness only. It does not claim installed post-F0 Excel/ETABS acceptance, ETABS COM/analysis/writeback capability, professional approval, engineering readiness, or release authority.