### PR TITLE
docs(release): record v0.24.0 publication

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,87 @@
 
 ---
 
+## 2026-08-28 — Session: RELEASE-0240 Public Publication Closeout
+
+**Agent:** Codex (`doc-master`, sole writer; no subagents).
+
+**Branch:** `codex/release-0240-public-closeout`.
+
+**Focus:** Record the final public `v0.24.0` identities only after publication
+was observable, close the maintained release task/checklist/ledger/handoff, and
+preserve every engineering, professional-review, Windows, and cleanup hold.
+
+**Completed:**
+
+- Bound the reviewed preparation candidate `6d0d2c15...`, authorization
+  descendant `3e7994f2...`, PR #886 merge `e66de6ef...`, exact tree
+  `e583493e...`, unchanged Python tree `d4f1af4f...`, and annotated
+  `v0.24.0` tag in one publication receipt.
+- Recorded production workflow `33150227524`, non-prerelease GitHub Release,
+  matching GitHub/PyPI wheel and sdist hashes, exact-wheel UAT PASS, and a fresh
+  isolated PyPI identity verification.
+- Updated only maintained documentation/evidence owners. The immutable release,
+  engineering runtime, protected Windows lane, detached dirty `e54a` lane, and
+  all unrelated retained state remain unchanged.
+
+### Issues encountered
+
+- The prior release session had passed clean validation but still had an
+  unmatched usage-start checkpoint, which blocked the canonical closeout
+  session start.
+- Maintained task, checklist, ledger, session, and handoff records necessarily
+  remained at candidate/authorization state because the public facts did not
+  exist before the immutable release commit and tag.
+- A first read-only source search used a pattern beginning with `--phase`, which
+  `rg` parsed as an option.
+- The first combined documentation patch used an exact ledger context that did
+  not match the file's wrapped line, so the atomic patch stopped without writes.
+- The first normal-hook command used the retired `--hook commit` spelling,
+  which the current checker rejected before running hooks.
+
+### Root causes and resolutions
+
+- Confirmed root cause: `session end` is a read-only repository verdict and does
+  not replace the separate measured `session usage --checkpoint closeout`
+  record. Resolution: recorded the exact two candidate heads, PR #886, merge
+  `e66de6ef...`, seven timing phases, retry counters, and five hosted runs before
+  starting this task. The canonical session start then passed.
+- Confirmed root cause: closeout freeze forbids inserting future hosted or
+  publication claims into the pre-publication candidate. Resolution: use this
+  bounded post-publication documentation packet and bind only already-observed
+  public facts. Public tag, workflow, release, hashes, and isolated install were
+  all re-queried before writing.
+- Confirmed root cause: an `rg` pattern starting with a dash requires the option
+  terminator. Resolution: rerun it as `rg -n -- <pattern>`; the search completed
+  without repository mutation. ⚠️ TERMINAL ISSUE: `rg` parsed `--phase` as an
+  unsupported flag -> the exact same read-only search passed with `--`.
+- Confirmed root cause: `apply_patch` requires exact surrounding text, including
+  Markdown wrapping. Resolution: inspect the ledger tail and apply bounded
+  file-specific patches; the failed atomic patch changed nothing. ⚠️ TERMINAL
+  ISSUE: one patch context did not match -> smaller exact-context patches passed.
+- Confirmed root cause: the canonical checker exposes normal hooks as
+  `./run.sh check --pre-commit`, not `--hook commit`. Resolution: use the
+  maintained option; every normal hook passed without bypass. ⚠️ TERMINAL ISSUE:
+  obsolete hook syntax was rejected -> `--pre-commit` passed.
+
+### Validation
+
+- The `v0.24.0` publication-surface check passes against current public
+  metadata; the new receipt is valid JSON and its tag, workflow, release, PyPI,
+  artifact, UAT, and isolated-install identities were re-queried before freeze.
+- Task format, next-session length, documentation structure/front matter,
+  1,095 maintained links, version synchronization, and context validation all
+  pass. Existing informational metadata warnings are unchanged and outside this
+  packet.
+- Quick gate passes 10/10, efficiency policy passes, and all normal hooks pass,
+  including 18 API contract tests, release/session/task/checklist controls, API
+  classification, family-facade generation, and React/FastAPI contract checks.
+- Clean session closeout, immutable documentation candidate, and required
+  hosted documentation checks remain candidate closeout steps.
+
+**Git handoff receipt:**
+`docs/verification/release-0240-public-closeout-git-handoff-receipt.json`
+
 ## 2026-08-28 — Session: RELEASE-0240 Normal Software Release
 
 **Agent:** Codex (`orchestrator`, sole writer; no subagents).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth for active work.** Keep it short and current.
 
-**Updated:** 2026-08-28 — post-R0 audit is merged; owner-authorized v0.24.0 normal-release preparation is active
+**Updated:** 2026-08-28 — v0.24.0 is the current normal software release; broader library development and cumulative engineer review remain in progress
 
 ---
 
@@ -69,9 +69,9 @@
 
 ## Current Release
 
-| **Current public release** | v0.24.0a1 | ✅ ALPHA RELEASED — immutable tag and GitHub/PyPI artifacts recorded; later `main` work is not included |
-| **Release candidate** | v0.24.0 | 🟡 LOCAL EXACT ARTIFACT READY — normal final version selected and owner-authorized after exact gates; immutable candidate, hosted checks, tag, and publication remain |
-- **Release evidence:** tag target `71b70652`; public wheel SHA-256 `b5e0df7b…6201a`; public sdist SHA-256 `8c1d6b76…0a53b`; exact workflow UAT and public identity are green
+| **Current public release** | v0.24.0 | ✅ NORMAL SOFTWARE RELEASE — immutable tag and non-prerelease GitHub/PyPI artifacts recorded; Beta maturity and supported-scope limitations remain |
+| **Release candidate** | — | No later candidate is selected or authorized |
+- **Release evidence:** tag target `e66de6ef`; public wheel SHA-256 `7b5bc0b6…a093`; public sdist SHA-256 `d530f10c…6640`; production workflow `33150227524`, exact-wheel UAT, and isolated public install are green
 - **Strategy:** Incremental micro-releases — each focuses on one quality dimension (tests, API, security, performance)
 - **Focus:** API introspection → security hardening → performance baselines → stabilization
 - **Target:** keep later roadmap work inactive until separately activated
@@ -92,7 +92,7 @@
 | **v0.21.8** | Performance & Property Testing | 📋 PLANNED | Benchmarks, Hypothesis, performance baselines |
 | **v0.22.0** | Stabilization Release | 📋 PLANNED | API naming convention (Batch 3), provenance, SP:16 verification |
 | **v0.23** | Bounded IS 456 slabs + footing completion | ✅ ALPHA RELEASED | Case-qualified development preview; professional review remains a final stable/engineering-use gate |
-| **v0.24** | Multi-Code Infrastructure and bounded IS 456 external preview | 🟡 NORMAL RELEASE PREPARATION | Public `v0.24.0a1` predates S0/B0/F0/R0; exact `v0.24.0` local wheel/UAT is green pending candidate, hosted gates, and publication |
+| **v0.24** | Multi-Code Infrastructure and bounded IS 456 external preview | ✅ NORMAL SOFTWARE RELEASED | `v0.24.0` contains accepted S0/B0/F0/R0 and the cumulative audit; normal distribution does not claim stable API, complete IS 456, or professional approval |
 | **v0.25** | ACI 318-19 Beam | 📋 PLANNED | ACI beam flexure + shear, PCA Notes ±0.1% benchmarks |
 | **v1.0** | Production Multi-Code | 📋 PLANNED | IS 456 complete, ACI 318 beam+column, EC2 beam, API stability guarantee |
 
@@ -183,9 +183,10 @@ at merge `b1ba36e3...`, tree `81854f06...`:
 13 generated cookbook journeys, 28 advertised Python/CLI entries, zero unowned
 promoted request fields, 7,165 broad Python and 526 FastAPI tests, and the
 source-free wheel `53e0485b...c39d4` pass. The immutable candidate passed its
-hosted cycle and merged unchanged. Release remains exact-candidate work rather
-than an F0/R0 gate, and the single engineer review remains deferred until the
-owner declares the intended library complete. Shared
+hosted cycle and merged unchanged. Exact `v0.24.0` was subsequently published
+as the normal software release; this does not retroactively make release an
+F0/R0 gate, and the single engineer review remains deferred until the owner
+declares the intended library complete. Shared
 validation, facade, result, manifest, generated API, documentation, task, and
 session owners remain single-writer surfaces.
 
@@ -415,7 +416,8 @@ write-back/nightly work remain outside E1.
 | LIB-PRO-013-F0 | Converge F1-F3 family construction/facades and exact-wheel recipes on the accepted B0 foundation | @structural-math | 16–26 engineer-days | P1 | ✅ COMPLETE ON MERGE — PR #882 merged unchanged as `59ef74c0...`, tree `295c7a61...`; Windows/professional/release claims remain held |
 | LIB-PRO-013-WINDOWS-REBIND | Bind the protected Windows source lane to accepted F0 before R0 uses it | bounded Windows evidence owner | evidence gate | P1 | ✅ COMPLETE — PR #883 merged at `879d32ca...`; exact F0 Git/Python source binding proved; no application evidence was run |
 | LIB-PRO-012-R0 | Close external-preview documentation, generated gates, cumulative artifact/evidence, and owner-decision package | Main Agent | final programme cycle | P1 | ✅ COMPLETE — PR #884 merged as `b1ba36e3...`, tree `81854f06...`; release, Windows application evidence, and professional claims remain held |
-| LIB-PRO-014-POST-R0-CUMULATIVE-AUDIT | Audit the public-tag-to-R0 programme, repair confirmed misses, and establish the next-tag posture | Main Agent | one bounded audit cycle | P1 | 🟡 LOCAL COMPLETE — no engineering defect reproduced; API inventory and linked-worktree launcher root causes repaired; focused/product/browser evidence passes; immutable candidate, hosted checks, and unchanged merge pending |
+| LIB-PRO-014-POST-R0-CUMULATIVE-AUDIT | Audit the public-tag-to-R0 programme, repair confirmed misses, and establish the next-tag posture | Main Agent | one bounded audit cycle | P1 | ✅ COMPLETE — PR #885 merged as `e7956f78...`; no engineering defect reproduced; API inventory and linked-worktree launcher root causes repaired |
+| RELEASE-0240-STABLE-SOFTWARE | Publish the audited supported scope as normal `v0.24.0` while preserving Beta/in-progress claim boundaries | Main Agent | one release cycle | P1 | ✅ RELEASED — PR #886 merged as `e66de6ef...`; tag, PyPI, non-prerelease GitHub Release, public hashes, and isolated install verified |
 | SPARK-001-G0 | Reassess the stale Spark work-program proposal before any implementation | repository owner | review gate | P2 | ⏸ OWNER REVIEW — the 2026-08-11 model/preview assumptions and bulk wave require refresh or rejection |
 
 ## Backlog

--- a/docs/getting-started/releases.md
+++ b/docs/getting-started/releases.md
@@ -1458,3 +1458,31 @@ engineering review was performed for this release candidate. Normal software
 release status does not grant stable-API compatibility, complete IS 456
 coverage, professional approval, engineering-use approval, or construction-use
 approval.
+
+---
+
+## v0.24.0 — Public normal software release receipt
+
+**Published (2026-08-28 07:09:50 UTC):** PR #886 preserved the reviewed
+candidate and authorization descendant and merged as
+`e66de6efa3bb80d3ebc54e6151b1d6c29275c502`, tree
+`e583493eed9943b7216d0b19c6749383f06a33a3`. Annotated tag `v0.24.0` peels to
+that exact merge. Production workflow `33150227524` completed successfully,
+published PyPI `0.24.0`, and created a non-prerelease GitHub Release.
+
+- wheel: `structural_lib_is456-0.24.0-py3-none-any.whl`, 822,111 bytes,
+  SHA-256 `7b5bc0b6ca6721897ae9ccce9860b6aaaa3c5647ded9fefd0945872ed354a093`;
+- sdist: `structural_lib_is456-0.24.0.tar.gz`, 685,836 bytes,
+  SHA-256 `d530f10ca4f64655eade86b9beb8ca3d8b5eb10ddfcf0d7db097e9252d406640`;
+- exact public install: `pip install structural-lib-is456===0.24.0`.
+
+GitHub and PyPI artifact hashes match. The exact workflow wheel passed all 29
+UAT cases across 28 advertised entries, including 15 CLI entries and 13 family
+facades; a separate isolated PyPI install verified package origin and exact
+version. The release is a normal package distribution with Beta maturity, not
+a stable-API, complete-standard, professional, engineering-use, or
+construction-use claim. Broader library development and one cumulative
+practicing-engineer review remain in progress.
+
+**Machine-readable receipt:**
+`docs/verification/release-0240-publication-receipt.json`.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,10 +4,10 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-28
-- Focus: Prepare, verify, and publish exact v0.24.0 as the normal software release
-- Completed: Selected v0.24.0; split normal distribution status from professional claims; prepared consistent metadata, policy, workflow support, and one exact local wheel/sdist pair
-- Git receipt: docs/verification/release-0240-preparation-git-handoff-receipt.json | sha256:63eba2cf0529ce9a3b01651d0070f40ab7e6ef0b69205332ad65d9fb82b0e85c | HOLD
-- Git identity: codex/release-0240-stable-software@e7956f78cc849f1c0cd26fed7c82e9f3cdce9e19 | upstream=origin/main@e7956f78cc849f1c0cd26fed7c82e9f3cdce9e19 | base=origin/main@e7956f78cc849f1c0cd26fed7c82e9f3cdce9e19 | tree=dirty | operation=none
+- Focus: Close exact v0.24.0 normal software publication and preserve the next-work boundary
+- Completed: PR #886 merged unchanged; annotated v0.24.0 tag, PyPI, non-prerelease GitHub Release, exact public hashes, workflow UAT, and isolated install verified
+- Git receipt: docs/verification/release-0240-public-closeout-git-handoff-receipt.json | sha256:a8d04ef613847fd3be96c692fbebe8bb92b699898eeaa486d44b783322cc82b6 | HOLD
+- Git identity: codex/release-0240-public-closeout@e66de6efa3bb80d3ebc54e6151b1d6c29275c502 | upstream=origin/main@e66de6efa3bb80d3ebc54e6151b1d6c29275c502 | base=origin/main@e66de6efa3bb80d3ebc54e6151b1d6c29275c502 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
 - Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
@@ -16,26 +16,22 @@
 
 | State | Exact boundary |
 |---|---|
-| **Public** | `v0.24.0a1` remains the immutable public Alpha at `71b7065216d4266d63ad6b31bd39bba81fa16efc`. |
-| **Current** | Accepted post-R0 audit PR #885 merged at `e7956f78cc849f1c0cd26fed7c82e9f3cdce9e19`, tree `7849482826f564023829bd9f9d71377654302dac`. The owner selected exact `v0.24.0` as the next normal software release. |
-| **Next** | Freeze the tracked release preparation, run the clean exact-wheel preflight, push one PR, pass required hosted checks and exact-head Weekly Verification, bind the owner review waiver and exact publication authorization, merge unchanged, then tag/publish/verify. |
+| **Public** | `v0.24.0` is the immutable current normal software release at merge `e66de6efa3bb80d3ebc54e6151b1d6c29275c502`; GitHub prerelease is false and PyPI selects it normally. |
+| **Current** | Release publication and public identity verification are complete. The package remains pre-1.0/Beta and the supported-scope limitations remain authoritative. |
+| **Next** | No later release or engineering packet is selected. Wait for the repository owner to choose the next bounded scope; do not infer a v0.24.1/v0.25 candidate. |
 | **Held** | Stable-API guarantee, complete IS 456 coverage, professional approval, engineering-use/construction-use approval, Windows/Excel/ETABS acceptance, protected-source mutation, and destructive cleanup. |
 
-## Prepared release evidence
+## Published release evidence
 
-- Normal PEP 440 final version: `0.24.0`; GitHub prerelease flag `false`;
-  maturity classifier `Development Status :: 4 - Beta`.
-- Local wheel: 822,111 bytes, SHA-256
-  `64343a33f02ff1231dda5c2552bbee4cb58046d2f679c0b3c6178fd5239e40d1`.
-- Local sdist: 688,176 bytes, SHA-256
-  `32fb86a0a90a9cdcc3c00170c3dc32099fc7695cb0cc0cf220aae3bebb18322c`.
-- Twine, clean installed import/version/CLI, 29/29 exact-wheel UAT cases, 28
-  advertised entries, 15 CLI entries, 13 family-facade entries, both public
-  examples, 152 focused release controls, and quick 10/10 pass.
-- The first full gate found only the version-bound generated API classification
-  projection. Its maintained generator refreshed the registry and compatibility
-  ledger; the frozen tracked-state rerun passes 32/32 with 15 unaffected checks
-  reused.
+- Annotated tag `v0.24.0` peels to merge `e66de6ef...`, exact authorized tree
+  `e583493e...`, and unchanged reviewed Python tree `d4f1af4f...`.
+- Production workflow `33150227524` passed release validation, immutable build,
+  clean exact-wheel UAT, SBOM, PyPI publication, and GitHub Release creation.
+- Public wheel: 822,111 bytes, SHA-256 `7b5bc0b6...a093`; public sdist:
+  685,836 bytes, SHA-256 `d530f10c...6640`. GitHub and PyPI hashes match.
+- Exact-wheel UAT passed 29/29 cases across 28 advertised entries, including 15
+  CLI and 13 family-facade entries. A fresh isolated PyPI install reported
+  `0.24.0` from its own site-packages environment.
 
 ## Release logic and claim boundary
 
@@ -59,11 +55,13 @@
   lane remains untouched.
 - Do not rebuild an existing public version, rewrite history, bypass checks,
   delete branches/worktrees/refs/data, or broaden the release claims.
+- Do not start the deferred practicing-engineer review until the owner declares
+  the intended integrated library complete and the cumulative dossier exists.
 
 ## Required Reading
 
-1. [Normal-release owner decision](../verification/release-0240-normal-software-owner-decision.json)
-2. [Local prepublication evidence](../verification/release-0240-local-prepublication-evidence.json)
+1. [Public v0.24.0 receipt](../verification/release-0240-publication-receipt.json)
+2. [Normal-release owner decision](../verification/release-0240-normal-software-owner-decision.json)
 3. [Post-R0 cumulative audit](../verification/lib-pro-014-post-r0-cumulative-audit-evidence.json)
 4. [Release checklist](pre-release-checklist.md)
 5. [Release ledger](../getting-started/releases.md)

--- a/docs/planning/pre-release-checklist.md
+++ b/docs/planning/pre-release-checklist.md
@@ -9,36 +9,42 @@
 
 ## Current State
 
-Current source metadata: 0.24.0 (prepared normal release candidate; unpublished)
-Current public Alpha: v0.24.0a1
+Current source metadata: 0.24.0 (published normal software release)
+Current public release: v0.24.0
 
-- **Published source:** tag `v0.24.0a1` at `71b7065216d4266d63ad6b31bd39bba81fa16efc`
-- **Published wheel:** 774,739 bytes; SHA-256 `b5e0df7b561e8c715f37c602200eaae2c369ec5dc992eec87110a77c1026201a`
-- **Published sdist:** 652,423 bytes; SHA-256 `8c1d6b762a779686be5d17ed0dd9719f7155a5863a764e943a0e1ba9aeb0a53b`
-- **Publication state:** `RELEASED_ALPHA` on PyPI and GitHub on 2026-08-24
+- **Published source:** annotated tag `v0.24.0` at merge `e66de6efa3bb80d3ebc54e6151b1d6c29275c502`, tree `e583493eed9943b7216d0b19c6749383f06a33a3`
+- **Published wheel:** 822,111 bytes; SHA-256 `7b5bc0b6ca6721897ae9ccce9860b6aaaa3c5647ded9fefd0945872ed354a093`
+- **Published sdist:** 685,836 bytes; SHA-256 `d530f10ca4f64655eade86b9beb8ca3d8b5eb10ddfcf0d7db097e9252d406640`
+- **Publication state:** `RELEASED_NORMAL_SOFTWARE` on PyPI and GitHub on 2026-08-28; GitHub prerelease flag `false`, maturity classifier Beta
 - **Prepared-candidate base:** accepted post-R0 cumulative audit merge `e7956f78cc849f1c0cd26fed7c82e9f3cdce9e19`, tree `7849482826f564023829bd9f9d71377654302dac`
-- **Candidate state:** `0.24.0` normal software release preparation; not yet tagged or published
+- **Candidate state:** no later release candidate is selected or authorized
 - **Review policy:** qualified structural-engineering review remains required before engineering-use, construction-use, or professional-approval claims; it is deferred until the owner declares the intended library complete and is not a gate on this normal software-release claim
 
-## v0.24.0 Normal Software Release Preparation
+## v0.24.0 Published Normal Software Release
 
 - [x] Owner selects normal final version `0.24.0` instead of another Alpha
 - [x] Base the release lane on the accepted post-R0 cumulative audit merge
 - [x] Preserve the 13-family supported inventory and reproduce no engineering-calculation, calculation-owner, facade-contract, or golden-outcome defect in the cumulative audit
 - [x] Separate normal package-manager/GitHub release status from professional, engineering-use, construction-use, stable-API, and whole-standard claims
 - [x] Record broader library development and cumulative practicing-engineer review as in progress
-- [ ] Freeze and build one exact `0.24.0` wheel/sdist pair
-- [ ] Pass source-free installed-package UAT and focused/cumulative release gates
-- [ ] Freeze one immutable candidate and pass every required hosted changed-path check plus exact-head Weekly Verification
-- [ ] Bind the exact reviewed candidate through an independent software-review receipt or the owner's bounded waiver, then record exact-target publication authorization
-- [ ] Rehearse the unchanged candidate on TestPyPI
-- [ ] Merge unchanged, tag exact `v0.24.0`, publish to PyPI and GitHub as a non-prerelease, and verify public hashes/install/UAT
+- [x] Freeze and build one exact `0.24.0` wheel/sdist pair
+- [x] Pass source-free installed-package UAT and focused/cumulative release gates
+- [x] Freeze one immutable candidate and pass every required hosted changed-path check plus exact-head Weekly Verification
+- [x] Bind the exact reviewed candidate through the owner's bounded waiver, then record exact-target publication authorization
+- [x] Rehearse the unchanged source candidate on TestPyPI
+- [x] Merge unchanged, tag exact `v0.24.0`, publish to PyPI and GitHub as a non-prerelease, and verify public hashes/install/UAT
 
 The owner decision is recorded in
 `docs/verification/release-0240-normal-software-owner-decision.json`. “No issues”
 is bounded to no reproduced outcome-changing defect in the cumulative audited
 supported scope; it is not an assertion that the whole library is complete or
 professionally approved.
+
+The exact public receipt is
+`docs/verification/release-0240-publication-receipt.json`. The release is the
+latest normal package-manager selection, but the project remains pre-1.0/Beta
+and broader library work plus one cumulative practicing-engineer review remain
+in progress.
 
 ## v0.24.0a1 Published Alpha State
 

--- a/docs/verification/release-0240-public-closeout-git-handoff-receipt.json
+++ b/docs/verification/release-0240-public-closeout-git-handoff-receipt.json
@@ -1,0 +1,130 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "a8d04ef613847fd3be96c692fbebe8bb92b699898eeaa486d44b783322cc82b6",
+    "state": {
+      "branch": "codex/release-0240-public-closeout",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "e66de6efa3bb80d3ebc54e6151b1d6c29275c502",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 112.113,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git/worktrees/structural_engineering_lib11",
+      "head_sha": "e66de6efa3bb80d3ebc54e6151b1d6c29275c502",
+      "hold_reasons": [
+        "changed paths: 6"
+      ],
+      "linked_worktree": true,
+      "locks": [],
+      "observed_at_utc": "2026-08-28T07:19:44.853780+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/.codex/worktrees/lib-pro-014/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 6,
+        "modified_paths": [],
+        "staged_paths": [
+          "docs/SESSION_LOG.md",
+          "docs/TASKS.md",
+          "docs/getting-started/releases.md",
+          "docs/planning/next-session-brief.md",
+          "docs/planning/pre-release-checklist.md",
+          "docs/verification/release-0240-publication-receipt.json"
+        ],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "e66de6efa3bb80d3ebc54e6151b1d6c29275c502",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/.codex/worktrees/lib-pro-014/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:a8d04ef613847fd3be96c692fbebe8bb92b699898eeaa486d44b783322cc82b6",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-28T07:19:44.853940+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Python",
+      "fastapi_app",
+      "react_app",
+      "docs/verification/windows"
+    ],
+    "integration_owner": "doc-master",
+    "owned_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/getting-started/releases.md",
+      "docs/planning/next-session-brief.md",
+      "docs/planning/pre-release-checklist.md",
+      "docs/verification/release-0240-publication-receipt.json"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/TASKS.md",
+      "docs/getting-started/releases.md",
+      "docs/planning/next-session-brief.md",
+      "docs/planning/pre-release-checklist.md"
+    ],
+    "task_id": "RELEASE-0240-PUBLIC-CLOSEOUT"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/docs/verification/release-0240-publication-receipt.json
+++ b/docs/verification/release-0240-publication-receipt.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "release-publication-receipt/v1",
+  "release": {
+    "version": "0.24.0",
+    "tag": "v0.24.0",
+    "status": "PUBLISHED_NORMAL_SOFTWARE_RELEASE",
+    "maturity": "BETA",
+    "github_prerelease": false,
+    "published_at_utc": "2026-08-28T07:09:50Z"
+  },
+  "source_identity": {
+    "reviewed_candidate_head": "6d0d2c150e391695fc2be7d39cbf240a20dd5a68",
+    "authorization_descendant_head": "3e7994f204582d56f21533d38cb31cd22e80c600",
+    "merge_commit": "e66de6efa3bb80d3ebc54e6151b1d6c29275c502",
+    "source_tree": "e583493eed9943b7216d0b19c6749383f06a33a3",
+    "python_tree": "d4f1af4f9f7a78d069e641fba46e8bdf12cc4efa",
+    "annotated_tag_object": "0c2c5a9fa1ae4d1200be2e798b89c7137edfbe86",
+    "tag_peeled_commit": "e66de6efa3bb80d3ebc54e6151b1d6c29275c502",
+    "pull_request": 886
+  },
+  "hosted_evidence": {
+    "reviewed_candidate_pr_validation_run": 33149305946,
+    "reviewed_candidate_weekly_verification_run": 33149315082,
+    "testpypi_run": 33149832121,
+    "authorization_head_pr_validation_run": 33149834491,
+    "production_release_run": 33150227524,
+    "production_release_status": "PASS"
+  },
+  "public_artifacts": {
+    "pypi_project_url": "https://pypi.org/project/structural-lib-is456/0.24.0/",
+    "github_release_url": "https://github.com/Pravin-surawase/structural_engineering_lib/releases/tag/v0.24.0",
+    "github_and_pypi_hashes_match": true,
+    "wheel": {
+      "filename": "structural_lib_is456-0.24.0-py3-none-any.whl",
+      "size_bytes": 822111,
+      "sha256": "7b5bc0b6ca6721897ae9ccce9860b6aaaa3c5647ded9fefd0945872ed354a093"
+    },
+    "sdist": {
+      "filename": "structural_lib_is456-0.24.0.tar.gz",
+      "size_bytes": 685836,
+      "sha256": "d530f10ca4f64655eade86b9beb8ca3d8b5eb10ddfcf0d7db097e9252d406640"
+    }
+  },
+  "exact_wheel_evidence": {
+    "status": "PASS",
+    "case_count": 29,
+    "advertised_entry_count": 28,
+    "cli_entry_count": 15,
+    "family_facade_entry_count": 13,
+    "library_content_identity": "6d6f704f096125e9b6bd0973cb7be47906282a4fcb076858983c50c080fc1153",
+    "matrix_sha256": "dd52015061a443e16f93bb5828016b5e96a580e3e0ebe4516e31a29db88c7757",
+    "public_pypi_identity_verification": "PASS"
+  },
+  "claim_boundary": {
+    "broader_library_development": "IN_PROGRESS",
+    "cumulative_practicing_engineer_review": "DEFERRED_UNTIL_INTEGRATED_LIBRARY",
+    "stable_api_guarantee": false,
+    "complete_is456_coverage": false,
+    "qualified_structural_engineering_review": false,
+    "professional_approval": false,
+    "engineering_use_approval": false,
+    "construction_use_approval": false,
+    "windows_excel_etabs_acceptance": false
+  }
+}


### PR DESCRIPTION
## Outcome

Records the already-completed public `v0.24.0` normal software release without changing the immutable tag or engineering runtime.

- binds PR #886 merge, annotated tag, workflow, GitHub Release, PyPI, exact hashes, UAT, and isolated install
- closes the maintained task/checklist/ledger/handoff state
- preserves Beta/in-progress, deferred cumulative engineer review, stable-API, professional, engineering-use, Windows, and cleanup boundaries

## Validation

- publication-surface check: pass
- task/brief/docs/links/version/context controls: pass
- quick gate: 10/10
- efficiency policy: pass
- normal hooks and 18 API contract tests: pass
- clean session closeout: pass