### PR TITLE
fix(etabs): accept comtypes list outputs

### DIFF
--- a/Python/structural_lib/services/etabs_live_bridge.py
+++ b/Python/structural_lib/services/etabs_live_bridge.py
@@ -305,15 +305,15 @@ def _require_zero_return(operation: str, value: object) -> None:
 def _decode_com_outputs(
     operation: str, value: object, *, output_count: int
 ) -> tuple[Any, ...]:
-    """Decode ETABS COM out values followed by the native integer return code."""
+    """Normalize ETABS COM out values followed by the native return code."""
 
-    if not isinstance(value, tuple) or len(value) != output_count + 1:
+    if not isinstance(value, (list, tuple)) or len(value) != output_count + 1:
         raise ETABSDataError(
             "ETABS_COM_SIGNATURE_MISMATCH",
             f"{operation} returned an unexpected COM result shape.",
         )
     _require_zero_return(operation, value[-1])
-    return value[:-1]
+    return tuple(value[:-1])
 
 
 class _ComtypesETABSSession:

--- a/Python/tests/unit/test_etabs_live_bridge.py
+++ b/Python/tests/unit/test_etabs_live_bridge.py
@@ -65,12 +65,13 @@ class _FakeSetup:
 
 
 class _FakeResults:
-    def __init__(self) -> None:
+    def __init__(self, output_container=tuple) -> None:
         self.Setup = _FakeSetup()
+        self.output_container = output_container
 
     def FrameForce(self, frame_name, item_type):
         assert item_type == 0
-        return (
+        outputs = (
             3,
             (frame_name,) * 3,
             (0.0, 2500.0, 5000.0),
@@ -87,13 +88,17 @@ class _FakeResults:
             (-150_000.0, 120_000.0, 100_000.0),
             0,
         )
+        return self.output_container(outputs)
 
 
 class _FakeFrameObj:
+    def __init__(self, output_container=tuple) -> None:
+        self.output_container = output_container
+
     def GetAllFrames(self, coordinate_system):
         assert coordinate_system == "Global"
         # B2 is intentionally listed first; deterministic story/name sorting picks B1.
-        return (
+        outputs = (
             3,
             ("B2", "C1", "B1"),
             ("R300x500", "R400x400", "R300x500"),
@@ -116,26 +121,31 @@ class _FakeFrameObj:
             (5, 5, 5),
             0,
         )
+        return self.output_container(outputs)
 
 
 class _FakePropFrame:
+    def __init__(self, output_container=tuple) -> None:
+        self.output_container = output_container
+
     def GetRectangle(self, name):
         assert name == "R300x500"
-        return ("", "M25", 500.0, 300.0, 1, "", "guid", 0)
+        return self.output_container(("", "M25", 500.0, 300.0, 1, "", "guid", 0))
 
 
 class _FakeSapModel:
-    def __init__(self) -> None:
-        self.FrameObj = _FakeFrameObj()
-        self.PropFrame = _FakePropFrame()
-        self.Results = _FakeResults()
+    def __init__(self, output_container=tuple) -> None:
+        self.output_container = output_container
+        self.FrameObj = _FakeFrameObj(output_container)
+        self.PropFrame = _FakePropFrame(output_container)
+        self.Results = _FakeResults(output_container)
         self.unit_calls: list[int] = []
 
     def GetModelFilepath(self):
         return r"C:\Models\Pilot Copy.edb"
 
     def GetVersion(self):
-        return ("ETABS 23.3.1", 23.31, 0)
+        return self.output_container(("ETABS 23.3.1", 23.31, 0))
 
     def GetPresentUnits(self):
         return 6
@@ -166,8 +176,11 @@ class _FakeSession:
             assert self.sap_model.SetPresentUnits(original) == 0
 
 
-def test_pilot_extracts_sorted_beams_preserves_stations_and_restores_units(monkeypatch):
-    sap_model = _FakeSapModel()
+@pytest.mark.parametrize("output_container", [tuple, list], ids=["tuple", "list"])
+def test_pilot_extracts_sorted_beams_preserves_stations_and_restores_units(
+    monkeypatch, output_container
+):
+    sap_model = _FakeSapModel(output_container)
     session = _FakeSession(sap_model)
     monkeypatch.setattr(bridge, "_library_identity", lambda: ("0.24.0", "a" * 64))
 
@@ -223,8 +236,11 @@ def test_com_signature_mismatch_is_a_stable_data_error():
     assert exc_info.value.code == "ETABS_COM_SIGNATURE_MISMATCH"
 
 
-def test_connect_returns_exact_open_model_without_unit_change(monkeypatch):
-    sap_model = _FakeSapModel()
+@pytest.mark.parametrize("output_container", [tuple, list], ids=["tuple", "list"])
+def test_connect_returns_exact_open_model_without_unit_change(
+    monkeypatch, output_container
+):
+    sap_model = _FakeSapModel(output_container)
     session = _FakeSession(sap_model)
     monkeypatch.setattr(bridge, "_library_identity", lambda: ("0.24.0", "c" * 64))
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,84 @@
 
 ---
 
+## 2026-08-28 — Session: ETABS comtypes list-output compatibility repair
+
+**Agent:** Codex (`backend`, sole writer; no subagents).
+
+**Branch:** `codex/etabs-com-list-compat` from observed current `origin/main`
+`d6e83cfd53d444b11637bb0e85f5b314a92333cc`.
+
+**Git handoff receipt:**
+`docs/verification/etabs-com-list-compat-git-handoff-receipt.json`
+
+**Focus:** Repair the Windows-blocking ETABS COM result-container mismatch and
+prove both tuple and list output shapes through connection and the complete
+bounded beam pilot. ETABS model access, analysis, save, write-back, Excel
+execution, design-scope expansion, and optimization remain outside this code
+repair.
+
+**Completed:**
+
+- The common ETABS COM decoder now accepts only the two observed outer result
+  containers, `list` and `tuple`, while preserving exact output-count and native
+  return-code validation and normalizing successful outputs to a tuple.
+- The existing connection and full beam-pilot tests now run against both outer
+  container types. This covers `SapModel.GetVersion`, frame inventory,
+  rectangular section extraction, and frame-force extraction without weakening
+  nested-array or ETABS return-code checks.
+
+### Issues encountered
+
+- Windows ETABS/comtypes returned COM output values as a list, while the merged
+  bridge accepted only a tuple. `/status` therefore passed but `/connect`
+  returned `ETABS_COM_SIGNATURE_MISMATCH`, preventing Excel and `/beam-pilot`
+  from starting.
+- The canonical session start was blocked by an unmatched checkpoint for the
+  already-merged parent pilot even though its recorded `session end` had passed.
+- A targeted mypy-command search included the nonexistent repository-root
+  `pyproject.toml` beside the maintained `Python/pyproject.toml`, causing `rg`
+  to return a path error after producing the requested matches.
+- The first normal-hook pass found that the generated Latest Handoff block still
+  referenced the merged parent pilot and its earlier Git receipt.
+
+### Root causes and resolutions
+
+- Confirmed root cause: `_decode_com_outputs` required `isinstance(value,
+  tuple)`, but comtypes 1.4.16 on the acceptance host materialized the same ETABS
+  out-parameter sequence as a list. Resolution: accept exactly list or tuple,
+  retain length and zero-return-code checks, and normalize the accepted prefix
+  to a tuple. Both connection and complete pilot regressions pass with each
+  container type.
+- Confirmed root cause: the shared usage log has a start for
+  `EXCEL-ETABS-PYTHON-BRIDGE-PILOT` without its separate usage-closeout record;
+  the successful session-end record does not replace that checkpoint.
+  Resolution: do not create a duplicate timer; continue the trusted active
+  parent-pilot timer for this directly related repair. `session usage --active
+  --json` identifies the exact parent task and `session trust` reports
+  `Trusted`/`READY_LOCAL`. ⚠️ TERMINAL ISSUE: new repair session start was
+  rejected by the unmatched parent checkpoint -> continued the trusted parent
+  session instead of bypassing the control.
+- Confirmed root cause: the project configuration lives under `Python/`, not at
+  the repository root. Resolution: run configured mypy using
+  `Python/pyproject.toml`; the changed service reports no issues. ⚠️ TERMINAL
+  ISSUE: mixed existing/nonexistent configuration paths made the search exit
+  nonzero -> used the maintained Python configuration path.
+- Confirmed root cause: creating the new receipt and session entry does not
+  mutate the generated handoff block during implementation. Resolution: run
+  the maintained `session end --fix` preparation step, which selected the new
+  receipt and updated the block; the failed session-doc hook and consolidated
+  quick gate are the only checks repeated after this documentation change.
+
+### Validation through content freeze
+
+- Focused service and REST transport selection: `12 passed`, including tuple
+  and Windows-style list output shapes through connect and full pilot behavior.
+- Changed service configured mypy: no issues. Changed-file Black and Ruff: pass.
+- No ETABS model, workbook, Excel add-in, FastAPI contract, structural
+  calculation, or design input was changed by this repair.
+
+---
+
 ## 2026-08-28 — Session: Excel -> Python -> live ETABS beam pilot
 
 **Agent:** Codex (`orchestrator`, sole writer; no subagents).

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,10 +4,10 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-28
-- Focus: Add and document a bounded Windows Office.js -> localhost FastAPI/
-- Completed: Added the optional `structural-lib-is456[etabs]` dependency extra and a; Added typed status, connect, and beam-pilot REST operations. The pilot selects; Extended the existing macro-free Office.js pane with an ETABS surface that is
-- Git receipt: docs/verification/excel-etabs-python-bridge-pilot-git-handoff-receipt.json | sha256:404a1248fb9c2f13fd61f46f3e98f8a0ddfd06593770c1fac9645e082f2e7756 | HOLD
-- Git identity: codex/excel-etabs-python-bridge-pilot@683760a4aef1c384aa475df6842c791eada85959 | upstream=NONE@UNKNOWN | base=origin/main@683760a4aef1c384aa475df6842c791eada85959 | tree=dirty | operation=none
+- Focus: Repair the Windows-blocking ETABS COM result-container mismatch and
+- Completed: The common ETABS COM decoder now accepts only the two observed outer result; The existing connection and full beam-pilot tests now run against both outer
+- Git receipt: docs/verification/etabs-com-list-compat-git-handoff-receipt.json | sha256:a84a498879cbc8d9dc512b1b80d42e8ca19d91ca8659e3928f03c1284ca17fda | HOLD
+- Git identity: codex/etabs-com-list-compat@d6e83cfd53d444b11637bb0e85f5b314a92333cc | upstream=origin/main@d6e83cfd53d444b11637bb0e85f5b314a92333cc | base=origin/main@d6e83cfd53d444b11637bb0e85f5b314a92333cc | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
 - Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
@@ -17,9 +17,9 @@
 | State | Exact boundary |
 |---|---|
 | **Public** | `v0.24.0` is the immutable current normal software release at merge `e66de6efa3bb80d3ebc54e6151b1d6c29275c502`; GitHub prerelease is false and PyPI selects it normally. |
-| **Current** | `codex/excel-etabs-python-bridge-pilot` contains the locally verified read-only Office.js -> FastAPI/Python -> already-open ETABS beam pilot. Broad Python/FastAPI/Office.js tests and the 32/32 repository gate pass; this is not yet installed Windows ETABS evidence or a release. |
-| **Next** | Run the documented exact-current installed Windows Excel + ETABS acceptance against a saved copied model, reconcile at least one beam's station forces/design independently, and record unit restoration. Do not start ETABS write-back or optimization before that gate passes. |
-| **Held** | ETABS analysis execution, unlock/save, member-size write-back, iterative whole-model optimization, full frame-solver claims, serviceability/adjacency/congestion/site-practice automation, stable-API guarantee, professional or construction-use approval, release, protected-source mutation, and destructive cleanup. |
+| **Current** | The exact copied Windows model has current locked analysis results. W1 reached `/connect` and exposed a tuple-only COM decoder defect; `codex/etabs-com-list-compat` contains the bounded repair with tuple/list connection and full-pilot regressions. This remains an unpublished repair candidate, not completed installed-Windows acceptance or a release. |
+| **Next** | Freeze and publish the repair candidate, require its hosted checks, then deploy that exact commit to the existing Windows evidence lane. Reuse the analyzed copied model and run `/connect`, one-beam `/beam-pilot`, Excel, and bounded five-beam evidence without rerunning analysis. |
+| **Held** | Additional ETABS analysis, unlock/save, member-size write-back, iterative whole-model optimization, full frame-solver claims, serviceability/adjacency/congestion/site-practice automation, stable-API guarantee, professional or construction-use approval, release, protected-source mutation, and destructive cleanup. |
 
 ## Published release evidence
 

--- a/docs/verification/etabs-com-list-compat-git-handoff-receipt.json
+++ b/docs/verification/etabs-com-list-compat-git-handoff-receipt.json
@@ -1,0 +1,118 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "a84a498879cbc8d9dc512b1b80d42e8ca19d91ca8659e3928f03c1284ca17fda",
+    "state": {
+      "branch": "codex/etabs-com-list-compat",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "d6e83cfd53d444b11637bb0e85f5b314a92333cc",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 90.752,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "head_sha": "d6e83cfd53d444b11637bb0e85f5b314a92333cc",
+      "hold_reasons": [
+        "changed paths: 3"
+      ],
+      "linked_worktree": false,
+      "locks": [],
+      "observed_at_utc": "2026-08-28T17:49:32.645663+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 3,
+        "modified_paths": [
+          "Python/structural_lib/services/etabs_live_bridge.py",
+          "Python/tests/unit/test_etabs_live_bridge.py",
+          "docs/SESSION_LOG.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": []
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "d6e83cfd53d444b11637bb0e85f5b314a92333cc",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:a84a498879cbc8d9dc512b1b80d42e8ca19d91ca8659e3928f03c1284ca17fda",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-28T17:49:32.645800+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "excel_addin",
+      "fastapi_app",
+      "Python/structural_lib/codes/is456"
+    ],
+    "integration_owner": "Codex",
+    "owned_paths": [
+      "Python/structural_lib/services/etabs_live_bridge.py",
+      "Python/tests/unit/test_etabs_live_bridge.py"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md"
+    ],
+    "task_id": "ETABS-COM-LIST-COMPAT"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}


### PR DESCRIPTION
## Summary
- accept list or tuple outer COM result containers while preserving exact length and return-code validation
- normalize accepted COM outputs to tuples at the shared boundary
- exercise both shapes through ETABS connect and the complete bounded beam pilot
- update the session evidence and Windows rerun handoff

## Verification
- 12 focused ETABS bridge and FastAPI tests passed
- changed service mypy passed
- changed-file Black and Ruff passed
- repository quick gate passed 10/10
- normal commit hooks passed

## Boundary
No ETABS model, workbook, Excel add-in, analysis result, structural calculation, design input, write-back, or optimization was changed.