### PR TITLE
fix(etabs): use exact open model filename

### DIFF
--- a/Python/structural_lib/services/etabs_live_bridge.py
+++ b/Python/structural_lib/services/etabs_live_bridge.py
@@ -398,17 +398,23 @@ def _default_session_factory() -> _ETABSSession:
 
 
 def _model_identity(sap_model: Any) -> ETABSModelIdentityV1:
-    model_path = str(sap_model.GetModelFilepath() or "").strip()
+    model_path = str(sap_model.GetModelFilename(True) or "").strip()
     if not model_path:
         raise ETABSConnectionError(
             "ETABS_MODEL_PATH_MISSING",
             "Save the copied ETABS model before running the Excel pilot.",
         )
+    parsed_path = PureWindowsPath(model_path)
+    if not parsed_path.is_absolute() or parsed_path.suffix.casefold() != ".edb":
+        raise ETABSConnectionError(
+            "ETABS_MODEL_PATH_INVALID",
+            "ETABS did not return the full path of a saved .edb model.",
+        )
     version, version_number = _decode_com_outputs(
         "SapModel.GetVersion", sap_model.GetVersion(), output_count=2
     )
     return ETABSModelIdentityV1(
-        model_name=PureWindowsPath(model_path).name,
+        model_name=parsed_path.name,
         model_path=model_path,
         etabs_version=str(version),
         etabs_version_number=float(version_number),

--- a/Python/tests/unit/test_etabs_live_bridge.py
+++ b/Python/tests/unit/test_etabs_live_bridge.py
@@ -134,15 +134,28 @@ class _FakePropFrame:
 
 
 class _FakeSapModel:
-    def __init__(self, output_container=tuple) -> None:
+    def __init__(
+        self,
+        output_container=tuple,
+        *,
+        model_filename: str = r"C:\Models\Pilot Copy.EDB",
+    ) -> None:
         self.output_container = output_container
+        self.model_filename = model_filename
         self.FrameObj = _FakeFrameObj(output_container)
         self.PropFrame = _FakePropFrame(output_container)
         self.Results = _FakeResults(output_container)
         self.unit_calls: list[int] = []
+        self.model_filename_calls: list[bool] = []
+        self.model_filepath_calls = 0
 
     def GetModelFilepath(self):
-        return r"C:\Models\Pilot Copy.edb"
+        self.model_filepath_calls += 1
+        return "C:\\Models\\"
+
+    def GetModelFilename(self, include_path):
+        self.model_filename_calls.append(include_path)
+        return self.model_filename
 
     def GetVersion(self):
         return self.output_container(("ETABS 23.3.1", 23.31, 0))
@@ -186,7 +199,8 @@ def test_pilot_extracts_sorted_beams_preserves_stations_and_restores_units(
 
     result = bridge.run_etabs_beam_pilot_v1(_request(), session_factory=lambda: session)
 
-    assert result.model.model_name == "Pilot Copy.edb"
+    assert result.model.model_name == "Pilot Copy.EDB"
+    assert result.model.model_path == r"C:\Models\Pilot Copy.EDB"
     assert result.candidate_beam_count == 2
     assert result.designed_beam_count == 2
     assert [item.geometry.frame_name for item in result.beams] == ["B1", "B2"]
@@ -204,6 +218,8 @@ def test_pilot_extracts_sorted_beams_preserves_stations_and_restores_units(
         ("deselect",),
         ("combo", "ULS-1", True),
     ]
+    assert sap_model.model_filename_calls == [True]
+    assert sap_model.model_filepath_calls == 0
     assert session.closed is True
 
 
@@ -247,8 +263,36 @@ def test_connect_returns_exact_open_model_without_unit_change(
     result = bridge.connect_etabs_v1(session_factory=lambda: session)
 
     assert result.bridge_status == "CONNECTED"
+    assert result.model.model_name == "Pilot Copy.EDB"
+    assert result.model.model_path == r"C:\Models\Pilot Copy.EDB"
     assert result.model.etabs_version == "ETABS 23.3.1"
+    assert sap_model.model_filename_calls == [True]
+    assert sap_model.model_filepath_calls == 0
     assert sap_model.unit_calls == []
+    assert session.closed is True
+
+
+@pytest.mark.parametrize(
+    ("model_filename", "expected_code"),
+    [
+        ("", "ETABS_MODEL_PATH_MISSING"),
+        ("C:\\Models\\", "ETABS_MODEL_PATH_INVALID"),
+        ("Pilot Copy.edb", "ETABS_MODEL_PATH_INVALID"),
+        (r"C:\Models\Pilot Copy.e2k", "ETABS_MODEL_PATH_INVALID"),
+    ],
+)
+def test_connect_rejects_missing_or_non_edb_model_identity(
+    model_filename, expected_code
+):
+    sap_model = _FakeSapModel(model_filename=model_filename)
+    session = _FakeSession(sap_model)
+
+    with pytest.raises(bridge.ETABSConnectionError) as exc_info:
+        bridge.connect_etabs_v1(session_factory=lambda: session)
+
+    assert exc_info.value.code == expected_code
+    assert sap_model.model_filename_calls == [True]
+    assert sap_model.model_filepath_calls == 0
     assert session.closed is True
 
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -5,6 +5,90 @@
 
 ---
 
+## 2026-08-28 — Session: ETABS exact open-model identity repair
+
+**Agent:** Codex (`backend`, sole writer; no subagents).
+
+**Branch:** `codex/etabs-model-filename-identity` from observed current
+`origin/main` `57ba94af5f5e207474629e1fa26a5a1946e51275`.
+
+**Git handoff receipt:**
+`docs/verification/etabs-model-filename-identity-git-handoff-receipt.json`
+
+**Focus:** Repair the installed-Windows model-identity failure after the prior
+COM list/tuple compatibility repair. Attach only to the already-open ETABS
+process, prove the exact saved `.edb` filename and full path, and preserve the
+existing read-only pilot boundary. Analysis, model unlock/save, section or load
+mutation, Excel execution, optimization, and engineering approval remain
+outside this code repair.
+
+**Completed:**
+
+- Open-model identity now uses `SapModel.GetModelFilename(True)`, the ETABS API
+  operation that requests the filename with its full path, rather than
+  `GetModelFilepath()`, which returned only the containing directory on the
+  ETABS 23.3.1 acceptance host.
+- Identity validation rejects empty, relative, directory-only, and non-`.edb`
+  values before reporting `CONNECTED` or extracting any beam. The exact path
+  and its Windows basename remain visible in the existing REST/Excel contract.
+- The fake COM model now reproduces the installed behavior: the old filepath
+  method returns only `C:\\Models\\`, while `GetModelFilename(True)` returns the
+  full uppercase-`.EDB` identity. Connection and full-pilot regressions prove
+  the correct method and fail if the directory-only method is called.
+- The Windows guide records the exact model-identity call, validation boundary,
+  observed ETABS 23.3.1 behavior, and official CSI API reference.
+
+### Issues encountered
+
+- `/connect` returned `CONNECTED` with model name `Downloads` and model path
+  `C:\\Users\\P\\Downloads\\` instead of the open copied model's exact `.EDB`
+  identity, preventing W1 from safely continuing to `/beam-pilot` and Excel.
+- The deterministic COM fake returned a full `.edb` filename from
+  `GetModelFilepath()`, so local tests encoded behavior that did not match the
+  installed ETABS 23.3.1 API result.
+- The canonical session start was rejected by the already-recorded unmatched
+  parent-pilot usage checkpoint.
+- The first targeted mypy invocation mixed repository-root and configured
+  Python package contexts and found the service package under two module names.
+
+### Root causes and resolutions
+
+- Confirmed root cause: `_model_identity` called `GetModelFilepath()`, which is
+  not the filename API and returned the open model's directory on the Windows
+  acceptance host. Resolution: call `GetModelFilename(True)`, parse it with
+  `PureWindowsPath`, and require an absolute `.edb` path. Focused connection and
+  full-pilot tests return the exact name/path and never call the old method.
+- Confirmed root cause: the fake's wrong `GetModelFilepath()` contract made the
+  production misuse look correct. Resolution: model the observed directory
+  return separately from `GetModelFilename(True)` and assert exact call history;
+  empty, directory-only, relative, and non-EDB identities all fail closed.
+- Confirmed root cause: the shared usage log still has the parent
+  `EXCEL-ETABS-PYTHON-BRIDGE-PILOT` start without a separate usage-closeout
+  record. Resolution: continue that trusted active timer, matching the preceding
+  directly related repair, rather than bypassing or duplicating the checkpoint.
+  `session trust` reports `Trusted`/`READY_LOCAL`. ⚠️ TERMINAL ISSUE: new repair
+  session start was rejected by the unmatched parent checkpoint -> continued
+  the trusted parent-pilot timer.
+- Confirmed root cause: configured mypy uses `explicit_package_bases=true` from
+  `Python/`, while the first command passed a root-relative source path.
+  Resolution: run the exact service from the configured `Python/` package
+  context through the worktree-bound runtime; it reports no issues.
+  ⚠️ TERMINAL ISSUE: root-level targeted mypy found the package twice -> used
+  the maintained configured package context.
+
+### Validation through content freeze
+
+- Focused service and REST selection: `16 passed`, covering tuple/list COM
+  containers, exact uppercase-`.EDB` identity, complete bounded beam extraction,
+  unit restoration, and four invalid model-identity shapes.
+- Changed service/test Black and Ruff: pass. Configured mypy for the changed
+  service: no issues. The consolidated quick gate passes `10/10`; normal commit
+  checks remain the candidate-freeze sequence.
+- No ETABS model, workbook, Excel add-in, FastAPI contract, structural formula,
+  design input, analysis state, or result selection was changed by this repair.
+
+---
+
 ## 2026-08-28 — Session: ETABS comtypes list-output compatibility repair
 
 **Agent:** Codex (`backend`, sole writer; no subagents).

--- a/docs/guides/excel-etabs-python-bridge-pilot.md
+++ b/docs/guides/excel-etabs-python-bridge-pilot.md
@@ -135,6 +135,14 @@ The optional dependency is `comtypes>=1.4,<2` and is installed only by the
 `etabs` package extra on Windows. The service creates and tears down COM inside
 the FastAPI worker thread that owns the request.
 
+After attaching to the running ETABS object, the service identifies the exact
+open model with `SapModel.GetModelFilename(True)`. The explicit `True` requests
+the filename with its full path; the bridge rejects an empty value, a directory,
+a relative filename, or a path that is not a saved `.edb` model. It does not use
+`GetModelFilepath()`, which ETABS 23.3.1 returned as the containing directory in
+the installed Windows pilot. See CSI's API documentation for
+[GetModelFilename](https://docs.csiamerica.com/help-files/etabs-api-2016/html/375b5267-61cc-04c2-d39c-34940d011f52.htm).
+
 The pilot records the current ETABS present-unit enumeration, temporarily sets
 `kN_mm_C` (CSI enumeration value 5), reads geometry and results, and restores
 the original setting in a `finally` path. CSI's API documentation identifies

--- a/docs/planning/next-session-brief.md
+++ b/docs/planning/next-session-brief.md
@@ -4,10 +4,10 @@
 
 <!-- HANDOFF:START -->
 - Date: 2026-08-28
-- Focus: Repair the Windows-blocking ETABS COM result-container mismatch and
-- Completed: The common ETABS COM decoder now accepts only the two observed outer result; The existing connection and full beam-pilot tests now run against both outer
-- Git receipt: docs/verification/etabs-com-list-compat-git-handoff-receipt.json | sha256:a84a498879cbc8d9dc512b1b80d42e8ca19d91ca8659e3928f03c1284ca17fda | HOLD
-- Git identity: codex/etabs-com-list-compat@d6e83cfd53d444b11637bb0e85f5b314a92333cc | upstream=origin/main@d6e83cfd53d444b11637bb0e85f5b314a92333cc | base=origin/main@d6e83cfd53d444b11637bb0e85f5b314a92333cc | tree=dirty | operation=none
+- Focus: Repair the installed-Windows model-identity failure after the prior
+- Completed: Open-model identity now uses `SapModel.GetModelFilename(True)`, the ETABS API; Identity validation rejects empty, relative, directory-only, and non-`.edb`; The fake COM model now reproduces the installed behavior: the old filepath
+- Git receipt: docs/verification/etabs-model-filename-identity-git-handoff-receipt.json | sha256:09ee2b5d47e6e2d1e75aa066f80e9ea21c72a22bb6ce88a8828f18098066152a | HOLD
+- Git identity: codex/etabs-model-filename-identity@57ba94af5f5e207474629e1fa26a5a1946e51275 | upstream=origin/main@57ba94af5f5e207474629e1fa26a5a1946e51275 | base=origin/main@57ba94af5f5e207474629e1fa26a5a1946e51275 | tree=dirty | operation=none
 - Hosted evidence: remote=NOT_CHECKED | PR=NOT_CHECKED#UNKNOWN | review=NOT_CHECKED | retention=NOT_CHECKED
 - Next action: HOLD_FOR_EXACT_EVIDENCE
 <!-- HANDOFF:END -->
@@ -17,8 +17,8 @@
 | State | Exact boundary |
 |---|---|
 | **Public** | `v0.24.0` is the immutable current normal software release at merge `e66de6efa3bb80d3ebc54e6151b1d6c29275c502`; GitHub prerelease is false and PyPI selects it normally. |
-| **Current** | The exact copied Windows model has current locked analysis results. W1 reached `/connect` and exposed a tuple-only COM decoder defect; `codex/etabs-com-list-compat` contains the bounded repair with tuple/list connection and full-pilot regressions. This remains an unpublished repair candidate, not completed installed-Windows acceptance or a release. |
-| **Next** | Freeze and publish the repair candidate, require its hosted checks, then deploy that exact commit to the existing Windows evidence lane. Reuse the analyzed copied model and run `/connect`, one-beam `/beam-pilot`, Excel, and bounded five-beam evidence without rerunning analysis. |
+| **Current** | The exact copied Windows model has current locked analysis results. The tuple/list repair is merged. W1 then proved that ETABS 23.3.1 returns only a directory from `GetModelFilepath()`; `codex/etabs-model-filename-identity` contains the bounded `GetModelFilename(True)` repair with exact full-path and fail-closed identity regressions. This remains an unpublished repair candidate, not completed installed-Windows acceptance or a release. |
+| **Next** | Freeze and publish the identity repair, require its hosted checks, then deploy that exact commit to the existing Windows evidence lane. Reuse the analyzed copied model and run `/connect`, one-beam `/beam-pilot`, Excel, and bounded five-beam evidence without rerunning analysis. |
 | **Held** | Additional ETABS analysis, unlock/save, member-size write-back, iterative whole-model optimization, full frame-solver claims, serviceability/adjacency/congestion/site-practice automation, stable-API guarantee, professional or construction-use approval, release, protected-source mutation, and destructive cleanup. |
 
 ## Published release evidence

--- a/docs/verification/etabs-model-filename-identity-git-handoff-receipt.json
+++ b/docs/verification/etabs-model-filename-identity-git-handoff-receipt.json
@@ -1,0 +1,124 @@
+{
+  "authorization": {
+    "authorized_actions": [],
+    "next_action": "HOLD_FOR_EXACT_EVIDENCE",
+    "prohibited_actions": [],
+    "status": "UNKNOWN"
+  },
+  "holds": [
+    "AUTHORIZATION_PROVENANCE_UNKNOWN",
+    "AUTHORIZATION_TARGET_BINDING_UNKNOWN",
+    "AUTHORIZATION_UNKNOWN",
+    "INTEGRATION_NOT_CHECKED",
+    "LOCAL_HOLD_DIRTY",
+    "PULL_REQUEST_NOT_CHECKED",
+    "REMOTE_NOT_CHECKED",
+    "RETENTION_NOT_CHECKED",
+    "REVIEW_NOT_CHECKED"
+  ],
+  "integration": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "local": {
+    "authority": "scripts/git_state.py",
+    "receipt_sha256": "09ee2b5d47e6e2d1e75aa066f80e9ea21c72a22bb6ce88a8828f18098066152a",
+    "state": {
+      "branch": "codex/etabs-model-filename-identity",
+      "default_base": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "57ba94af5f5e207474629e1fa26a5a1946e51275",
+        "status": "equal"
+      },
+      "derived_action": "HOLD_DIRTY",
+      "duration_ms": 90.212,
+      "git_common_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "git_dir": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib/.git",
+      "head_sha": "57ba94af5f5e207474629e1fa26a5a1946e51275",
+      "hold_reasons": [
+        "changed paths: 6"
+      ],
+      "linked_worktree": false,
+      "locks": [],
+      "observed_at_utc": "2026-08-28T18:21:15.051442+00:00",
+      "operation": "none",
+      "operation_markers": [],
+      "query_failures": [],
+      "ready_local": false,
+      "remote_freshness": "NOT_CHECKED",
+      "repository_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib",
+      "schema_version": 1,
+      "tree": {
+        "clean": false,
+        "conflicted_paths": [],
+        "dirty_count": 6,
+        "modified_paths": [
+          "Python/structural_lib/services/etabs_live_bridge.py",
+          "Python/tests/unit/test_etabs_live_bridge.py",
+          "docs/SESSION_LOG.md",
+          "docs/guides/excel-etabs-python-bridge-pilot.md",
+          "docs/planning/next-session-brief.md"
+        ],
+        "staged_paths": [],
+        "untracked_paths": [
+          "docs/verification/etabs-model-filename-identity-git-handoff-receipt.json"
+        ]
+      },
+      "upstream": {
+        "ahead": 0,
+        "behind": 0,
+        "ref": "origin/main",
+        "sha": "57ba94af5f5e207474629e1fa26a5a1946e51275",
+        "status": "equal"
+      },
+      "worktree_root": "/Users/pravinsurawase/VS_code_project/structural_engineering_lib"
+    }
+  },
+  "local_state_receipt_hash": "sha256:09ee2b5d47e6e2d1e75aa066f80e9ea21c72a22bb6ce88a8828f18098066152a",
+  "mutation_policy": "READ_ONLY_EVIDENCE_NO_GIT_OR_GITHUB_MUTATION",
+  "observed_at_utc": "2026-08-28T18:21:15.051581+00:00",
+  "pull_request": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "receipt_grants_authority": false,
+  "receipt_kind": "task_to_git_handoff",
+  "receipt_status": "HOLD",
+  "remote": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "retention": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "review": {
+    "query_status": "UNKNOWN",
+    "status": "NOT_CHECKED"
+  },
+  "schema_version": 1,
+  "task": {
+    "forbidden_paths": [
+      "excel_addin",
+      "fastapi_app",
+      "Python/structural_lib/codes/is456"
+    ],
+    "integration_owner": "Codex",
+    "owned_paths": [
+      "Python/structural_lib/services/etabs_live_bridge.py",
+      "Python/tests/unit/test_etabs_live_bridge.py",
+      "docs/guides/excel-etabs-python-bridge-pilot.md"
+    ],
+    "shared_paths": [
+      "docs/SESSION_LOG.md",
+      "docs/planning/next-session-brief.md"
+    ],
+    "task_id": "ETABS-MODEL-FILENAME-IDENTITY"
+  },
+  "task_archive": {
+    "is_git_retention_evidence": false,
+    "status": "NOT_CHECKED"
+  }
+}


### PR DESCRIPTION
## Summary
- identify the already-open ETABS model with `GetModelFilename(True)` instead of the directory-only filepath call
- fail closed for empty, relative, directory-only, or non-EDB identities
- reproduce the installed ETABS 23.3.1 behavior in COM fakes and document the Windows boundary

## Verification
- focused ETABS service and REST tests: 16 passed
- changed-file Black and Ruff: passed
- configured mypy: passed
- quick gate: 10/10 passed
- normal pre-commit hooks: passed

## Boundary
No ETABS analysis, unlock, save, section/load mutation, Excel execution, optimization, or structural calculation changes.