### PR TITLE
feat: add Excel Python ETABS beam pilot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 Open-source IS 456 RC beam design library. Full stack:
 - **Python core** (`Python/structural_lib/`) — Pure math, IS 456:2000 code
-- **FastAPI backend** (`fastapi_app/`) — 90 OpenAPI HTTP operations across 27 router modules, plus a WebSocket route
+- **FastAPI backend** (`fastapi_app/`) — 93 OpenAPI HTTP operations across 28 router modules, plus a WebSocket route
 - **React 19 frontend** (`react_app/`) — R3F 3D visualization + Tailwind
 
 ## Owner Decision — Required IS Code Content and Distribution (2026-08-10/11)

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -60,6 +60,7 @@ docs = [
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.25",
 ]
+etabs = ["comtypes>=1.4,<2; platform_system == 'Windows'"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/Python/structural_lib/services/etabs_live_bridge.py
+++ b/Python/structural_lib/services/etabs_live_bridge.py
@@ -1,0 +1,749 @@
+"""Fail-closed Windows ETABS-to-canonical-beam pilot service.
+
+This module keeps COM access optional and isolated at the service boundary.  The
+pilot attaches to an already-open ETABS process, reads one exact result selection,
+and restores the user's present-unit setting before returning.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+import platform
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import AbstractContextManager, contextmanager
+from enum import StrEnum
+from importlib.util import find_spec
+from pathlib import PureWindowsPath
+from typing import Any, Literal, Protocol
+
+from pydantic import Field
+
+from structural_lib.core.errors import InputContractError
+from structural_lib.services.canonical_beam import design_and_detail
+from structural_lib.services.common_api import get_library_version
+from structural_lib.services.contracts.beam import (
+    BeamDesignInputV1,
+    BeamDetailingOptionsV1,
+    EffectiveDepthBasisRequestV1,
+    IS456MaterialsV1,
+)
+from structural_lib.services.contracts.common import (
+    StrictPublicModel,
+    model_validate_or_error,
+)
+from structural_lib.services.evidence import get_library_content_identity
+
+__all__ = [
+    "ETABSBridgeError",
+    "ETABSBridgeStatusV1",
+    "ETABSConnectionError",
+    "ETABSConnectionV1",
+    "ETABSDataError",
+    "ETABSPilotDesignBasisV1",
+    "ETABSPilotRequestV1",
+    "ETABSPilotResultV1",
+    "ETABSResultSelectionKind",
+    "ETABSResultSelectionV1",
+    "ETABSUnavailableError",
+    "InputContractError",
+    "connect_etabs_v1",
+    "get_etabs_bridge_status_v1",
+    "run_etabs_beam_pilot_v1",
+]
+
+
+ETABS_BRIDGE_SCHEMA_VERSION: Literal["etabs-live-bridge/v1"] = "etabs-live-bridge/v1"
+ETABS_PILOT_SCHEMA_VERSION: Literal["etabs-beam-pilot/v1"] = "etabs-beam-pilot/v1"
+ETABS_OBJECT_ITEM_TYPE = 0
+ETABS_KN_MM_C_UNITS = 5
+MAX_RESULT_ROWS_PER_BEAM = 2_000
+HORIZONTAL_TOLERANCE_MM = 1.0
+
+
+class ETABSResultSelectionKind(StrEnum):
+    """Exact ETABS result source requested by the caller."""
+
+    CASE = "CASE"
+    COMBINATION = "COMBINATION"
+
+
+class ETABSResultSelectionV1(StrictPublicModel):
+    """One exact ETABS case or response combination."""
+
+    kind: ETABSResultSelectionKind = Field(strict=False)
+    name: str = Field(min_length=1, max_length=80)
+
+
+class ETABSPilotDesignBasisV1(StrictPublicModel):
+    """Explicit caller-owned design and detailing choices for every pilot beam."""
+
+    materials: IS456MaterialsV1
+    effective_depth_basis: EffectiveDepthBasisRequestV1
+    d_dash_mm: float = Field(gt=0)
+    detailing: BeamDetailingOptionsV1
+    pt_percent: float | None = Field(default=None, gt=0)
+    ast_mm2_for_shear: float | None = Field(default=None, gt=0)
+
+
+class ETABSPilotRequestV1(StrictPublicModel):
+    """Bounded read-and-design request for no more than five ETABS beams."""
+
+    schema_version: Literal["etabs-beam-pilot/v1"] = ETABS_PILOT_SCHEMA_VERSION
+    result_selection: ETABSResultSelectionV1
+    design_basis: ETABSPilotDesignBasisV1
+    limit: int = Field(default=5, ge=1, le=5)
+
+
+class ETABSModelIdentityV1(StrictPublicModel):
+    """Identity of the ETABS model actually attached by COM."""
+
+    model_name: str
+    model_path: str
+    etabs_version: str
+    etabs_version_number: float
+
+
+class ETABSBridgeStatusV1(StrictPublicModel):
+    """Non-calculation availability and library identity."""
+
+    schema_version: Literal["etabs-live-bridge/v1"] = ETABS_BRIDGE_SCHEMA_VERSION
+    bridge_status: Literal[
+        "READY_TO_CONNECT",
+        "CONNECTED",
+        "PLATFORM_UNSUPPORTED",
+        "DEPENDENCY_MISSING",
+    ]
+    platform: str
+    com_dependency: Literal["INSTALLED", "MISSING", "NOT_APPLICABLE"]
+    library_version: str
+    library_content_identity: str
+    model: ETABSModelIdentityV1 | None = None
+    issues: tuple[str, ...] = ()
+
+
+class ETABSConnectionV1(StrictPublicModel):
+    """Successful attachment proof without analysis or model mutation."""
+
+    schema_version: Literal["etabs-live-bridge/v1"] = ETABS_BRIDGE_SCHEMA_VERSION
+    bridge_status: Literal["CONNECTED"] = "CONNECTED"
+    library_version: str
+    library_content_identity: str
+    model: ETABSModelIdentityV1
+
+
+class ETABSFrameGeometryV1(StrictPublicModel):
+    """ETABS frame identity and rectangular section geometry in millimetres."""
+
+    frame_name: str
+    story: str
+    section_name: str
+    material_property: str
+    point_i: str
+    point_j: str
+    x_i_mm: float
+    y_i_mm: float
+    z_i_mm: float
+    x_j_mm: float
+    y_j_mm: float
+    z_j_mm: float
+    span_mm: float = Field(gt=0)
+    b_mm: float = Field(gt=0)
+    D_mm: float = Field(gt=0)
+
+
+class ETABSFrameForceStationV1(StrictPublicModel):
+    """One untruncated ETABS FrameForce row converted to canonical units."""
+
+    row_index: int = Field(ge=0)
+    object_name: str
+    object_station_mm: float
+    element_name: str
+    element_station_mm: float
+    load_case: str
+    step_type: str
+    step_number: float
+    p_kn: float
+    v2_kn: float
+    v3_kn: float
+    t_knm: float
+    m2_knm: float
+    m3_knm: float
+
+
+class ETABSForceExtremeV1(StrictPublicModel):
+    """Signed governing value retained alongside its absolute magnitude."""
+
+    component: Literal["V2", "T", "M3"]
+    signed_value: float
+    absolute_value: float = Field(ge=0)
+    row_index: int = Field(ge=0)
+    object_station_mm: float
+    load_case: str
+    step_type: str
+    step_number: float
+
+
+class ETABSFrameForcesV1(StrictPublicModel):
+    """Complete returned rows plus the three pilot governing actions."""
+
+    selection: ETABSResultSelectionV1
+    result_row_count: int = Field(gt=0, le=MAX_RESULT_ROWS_PER_BEAM)
+    stations: tuple[ETABSFrameForceStationV1, ...]
+    governing_v2: ETABSForceExtremeV1
+    governing_t: ETABSForceExtremeV1
+    governing_m3: ETABSForceExtremeV1
+
+
+class ETABSPilotBeamResultV1(StrictPublicModel):
+    """Extracted ETABS beam and canonical library design result."""
+
+    geometry: ETABSFrameGeometryV1
+    forces: ETABSFrameForcesV1
+    design_result: dict[str, Any]
+
+
+class ETABSPilotResultV1(StrictPublicModel):
+    """Completed bounded ETABS read and canonical beam-design proof."""
+
+    schema_version: Literal["etabs-beam-pilot/v1"] = ETABS_PILOT_SCHEMA_VERSION
+    pilot_status: Literal["COMPLETED"] = "COMPLETED"
+    model: ETABSModelIdentityV1
+    result_selection: ETABSResultSelectionV1
+    units: dict[str, str]
+    candidate_beam_count: int = Field(ge=1)
+    designed_beam_count: int = Field(ge=1, le=5)
+    beams: tuple[ETABSPilotBeamResultV1, ...]
+    library_version: str
+    library_content_identity: str
+    qualified_review_required: Literal[True] = True
+    limitations: tuple[str, ...]
+
+
+class ETABSBridgeError(RuntimeError):
+    """Base error carrying a stable problem code across the REST boundary."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+    def to_problem(self) -> dict[str, str]:
+        return {"code": self.code, "message": str(self)}
+
+
+class ETABSUnavailableError(ETABSBridgeError):
+    """The current host cannot provide the optional ETABS capability."""
+
+
+class ETABSConnectionError(ETABSBridgeError):
+    """ETABS is supported locally but no usable open model was attached."""
+
+
+class ETABSDataError(ETABSBridgeError):
+    """The attached model or requested result is outside the pilot contract."""
+
+
+class _ETABSSession(Protocol):
+    sap_model: Any
+
+    def __enter__(self) -> _ETABSSession: ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None: ...
+
+    def normalized_kn_mm_units(self) -> AbstractContextManager[None]: ...
+
+
+SessionFactory = Callable[[], _ETABSSession]
+
+
+def _library_identity() -> tuple[str, str]:
+    return get_library_version(), get_library_content_identity()
+
+
+def get_etabs_bridge_status_v1() -> ETABSBridgeStatusV1:
+    """Report readiness without starting or attaching to ETABS."""
+
+    host = platform.system()
+    library_version, content_identity = _library_identity()
+    if host != "Windows":
+        return ETABSBridgeStatusV1(
+            bridge_status="PLATFORM_UNSUPPORTED",
+            platform=host,
+            com_dependency="NOT_APPLICABLE",
+            library_version=library_version,
+            library_content_identity=content_identity,
+            issues=("Live ETABS COM access is supported only on Windows.",),
+        )
+    if find_spec("comtypes") is None:
+        return ETABSBridgeStatusV1(
+            bridge_status="DEPENDENCY_MISSING",
+            platform=host,
+            com_dependency="MISSING",
+            library_version=library_version,
+            library_content_identity=content_identity,
+            issues=(
+                "Install the optional Python package extra: structural-lib-is456[etabs].",
+            ),
+        )
+    return ETABSBridgeStatusV1(
+        bridge_status="READY_TO_CONNECT",
+        platform=host,
+        com_dependency="INSTALLED",
+        library_version=library_version,
+        library_content_identity=content_identity,
+    )
+
+
+def _require_zero_return(operation: str, value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value != 0:
+        raise ETABSDataError(
+            "ETABS_API_CALL_FAILED",
+            f"{operation} returned {value!r}; expected ETABS return code 0.",
+        )
+
+
+def _decode_com_outputs(
+    operation: str, value: object, *, output_count: int
+) -> tuple[Any, ...]:
+    """Decode ETABS COM out values followed by the native integer return code."""
+
+    if not isinstance(value, tuple) or len(value) != output_count + 1:
+        raise ETABSDataError(
+            "ETABS_COM_SIGNATURE_MISMATCH",
+            f"{operation} returned an unexpected COM result shape.",
+        )
+    _require_zero_return(operation, value[-1])
+    return value[:-1]
+
+
+class _ComtypesETABSSession:
+    """One worker-thread COM apartment attached to an open ETABS process."""
+
+    def __init__(self) -> None:
+        if platform.system() != "Windows":
+            raise ETABSUnavailableError(
+                "ETABS_PLATFORM_UNSUPPORTED",
+                "Live ETABS COM access is supported only on Windows.",
+            )
+        try:
+            comtypes = importlib.import_module("comtypes")
+            com_client = importlib.import_module("comtypes.client")
+        except ImportError as exc:
+            raise ETABSUnavailableError(
+                "ETABS_COM_DEPENDENCY_MISSING",
+                "Install structural-lib-is456[etabs] in the FastAPI Python environment.",
+            ) from exc
+
+        self._comtypes = comtypes
+        self._closed = False
+        comtypes.CoInitialize()
+        try:
+            helper = com_client.CreateObject("ETABSv1.Helper")
+            etabs_object = helper.GetObject("CSI.ETABS.API.ETABSObject")
+            sap_model = etabs_object.SapModel
+        except Exception as exc:
+            comtypes.CoUninitialize()
+            raise ETABSConnectionError(
+                "ETABS_OPEN_INSTANCE_NOT_FOUND",
+                "Open ETABS with the copied model before connecting from Excel.",
+            ) from exc
+        if sap_model is None:
+            comtypes.CoUninitialize()
+            raise ETABSConnectionError(
+                "ETABS_MODEL_NOT_AVAILABLE",
+                "The attached ETABS process did not expose an open model.",
+            )
+        self._helper = helper
+        self._etabs_object = etabs_object
+        self.sap_model = sap_model
+
+    def __enter__(self) -> _ComtypesETABSSession:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self.sap_model = None
+        self._etabs_object = None
+        self._helper = None
+        self._comtypes.CoUninitialize()
+        self._closed = True
+
+    @contextmanager
+    def normalized_kn_mm_units(self) -> Iterator[None]:
+        original_units = self.sap_model.GetPresentUnits()
+        if isinstance(original_units, bool) or not isinstance(original_units, int):
+            raise ETABSDataError(
+                "ETABS_PRESENT_UNITS_INVALID",
+                "ETABS did not return a valid present-unit enumeration.",
+            )
+        _require_zero_return(
+            "SapModel.SetPresentUnits(kN_mm_C)",
+            self.sap_model.SetPresentUnits(ETABS_KN_MM_C_UNITS),
+        )
+        try:
+            yield
+        finally:
+            _require_zero_return(
+                "SapModel.SetPresentUnits(restore)",
+                self.sap_model.SetPresentUnits(original_units),
+            )
+
+
+def _default_session_factory() -> _ETABSSession:
+    return _ComtypesETABSSession()
+
+
+def _model_identity(sap_model: Any) -> ETABSModelIdentityV1:
+    model_path = str(sap_model.GetModelFilepath() or "").strip()
+    if not model_path:
+        raise ETABSConnectionError(
+            "ETABS_MODEL_PATH_MISSING",
+            "Save the copied ETABS model before running the Excel pilot.",
+        )
+    version, version_number = _decode_com_outputs(
+        "SapModel.GetVersion", sap_model.GetVersion(), output_count=2
+    )
+    return ETABSModelIdentityV1(
+        model_name=PureWindowsPath(model_path).name,
+        model_path=model_path,
+        etabs_version=str(version),
+        etabs_version_number=float(version_number),
+    )
+
+
+def connect_etabs_v1(
+    *, session_factory: SessionFactory = _default_session_factory
+) -> ETABSConnectionV1:
+    """Attach to ETABS and return the exact open-model identity."""
+
+    with session_factory() as session:
+        model = _model_identity(session.sap_model)
+    library_version, content_identity = _library_identity()
+    return ETABSConnectionV1(
+        library_version=library_version,
+        library_content_identity=content_identity,
+        model=model,
+    )
+
+
+def _checked_sequence(
+    operation: str, name: str, value: object, *, expected_count: int
+) -> Sequence[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ETABSDataError(
+            "ETABS_COM_SIGNATURE_MISMATCH",
+            f"{operation} did not return the expected {name} array.",
+        )
+    if len(value) < expected_count:
+        raise ETABSDataError(
+            "ETABS_RESULT_ARRAY_MISMATCH",
+            f"{operation} returned {len(value)} {name} values for {expected_count} rows.",
+        )
+    return value
+
+
+def _frame_inventory(sap_model: Any) -> list[dict[str, Any]]:
+    outputs = _decode_com_outputs(
+        "FrameObj.GetAllFrames",
+        sap_model.FrameObj.GetAllFrames("Global"),
+        output_count=20,
+    )
+    number = int(outputs[0])
+    if number <= 0:
+        raise ETABSDataError(
+            "ETABS_FRAME_INVENTORY_EMPTY",
+            "The attached ETABS model has no frame objects.",
+        )
+    names = (
+        "frame_name",
+        "section_name",
+        "story",
+        "point_i",
+        "point_j",
+        "x_i",
+        "y_i",
+        "z_i",
+        "x_j",
+        "y_j",
+        "z_j",
+    )
+    arrays = {
+        name: _checked_sequence(
+            "FrameObj.GetAllFrames", name, outputs[index], expected_count=number
+        )
+        for index, name in enumerate(names, start=1)
+    }
+    frames: list[dict[str, Any]] = []
+    for index in range(number):
+        frame = {name: values[index] for name, values in arrays.items()}
+        dx = float(frame["x_j"]) - float(frame["x_i"])
+        dy = float(frame["y_j"]) - float(frame["y_i"])
+        dz = float(frame["z_j"]) - float(frame["z_i"])
+        span = math.sqrt(dx * dx + dy * dy + dz * dz)
+        if span <= 0:
+            raise ETABSDataError(
+                "ETABS_FRAME_LENGTH_INVALID",
+                f"Frame {frame['frame_name']} has zero or invalid length.",
+            )
+        if abs(dz) <= HORIZONTAL_TOLERANCE_MM:
+            frame["span_mm"] = span
+            frames.append(frame)
+    if not frames:
+        raise ETABSDataError(
+            "ETABS_BEAM_CANDIDATES_EMPTY",
+            "No horizontal frame objects were found within the 1 mm pilot tolerance.",
+        )
+    return sorted(
+        frames, key=lambda item: (str(item["story"]), str(item["frame_name"]))
+    )
+
+
+def _rectangular_geometry(
+    sap_model: Any, frame: dict[str, Any]
+) -> ETABSFrameGeometryV1:
+    section_name = str(frame["section_name"])
+    try:
+        outputs = _decode_com_outputs(
+            "PropFrame.GetRectangle",
+            sap_model.PropFrame.GetRectangle(section_name),
+            output_count=7,
+        )
+    except ETABSDataError as exc:
+        raise ETABSDataError(
+            "ETABS_SECTION_NOT_RECTANGULAR",
+            f"Frame {frame['frame_name']} section {section_name} is not a supported rectangle.",
+        ) from exc
+    _file_name, material, t3, t2, _color, _notes, _guid = outputs
+    return ETABSFrameGeometryV1(
+        frame_name=str(frame["frame_name"]),
+        story=str(frame["story"]),
+        section_name=section_name,
+        material_property=str(material),
+        point_i=str(frame["point_i"]),
+        point_j=str(frame["point_j"]),
+        x_i_mm=float(frame["x_i"]),
+        y_i_mm=float(frame["y_i"]),
+        z_i_mm=float(frame["z_i"]),
+        x_j_mm=float(frame["x_j"]),
+        y_j_mm=float(frame["y_j"]),
+        z_j_mm=float(frame["z_j"]),
+        span_mm=float(frame["span_mm"]),
+        b_mm=float(t2),
+        D_mm=float(t3),
+    )
+
+
+def _select_results(sap_model: Any, selection: ETABSResultSelectionV1) -> None:
+    setup = sap_model.Results.Setup
+    _require_zero_return(
+        "Results.Setup.DeselectAllCasesAndCombosForOutput",
+        setup.DeselectAllCasesAndCombosForOutput(),
+    )
+    if selection.kind is ETABSResultSelectionKind.CASE:
+        result = setup.SetCaseSelectedForOutput(selection.name, True)
+    else:
+        result = setup.SetComboSelectedForOutput(selection.name, True)
+    if isinstance(result, bool) or not isinstance(result, int) or result != 0:
+        raise ETABSDataError(
+            "ETABS_RESULT_SELECTION_NOT_FOUND",
+            f"ETABS did not accept {selection.kind.value} {selection.name!r} for output.",
+        )
+
+
+def _force_extreme(
+    stations: tuple[ETABSFrameForceStationV1, ...],
+    *,
+    component: Literal["V2", "T", "M3"],
+    attribute: str,
+) -> ETABSForceExtremeV1:
+    station = max(stations, key=lambda item: abs(float(getattr(item, attribute))))
+    value = float(getattr(station, attribute))
+    return ETABSForceExtremeV1(
+        component=component,
+        signed_value=value,
+        absolute_value=abs(value),
+        row_index=station.row_index,
+        object_station_mm=station.object_station_mm,
+        load_case=station.load_case,
+        step_type=station.step_type,
+        step_number=station.step_number,
+    )
+
+
+def _frame_forces(
+    sap_model: Any,
+    frame_name: str,
+    selection: ETABSResultSelectionV1,
+) -> ETABSFrameForcesV1:
+    outputs = _decode_com_outputs(
+        "Results.FrameForce",
+        sap_model.Results.FrameForce(frame_name, ETABS_OBJECT_ITEM_TYPE),
+        output_count=14,
+    )
+    count = int(outputs[0])
+    if count <= 0:
+        raise ETABSDataError(
+            "ETABS_FRAME_RESULTS_EMPTY",
+            f"No frame-force rows were returned for frame {frame_name} and {selection.name}.",
+        )
+    if count > MAX_RESULT_ROWS_PER_BEAM:
+        raise ETABSDataError(
+            "ETABS_FRAME_RESULTS_TOO_LARGE",
+            f"Frame {frame_name} returned {count} rows; the pilot limit is {MAX_RESULT_ROWS_PER_BEAM}.",
+        )
+    array_names = (
+        "object_name",
+        "object_station_mm",
+        "element_name",
+        "element_station_mm",
+        "load_case",
+        "step_type",
+        "step_number",
+        "p_kn",
+        "v2_kn",
+        "v3_kn",
+        "t_knmm",
+        "m2_knmm",
+        "m3_knmm",
+    )
+    arrays = {
+        name: _checked_sequence(
+            "Results.FrameForce", name, outputs[index], expected_count=count
+        )
+        for index, name in enumerate(array_names, start=1)
+    }
+    stations = tuple(
+        ETABSFrameForceStationV1(
+            row_index=index,
+            object_name=str(arrays["object_name"][index]),
+            object_station_mm=float(arrays["object_station_mm"][index]),
+            element_name=str(arrays["element_name"][index]),
+            element_station_mm=float(arrays["element_station_mm"][index]),
+            load_case=str(arrays["load_case"][index]),
+            step_type=str(arrays["step_type"][index]),
+            step_number=float(arrays["step_number"][index]),
+            p_kn=float(arrays["p_kn"][index]),
+            v2_kn=float(arrays["v2_kn"][index]),
+            v3_kn=float(arrays["v3_kn"][index]),
+            t_knm=float(arrays["t_knmm"][index]) / 1_000.0,
+            m2_knm=float(arrays["m2_knmm"][index]) / 1_000.0,
+            m3_knm=float(arrays["m3_knmm"][index]) / 1_000.0,
+        )
+        for index in range(count)
+    )
+    if selection.name not in {station.load_case for station in stations}:
+        raise ETABSDataError(
+            "ETABS_RESULT_IDENTITY_MISMATCH",
+            f"Frame {frame_name} results do not identify the selected result {selection.name!r}.",
+        )
+    return ETABSFrameForcesV1(
+        selection=selection,
+        result_row_count=count,
+        stations=stations,
+        governing_v2=_force_extreme(stations, component="V2", attribute="v2_kn"),
+        governing_t=_force_extreme(stations, component="T", attribute="t_knm"),
+        governing_m3=_force_extreme(stations, component="M3", attribute="m3_knm"),
+    )
+
+
+def _design_beam(
+    geometry: ETABSFrameGeometryV1,
+    forces: ETABSFrameForcesV1,
+    basis: ETABSPilotDesignBasisV1,
+) -> dict[str, Any]:
+    options = basis.detailing
+    request = model_validate_or_error(
+        BeamDesignInputV1,
+        {
+            "identity": {
+                "member_id": geometry.frame_name,
+                "story": geometry.story,
+                "case_id": forces.selection.name,
+            },
+            "section": {
+                "span_mm": geometry.span_mm,
+                "b_mm": geometry.b_mm,
+                "D_mm": geometry.D_mm,
+                "d_mm": None,
+                "effective_depth_basis": basis.effective_depth_basis,
+            },
+            "materials": basis.materials,
+            "actions": {
+                "mu_knm": forces.governing_m3.absolute_value,
+                "vu_kn": forces.governing_v2.absolute_value,
+                "tu_knm": forces.governing_t.absolute_value,
+            },
+            "calculation_basis": {
+                "d_dash_mm": basis.d_dash_mm,
+                "asv_mm2": options.asv_mm2,
+                "pt_percent": basis.pt_percent,
+                "ast_mm2_for_shear": basis.ast_mm2_for_shear,
+            },
+            "detailing": options,
+            "serviceability": None,
+            "source_provenance": (
+                f"ETABS:{geometry.frame_name}:{geometry.story}:"
+                f"{forces.selection.kind.value}:{forces.selection.name}"
+            ),
+        },
+    )
+    return design_and_detail(request, detailing_standard=options.standard).to_dict()
+
+
+def run_etabs_beam_pilot_v1(
+    request: ETABSPilotRequestV1,
+    *,
+    session_factory: SessionFactory = _default_session_factory,
+) -> ETABSPilotResultV1:
+    """Extract and design the first bounded set of deterministic beam candidates."""
+
+    with session_factory() as session:
+        model = _model_identity(session.sap_model)
+        with session.normalized_kn_mm_units():
+            inventory = _frame_inventory(session.sap_model)
+            _select_results(session.sap_model, request.result_selection)
+            results: list[ETABSPilotBeamResultV1] = []
+            for frame in inventory[: request.limit]:
+                geometry = _rectangular_geometry(session.sap_model, frame)
+                forces = _frame_forces(
+                    session.sap_model,
+                    geometry.frame_name,
+                    request.result_selection,
+                )
+                results.append(
+                    ETABSPilotBeamResultV1(
+                        geometry=geometry,
+                        forces=forces,
+                        design_result=_design_beam(
+                            geometry, forces, request.design_basis
+                        ),
+                    )
+                )
+    library_version, content_identity = _library_identity()
+    return ETABSPilotResultV1(
+        model=model,
+        result_selection=request.result_selection,
+        units={
+            "length": "mm",
+            "force": "kN",
+            "moment": "kN.m",
+            "stress": "N/mm2",
+        },
+        candidate_beam_count=len(inventory),
+        designed_beam_count=len(results),
+        beams=tuple(results),
+        library_version=library_version,
+        library_content_identity=content_identity,
+        limitations=(
+            "Read-only pilot: no ETABS analysis run, section write-back, or model save.",
+            "Only frame objects horizontal within 1 mm and using rectangular sections are supported.",
+            "Canonical actions use absolute governing ETABS V2, T, and M3 values; signed source rows are retained.",
+            "Materials and reinforcement/detailing choices are explicit caller inputs, not inferred from ETABS material names.",
+            "Serviceability, adjacent-member continuity, joint congestion, constructability optimization, and whole-building iteration are not evaluated.",
+            "Every result requires qualified structural-engineer review.",
+        ),
+    )

--- a/Python/tests/unit/test_etabs_live_bridge.py
+++ b/Python/tests/unit/test_etabs_live_bridge.py
@@ -1,0 +1,248 @@
+"""Deterministic tests for the optional live ETABS beam-pilot service."""
+
+# ruff: noqa: N802 - fakes intentionally mirror the ETABS COM method names.
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+from structural_lib.services import etabs_live_bridge as bridge
+
+
+def _design_basis() -> bridge.ETABSPilotDesignBasisV1:
+    return bridge.ETABSPilotDesignBasisV1.model_validate(
+        {
+            "materials": {"fck_nmm2": 25.0, "fy_nmm2": 500.0},
+            "effective_depth_basis": {
+                "clear_cover_mm": 40.0,
+                "stirrup_diameter_mm": 8.0,
+                "tension_bar_diameter_mm": 20.0,
+            },
+            "d_dash_mm": 40.0,
+            "detailing": {
+                "standard": "IS456",
+                "clear_cover_mm": 40.0,
+                "tension_bar_diameter_mm": 20.0,
+                "compression_bar_diameter_mm": 16.0,
+                "nominal_top_steel_ratio": 0.25,
+                "stirrup_diameter_mm": 8.0,
+                "stirrup_legs": 2,
+                "stirrup_spacing_support_mm": 150.0,
+                "stirrup_spacing_mid_mm": 200.0,
+            },
+        }
+    )
+
+
+def _request(*, limit: int = 2) -> bridge.ETABSPilotRequestV1:
+    return bridge.ETABSPilotRequestV1(
+        result_selection=bridge.ETABSResultSelectionV1(
+            kind=bridge.ETABSResultSelectionKind.COMBINATION,
+            name="ULS-1",
+        ),
+        design_basis=_design_basis(),
+        limit=limit,
+    )
+
+
+class _FakeSetup:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def DeselectAllCasesAndCombosForOutput(self):
+        self.calls.append(("deselect",))
+        return 0
+
+    def SetComboSelectedForOutput(self, name, selected):
+        self.calls.append(("combo", name, selected))
+        return 0
+
+    def SetCaseSelectedForOutput(self, name, selected):
+        self.calls.append(("case", name, selected))
+        return 0
+
+
+class _FakeResults:
+    def __init__(self) -> None:
+        self.Setup = _FakeSetup()
+
+    def FrameForce(self, frame_name, item_type):
+        assert item_type == 0
+        return (
+            3,
+            (frame_name,) * 3,
+            (0.0, 2500.0, 5000.0),
+            (f"E-{frame_name}",) * 3,
+            (0.0, 2500.0, 5000.0),
+            ("ULS-1",) * 3,
+            ("Max", "Max", "Min"),
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (80.0, -110.0, 90.0),
+            (5.0, 4.0, -6.0),
+            (1000.0, -1500.0, 500.0),
+            (10_000.0, 20_000.0, -15_000.0),
+            (-150_000.0, 120_000.0, 100_000.0),
+            0,
+        )
+
+
+class _FakeFrameObj:
+    def GetAllFrames(self, coordinate_system):
+        assert coordinate_system == "Global"
+        # B2 is intentionally listed first; deterministic story/name sorting picks B1.
+        return (
+            3,
+            ("B2", "C1", "B1"),
+            ("R300x500", "R400x400", "R300x500"),
+            ("L2", "L1", "L1"),
+            ("P3", "P5", "P1"),
+            ("P4", "P6", "P2"),
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (3000.0, 0.0, 0.0),
+            (5000.0, 0.0, 5000.0),
+            (0.0, 0.0, 0.0),
+            (3000.0, 3000.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0),
+            (5, 5, 5),
+            0,
+        )
+
+
+class _FakePropFrame:
+    def GetRectangle(self, name):
+        assert name == "R300x500"
+        return ("", "M25", 500.0, 300.0, 1, "", "guid", 0)
+
+
+class _FakeSapModel:
+    def __init__(self) -> None:
+        self.FrameObj = _FakeFrameObj()
+        self.PropFrame = _FakePropFrame()
+        self.Results = _FakeResults()
+        self.unit_calls: list[int] = []
+
+    def GetModelFilepath(self):
+        return r"C:\Models\Pilot Copy.edb"
+
+    def GetVersion(self):
+        return ("ETABS 23.3.1", 23.31, 0)
+
+    def GetPresentUnits(self):
+        return 6
+
+    def SetPresentUnits(self, units):
+        self.unit_calls.append(units)
+        return 0
+
+
+class _FakeSession:
+    def __init__(self, sap_model: _FakeSapModel) -> None:
+        self.sap_model = sap_model
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.closed = True
+
+    @contextmanager
+    def normalized_kn_mm_units(self):
+        original = self.sap_model.GetPresentUnits()
+        assert self.sap_model.SetPresentUnits(5) == 0
+        try:
+            yield
+        finally:
+            assert self.sap_model.SetPresentUnits(original) == 0
+
+
+def test_pilot_extracts_sorted_beams_preserves_stations_and_restores_units(monkeypatch):
+    sap_model = _FakeSapModel()
+    session = _FakeSession(sap_model)
+    monkeypatch.setattr(bridge, "_library_identity", lambda: ("0.24.0", "a" * 64))
+
+    result = bridge.run_etabs_beam_pilot_v1(_request(), session_factory=lambda: session)
+
+    assert result.model.model_name == "Pilot Copy.edb"
+    assert result.candidate_beam_count == 2
+    assert result.designed_beam_count == 2
+    assert [item.geometry.frame_name for item in result.beams] == ["B1", "B2"]
+    assert result.beams[0].geometry.b_mm == 300.0
+    assert result.beams[0].geometry.D_mm == 500.0
+    assert result.beams[0].forces.result_row_count == 3
+    assert result.beams[0].forces.governing_v2.signed_value == -110.0
+    assert result.beams[0].forces.governing_m3.signed_value == -150.0
+    assert result.beams[0].forces.governing_t.absolute_value == 1.5
+    assert (
+        result.beams[0].design_result["envelope"]["qualified_review_required"] is True
+    )
+    assert sap_model.unit_calls == [5, 6]
+    assert sap_model.Results.Setup.calls == [
+        ("deselect",),
+        ("combo", "ULS-1", True),
+    ]
+    assert session.closed is True
+
+
+def test_pilot_limit_is_enforced_before_etabs_calls():
+    with pytest.raises(ValueError):
+        bridge.ETABSPilotRequestV1(
+            result_selection=bridge.ETABSResultSelectionV1(
+                kind=bridge.ETABSResultSelectionKind.CASE,
+                name="DEAD",
+            ),
+            design_basis=_design_basis(),
+            limit=6,
+        )
+
+
+def test_status_is_truthful_on_non_windows(monkeypatch):
+    monkeypatch.setattr(bridge.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(bridge, "_library_identity", lambda: ("0.24.0", "b" * 64))
+
+    status = bridge.get_etabs_bridge_status_v1()
+
+    assert status.bridge_status == "PLATFORM_UNSUPPORTED"
+    assert status.com_dependency == "NOT_APPLICABLE"
+    assert status.model is None
+
+
+def test_com_signature_mismatch_is_a_stable_data_error():
+    with pytest.raises(bridge.ETABSDataError) as exc_info:
+        bridge._decode_com_outputs("FrameObj.GetAllFrames", (1, 0), output_count=20)
+    assert exc_info.value.code == "ETABS_COM_SIGNATURE_MISMATCH"
+
+
+def test_connect_returns_exact_open_model_without_unit_change(monkeypatch):
+    sap_model = _FakeSapModel()
+    session = _FakeSession(sap_model)
+    monkeypatch.setattr(bridge, "_library_identity", lambda: ("0.24.0", "c" * 64))
+
+    result = bridge.connect_etabs_v1(session_factory=lambda: session)
+
+    assert result.bridge_status == "CONNECTED"
+    assert result.model.etabs_version == "ETABS 23.3.1"
+    assert sap_model.unit_calls == []
+    assert session.closed is True
+
+
+def test_real_session_unit_context_restores_units_after_extraction_failure():
+    sap_model = _FakeSapModel()
+    session = object.__new__(bridge._ComtypesETABSSession)
+    session.sap_model = sap_model
+
+    with pytest.raises(RuntimeError, match="simulated extraction failure"):
+        with session.normalized_kn_mm_units():
+            raise RuntimeError("simulated extraction failure")
+
+    assert sap_model.unit_calls == [5, 6]

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,106 @@
 
 ---
 
+## 2026-08-28 — Session: Excel -> Python -> live ETABS beam pilot
+
+**Agent:** Codex (`orchestrator`, sole writer; no subagents).
+
+**Branch:** `codex/excel-etabs-python-bridge-pilot` from observed current
+`origin/main` `683760a4aef1c384aa475df6842c791eada85959`.
+
+**Git handoff receipt:**
+`docs/verification/excel-etabs-python-bridge-pilot-git-handoff-receipt.json`
+
+**Focus:** Add and document a bounded Windows Office.js -> localhost FastAPI/
+Python -> already-open ETABS COM proof: report library/bridge status, attach and
+identify the open copied model, preserve exact frame-force rows, canonically
+design up to five horizontal rectangular beams, and write only a controlled
+Excel result table. ETABS analysis, model save, section write-back, global
+optimization, serviceability, adjacent-member detailing, construction checks,
+release, and professional-approval claims remain held.
+
+**Completed:**
+
+- Added the optional `structural-lib-is456[etabs]` dependency extra and a
+  fail-closed service that keeps COM imports Windows-only, owns COM apartment
+  initialization in the FastAPI worker thread, attaches without launching
+  ETABS, reads exact model/version identity, and does not call analysis, unlock,
+  save, or frame-section setters.
+- Added typed status, connect, and beam-pilot REST operations. The pilot selects
+  one exact case/combination, temporarily uses CSI `kN_mm_C`, restores the
+  original present-unit setting, filters horizontal frame objects
+  deterministically, accepts rectangular sections only, preserves every
+  returned `FrameForce` station, and feeds absolute governing `V2`, `T`, and
+  `M3` actions plus explicit caller-owned material/detailing inputs to the
+  canonical beam service.
+- Extended the existing macro-free Office.js pane with an ETABS surface that is
+  independent of the packaged E1 workbook. It displays bridge/library and model
+  identity, builds the strict request, and creates or updates only
+  `ETABS_Pilot / tbl_ETABS_Pilot_V1`; worksheet/table collisions or changed
+  headers block without overwrite.
+- Added the Windows setup, architecture, COM/unit behavior, failure contract,
+  exact limitations, installed-application evidence gate, and next-phase
+  boundary in `docs/guides/excel-etabs-python-bridge-pilot.md`. The guide also
+  records why cloud-hosted Python in Excel cannot attach to local ETABS and why
+  no VBA module is required for this Office.js route.
+- Updated the OpenAPI baseline to 93 operations and 471 schemas and synchronized
+  maintained endpoint/router counts to 93 operations across 28 routers.
+
+**Verification:**
+
+- Focused Python/FastAPI: `16 passed` for the new bridge, REST transport, and
+  predecessor Excel Workbench routes.
+- Office.js: `npm test` in `excel_addin` -> `27 passed`.
+- Broad Python: `./run.sh test` -> `7177 passed, 3 skipped, 6 deselected`.
+- Broad FastAPI: `./run.sh test --fastapi` -> `530 passed`.
+- OpenAPI: exact baseline match at `93 endpoints, 471 schemas`.
+- Architecture/import/type/governance: zero boundary violations, zero broken
+  imports, 100% checked annotations, governance pass.
+- Quick gate: `./run.sh check --quick` -> `10/10 passed`.
+- Full gate: `./run.sh check` -> `32/32 passed`; installed Windows Excel +
+  ETABS application acceptance remains explicitly `TO_VERIFY_WINDOWS`.
+
+### Issues encountered
+
+- The first cross-platform fake-COM run returned the full Windows path as the
+  model name instead of `Pilot Copy.edb`, changing the visible Excel/model
+  identity outcome.
+- The first consolidated full gate found missing context-manager return types
+  and one governance-layer violation in the new service. Static import
+  validation also rejected a direct optional `comtypes` import on macOS, and the
+  first router draft imported a core exception across the UI boundary.
+- ⚠️ TERMINAL ISSUE: guessed `scripts/check_architecture.py` and
+  `scripts/check_imports.py` did not exist -> `./run.sh find "architecture
+  import boundary"` resolved the maintained
+  `check_architecture_boundaries.py` and `validate_imports.py` commands.
+- ⚠️ TERMINAL ISSUE: `scripts/sync_numbers.py --write` was not a supported
+  option -> the script's usage output identified and `--fix` applied the
+  maintained count updates.
+
+### Root causes and resolutions
+
+- `pathlib.Path` uses host path semantics, so macOS does not parse backslashes
+  in a Windows ETABS path. The model identity now uses `PureWindowsPath`; the
+  focused service test proves the exact basename and preserved full path.
+- The new context-manager methods lacked explicit return annotations, and the
+  service initially entered the canonical beam through the public
+  `structural_lib.design` facade rather than its own allowed service layer. The
+  methods now declare `AbstractContextManager[None]`/`Iterator[None]`, and the
+  bridge builds the strict contract through `model_validate_or_error` before
+  calling `services.canonical_beam.design_and_detail`. Type, governance, and
+  both architecture checkers pass.
+- Optional COM capability was represented as a normal Python import, which made
+  a valid Windows-only dependency look broken on non-Windows hosts. The service
+  now probes with `find_spec` and loads `comtypes` dynamically only after the
+  Windows gate. The service re-exports the core input exception so the UI router
+  imports only from the allowed service boundary. Import validation reports
+  zero broken imports and the Mac status route remains deterministic.
+- The terminal failures were stale guessed command names/options rather than
+  product defects. Maintained command discovery supplied the exact replacements;
+  no data, worktree, ETABS model, workbook, or unrelated dirty lane was mutated.
+
+---
+
 ## 2026-08-28 — Session: External documentation 0.24.0 polish
 
 **Agent:** Codex (`documentation`, sole writer; no subagents).

--- a/docs/getting-started/agent-bootstrap.md
+++ b/docs/getting-started/agent-bootstrap.md
@@ -134,8 +134,8 @@ Core CANNOT import from Services or UI. Services CANNOT import from UI. Units al
 
 ### FastAPI Endpoints (`fastapi_app/routers/`)
 
-90 OpenAPI HTTP operation endpoints across 27 router modules. The separate
-React-contract scanner currently matches 89 OpenAPI paths; that path metric is
+93 OpenAPI HTTP operation endpoints across 28 router modules. The separate
+React-contract scanner currently matches 92 OpenAPI paths; that path metric is
 not the operation count. The WebSocket route is also outside OpenAPI:
 
 | Router | Endpoint | Purpose |
@@ -346,7 +346,7 @@ npm run dev
 # React is now at http://localhost:5173
 ```
 
-This builds and runs the FastAPI container with all Python dependencies + sample data (`Etabs_CSV/`). The `/docs` page auto-generates interactive Swagger UI for all 90 current OpenAPI HTTP operations.
+This builds and runs the FastAPI container with all Python dependencies + sample data (`Etabs_CSV/`). The `/docs` page auto-generates interactive Swagger UI for all 93 current OpenAPI HTTP operations.
 
 For development with hot-reload (code changes reflect without rebuild):
 ```bash

--- a/docs/getting-started/mac-mini-setup.md
+++ b/docs/getting-started/mac-mini-setup.md
@@ -274,8 +274,8 @@ structural_engineering_lib/
 │   ├── insights/               #   Design insights & analysis
 │   ├── visualization/          #   3D geometry generation
 │   └── reports/                #   Report templates
-├── fastapi_app/                # REST backend (90 OpenAPI operations) + WebSocket
-│   └── routers/                #   27 routers (design, column, geometry, import, export...)
+├── fastapi_app/                # REST backend (93 OpenAPI operations) + WebSocket
+│   └── routers/                #   28 routers (design, column, geometry, import, export...)
 ├── react_app/src/              # React 19 + TypeScript + R3F + Tailwind
 │   ├── components/             #   UI components by feature
 │   ├── hooks/                  #   Custom hooks (CSV, geometry, design, export)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -9,6 +9,7 @@ End-user and developer guides for specific workflows.
 | `ai-agent-coding-guide.md` | AI agent coding practices |
 | `cross-surface-parity-v1.md` | Canonical Python, REST, React, and Excel identity/freshness contract |
 | `etabs-exported-snapshot-v1.md` | Read-only, trial-compatible ETABS exported-file snapshot workflow |
+| `excel-etabs-python-bridge-pilot.md` | Windows Office.js -> local Python -> live ETABS read-only beam pilot |
 | `code-reuse-and-library-structure.md` | Library structure and reuse patterns |
 
 See also: `docs/agents/guides/` for agent-specific workflow guides.

--- a/docs/guides/excel-etabs-python-bridge-pilot.md
+++ b/docs/guides/excel-etabs-python-bridge-pilot.md
@@ -1,0 +1,189 @@
+# Excel -> Python -> ETABS Beam Pilot V1
+
+**Type:** Guide
+**Audience:** Developers
+**Status:** In Progress
+**Created:** 2026-08-28
+**Last Updated:** 2026-08-28
+**Importance:** High
+
+## Outcome
+
+The repository now contains a bounded Windows pilot that lets the existing
+macro-free Excel Office.js task pane call local Python, attach to an already-open
+ETABS model, read an exact result case or combination, design up to five beams
+with the canonical IS 456 library, and write a controlled result table back to
+Excel.
+
+```text
+Excel Office.js task pane
+        | trusted localhost HTTPS
+        v
+FastAPI /api/v1/etabs-bridge/v1
+        | worker-thread COM apartment
+        v
+already-open ETABS copied model
+        |
+        +-- geometry + every FrameForce station
+        v
+canonical Python beam design/detailing
+        |
+        v
+Excel ETABS_Pilot / tbl_ETABS_Pilot_V1
+```
+
+Excel is the operator and review surface. ETABS remains the global-analysis
+source. Python owns validation, action selection, and the canonical beam design.
+No VBA module is required for this route.
+
+## Why this route
+
+Python in Excel is not the local integration runtime for this task. Microsoft
+documents that its Python calculations run in a secure Microsoft Cloud
+container and cannot access the local computer or network. That prevents it
+from attaching to a desktop ETABS COM process or importing an arbitrary local
+repository checkout. See [Microsoft's Python in Excel data-security
+documentation](https://support.microsoft.com/en-us/office/data-security-and-python-in-excel-33cc88a4-4a87-485e-9ff9-f35958278327).
+
+The existing Office.js add-in already has a trusted localhost HTTPS server and
+same-origin `/api/` proxy, so the pilot extends that maintained transport. A
+direct desktop-Python Excel add-in such as PyXLL could be evaluated later, but it
+would add a second deployment and trust model and is not needed for this proof.
+
+## Implemented contract
+
+| Operation | Endpoint | Effect |
+|---|---|---|
+| Check Python/library/COM readiness | `GET /api/v1/etabs-bridge/v1/status` | Read-only; does not attach to ETABS |
+| Prove the open model identity | `POST /api/v1/etabs-bridge/v1/connect` | Attaches, reads model path/name and ETABS version, then releases the COM apartment |
+| Extract and design beams | `POST /api/v1/etabs-bridge/v1/beam-pilot` | Reads an exact result selection and writes nothing to ETABS |
+
+The beam-pilot request must explicitly provide:
+
+- exact ETABS case or combination name and kind;
+- beam count from 1 to 5;
+- `fck` and `fy`;
+- clear cover, selected longitudinal bar diameters, stirrup diameter/legs and
+  support/midspan spacing;
+- compression-steel depth `d'`; and
+- IS 456 or IS 13920 detailing selection.
+
+ETABS supplies frame identity, storey, endpoints, span, rectangular section
+width/depth, section material-property name, and all returned `FrameForce`
+rows. The pilot retains signed station results and sends the absolute governing
+`V2`, `T`, and `M3` magnitudes to the canonical beam design. It never infers
+concrete or reinforcement grades from an ETABS material-property label.
+
+## Windows setup
+
+Prerequisites:
+
+- 64-bit Windows with a supported 64-bit Python and ETABS installation;
+- Microsoft Excel capable of sideloading the existing Office.js manifest;
+- Node.js for the local task-pane HTTPS server;
+- a trusted localhost certificate as described in
+  [the add-in README](../../excel_addin/README.md); and
+- a saved copied ETABS model with the requested case/combination already
+  analyzed.
+
+Run ETABS and the FastAPI process at the same Windows privilege level. For
+example, do not run one as Administrator and the other as a normal user.
+
+From repository root in PowerShell:
+
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install --upgrade pip
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
+.\.venv\Scripts\python.exe -m pip install -e "Python[etabs]"
+```
+
+Start FastAPI from repository root:
+
+```powershell
+.\.venv\Scripts\python.exe -m uvicorn fastapi_app.main:app --host 127.0.0.1 --port 8000
+```
+
+In a second PowerShell window, start the existing trusted add-in origin:
+
+```powershell
+Set-Location excel_addin
+npm install
+$env:E1_OFFICE_KEY_PATH = "C:\absolute\path\localhost.key"
+$env:E1_OFFICE_CERT_PATH = "C:\absolute\path\localhost.crt"
+npm run serve
+```
+
+Then:
+
+1. Open ETABS and the saved copied `.edb` model. Confirm the intended result
+   case or combination exists and has current analysis results.
+2. Sideload `excel_addin/manifest.xml` and open the task pane in Excel.
+3. In **ETABS beam pilot**, confirm that bridge status is
+   `READY_TO_CONNECT`.
+4. Select **Connect to open ETABS model** and verify the displayed `.edb` name
+   and ETABS version.
+5. Enter the exact result name and all explicit design/detailing values.
+6. Select **Read and design first beams**.
+7. Review `ETABS_Pilot / tbl_ETABS_Pilot_V1`. The add-in creates this surface
+   only when absent, updates only the exact V1 table, and refuses to overwrite a
+   colliding worksheet or altered table.
+
+## COM and unit behavior
+
+The optional dependency is `comtypes>=1.4,<2` and is installed only by the
+`etabs` package extra on Windows. The service creates and tears down COM inside
+the FastAPI worker thread that owns the request.
+
+The pilot records the current ETABS present-unit enumeration, temporarily sets
+`kN_mm_C` (CSI enumeration value 5), reads geometry and results, and restores
+the original setting in a `finally` path. CSI's API documentation identifies
+`SetPresentUnits`, `GetAllFrames`, `GetRectangle`, result-selection setup, and
+`FrameForce` as the relevant calls. See the official CSI API pages for
+[units](https://docs.csiamerica.com/help-files/etabs-api-2016/html/cff40d28-9b1a-7f00-cfb9-0386da2464cc.htm),
+[frame inventory](https://docs.csiamerica.com/help-files/etabs-api-2016/html/9346cf4e-be74-b7be-d1eb-afe69d0f609c.htm), and
+[frame forces](https://docs.csiamerica.com/help-files/etabs-api-2016/html/87689f3e-4175-1627-618b-c4ebae5e89b5.htm).
+
+## Fail-closed boundaries
+
+The current pilot blocks when:
+
+- the host is not Windows or the optional COM dependency is missing;
+- no already-open ETABS model can be attached or the copied model is unsaved;
+- the exact case/combination cannot be selected or has no frame-force results;
+- no horizontal frame candidates exist within the fixed 1 mm vertical
+  tolerance;
+- one of the selected first beams is not rectangular;
+- a returned COM tuple or result-array count differs from the declared CSI API
+  shape;
+- any beam returns more than 2,000 result rows; or
+- canonical beam intake rejects the section, materials, actions, or detailing
+  basis.
+
+The pilot does **not** run ETABS analysis, unlock/save the model, change member
+sizes, perform a second frame analysis, optimize sections, check slabs/columns/
+joints/foundations, evaluate serviceability, coordinate bars across adjacent
+beams, check congestion/layers/site sequence, or claim professional approval.
+All returned designs require qualified structural-engineer review.
+
+## Evidence status and next gate
+
+The Python service, REST contracts, Office.js request/projection, and controlled
+worksheet writes have deterministic macOS/CI-test coverage through fake COM and
+fake Office hosts. That proves the local software contract, not actual ETABS
+application compatibility.
+
+The next gate is an installed Windows run that records:
+
+- exact repository commit and installed package identity;
+- Windows, Python, Excel, Office.js, ETABS, and `comtypes` versions;
+- copied `.edb` name/hash and exact result-selection name;
+- status, connect, and beam-pilot responses;
+- the generated `ETABS_Pilot` table and reconciliation to ETABS station rows;
+- proof that the original ETABS present units were restored; and
+- an independent engineer review of at least one beam's ETABS actions and
+  canonical design result.
+
+Only after that evidence passes should the next phase add a reviewed section-
+change proposal, explicit write-back confirmation, ETABS re-analysis, global
+response checks, and a bounded optimization loop.

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,10 +4,10 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-28
-- Focus: Apply the external-user review of the published
-- Completed: Kept the typed family facade as the recommended integration route and added; Documented the `beam_id` versus `case_id` distinction, standardized current; Corrected stale Alpha-era labels, clarified that FastAPI/React are exact-head
-- Git receipt: docs/verification/external-docs-polish-git-handoff-receipt.json | sha256:b67b11a97c962c477ed768e89d4351b60cc87c032e309b007aeb394fb4308358 | HOLD
-- Git identity: codex/external-docs-polish@bda7dec0dc65f96ba8fada55960e3682cd3b80cb | upstream=origin/main@bda7dec0dc65f96ba8fada55960e3682cd3b80cb | base=origin/main@bda7dec0dc65f96ba8fada55960e3682cd3b80cb | tree=dirty | operation=none
+- Focus: Add and document a bounded Windows Office.js -> localhost FastAPI/
+- Completed: Added the optional `structural-lib-is456[etabs]` dependency extra and a; Added typed status, connect, and beam-pilot REST operations. The pilot selects; Extended the existing macro-free Office.js pane with an ETABS surface that is
+- Git receipt: docs/verification/excel-etabs-python-bridge-pilot-git-handoff-receipt.json | sha256:404a1248fb9c2f13fd61f46f3e98f8a0ddfd06593770c1fac9645e082f2e7756 | HOLD
+- Git identity: codex/excel-etabs-python-bridge-pilot@683760a4aef1c384aa475df6842c791eada85959 | upstream=NONE@UNKNOWN | base=origin/main@683760a4aef1c384aa475df6842c791eada85959 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
 - Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
@@ -17,9 +17,9 @@
 | State | Exact boundary |
 |---|---|
 | **Public** | `v0.24.0` is the immutable current normal software release at merge `e66de6efa3bb80d3ebc54e6151b1d6c29275c502`; GitHub prerelease is false and PyPI selects it normally. |
-| **Current** | Release publication and public identity verification are complete. The package remains pre-1.0/Beta and the supported-scope limitations remain authoritative. |
-| **Next** | No later release or engineering packet is selected. Wait for the repository owner to choose the next bounded scope; do not infer a v0.24.1/v0.25 candidate. |
-| **Held** | Stable-API guarantee, complete IS 456 coverage, professional approval, engineering-use/construction-use approval, Windows/Excel/ETABS acceptance, protected-source mutation, and destructive cleanup. |
+| **Current** | `codex/excel-etabs-python-bridge-pilot` contains the locally verified read-only Office.js -> FastAPI/Python -> already-open ETABS beam pilot. Broad Python/FastAPI/Office.js tests and the 32/32 repository gate pass; this is not yet installed Windows ETABS evidence or a release. |
+| **Next** | Run the documented exact-current installed Windows Excel + ETABS acceptance against a saved copied model, reconcile at least one beam's station forces/design independently, and record unit restoration. Do not start ETABS write-back or optimization before that gate passes. |
+| **Held** | ETABS analysis execution, unlock/save, member-size write-back, iterative whole-model optimization, full frame-solver claims, serviceability/adjacency/congestion/site-practice automation, stable-API guarantee, professional or construction-use approval, release, protected-source mutation, and destructive cleanup. |
 
 ## Published release evidence
 

--- a/docs/verification/excel-etabs-python-bridge-pilot-git-handoff-receipt.json
+++ b/docs/verification/excel-etabs-python-bridge-pilot-git-handoff-receipt.json
@@ -1,0 +1,150 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "404a1248fb9c2f13fd61f46f3e98f8a0ddfd06593770c1fac9645e082f2e7756",
+    "state": {
+      "branch": "codex/excel-etabs-python-bridge-pilot",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "683760a4aef1c384aa475df6842c791eada85959",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 94.087,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "head_sha": "683760a4aef1c384aa475df6842c791eada85959",
+      "hold_reasons": [
+        "changed paths: 23"
+      ],
+      "linked_worktree": false,
+      "locks": [],
+      "observed_at_utc": "2026-08-28T11:26:02.317984+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 23,
+        "modified_paths": [
+          "AGENTS.md",
+          "Python/pyproject.toml",
+          "docs/SESSION_LOG.md",
+          "docs/getting-started/agent-bootstrap.md",
+          "docs/getting-started/mac-mini-setup.md",
+          "docs/guides/README.md",
+          "excel_addin/README.md",
+          "excel_addin/taskpane-core.mjs",
+          "excel_addin/taskpane-office.mjs",
+          "excel_addin/taskpane.css",
+          "excel_addin/taskpane.html",
+          "excel_addin/taskpane.mjs",
+          "excel_addin/tests/serve-static-files.test.mjs",
+          "excel_addin/tests/taskpane-core.test.mjs",
+          "excel_addin/tests/taskpane-office.test.mjs",
+          "fastapi_app/main.py",
+          "fastapi_app/openapi_baseline.json",
+          "llms.txt"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "Python/structural_lib/services/etabs_live_bridge.py",
+          "Python/tests/unit/test_etabs_live_bridge.py",
+          "docs/guides/excel-etabs-python-bridge-pilot.md",
+          "fastapi_app/routers/etabs_bridge.py",
+          "fastapi_app/tests/test_etabs_bridge.py"
+        ]
+      },
+      "upstream": {
+        "ahead": null,
+        "behind": null,
+        "ref": "NONE",
+        "sha": null,
+        "status": "none"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:404a1248fb9c2f13fd61f46f3e98f8a0ddfd06593770c1fac9645e082f2e7756",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-28T11:26:02.318166+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "Etabs_CSV",
+      "Python/structural_lib/codes/is456",
+      "Python/structural_lib/data/excel/outputs"
+    ],
+    "integration_owner": "Codex",
+    "owned_paths": [
+      "Python/pyproject.toml",
+      "Python/structural_lib/services/etabs_live_bridge.py",
+      "Python/tests/unit/test_etabs_live_bridge.py",
+      "fastapi_app/routers/etabs_bridge.py",
+      "fastapi_app/tests/test_etabs_bridge.py",
+      "excel_addin",
+      "docs/guides/excel-etabs-python-bridge-pilot.md"
+    ],
+    "shared_paths": [
+      "fastapi_app/main.py",
+      "fastapi_app/openapi_baseline.json",
+      "docs/SESSION_LOG.md",
+      "AGENTS.md",
+      "llms.txt",
+      "docs/getting-started/agent-bootstrap.md",
+      "docs/getting-started/mac-mini-setup.md"
+    ],
+    "task_id": "EXCEL-ETABS-PYTHON-BRIDGE-PILOT"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}

--- a/excel_addin/README.md
+++ b/excel_addin/README.md
@@ -2,6 +2,13 @@
 
 This macro-free Office.js task pane reads only `Beam_Workbench / tbl_Beam_Workbench_V1`, previews the strict mapping, and sends a confirmed snapshot through the local FastAPI Excel Workbench V1 endpoints. It writes the returned row ledger, canonical result projections, and calculation passports to their named workbook tables. After a current run or an explicit `CURRENT` freshness check, it can download a complete deterministic JSON review bundle whose bytes and result identities are verified before save.
 
+The same pane also contains a separate Windows-only **ETABS beam pilot**. It
+checks the local Python/library/COM bridge, attaches to an already-open copied
+ETABS model, reads one exact result case or combination, designs up to five
+horizontal rectangular beams, and writes only
+`ETABS_Pilot / tbl_ETABS_Pilot_V1`. See the complete
+[setup and boundary guide](../docs/guides/excel-etabs-python-bridge-pilot.md).
+
 ## Local development transport
 
 The manifest requires HTTPS. Start the FastAPI application on `127.0.0.1:8000`, provide trusted localhost development certificate paths, and run:
@@ -22,6 +29,13 @@ The HTTPS server exposes `https://localhost:3000/taskpane.html` and proxies same
 - The Office document settings retain the workbook instance ID, four-hash freshness evidence, and stale flag across task-pane sessions; complete ledgers, results, and passports remain in their workbook tables.
 - Export sends the current source snapshot and retained identities back to Python. The service regenerates the canonical result, requires exact source/mapping/library/result agreement, and returns complete JSON evidence; Excel never packages a client-supplied old result.
 - Any edit disables export immediately. A reopened workbook must pass an explicit freshness check before export is re-enabled.
-- Excel does not execute structural-design formulas. VBA/macros, torsion, serviceability, ETABS access, write-back, release claims, and professional approval are outside E1.
+- Excel does not execute structural-design formulas. VBA/macros, ETABS analysis
+  or write-back, serviceability, continuity/congestion optimization, release
+  claims, and professional approval remain outside the implemented surfaces.
+- The ETABS pilot uses explicit task-pane buttons and a dedicated controlled
+  table. It is independent of the E1 workbook surface and refuses to overwrite
+  a colliding worksheet or changed table.
 
-Installed Windows Excel evidence is a separate gate and remains `TO_VERIFY_WINDOWS` until executed on the supported environment.
+The prior installed Windows Excel journey does not prove this new COM bridge.
+Installed Windows Excel + ETABS pilot evidence remains a separate gate until the
+exact current implementation is executed on the supported environment.

--- a/excel_addin/taskpane-core.mjs
+++ b/excel_addin/taskpane-core.mjs
@@ -6,6 +6,28 @@ const TEMPLATE = Object.freeze({
 });
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 
+export const ETABS_PILOT_HEADERS = Object.freeze([
+  "Frame",
+  "Story",
+  "Section",
+  "Material",
+  "Span (mm)",
+  "b (mm)",
+  "D (mm)",
+  "Result selection",
+  "Force rows",
+  "V2 signed (kN)",
+  "|V2| (kN)",
+  "T signed (kN.m)",
+  "|T| (kN.m)",
+  "M3 signed (kN.m)",
+  "|M3| (kN.m)",
+  "Overall status",
+  "Ast required (mm2)",
+  "Shear spacing (mm)",
+  "Canonical result JSON",
+]);
+
 export const SETTINGS_KEYS = Object.freeze({
   workbookId: "excel_workbench_v1.workbook_instance_id",
   previousEvidence: "excel_workbench_v1.previous_evidence",
@@ -23,6 +45,76 @@ export function normalizeCalculationMode(value) {
     return "AUTOMATIC_EXCEPT_TABLES";
   }
   throw new Error(`Unsupported Excel calculation mode: ${value}`);
+}
+
+function requiredNumber(name, value, { minimum = 0, integer = false } = {}) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= minimum) {
+    throw new Error(`${name} must be a finite number greater than ${minimum}.`);
+  }
+  if (integer && !Number.isInteger(parsed)) {
+    throw new Error(`${name} must be an integer.`);
+  }
+  return parsed;
+}
+
+export function buildEtabsPilotRequest(values) {
+  const selectionName = String(values.selectionName ?? "").trim();
+  if (!selectionName) throw new Error("An exact ETABS case or combination name is required.");
+  const selectionKind = String(values.selectionKind ?? "");
+  if (!new Set(["CASE", "COMBINATION"]).has(selectionKind)) {
+    throw new Error("ETABS result selection must be CASE or COMBINATION.");
+  }
+  const standard = String(values.standard ?? "");
+  if (!new Set(["IS456", "IS13920"]).has(standard)) {
+    throw new Error("Detailing standard must be IS456 or IS13920.");
+  }
+  const limit = requiredNumber("Beam limit", values.limit, { integer: true });
+  if (limit > 5) throw new Error("Beam limit must not exceed 5.");
+  const clearCover = requiredNumber("Clear cover", values.clearCover);
+  const stirrupDiameter = requiredNumber("Stirrup diameter", values.stirrupDiameter);
+  const tensionBarDiameter = requiredNumber("Tension bar diameter", values.tensionBarDiameter);
+  const detailing = {
+    standard,
+    clear_cover_mm: clearCover,
+    tension_bar_diameter_mm: tensionBarDiameter,
+    compression_bar_diameter_mm: requiredNumber(
+      "Compression bar diameter",
+      values.compressionBarDiameter,
+    ),
+    nominal_top_steel_ratio: requiredNumber(
+      "Nominal top steel ratio",
+      values.nominalTopSteelRatio,
+    ),
+    stirrup_diameter_mm: stirrupDiameter,
+    stirrup_legs: requiredNumber("Stirrup legs", values.stirrupLegs, { integer: true }),
+    stirrup_spacing_support_mm: requiredNumber(
+      "Support stirrup spacing",
+      values.stirrupSpacingSupport,
+    ),
+    stirrup_spacing_mid_mm: requiredNumber(
+      "Midspan stirrup spacing",
+      values.stirrupSpacingMid,
+    ),
+  };
+  return {
+    schema_version: "etabs-beam-pilot/v1",
+    result_selection: { kind: selectionKind, name: selectionName },
+    design_basis: {
+      materials: {
+        fck_nmm2: requiredNumber("fck", values.fck),
+        fy_nmm2: requiredNumber("fy", values.fy),
+      },
+      effective_depth_basis: {
+        clear_cover_mm: clearCover,
+        stirrup_diameter_mm: stirrupDiameter,
+        tension_bar_diameter_mm: tensionBarDiameter,
+      },
+      d_dash_mm: requiredNumber("Compression steel depth d'", values.dDash),
+      detailing,
+    },
+    limit,
+  };
 }
 
 export function buildPreviewRequest({
@@ -349,6 +441,43 @@ export function projectResultRows(result) {
           : null,
       JSON.stringify(row.result),
     ]);
+}
+
+export function projectEtabsPilotRows(result) {
+  if (
+    result?.schema_version !== "etabs-beam-pilot/v1" ||
+    result?.pilot_status !== "COMPLETED" ||
+    !Array.isArray(result?.beams) ||
+    result.beams.length === 0
+  ) {
+    throw new Error("The ETABS pilot response is incomplete.");
+  }
+  return result.beams.map((item) => {
+    const geometry = item.geometry;
+    const forces = item.forces;
+    const design = item.design_result;
+    return [
+      geometry.frame_name,
+      geometry.story,
+      geometry.section_name,
+      geometry.material_property,
+      geometry.span_mm,
+      geometry.b_mm,
+      geometry.D_mm,
+      `${forces.selection.kind}:${forces.selection.name}`,
+      forces.result_row_count,
+      forces.governing_v2.signed_value,
+      forces.governing_v2.absolute_value,
+      forces.governing_t.signed_value,
+      forces.governing_t.absolute_value,
+      forces.governing_m3.signed_value,
+      forces.governing_m3.absolute_value,
+      design?.envelope?.overall_status ?? null,
+      design?.design?.calculation?.flexure?.Ast_required ?? null,
+      design?.design?.calculation?.shear?.spacing ?? null,
+      JSON.stringify(item),
+    ];
+  });
 }
 
 export function projectPassportRows(result) {

--- a/excel_addin/taskpane-office.mjs
+++ b/excel_addin/taskpane-office.mjs
@@ -1,3 +1,8 @@
+import { ETABS_PILOT_HEADERS } from "./taskpane-core.mjs";
+
+const ETABS_PILOT_SHEET = "ETABS_Pilot";
+const ETABS_PILOT_TABLE = "tbl_ETABS_Pilot_V1";
+
 function officeAsyncError(error) {
   const wrapped = new Error(
     error?.message || "Office document settings could not be saved.",
@@ -83,5 +88,64 @@ export async function registerWorksheetChange(
     const sheet = context.workbook.worksheets.getItem(worksheetName);
     sheet.onChanged.add(handler);
     await context.sync();
+  });
+}
+
+export async function writeEtabsPilotResults(excelApi, rows) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new Error("At least one completed ETABS pilot row is required.");
+  }
+  if (rows.some((row) => !Array.isArray(row) || row.length !== ETABS_PILOT_HEADERS.length)) {
+    throw new Error("ETABS pilot rows do not match the controlled output contract.");
+  }
+  return excelApi.run(async (context) => {
+    const worksheets = context.workbook.worksheets;
+    let sheet = worksheets.getItemOrNullObject(ETABS_PILOT_SHEET);
+    sheet.load("isNullObject");
+    await context.sync();
+
+    if (sheet.isNullObject) {
+      sheet = worksheets.add(ETABS_PILOT_SHEET);
+      const range = sheet.getRangeByIndexes(
+        0,
+        0,
+        rows.length + 1,
+        ETABS_PILOT_HEADERS.length,
+      );
+      range.values = [ETABS_PILOT_HEADERS, ...rows];
+      const table = sheet.tables.add(range, true);
+      table.name = ETABS_PILOT_TABLE;
+      sheet.activate();
+      await context.sync();
+      return { disposition: "CREATED", sheetName: ETABS_PILOT_SHEET };
+    }
+
+    const table = sheet.tables.getItemOrNullObject(ETABS_PILOT_TABLE);
+    table.load("isNullObject");
+    await context.sync();
+    if (table.isNullObject) {
+      throw new Error(
+        `${ETABS_PILOT_SHEET} already exists without ${ETABS_PILOT_TABLE}; no cells were overwritten.`,
+      );
+    }
+    const header = table.getHeaderRowRange();
+    header.load(["values", "rowIndex", "columnIndex", "columnCount"]);
+    await context.sync();
+    if (JSON.stringify(header.values[0]) !== JSON.stringify(ETABS_PILOT_HEADERS)) {
+      throw new Error("The existing ETABS pilot table headers do not match V1; no cells were overwritten.");
+    }
+    table.resize(
+      sheet.getRangeByIndexes(
+        header.rowIndex,
+        header.columnIndex,
+        rows.length + 1,
+        header.columnCount,
+      ),
+    );
+    await context.sync();
+    table.getDataBodyRange().values = rows;
+    sheet.activate();
+    await context.sync();
+    return { disposition: "UPDATED", sheetName: ETABS_PILOT_SHEET };
   });
 }

--- a/excel_addin/taskpane.css
+++ b/excel_addin/taskpane.css
@@ -26,11 +26,14 @@ main { display: grid; gap: 12px; padding: 14px; }
 button { width: 100%; margin-top: 10px; padding: 10px 12px; border: 0; border-radius: 5px; color: white; background: #087e8b; font-weight: 700; cursor: pointer; }
 button.secondary { color: #16324f; border: 1px solid #9fb0bc; background: white; }
 button:disabled { cursor: not-allowed; opacity: .45; }
-button:focus-visible, input:focus-visible, summary:focus-visible { outline: 3px solid #f0a202; outline-offset: 2px; }
+button:focus-visible, input:focus-visible, select:focus-visible, summary:focus-visible { outline: 3px solid #f0a202; outline-offset: 2px; }
 .check { display: flex; gap: 8px; align-items: flex-start; margin-top: 10px; }
 .check input { margin-top: 2px; }
 code { font-size: 11px; }
 details summary { cursor: pointer; font-weight: 700; }
 details label { display: block; margin: 10px 0 5px; }
-input[type="password"] { width: 100%; padding: 8px; border: 1px solid #9fb0bc; border-radius: 4px; }
+input[type="password"], input[type="text"], input[type="number"], select { width: 100%; padding: 8px; border: 1px solid #9fb0bc; border-radius: 4px; background: white; }
+.input-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 7px 10px; align-items: center; margin-top: 12px; }
+.input-grid label { margin: 0; }
+.pilot-card .status { margin-top: 10px; }
 aside { border-color: #d7b45c; background: #fff9e8; }

--- a/excel_addin/taskpane.html
+++ b/excel_addin/taskpane.html
@@ -47,6 +47,56 @@
         <p id="export-detail" class="detail" aria-live="polite" aria-atomic="true">Export becomes available after a current reviewed run.</p>
       </section>
 
+      <section class="card pilot-card">
+        <h2>ETABS beam pilot</h2>
+        <p>Windows only. Attaches to an already-open copied model, reads one exact result case or combination, and designs up to five horizontal rectangular beams in Python.</p>
+        <section id="etabs-status" class="status hold" aria-live="polite" aria-atomic="true" aria-busy="true">
+          <strong id="etabs-status-title">CHECKING PYTHON BRIDGE</strong>
+          <span id="etabs-status-detail">No ETABS connection has been attempted.</span>
+        </section>
+        <button id="etabs-connect" class="secondary" type="button" disabled>Connect to open ETABS model</button>
+        <div class="input-grid">
+          <label for="etabs-selection-kind">Result type</label>
+          <select id="etabs-selection-kind">
+            <option value="COMBINATION">Combination</option>
+            <option value="CASE">Case</option>
+          </select>
+          <label for="etabs-selection-name">Exact ETABS name</label>
+          <input id="etabs-selection-name" type="text" value="ULS-1" />
+          <label for="etabs-limit">Beam count (1–5)</label>
+          <input id="etabs-limit" type="number" min="1" max="5" step="1" value="5" />
+          <label for="etabs-standard">Detailing standard</label>
+          <select id="etabs-standard">
+            <option value="IS456">IS 456</option>
+            <option value="IS13920">IS 13920</option>
+          </select>
+          <label for="etabs-fck">fck (N/mm²)</label>
+          <input id="etabs-fck" type="number" min="15" max="40" value="25" />
+          <label for="etabs-fy">fy (N/mm²)</label>
+          <input id="etabs-fy" type="number" min="250" max="500" value="500" />
+          <label for="etabs-cover">Clear cover (mm)</label>
+          <input id="etabs-cover" type="number" min="1" value="40" />
+          <label for="etabs-stirrup-dia">Stirrup diameter (mm)</label>
+          <input id="etabs-stirrup-dia" type="number" min="6" max="16" value="8" />
+          <label for="etabs-tension-dia">Tension bar diameter (mm)</label>
+          <input id="etabs-tension-dia" type="number" min="8" max="36" value="20" />
+          <label for="etabs-compression-dia">Compression bar diameter (mm)</label>
+          <input id="etabs-compression-dia" type="number" min="8" max="36" value="16" />
+          <label for="etabs-d-dash">Compression steel d′ (mm)</label>
+          <input id="etabs-d-dash" type="number" min="1" value="40" />
+          <label for="etabs-top-ratio">Nominal top steel ratio</label>
+          <input id="etabs-top-ratio" type="number" min="0.01" max="1" step="0.01" value="0.25" />
+          <label for="etabs-stirrup-legs">Stirrup legs</label>
+          <input id="etabs-stirrup-legs" type="number" min="2" max="6" step="1" value="2" />
+          <label for="etabs-spacing-support">Support spacing (mm)</label>
+          <input id="etabs-spacing-support" type="number" min="1" value="150" />
+          <label for="etabs-spacing-mid">Midspan spacing (mm)</label>
+          <input id="etabs-spacing-mid" type="number" min="1" value="200" />
+        </div>
+        <button id="etabs-run" type="button" disabled>Read and design first beams</button>
+        <p class="detail">The explicit values above are design inputs. Section width/depth, span, and force stations come from ETABS. Results are written only to the controlled <code>ETABS_Pilot</code> sheet.</p>
+      </section>
+
       <details class="card">
         <summary>Local API authentication</summary>
         <label for="token">Bearer token (only when local auth is enabled)</label>
@@ -55,7 +105,7 @@
 
       <aside>
         <strong>Boundaries</strong>
-        <p>No VBA, structural formulas, torsion, serviceability, ETABS access, write-back, or professional-approval claim.</p>
+        <p>No VBA or Excel structural formulas. The ETABS pilot is read-only: no analysis run, size write-back, serviceability, continuity/congestion optimization, or professional-approval claim.</p>
       </aside>
     </main>
   </body>

--- a/excel_addin/taskpane.mjs
+++ b/excel_addin/taskpane.mjs
@@ -1,5 +1,6 @@
 import {
   SETTINGS_KEYS,
+  buildEtabsPilotRequest,
   buildPreviewRequest,
   buildReviewBundleExportRequest,
   buildRunRequest,
@@ -7,6 +8,7 @@ import {
   getWorkbenchApi,
   postWorkbenchApi,
   postReviewBundleApi,
+  projectEtabsPilotRows,
   projectLedgerRows,
   projectMappingRows,
   projectPassportRows,
@@ -22,6 +24,7 @@ import {
   officeErrorDetail,
   registerWorksheetChange,
   saveDocumentSettings,
+  writeEtabsPilotResults,
 } from "./taskpane-office.mjs";
 
 const INPUT_SHEET = "Beam_Workbench";
@@ -40,6 +43,8 @@ const state = {
   inputRevision: 0,
   eventRegistered: false,
   workbookSurfaceAvailable: false,
+  etabsBridgeStatus: null,
+  etabsConnected: false,
 };
 
 const ui = {};
@@ -64,6 +69,119 @@ function setBusy(busy) {
     freshnessVerified: state.freshnessVerified,
   });
   ui.status.setAttribute("aria-busy", busy ? "true" : "false");
+}
+
+function setPilotStatus(kind, title, detail = "") {
+  ui.etabsStatus.className = `status ${kind}`;
+  ui.etabsStatusTitle.textContent = title;
+  ui.etabsStatusDetail.textContent = detail;
+}
+
+function setPilotBusy(busy) {
+  ui.etabsConnect.disabled =
+    busy || state.etabsBridgeStatus?.bridge_status !== "READY_TO_CONNECT";
+  ui.etabsRun.disabled = busy || !state.etabsConnected;
+  ui.etabsStatus.setAttribute("aria-busy", busy ? "true" : "false");
+}
+
+function captureEtabsPilotValues() {
+  return {
+    selectionKind: ui.etabsSelectionKind.value,
+    selectionName: ui.etabsSelectionName.value,
+    limit: ui.etabsLimit.value,
+    standard: ui.etabsStandard.value,
+    fck: ui.etabsFck.value,
+    fy: ui.etabsFy.value,
+    clearCover: ui.etabsClearCover.value,
+    stirrupDiameter: ui.etabsStirrupDiameter.value,
+    tensionBarDiameter: ui.etabsTensionBarDiameter.value,
+    compressionBarDiameter: ui.etabsCompressionBarDiameter.value,
+    dDash: ui.etabsDDash.value,
+    nominalTopSteelRatio: ui.etabsTopRatio.value,
+    stirrupLegs: ui.etabsStirrupLegs.value,
+    stirrupSpacingSupport: ui.etabsSpacingSupport.value,
+    stirrupSpacingMid: ui.etabsSpacingMid.value,
+  };
+}
+
+async function refreshEtabsStatus() {
+  setPilotBusy(true);
+  try {
+    const status = await getWorkbenchApi(
+      API_ROOT,
+      "/etabs-bridge/v1/status",
+      { token: ui.token.value },
+    );
+    state.etabsBridgeStatus = status;
+    state.etabsConnected = false;
+    const available = status.bridge_status === "READY_TO_CONNECT";
+    setPilotStatus(
+      available ? "hold" : "blocked",
+      status.bridge_status,
+      available
+        ? `Python library ${status.library_version} is ready. Open the copied model in ETABS, then connect.`
+        : status.issues.join(" "),
+    );
+  } catch (error) {
+    state.etabsBridgeStatus = null;
+    state.etabsConnected = false;
+    setPilotStatus("blocked", "BRIDGE STATUS FAILED", error.message);
+  } finally {
+    setPilotBusy(false);
+  }
+}
+
+async function connectEtabs() {
+  setPilotBusy(true);
+  setPilotStatus("working", "CONNECTING", "Attaching to an already-open ETABS model.");
+  try {
+    const connection = await postWorkbenchApi(
+      API_ROOT,
+      "/etabs-bridge/v1/connect",
+      {},
+      { token: ui.token.value },
+    );
+    state.etabsConnected = true;
+    setPilotStatus(
+      "ready",
+      "ETABS CONNECTED",
+      `${connection.model.model_name} · ${connection.model.etabs_version} · library ${connection.library_version}`,
+    );
+  } catch (error) {
+    state.etabsConnected = false;
+    setPilotStatus("blocked", "ETABS CONNECTION FAILED", error.message);
+  } finally {
+    setPilotBusy(false);
+  }
+}
+
+async function runEtabsPilot() {
+  setPilotBusy(true);
+  setPilotStatus(
+    "working",
+    "READING ETABS",
+    "Extracting the exact selected result and running canonical beam design.",
+  );
+  try {
+    const request = buildEtabsPilotRequest(captureEtabsPilotValues());
+    const result = await postWorkbenchApi(
+      API_ROOT,
+      "/etabs-bridge/v1/beam-pilot",
+      request,
+      { token: ui.token.value },
+    );
+    const rows = projectEtabsPilotRows(result);
+    const write = await writeEtabsPilotResults(Excel, rows);
+    setPilotStatus(
+      "ready",
+      "PILOT COMPLETED",
+      `${result.designed_beam_count} beam(s) from ${result.model.model_name} written to ${write.sheetName} (${write.disposition}). Qualified review is required.`,
+    );
+  } catch (error) {
+    setPilotStatus("blocked", "PILOT BLOCKED", officeErrorDetail(error));
+  } finally {
+    setPilotBusy(false);
+  }
 }
 
 async function persistEvidence(evidence, stale) {
@@ -364,12 +482,35 @@ async function initialize() {
   ui.mapping = document.getElementById("mapping");
   ui.context = document.getElementById("context");
   ui.token = document.getElementById("token");
+  ui.etabsStatus = document.getElementById("etabs-status");
+  ui.etabsStatusTitle = document.getElementById("etabs-status-title");
+  ui.etabsStatusDetail = document.getElementById("etabs-status-detail");
+  ui.etabsConnect = document.getElementById("etabs-connect");
+  ui.etabsRun = document.getElementById("etabs-run");
+  ui.etabsSelectionKind = document.getElementById("etabs-selection-kind");
+  ui.etabsSelectionName = document.getElementById("etabs-selection-name");
+  ui.etabsLimit = document.getElementById("etabs-limit");
+  ui.etabsStandard = document.getElementById("etabs-standard");
+  ui.etabsFck = document.getElementById("etabs-fck");
+  ui.etabsFy = document.getElementById("etabs-fy");
+  ui.etabsClearCover = document.getElementById("etabs-cover");
+  ui.etabsStirrupDiameter = document.getElementById("etabs-stirrup-dia");
+  ui.etabsTensionBarDiameter = document.getElementById("etabs-tension-dia");
+  ui.etabsCompressionBarDiameter = document.getElementById("etabs-compression-dia");
+  ui.etabsDDash = document.getElementById("etabs-d-dash");
+  ui.etabsTopRatio = document.getElementById("etabs-top-ratio");
+  ui.etabsStirrupLegs = document.getElementById("etabs-stirrup-legs");
+  ui.etabsSpacingSupport = document.getElementById("etabs-spacing-support");
+  ui.etabsSpacingMid = document.getElementById("etabs-spacing-mid");
   ui.preview.addEventListener("click", previewMapping);
   ui.review.addEventListener("change", mappingReviewChanged);
   ui.run.addEventListener("click", runCalculation);
   ui.freshness.addEventListener("click", checkFreshness);
   ui.export.addEventListener("click", exportReviewBundle);
+  ui.etabsConnect.addEventListener("click", connectEtabs);
+  ui.etabsRun.addEventListener("click", runEtabsPilot);
   setBusy(true);
+  setPilotBusy(true);
 
   let surface;
   try {
@@ -396,6 +537,7 @@ async function initialize() {
   }
 
   ui.context.textContent = `Connected · library ${state.definition.library_version} · engine ${state.definition.library_content_identity.slice(0, 12)}… · workbook ${state.definition.workbook_artifact_sha256.slice(0, 12)}… · Windows ${state.definition.installed_windows_excel_evidence}`;
+  await refreshEtabsStatus();
   if (!surface.available) {
     setStatus("hold", "E1 WORKBOOK NOT OPEN", surface.detail);
     setBusy(false);

--- a/excel_addin/tests/serve-static-files.test.mjs
+++ b/excel_addin/tests/serve-static-files.test.mjs
@@ -40,3 +40,11 @@ test("installed pane exposes and wires fail-closed review-bundle export", () => 
   assert.match(taskpaneSource, /ui\.export\.addEventListener\("click", exportReviewBundle\)/);
   assert.match(taskpaneSource, /state\.freshnessVerified = false/);
 });
+
+test("installed pane exposes the explicit read-only ETABS pilot controls", () => {
+  assert.match(taskpaneHtml, /id="etabs-connect"[^>]*disabled/);
+  assert.match(taskpaneHtml, /id="etabs-run"[^>]*disabled/);
+  assert.match(taskpaneSource, /\/etabs-bridge\/v1\/status/);
+  assert.match(taskpaneSource, /\/etabs-bridge\/v1\/beam-pilot/);
+  assert.match(taskpaneSource, /writeEtabsPilotResults\(Excel, rows\)/);
+});

--- a/excel_addin/tests/taskpane-core.test.mjs
+++ b/excel_addin/tests/taskpane-core.test.mjs
@@ -3,6 +3,7 @@ import { createHash, webcrypto } from "node:crypto";
 import test from "node:test";
 
 import {
+  buildEtabsPilotRequest,
   buildPreviewRequest,
   buildReviewBundleExportRequest,
   buildRunRequest,
@@ -11,6 +12,7 @@ import {
   normalizeCalculationMode,
   postWorkbenchApi,
   postReviewBundleApi,
+  projectEtabsPilotRows,
   projectLedgerRows,
   projectPassportRows,
   projectResultRows,
@@ -19,6 +21,24 @@ import {
   retainEvidence,
   sameSourceSnapshot,
 } from "../taskpane-core.mjs";
+
+const etabsValues = {
+  selectionKind: "COMBINATION",
+  selectionName: "ULS-1",
+  limit: "5",
+  standard: "IS456",
+  fck: "25",
+  fy: "500",
+  clearCover: "40",
+  stirrupDiameter: "8",
+  tensionBarDiameter: "20",
+  compressionBarDiameter: "16",
+  dDash: "40",
+  nominalTopSteelRatio: "0.25",
+  stirrupLegs: "2",
+  stirrupSpacingSupport: "150",
+  stirrupSpacingMid: "200",
+};
 
 const HASH_A = "a".repeat(64);
 const HASH_B = "b".repeat(64);
@@ -51,6 +71,55 @@ test("calculation modes are explicit and unknown modes fail closed", () => {
     "AUTOMATIC_EXCEPT_TABLES",
   );
   assert.throws(() => normalizeCalculationMode("Mystery"), /Unsupported/);
+});
+
+test("ETABS pilot request makes result, material, depth, and detailing basis explicit", () => {
+  const request = buildEtabsPilotRequest(etabsValues);
+  assert.equal(request.schema_version, "etabs-beam-pilot/v1");
+  assert.deepEqual(request.result_selection, {
+    kind: "COMBINATION",
+    name: "ULS-1",
+  });
+  assert.equal(request.design_basis.materials.fck_nmm2, 25);
+  assert.equal(request.design_basis.effective_depth_basis.clear_cover_mm, 40);
+  assert.equal(request.design_basis.detailing.stirrup_legs, 2);
+  assert.equal(request.limit, 5);
+  assert.throws(
+    () => buildEtabsPilotRequest({ ...etabsValues, limit: "6" }),
+    /must not exceed 5/,
+  );
+  assert.throws(
+    () => buildEtabsPilotRequest({ ...etabsValues, selectionName: " " }),
+    /exact ETABS case or combination/,
+  );
+});
+
+test("ETABS projection preserves signed actions, design status, and full JSON", () => {
+  const beam = {
+    geometry: {
+      frame_name: "B1", story: "L1", section_name: "R1", material_property: "M25",
+      span_mm: 5000, b_mm: 300, D_mm: 500,
+    },
+    forces: {
+      selection: { kind: "COMBINATION", name: "ULS-1" }, result_row_count: 3,
+      governing_v2: { signed_value: -110, absolute_value: 110 },
+      governing_t: { signed_value: 1.5, absolute_value: 1.5 },
+      governing_m3: { signed_value: -150, absolute_value: 150 },
+    },
+    design_result: {
+      envelope: { overall_status: "PASS" },
+      design: { calculation: { flexure: { Ast_required: 900 }, shear: { spacing: 175 } } },
+    },
+  };
+  const rows = projectEtabsPilotRows({
+    schema_version: "etabs-beam-pilot/v1",
+    pilot_status: "COMPLETED",
+    beams: [beam],
+  });
+  assert.equal(rows[0][9], -110);
+  assert.equal(rows[0][15], "PASS");
+  assert.equal(rows[0][16], 900);
+  assert.match(rows[0][18], /"frame_name":"B1"/);
 });
 
 test("run request requires a reviewed mapping hash", () => {

--- a/excel_addin/tests/taskpane-office.test.mjs
+++ b/excel_addin/tests/taskpane-office.test.mjs
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { SETTINGS_KEYS } from "../taskpane-core.mjs";
+import { ETABS_PILOT_HEADERS, SETTINGS_KEYS } from "../taskpane-core.mjs";
 import {
   ensureWorkbookId,
   inspectWorkbookSurface,
   officeErrorDetail,
   registerWorksheetChange,
+  writeEtabsPilotResults,
 } from "../taskpane-office.mjs";
 
 function surfaceExcel(
@@ -222,4 +223,90 @@ test("change handler registration remains strict after surface acceptance", asyn
     ["add", handler],
     ["sync"],
   ]);
+});
+
+function pilotRow(label = "B1") {
+  return ETABS_PILOT_HEADERS.map((_, index) => (index === 0 ? label : null));
+}
+
+function pilotExcel({ existingSheet = false, existingTable = true, wrongHeaders = false } = {}) {
+  const calls = [];
+  const body = {};
+  const header = {
+    values: [wrongHeaders ? ["Wrong"] : [...ETABS_PILOT_HEADERS]],
+    rowIndex: 0,
+    columnIndex: 0,
+    columnCount: ETABS_PILOT_HEADERS.length,
+    load(properties) { calls.push(["header.load", properties]); },
+  };
+  const table = {
+    isNullObject: !existingTable,
+    name: null,
+    load(property) { calls.push(["table.load", property]); },
+    getHeaderRowRange() { return header; },
+    getDataBodyRange() { return body; },
+    resize(range) { calls.push(["table.resize", range]); },
+  };
+  const createdRange = {};
+  const sheet = {
+    isNullObject: !existingSheet,
+    load(property) { calls.push(["sheet.load", property]); },
+    getRangeByIndexes(...args) {
+      calls.push(["range", ...args]);
+      return existingSheet ? { args } : createdRange;
+    },
+    activate() { calls.push(["activate"]); },
+    tables: {
+      getItemOrNullObject(name) { calls.push(["table.get", name]); return table; },
+      add(range, hasHeaders) { calls.push(["table.add", range, hasHeaders]); return table; },
+    },
+  };
+  const context = {
+    workbook: {
+      worksheets: {
+        getItemOrNullObject(name) { calls.push(["sheet.get", name]); return sheet; },
+        add(name) { calls.push(["sheet.add", name]); sheet.isNullObject = false; return sheet; },
+      },
+    },
+    async sync() { calls.push(["sync"]); },
+  };
+  return {
+    calls,
+    body,
+    createdRange,
+    table,
+    api: { async run(callback) { return callback(context); } },
+  };
+}
+
+test("ETABS pilot creates only its controlled sheet and named table", async () => {
+  const excel = pilotExcel();
+  const row = pilotRow();
+  const result = await writeEtabsPilotResults(excel.api, [row]);
+  assert.deepEqual(result, { disposition: "CREATED", sheetName: "ETABS_Pilot" });
+  assert.deepEqual(excel.createdRange.values, [ETABS_PILOT_HEADERS, row]);
+  assert.equal(excel.table.name, "tbl_ETABS_Pilot_V1");
+  assert.equal(excel.calls.some(([name]) => name === "sheet.add"), true);
+});
+
+test("ETABS pilot updates only an exact existing V1 table", async () => {
+  const excel = pilotExcel({ existingSheet: true });
+  const row = pilotRow("B2");
+  const result = await writeEtabsPilotResults(excel.api, [row]);
+  assert.deepEqual(result, { disposition: "UPDATED", sheetName: "ETABS_Pilot" });
+  assert.deepEqual(excel.body.values, [row]);
+  assert.equal(excel.calls.some(([name]) => name === "table.resize"), true);
+});
+
+test("ETABS pilot never overwrites a colliding user worksheet", async () => {
+  const missing = pilotExcel({ existingSheet: true, existingTable: false });
+  await assert.rejects(
+    writeEtabsPilotResults(missing.api, [pilotRow()]),
+    /already exists without tbl_ETABS_Pilot_V1/,
+  );
+  const changed = pilotExcel({ existingSheet: true, wrongHeaders: true });
+  await assert.rejects(
+    writeEtabsPilotResults(changed.api, [pilotRow()]),
+    /headers do not match V1/,
+  );
 });

--- a/fastapi_app/main.py
+++ b/fastapi_app/main.py
@@ -46,6 +46,7 @@ from fastapi_app.routers import (
     design,
     design_v2,
     detailing,
+    etabs_bridge,
     excel_workbench,
     export,
     flat_slab,
@@ -180,6 +181,10 @@ API_TAGS_METADATA = [
     {
         "name": "excel-workbench",
         "description": "Selected-table Excel mapping, canonical beam review, and stale evidence.",
+    },
+    {
+        "name": "etabs-bridge",
+        "description": "Bounded Windows ETABS attachment, beam-force extraction, and canonical design pilot.",
     },
     {
         "name": "geometry",
@@ -655,6 +660,10 @@ app.include_router(
 )
 app.include_router(
     excel_workbench.router,
+    prefix=API_V1_PREFIX,
+)
+app.include_router(
+    etabs_bridge.router,
     prefix=API_V1_PREFIX,
 )
 app.include_router(

--- a/fastapi_app/openapi_baseline.json
+++ b/fastapi_app/openapi_baseline.json
@@ -1670,6 +1670,150 @@
         "title": "APIResponse[DuctilityCheckResponse]",
         "type": "object"
       },
+      "APIResponse_ETABSBridgeStatusV1_": {
+        "example": {
+          "data": {
+            "Ast_mm2": 603.2
+          },
+          "success": true
+        },
+        "properties": {
+          "clause_refs": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clause Refs"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ETABSBridgeStatusV1"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProblemDetailResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "success": {
+            "const": true,
+            "default": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "APIResponse[ETABSBridgeStatusV1]",
+        "type": "object"
+      },
+      "APIResponse_ETABSConnectionV1_": {
+        "example": {
+          "data": {
+            "Ast_mm2": 603.2
+          },
+          "success": true
+        },
+        "properties": {
+          "clause_refs": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clause Refs"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ETABSConnectionV1"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProblemDetailResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "success": {
+            "const": true,
+            "default": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "APIResponse[ETABSConnectionV1]",
+        "type": "object"
+      },
+      "APIResponse_ETABSPilotResultV1_": {
+        "example": {
+          "data": {
+            "Ast_mm2": 603.2
+          },
+          "success": true
+        },
+        "properties": {
+          "clause_refs": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clause Refs"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ETABSPilotResultV1"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProblemDetailResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "success": {
+            "const": true,
+            "default": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "APIResponse[ETABSPilotResultV1]",
+        "type": "object"
+      },
       "APIResponse_EffectiveLengthResponse_": {
         "example": {
           "data": {
@@ -14439,6 +14583,629 @@
           "clause_refs"
         ],
         "title": "DuctilityCheckResponse",
+        "type": "object"
+      },
+      "ETABSBridgeStatusV1": {
+        "additionalProperties": false,
+        "description": "Non-calculation availability and library identity.",
+        "properties": {
+          "bridge_status": {
+            "enum": [
+              "READY_TO_CONNECT",
+              "CONNECTED",
+              "PLATFORM_UNSUPPORTED",
+              "DEPENDENCY_MISSING"
+            ],
+            "title": "Bridge Status",
+            "type": "string"
+          },
+          "com_dependency": {
+            "enum": [
+              "INSTALLED",
+              "MISSING",
+              "NOT_APPLICABLE"
+            ],
+            "title": "Com Dependency",
+            "type": "string"
+          },
+          "issues": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Issues",
+            "type": "array"
+          },
+          "library_content_identity": {
+            "title": "Library Content Identity",
+            "type": "string"
+          },
+          "library_version": {
+            "title": "Library Version",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ETABSModelIdentityV1"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "platform": {
+            "title": "Platform",
+            "type": "string"
+          },
+          "schema_version": {
+            "const": "etabs-live-bridge/v1",
+            "default": "etabs-live-bridge/v1",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bridge_status",
+          "platform",
+          "com_dependency",
+          "library_version",
+          "library_content_identity"
+        ],
+        "title": "ETABSBridgeStatusV1",
+        "type": "object"
+      },
+      "ETABSConnectionV1": {
+        "additionalProperties": false,
+        "description": "Successful attachment proof without analysis or model mutation.",
+        "properties": {
+          "bridge_status": {
+            "const": "CONNECTED",
+            "default": "CONNECTED",
+            "title": "Bridge Status",
+            "type": "string"
+          },
+          "library_content_identity": {
+            "title": "Library Content Identity",
+            "type": "string"
+          },
+          "library_version": {
+            "title": "Library Version",
+            "type": "string"
+          },
+          "model": {
+            "$ref": "#/components/schemas/ETABSModelIdentityV1"
+          },
+          "schema_version": {
+            "const": "etabs-live-bridge/v1",
+            "default": "etabs-live-bridge/v1",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "library_version",
+          "library_content_identity",
+          "model"
+        ],
+        "title": "ETABSConnectionV1",
+        "type": "object"
+      },
+      "ETABSForceExtremeV1": {
+        "additionalProperties": false,
+        "description": "Signed governing value retained alongside its absolute magnitude.",
+        "properties": {
+          "absolute_value": {
+            "minimum": 0.0,
+            "title": "Absolute Value",
+            "type": "number"
+          },
+          "component": {
+            "enum": [
+              "V2",
+              "T",
+              "M3"
+            ],
+            "title": "Component",
+            "type": "string"
+          },
+          "load_case": {
+            "title": "Load Case",
+            "type": "string"
+          },
+          "object_station_mm": {
+            "title": "Object Station Mm",
+            "type": "number"
+          },
+          "row_index": {
+            "minimum": 0.0,
+            "title": "Row Index",
+            "type": "integer"
+          },
+          "signed_value": {
+            "title": "Signed Value",
+            "type": "number"
+          },
+          "step_number": {
+            "title": "Step Number",
+            "type": "number"
+          },
+          "step_type": {
+            "title": "Step Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "component",
+          "signed_value",
+          "absolute_value",
+          "row_index",
+          "object_station_mm",
+          "load_case",
+          "step_type",
+          "step_number"
+        ],
+        "title": "ETABSForceExtremeV1",
+        "type": "object"
+      },
+      "ETABSFrameForceStationV1": {
+        "additionalProperties": false,
+        "description": "One untruncated ETABS FrameForce row converted to canonical units.",
+        "properties": {
+          "element_name": {
+            "title": "Element Name",
+            "type": "string"
+          },
+          "element_station_mm": {
+            "title": "Element Station Mm",
+            "type": "number"
+          },
+          "load_case": {
+            "title": "Load Case",
+            "type": "string"
+          },
+          "m2_knm": {
+            "title": "M2 Knm",
+            "type": "number"
+          },
+          "m3_knm": {
+            "title": "M3 Knm",
+            "type": "number"
+          },
+          "object_name": {
+            "title": "Object Name",
+            "type": "string"
+          },
+          "object_station_mm": {
+            "title": "Object Station Mm",
+            "type": "number"
+          },
+          "p_kn": {
+            "title": "P Kn",
+            "type": "number"
+          },
+          "row_index": {
+            "minimum": 0.0,
+            "title": "Row Index",
+            "type": "integer"
+          },
+          "step_number": {
+            "title": "Step Number",
+            "type": "number"
+          },
+          "step_type": {
+            "title": "Step Type",
+            "type": "string"
+          },
+          "t_knm": {
+            "title": "T Knm",
+            "type": "number"
+          },
+          "v2_kn": {
+            "title": "V2 Kn",
+            "type": "number"
+          },
+          "v3_kn": {
+            "title": "V3 Kn",
+            "type": "number"
+          }
+        },
+        "required": [
+          "row_index",
+          "object_name",
+          "object_station_mm",
+          "element_name",
+          "element_station_mm",
+          "load_case",
+          "step_type",
+          "step_number",
+          "p_kn",
+          "v2_kn",
+          "v3_kn",
+          "t_knm",
+          "m2_knm",
+          "m3_knm"
+        ],
+        "title": "ETABSFrameForceStationV1",
+        "type": "object"
+      },
+      "ETABSFrameForcesV1": {
+        "additionalProperties": false,
+        "description": "Complete returned rows plus the three pilot governing actions.",
+        "properties": {
+          "governing_m3": {
+            "$ref": "#/components/schemas/ETABSForceExtremeV1"
+          },
+          "governing_t": {
+            "$ref": "#/components/schemas/ETABSForceExtremeV1"
+          },
+          "governing_v2": {
+            "$ref": "#/components/schemas/ETABSForceExtremeV1"
+          },
+          "result_row_count": {
+            "exclusiveMinimum": 0.0,
+            "maximum": 2000.0,
+            "title": "Result Row Count",
+            "type": "integer"
+          },
+          "selection": {
+            "$ref": "#/components/schemas/ETABSResultSelectionV1"
+          },
+          "stations": {
+            "items": {
+              "$ref": "#/components/schemas/ETABSFrameForceStationV1"
+            },
+            "title": "Stations",
+            "type": "array"
+          }
+        },
+        "required": [
+          "selection",
+          "result_row_count",
+          "stations",
+          "governing_v2",
+          "governing_t",
+          "governing_m3"
+        ],
+        "title": "ETABSFrameForcesV1",
+        "type": "object"
+      },
+      "ETABSFrameGeometryV1": {
+        "additionalProperties": false,
+        "description": "ETABS frame identity and rectangular section geometry in millimetres.",
+        "properties": {
+          "D_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "D Mm",
+            "type": "number"
+          },
+          "b_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "B Mm",
+            "type": "number"
+          },
+          "frame_name": {
+            "title": "Frame Name",
+            "type": "string"
+          },
+          "material_property": {
+            "title": "Material Property",
+            "type": "string"
+          },
+          "point_i": {
+            "title": "Point I",
+            "type": "string"
+          },
+          "point_j": {
+            "title": "Point J",
+            "type": "string"
+          },
+          "section_name": {
+            "title": "Section Name",
+            "type": "string"
+          },
+          "span_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Span Mm",
+            "type": "number"
+          },
+          "story": {
+            "title": "Story",
+            "type": "string"
+          },
+          "x_i_mm": {
+            "title": "X I Mm",
+            "type": "number"
+          },
+          "x_j_mm": {
+            "title": "X J Mm",
+            "type": "number"
+          },
+          "y_i_mm": {
+            "title": "Y I Mm",
+            "type": "number"
+          },
+          "y_j_mm": {
+            "title": "Y J Mm",
+            "type": "number"
+          },
+          "z_i_mm": {
+            "title": "Z I Mm",
+            "type": "number"
+          },
+          "z_j_mm": {
+            "title": "Z J Mm",
+            "type": "number"
+          }
+        },
+        "required": [
+          "frame_name",
+          "story",
+          "section_name",
+          "material_property",
+          "point_i",
+          "point_j",
+          "x_i_mm",
+          "y_i_mm",
+          "z_i_mm",
+          "x_j_mm",
+          "y_j_mm",
+          "z_j_mm",
+          "span_mm",
+          "b_mm",
+          "D_mm"
+        ],
+        "title": "ETABSFrameGeometryV1",
+        "type": "object"
+      },
+      "ETABSModelIdentityV1": {
+        "additionalProperties": false,
+        "description": "Identity of the ETABS model actually attached by COM.",
+        "properties": {
+          "etabs_version": {
+            "title": "Etabs Version",
+            "type": "string"
+          },
+          "etabs_version_number": {
+            "title": "Etabs Version Number",
+            "type": "number"
+          },
+          "model_name": {
+            "title": "Model Name",
+            "type": "string"
+          },
+          "model_path": {
+            "title": "Model Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model_name",
+          "model_path",
+          "etabs_version",
+          "etabs_version_number"
+        ],
+        "title": "ETABSModelIdentityV1",
+        "type": "object"
+      },
+      "ETABSPilotBeamResultV1": {
+        "additionalProperties": false,
+        "description": "Extracted ETABS beam and canonical library design result.",
+        "properties": {
+          "design_result": {
+            "additionalProperties": true,
+            "title": "Design Result",
+            "type": "object"
+          },
+          "forces": {
+            "$ref": "#/components/schemas/ETABSFrameForcesV1"
+          },
+          "geometry": {
+            "$ref": "#/components/schemas/ETABSFrameGeometryV1"
+          }
+        },
+        "required": [
+          "geometry",
+          "forces",
+          "design_result"
+        ],
+        "title": "ETABSPilotBeamResultV1",
+        "type": "object"
+      },
+      "ETABSPilotDesignBasisV1": {
+        "additionalProperties": false,
+        "description": "Explicit caller-owned design and detailing choices for every pilot beam.",
+        "properties": {
+          "ast_mm2_for_shear": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ast Mm2 For Shear"
+          },
+          "d_dash_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "D Dash Mm",
+            "type": "number"
+          },
+          "detailing": {
+            "$ref": "#/components/schemas/BeamDetailingOptionsV1"
+          },
+          "effective_depth_basis": {
+            "$ref": "#/components/schemas/EffectiveDepthBasisRequestV1"
+          },
+          "materials": {
+            "$ref": "#/components/schemas/IS456MaterialsV1"
+          },
+          "pt_percent": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pt Percent"
+          }
+        },
+        "required": [
+          "materials",
+          "effective_depth_basis",
+          "d_dash_mm",
+          "detailing"
+        ],
+        "title": "ETABSPilotDesignBasisV1",
+        "type": "object"
+      },
+      "ETABSPilotRequestV1": {
+        "additionalProperties": false,
+        "description": "Bounded read-and-design request for no more than five ETABS beams.",
+        "properties": {
+          "design_basis": {
+            "$ref": "#/components/schemas/ETABSPilotDesignBasisV1"
+          },
+          "limit": {
+            "default": 5,
+            "maximum": 5.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "result_selection": {
+            "$ref": "#/components/schemas/ETABSResultSelectionV1"
+          },
+          "schema_version": {
+            "const": "etabs-beam-pilot/v1",
+            "default": "etabs-beam-pilot/v1",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "result_selection",
+          "design_basis"
+        ],
+        "title": "ETABSPilotRequestV1",
+        "type": "object"
+      },
+      "ETABSPilotResultV1": {
+        "additionalProperties": false,
+        "description": "Completed bounded ETABS read and canonical beam-design proof.",
+        "properties": {
+          "beams": {
+            "items": {
+              "$ref": "#/components/schemas/ETABSPilotBeamResultV1"
+            },
+            "title": "Beams",
+            "type": "array"
+          },
+          "candidate_beam_count": {
+            "minimum": 1.0,
+            "title": "Candidate Beam Count",
+            "type": "integer"
+          },
+          "designed_beam_count": {
+            "maximum": 5.0,
+            "minimum": 1.0,
+            "title": "Designed Beam Count",
+            "type": "integer"
+          },
+          "library_content_identity": {
+            "title": "Library Content Identity",
+            "type": "string"
+          },
+          "library_version": {
+            "title": "Library Version",
+            "type": "string"
+          },
+          "limitations": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Limitations",
+            "type": "array"
+          },
+          "model": {
+            "$ref": "#/components/schemas/ETABSModelIdentityV1"
+          },
+          "pilot_status": {
+            "const": "COMPLETED",
+            "default": "COMPLETED",
+            "title": "Pilot Status",
+            "type": "string"
+          },
+          "qualified_review_required": {
+            "const": true,
+            "default": true,
+            "title": "Qualified Review Required",
+            "type": "boolean"
+          },
+          "result_selection": {
+            "$ref": "#/components/schemas/ETABSResultSelectionV1"
+          },
+          "schema_version": {
+            "const": "etabs-beam-pilot/v1",
+            "default": "etabs-beam-pilot/v1",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "units": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Units",
+            "type": "object"
+          }
+        },
+        "required": [
+          "model",
+          "result_selection",
+          "units",
+          "candidate_beam_count",
+          "designed_beam_count",
+          "beams",
+          "library_version",
+          "library_content_identity",
+          "limitations"
+        ],
+        "title": "ETABSPilotResultV1",
+        "type": "object"
+      },
+      "ETABSResultSelectionKind": {
+        "description": "Exact ETABS result source requested by the caller.",
+        "enum": [
+          "CASE",
+          "COMBINATION"
+        ],
+        "title": "ETABSResultSelectionKind",
+        "type": "string"
+      },
+      "ETABSResultSelectionV1": {
+        "additionalProperties": false,
+        "description": "One exact ETABS case or response combination.",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/ETABSResultSelectionKind"
+          },
+          "name": {
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "title": "ETABSResultSelectionV1",
         "type": "object"
       },
       "EffectiveDepthBasisRequestV1": {
@@ -36230,6 +36997,349 @@
         ]
       }
     },
+    "/api/v1/etabs-bridge/v1/beam-pilot": {
+      "post": {
+        "operationId": "run_etabs_beam_pilot_api_v1_etabs_bridge_v1_beam_pilot_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ETABSPilotRequestV1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse_ETABSPilotResultV1_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "State conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Request validation failed"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Concurrency or rate limit"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Internal application error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Capability unavailable"
+          }
+        },
+        "summary": "Extract and canonically design up to five rectangular ETABS beams",
+        "tags": [
+          "etabs-bridge"
+        ]
+      }
+    },
+    "/api/v1/etabs-bridge/v1/connect": {
+      "post": {
+        "operationId": "connect_etabs_api_v1_etabs_bridge_v1_connect_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse_ETABSConnectionV1_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "State conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Request validation failed"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Concurrency or rate limit"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Internal application error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Capability unavailable"
+          }
+        },
+        "summary": "Attach to the already-open ETABS model and return its identity",
+        "tags": [
+          "etabs-bridge"
+        ]
+      }
+    },
+    "/api/v1/etabs-bridge/v1/status": {
+      "get": {
+        "operationId": "get_etabs_bridge_status_api_v1_etabs_bridge_v1_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse_ETABSBridgeStatusV1_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "State conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Request validation failed"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Concurrency or rate limit"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Internal application error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemResponse"
+                }
+              }
+            },
+            "description": "Capability unavailable"
+          }
+        },
+        "summary": "Check local Python and ETABS COM bridge readiness",
+        "tags": [
+          "etabs-bridge"
+        ]
+      }
+    },
     "/api/v1/excel-workbench/v1/definition": {
       "get": {
         "operationId": "get_excel_workbench_definition_api_v1_excel_workbench_v1_definition_get",
@@ -41408,6 +42518,10 @@
     {
       "description": "Selected-table Excel mapping, canonical beam review, and stale evidence.",
       "name": "excel-workbench"
+    },
+    {
+      "description": "Bounded Windows ETABS attachment, beam-force extraction, and canonical design pilot.",
+      "name": "etabs-bridge"
     },
     {
       "description": "3D geometry generation for visualization.",

--- a/fastapi_app/routers/etabs_bridge.py
+++ b/fastapi_app/routers/etabs_bridge.py
@@ -1,0 +1,104 @@
+"""Versioned localhost transport for the bounded live ETABS beam pilot."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
+
+from fastapi_app.error_utils import sanitize_error
+from fastapi_app.models.response import APIResponse, error_response, success_response
+from structural_lib.services.etabs_live_bridge import (
+    ETABSBridgeStatusV1,
+    ETABSConnectionError,
+    ETABSConnectionV1,
+    ETABSDataError,
+    ETABSPilotRequestV1,
+    ETABSPilotResultV1,
+    ETABSUnavailableError,
+    InputContractError,
+    connect_etabs_v1,
+    get_etabs_bridge_status_v1,
+    run_etabs_beam_pilot_v1,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/etabs-bridge/v1", tags=["etabs-bridge"])
+
+
+@router.get(
+    "/status",
+    response_model=APIResponse[ETABSBridgeStatusV1],
+    summary="Check local Python and ETABS COM bridge readiness",
+)
+async def get_etabs_bridge_status():
+    return success_response(get_etabs_bridge_status_v1())
+
+
+@router.post(
+    "/connect",
+    response_model=APIResponse[ETABSConnectionV1],
+    summary="Attach to the already-open ETABS model and return its identity",
+)
+async def connect_etabs():
+    try:
+        result = await run_in_threadpool(connect_etabs_v1)
+        return success_response(result)
+    except ETABSUnavailableError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content=error_response(exc.to_problem()),
+        )
+    except ETABSConnectionError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=error_response(exc.to_problem()),
+        )
+    except Exception as exc:  # pragma: no cover - defensive COM boundary
+        logger.exception("ETABS connection failed")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content=error_response(sanitize_error(exc, "ETABS connection")),
+        )
+
+
+@router.post(
+    "/beam-pilot",
+    response_model=APIResponse[ETABSPilotResultV1],
+    summary="Extract and canonically design up to five rectangular ETABS beams",
+)
+async def run_etabs_beam_pilot(request: ETABSPilotRequestV1):
+    try:
+        result = await run_in_threadpool(run_etabs_beam_pilot_v1, request)
+        return success_response(result)
+    except InputContractError:
+        raise
+    except ETABSUnavailableError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content=error_response(exc.to_problem()),
+        )
+    except ETABSConnectionError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=error_response(exc.to_problem()),
+        )
+    except ETABSDataError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=error_response(exc.to_problem()),
+        )
+    except (TypeError, ValueError) as exc:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=error_response(sanitize_error(exc, "ETABS beam pilot")),
+        )
+    except Exception as exc:  # pragma: no cover - defensive COM boundary
+        logger.exception("ETABS beam pilot failed")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content=error_response(sanitize_error(exc, "ETABS beam pilot")),
+        )

--- a/fastapi_app/tests/test_etabs_bridge.py
+++ b/fastapi_app/tests/test_etabs_bridge.py
@@ -1,0 +1,91 @@
+"""REST semantics for the bounded live ETABS bridge."""
+
+from __future__ import annotations
+
+from fastapi_app.routers import etabs_bridge
+from fastapi_app.tests.conftest import unwrap
+from structural_lib.services.etabs_live_bridge import (
+    ETABSBridgeStatusV1,
+    ETABSConnectionError,
+    ETABSDataError,
+)
+
+
+def test_status_exposes_python_library_and_bridge_readiness(client, monkeypatch):
+    monkeypatch.setattr(
+        etabs_bridge,
+        "get_etabs_bridge_status_v1",
+        lambda: ETABSBridgeStatusV1(
+            bridge_status="READY_TO_CONNECT",
+            platform="Windows",
+            com_dependency="INSTALLED",
+            library_version="0.24.0",
+            library_content_identity="a" * 64,
+        ),
+    )
+
+    response = client.get("/api/v1/etabs-bridge/v1/status")
+
+    assert response.status_code == 200
+    assert unwrap(response)["bridge_status"] == "READY_TO_CONNECT"
+    assert unwrap(response)["library_content_identity"] == "a" * 64
+
+
+def test_connect_maps_missing_open_etabs_to_conflict(client, monkeypatch):
+    def fail():
+        raise ETABSConnectionError(
+            "ETABS_OPEN_INSTANCE_NOT_FOUND", "Open ETABS before connecting."
+        )
+
+    monkeypatch.setattr(etabs_bridge, "connect_etabs_v1", fail)
+
+    response = client.post("/api/v1/etabs-bridge/v1/connect")
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "ETABS_OPEN_INSTANCE_NOT_FOUND"
+
+
+def test_pilot_maps_unsupported_model_data_to_unprocessable(client, monkeypatch):
+    def fail(_request):
+        raise ETABSDataError(
+            "ETABS_SECTION_NOT_RECTANGULAR", "The first beam is not rectangular."
+        )
+
+    monkeypatch.setattr(etabs_bridge, "run_etabs_beam_pilot_v1", fail)
+    response = client.post(
+        "/api/v1/etabs-bridge/v1/beam-pilot",
+        json={
+            "result_selection": {"kind": "COMBINATION", "name": "ULS-1"},
+            "design_basis": {
+                "materials": {"fck_nmm2": 25.0, "fy_nmm2": 500.0},
+                "effective_depth_basis": {
+                    "clear_cover_mm": 40.0,
+                    "stirrup_diameter_mm": 8.0,
+                    "tension_bar_diameter_mm": 20.0,
+                },
+                "d_dash_mm": 40.0,
+                "detailing": {
+                    "standard": "IS456",
+                    "clear_cover_mm": 40.0,
+                    "tension_bar_diameter_mm": 20.0,
+                    "compression_bar_diameter_mm": 16.0,
+                    "nominal_top_steel_ratio": 0.25,
+                    "stirrup_diameter_mm": 8.0,
+                    "stirrup_legs": 2,
+                    "stirrup_spacing_support_mm": 150.0,
+                    "stirrup_spacing_mid_mm": 200.0,
+                },
+            },
+            "limit": 5,
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "ETABS_SECTION_NOT_RECTANGULAR"
+
+
+def test_openapi_exposes_three_typed_etabs_operations(client):
+    paths = client.app.openapi()["paths"]
+    assert "/api/v1/etabs-bridge/v1/status" in paths
+    assert "/api/v1/etabs-bridge/v1/connect" in paths
+    assert "/api/v1/etabs-bridge/v1/beam-pilot" in paths

--- a/llms.txt
+++ b/llms.txt
@@ -27,7 +27,7 @@ V3 Stack
 - Python structural_lib core (Python/structural_lib/)
 - Docker deployment (docker-compose.yml)
 
-Key API Endpoints (FastAPI) — 90 endpoints across 27 routers
+Key API Endpoints (FastAPI) — 93 endpoints across 28 routers
 - GET /api/v1/library/capabilities - Canonical supported/held contract
 - POST /api/v1/design/beam - Beam design (Mu, Vu, Ast)
 - POST /api/v1/design/beam/check - Check existing design


### PR DESCRIPTION
## Summary
- add a Windows-only optional comtypes ETABS bridge with typed status, connect, and beam-pilot endpoints
- extend the Office.js task pane to design up to five rectangular beams and write only a controlled ETABS_Pilot table
- document setup, unit restoration, failure modes, and the installed Windows evidence gate

## Verification
- 7177 Python tests passed; 3 skipped; 6 deselected
- 530 FastAPI tests passed
- 27 Office.js tests passed
- full repository gate: 32/32 passed
- normal pre-commit hooks passed

## Boundary
This is a read-only pilot. It does not run ETABS analysis, save or unlock the model, change section sizes, optimize the global model, or claim installed Windows ETABS acceptance or professional approval.